### PR TITLE
refactor: fix duplicate type names in lib/types/contexts (fixes #40)

### DIFF
--- a/gamesformykids/lib/types/contexts/game-config.ts
+++ b/gamesformykids/lib/types/contexts/game-config.ts
@@ -17,7 +17,7 @@ export type { GameUIConfig } from '../../constants/ui/gameConfigs';
  */
 export type AutoGameType = TypedConfiguration;
 
-// הערה: GameCardProps מוגדר ב-components/game.ts לפי עקרון DRY
+
 
 /**
  * מידע משחק נוכחי - עקרון Single Responsibility
@@ -52,14 +52,6 @@ export interface GameConfigContextValue extends
 export interface GameConfigProviderProps {
   readonly children: React.ReactNode;
   readonly gameType?: GameType;
-}
-
-/**
- * Props לכרטיס משחק מתוך context
- */
-export interface GameCardProps {
-  readonly gameType: GameType;
-  readonly items?: readonly BaseGameItem[];
 }
 
 // הערה: GameConfigProviderProps מוגדר כאן לפי עקרון DRY

--- a/gamesformykids/lib/types/contexts/general.ts
+++ b/gamesformykids/lib/types/contexts/general.ts
@@ -23,19 +23,8 @@ export interface DefaultGameTypeConfig {
 
 // הוסר SpecificGameTypeConfig - השתמש ישירות ב-GameTyped עקרון DRY
 
-/**
- * Props ל-Universal Game Provider - עקרון Interface Segregation
- */
-export interface UniversalGameProviderProps extends 
-  BaseProviderProps,
-  DefaultGameTypeConfig {}
-
-/**
- * Props ל-Simple Game Progress Provider - עקרון Interface Segregation
- */
-export interface SimpleGameProgressProviderProps extends 
-  BaseProviderProps,
-  GameTyped {}
+// הערה: UniversalGameProviderProps מוגדר ב-contexts/universal-game.ts
+// הערה: SimpleGameProgressProviderProps מוגדר ב-contexts/simple-game-progress.ts
 
 /**
  * הגדרת סוג משחק אופציונלי - עקרון Single Responsibility
@@ -43,13 +32,6 @@ export interface SimpleGameProgressProviderProps extends
 export interface OptionalGameTypeConfig {
   readonly gameType?: string;
 }
-
-/**
- * Props ל-GameType Provider - עקרון Interface Segregation
- */
-export interface GameTypeProviderProps extends 
-  BaseProviderProps,
-  DefaultGameTypeConfig {}
 
 /**
  * Props ל-GameProgress Provider - עקרון Interface Segregation
@@ -65,9 +47,5 @@ export interface GameLogicProviderProps extends
   BaseProviderProps,
   GameTyped {}
 
-/**
- * Props ל-GameConfig Provider - עקרון Interface Segregation
- */
-export interface GameConfigProviderProps extends 
-  BaseProviderProps,
-  GameTyped {}
+// הערה: GameTypeProviderProps מוגדר ב-contexts/game-type.ts
+// הערה: GameConfigProviderProps מוגדר ב-contexts/game-config.ts

--- a/gamesformykids/lib/types/contexts/index.ts
+++ b/gamesformykids/lib/types/contexts/index.ts
@@ -10,8 +10,7 @@ export * from './general';
 // ייצוא ממשקים מתוקנים
 export type { 
   GameConfigContextValue,
-  GameConfigProviderProps,
-  GameCardProps
+  GameConfigProviderProps
 } from './game-config';
 
 export type {

--- a/gamesformykids/lib/types/hooks/game-state.ts
+++ b/gamesformykids/lib/types/hooks/game-state.ts
@@ -11,9 +11,6 @@ import { UniversalGameConfiguration, GameUI } from '../contexts/universal-game';
 // ייצוא הטייפ למען תאימות - עקרון Liskov Substitution
 export type { GameItemCardProps };
 
-// Alias for backward compatibility - עקרון Liskov Substitution
-export type GameCardProps = GameItemCardProps;
-
 /**
  * תצורת UI בסיסית למשחק - עקרון Single Responsibility
  */


### PR DESCRIPTION
- Remove GameCardProps alias from hooks/game-state.ts (was duplicate of GameItemCardProps)
- Remove GameCardProps interface from contexts/game-config.ts (unused, conflicted with components/game.ts)
- Remove 4 shadowed ProviderProps from contexts/general.ts: GameConfigProviderProps, GameTypeProviderProps, SimpleGameProgressProviderProps, UniversalGameProviderProps each is already canonically defined in its own dedicated file
- Remove GameCardProps re-export from contexts/index.ts
- Replace removed blocks with comments pointing to canonical locations