### PR TITLE
fix: correct BaseGameItem/BaseGameItemLegacy naming inversion

### DIFF
--- a/gamesformykids/lib/types/core/base.ts
+++ b/gamesformykids/lib/types/core/base.ts
@@ -94,7 +94,7 @@ export interface GameDataItem {
   readonly sound?: number[];
 }
 
-// טייפ אליאס זמני לתאימות לאחור  
+// טייפ בסיס לנתוני פריטי משחק
 export type BaseGameItem = GameDataItem & { 
   id?: string;
   svg?: string; // לצורות

--- a/gamesformykids/lib/types/games/index.ts
+++ b/gamesformykids/lib/types/games/index.ts
@@ -11,12 +11,11 @@ export * from './ui';
 export * from './phase';
 export * from './shared';
 
-// ייצוא לתאימות לאחור - משתמש בגרסה הישנה שלא דורשת id
+// ייצוא טיפוסי הבסיס מ-core
 export type {
-  BaseGameItemLegacy as BaseGameItem,
-  BaseGameItem as BaseGameItemWithId,
+  BaseGameItem,
+  BaseGameItemLegacy,
   GameType
 } from '../core/base';
 
-// הערה: טיפוסים נוספים מוגדרים בקבצים נפרדים לפי עקרון Single Responsibility
 // הערה: טיפוסים נוספים מוגדרים בקבצים נפרדים לפי עקרון Single Responsibility


### PR DESCRIPTION
- lib/types/games/index.ts: export BaseGameItem (modern, canonical) directly instead of as BaseGameItemWithId; export BaseGameItemLegacy under its real name; remove unused BaseGameItemWithId alias; remove duplicate comment line
- lib/types/core/base.ts: remove misleading 'זמני' (temporary) label from BaseGameItem type alias comment

Closes #53