### PR TITLE
feat: add loading.tsx route segments for navigation skeleton

### DIFF
--- a/gamesformykids/app/analytics/loading.tsx
+++ b/gamesformykids/app/analytics/loading.tsx
@@ -1,0 +1,15 @@
+export default function AnalyticsLoading() {
+  return (
+    <div className="min-h-screen bg-gray-50 p-6">
+      <div className="max-w-4xl mx-auto space-y-4 animate-pulse">
+        <div className="h-16 bg-white rounded-2xl shadow-sm" />
+        <div className="grid grid-cols-2 gap-4">
+          <div className="h-40 bg-white rounded-2xl shadow-sm" />
+          <div className="h-40 bg-white rounded-2xl shadow-sm" />
+          <div className="h-40 bg-white rounded-2xl shadow-sm" />
+          <div className="h-40 bg-white rounded-2xl shadow-sm" />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/gamesformykids/app/games/[gameType]/loading.tsx
+++ b/gamesformykids/app/games/[gameType]/loading.tsx
@@ -1,0 +1,15 @@
+export default function GameLoading() {
+  return (
+    <div className="min-h-screen flex flex-col items-center justify-center bg-gradient-to-br from-blue-100 via-purple-100 to-pink-100">
+      <div className="flex flex-col items-center gap-6">
+        <div className="text-7xl animate-spin" style={{ animationDuration: '2s' }}>⭐</div>
+        <div className="flex gap-2">
+          <span className="w-4 h-4 rounded-full bg-blue-400 animate-bounce [animation-delay:0ms]" />
+          <span className="w-4 h-4 rounded-full bg-purple-400 animate-bounce [animation-delay:150ms]" />
+          <span className="w-4 h-4 rounded-full bg-pink-400 animate-bounce [animation-delay:300ms]" />
+        </div>
+        <p className="text-xl font-bold text-blue-700">המשחק נטען...</p>
+      </div>
+    </div>
+  );
+}

--- a/gamesformykids/app/loading.tsx
+++ b/gamesformykids/app/loading.tsx
@@ -1,0 +1,15 @@
+export default function RootLoading() {
+  return (
+    <div className="min-h-screen flex flex-col items-center justify-center bg-gradient-to-br from-purple-100 via-pink-100 to-yellow-100">
+      <div className="flex flex-col items-center gap-6">
+        <div className="text-7xl animate-bounce">🎮</div>
+        <div className="flex gap-2">
+          <span className="w-4 h-4 rounded-full bg-purple-400 animate-bounce [animation-delay:0ms]" />
+          <span className="w-4 h-4 rounded-full bg-pink-400 animate-bounce [animation-delay:150ms]" />
+          <span className="w-4 h-4 rounded-full bg-yellow-400 animate-bounce [animation-delay:300ms]" />
+        </div>
+        <p className="text-xl font-bold text-purple-700">טוען...</p>
+      </div>
+    </div>
+  );
+}

--- a/gamesformykids/app/profile/loading.tsx
+++ b/gamesformykids/app/profile/loading.tsx
@@ -1,0 +1,16 @@
+export default function ProfileLoading() {
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-blue-50 to-purple-50 p-6" dir="rtl">
+      <div className="max-w-2xl mx-auto space-y-4 animate-pulse">
+        <div className="h-32 bg-white rounded-2xl shadow-sm" />
+        <div className="grid grid-cols-3 gap-4">
+          <div className="h-24 bg-white rounded-2xl shadow-sm" />
+          <div className="h-24 bg-white rounded-2xl shadow-sm" />
+          <div className="h-24 bg-white rounded-2xl shadow-sm" />
+        </div>
+        <div className="h-48 bg-white rounded-2xl shadow-sm" />
+        <div className="h-48 bg-white rounded-2xl shadow-sm" />
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
Closes #70

## Summary
- `app/loading.tsx` — root loading screen with bouncing dots (covers all routes during navigation)
- `app/games/[gameType]/loading.tsx` — game-specific loading with star spinner
- `app/profile/loading.tsx` — profile skeleton (card + stat boxes)
- `app/analytics/loading.tsx` — analytics skeleton (grid of cards)

All loading screens are kid-friendly with colorful gradients and animations matching the app's design language.

🤖 Generated with [Claude Code](https://claude.com/claude-code)