### PR TITLE
fix: remove duplicate prop type aliases in feedback.ts and icons.ts

### DIFF
--- a/gamesformykids/components/shared/feedback/CelebrationBox.tsx
+++ b/gamesformykids/components/shared/feedback/CelebrationBox.tsx
@@ -7,7 +7,7 @@ import type { ComponentTypes } from "@/lib/types";
  */
 export default function CelebrationBox({ 
   className = "" 
-}: ComponentTypes.CelebrationBoxProps) {
+}: ComponentTypes.ContextBasedComponentProps) {
   const { 
     config, 
     currentChallenge, 

--- a/gamesformykids/components/shared/feedback/ChallengeBox.tsx
+++ b/gamesformykids/components/shared/feedback/ChallengeBox.tsx
@@ -7,7 +7,7 @@ import type { ComponentTypes } from "@/lib/types";
  */
 export default function ChallengeBox({ 
   className = "" 
-}: ComponentTypes.ChallengeBoxProps) {
+}: ComponentTypes.ContextBasedComponentProps) {
   const { 
     config, 
     currentChallenge, 

--- a/gamesformykids/components/shared/feedback/GameInstructions.tsx
+++ b/gamesformykids/components/shared/feedback/GameInstructions.tsx
@@ -6,7 +6,7 @@ import type { ComponentTypes } from "@/lib/types";
  */
 export default function GameInstructions({ 
   className = "" 
-}: ComponentTypes.GameInstructionsProps) {
+}: ComponentTypes.ContextBasedComponentProps) {
   const { config } = useUniversalGame();
   
   if (!config || !config.steps) {

--- a/gamesformykids/lib/types/components/feedback.ts
+++ b/gamesformykids/lib/types/components/feedback.ts
@@ -36,14 +36,9 @@ export interface SimpleGameInstructionsProps {
 
 /**
  * Base props for context-based components - עקרון DRY
+ * Used by: GameInstructions, CelebrationBox, ChallengeBox
  */
 export interface ContextBasedComponentProps {
   // Context-based component - no props needed
   className?: string;
 }
-
-export type GameInstructionsProps = ContextBasedComponentProps;
-
-export type CelebrationBoxProps = ContextBasedComponentProps;
-
-export type ChallengeBoxProps = ContextBasedComponentProps;

--- a/gamesformykids/lib/types/components/icons.ts
+++ b/gamesformykids/lib/types/components/icons.ts
@@ -12,12 +12,4 @@ export interface BaseIconProps {
   className?: string;
 }
 
-/**
- * Props עבור אייקון צורה - type alias for clarity
- */
-export type ShapeIconProps = BaseIconProps;
 
-/**
- * Props עבור אייקון עברי - type alias for clarity
- */
-export type HebrewIconProps = BaseIconProps;

--- a/gamesformykids/public/icons/HebrewIcons.tsx
+++ b/gamesformykids/public/icons/HebrewIcons.tsx
@@ -1,7 +1,7 @@
-import { HebrewIconProps } from '@/lib/types/components/icons';
+import { BaseIconProps } from '@/lib/types/components/icons';
 
 // קומפוננט פשוט שמציג את האות א׳ בעברית
-export const HebrewLettersIcon = ({ size = 24, className = "" }: HebrewIconProps) => (
+export const HebrewLettersIcon = ({ size = 24, className = "" }: BaseIconProps) => (
   <div 
     className={`flex items-center justify-center font-bold ${className}`}
     style={{ fontSize: `${size * 1.2}px`, lineHeight: 1 }}

--- a/gamesformykids/public/icons/ShapeIcons.tsx
+++ b/gamesformykids/public/icons/ShapeIcons.tsx
@@ -1,30 +1,30 @@
-import { ShapeIconProps } from '@/lib/types/components/icons';
+import { BaseIconProps } from '@/lib/types/components/icons';
 
-export const CircleIcon = ({ size = 120, className = "" }: ShapeIconProps) => (
+export const CircleIcon = ({ size = 120, className = "" }: BaseIconProps) => (
   <svg width={size} height={size} viewBox="0 0 120 120" className={className}>
     <circle cx="60" cy="60" r="50" fill="currentColor" />
   </svg>
 );
 
-export const SquareIcon = ({ size = 120, className = "" }: ShapeIconProps) => (
+export const SquareIcon = ({ size = 120, className = "" }: BaseIconProps) => (
   <svg width={size} height={size} viewBox="0 0 120 120" className={className}>
     <rect x="10" y="10" width="100" height="100" rx="8" fill="currentColor" />
   </svg>
 );
 
-export const TriangleIcon = ({ size = 120, className = "" }: ShapeIconProps) => (
+export const TriangleIcon = ({ size = 120, className = "" }: BaseIconProps) => (
   <svg width={size} height={size} viewBox="0 0 120 120" className={className}>
     <polygon points="60,10 110,100 10,100" fill="currentColor" />
   </svg>
 );
 
-export const RectangleIcon = ({ size = 120, className = "" }: ShapeIconProps) => (
+export const RectangleIcon = ({ size = 120, className = "" }: BaseIconProps) => (
   <svg width={size} height={size} viewBox="0 0 120 120" className={className}>
     <rect x="10" y="35" width="100" height="50" rx="8" fill="currentColor" />
   </svg>
 );
 
-export const StarIcon = ({ size = 120, className = "" }: ShapeIconProps) => (
+export const StarIcon = ({ size = 120, className = "" }: BaseIconProps) => (
   <svg width={size} height={size} viewBox="0 0 120 120" className={className}>
     <polygon 
       points="60,10 73,40 105,40 79,60 90,95 60,75 30,95 41,60 15,40 47,40" 
@@ -33,7 +33,7 @@ export const StarIcon = ({ size = 120, className = "" }: ShapeIconProps) => (
   </svg>
 );
 
-export const HeartIcon = ({ size = 120, className = "" }: ShapeIconProps) => (
+export const HeartIcon = ({ size = 120, className = "" }: BaseIconProps) => (
   <svg width={size} height={size} viewBox="0 0 120 120" className={className}>
     <path 
       d="M60,105 C60,105 15,75 15,45 C15,30 25,20 40,20 C50,20 60,30 60,30 C60,30 70,20 80,20 C95,20 105,30 105,45 C105,75 60,105 60,105 Z" 
@@ -42,13 +42,13 @@ export const HeartIcon = ({ size = 120, className = "" }: ShapeIconProps) => (
   </svg>
 );
 
-export const DiamondIcon = ({ size = 120, className = "" }: ShapeIconProps) => (
+export const DiamondIcon = ({ size = 120, className = "" }: BaseIconProps) => (
   <svg width={size} height={size} viewBox="0 0 120 120" className={className}>
     <polygon points="60,10 110,60 60,110 10,60" fill="currentColor" />
   </svg>
 );
 
-export const OvalIcon = ({ size = 120, className = "" }: ShapeIconProps) => (
+export const OvalIcon = ({ size = 120, className = "" }: BaseIconProps) => (
   <svg width={size} height={size} viewBox="0 0 120 120" className={className}>
     <ellipse cx="60" cy="60" rx="50" ry="30" fill="currentColor" />
   </svg>


### PR DESCRIPTION
- feedback.ts: removed GameInstructionsProps, CelebrationBoxProps, ChallengeBoxProps (all were identical aliases for ContextBasedComponentProps); components now reference ContextBasedComponentProps directly
- icons.ts: removed ShapeIconProps and HebrewIconProps (both were identical aliases for BaseIconProps); icon components now use BaseIconProps directly

Closes #54