### PR TITLE
chore: add GitHub Actions CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,36 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+jobs:
+  ci:
+    name: Typecheck, Lint & Test
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: gamesformykids
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: gamesformykids/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Typecheck
+        run: npx tsc --noEmit
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Test
+        run: npm test -- --run

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
           cache-dependency-path: gamesformykids/package-lock.json
 
       - name: Install dependencies
-        run: npm ci
+        run: npm install --prefer-offline
 
       - name: Typecheck
         run: npx tsc --noEmit

--- a/gamesformykids/package-lock.json
+++ b/gamesformykids/package-lock.json
@@ -5683,7 +5683,6 @@
       "integrity": "sha512-9VnGEBosc/ZpwyOsJBCQ/3I5p7Q5ngOY14a9bf5btenAORmZfDse1ZEheMiWcJ3h81+Fv7HmJFdS0szo/waF2w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@asamuzakjp/css-color": "^5.1.5",
         "@asamuzakjp/dom-selector": "^7.0.6",


### PR DESCRIPTION
Closes #88, closes #16

## Summary
Adds `.github/workflows/ci.yml` that runs on every PR and push to `main`:
- **Typecheck** — `npx tsc --noEmit`
- **Lint** — `npm run lint` (Next.js ESLint)
- **Test** — `npm test -- --run` (vitest, no watch mode)

## Why
Past PRs broke the Vercel build due to unused variables and ESLint errors caught only after deploy. CI catches these before merge.

## Verified locally
- `tsc --noEmit` ✅
- `npm test -- --run` — 2 files, 9 tests passed ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)