### PR TITLE
refactor: decouple animalsStore from cross-store getState() calls

### DIFF
--- a/gamesformykids/app/games/animals/components/AnimalsMenuScreen.tsx
+++ b/gamesformykids/app/games/animals/components/AnimalsMenuScreen.tsx
@@ -1,9 +1,9 @@
 'use client';
-import { useAnimalsStore } from '@/lib/stores/animalsStore';
+import { useAnimalsSession } from '../hooks/useAnimalsSession';
 import { CATEGORY_ORDER, CATEGORY_DISPLAY } from '../data/animals';
 
 export default function AnimalsMenuScreen() {
-  const startGame = useAnimalsStore(s => s.startGame);
+  const { startGame } = useAnimalsSession();
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-green-50 to-teal-100 p-4" dir="rtl">

--- a/gamesformykids/app/games/animals/components/AnimalsQuestionCard.tsx
+++ b/gamesformykids/app/games/animals/components/AnimalsQuestionCard.tsx
@@ -1,19 +1,12 @@
 'use client';
 import { useQuizGameStore } from '@/lib/stores';
-import { useAnimalsStore } from '@/lib/stores/animalsStore';
+import { useAnimalsSession } from '../hooks/useAnimalsSession';
 
 export default function AnimalsQuestionCard() {
-  const index     = useQuizGameStore(s => s.index);
-  const total     = useQuizGameStore(s => s.total);
-  const score     = useQuizGameStore(s => s.score);
-  const selected  = useQuizGameStore(s => s.selected);
-  const isCorrect = useQuizGameStore(s => s.isCorrect);
+  const total        = useQuizGameStore(s => s.total);
   const nextQuestion = useQuizGameStore(s => s.nextQuestion);
 
-  const questions    = useAnimalsStore(s => s.questions);
-  const selectAnswer = useAnimalsStore(s => s.selectAnswer);
-
-  const current = questions[index] ?? null;
+  const { index, score, selected, isCorrect, current, selectAnswer } = useAnimalsSession();
   if (!current) return null;
   const prompt = current.mode === 'emoji-to-name' ? current.animal.emoji : current.animal.hebrew;
   const promptLabel = current.mode === 'emoji-to-name' ? 'מה שם החיה?' : 'מה הסמל של החיה?';

--- a/gamesformykids/app/games/animals/components/AnimalsResultScreen.tsx
+++ b/gamesformykids/app/games/animals/components/AnimalsResultScreen.tsx
@@ -1,11 +1,10 @@
 'use client';
-import { useAnimalsStore } from '@/lib/stores/animalsStore';
 import { useQuizGameStore } from '@/lib/stores/quizGameStore';
+import { useAnimalsSession } from '../hooks/useAnimalsSession';
 
 export default function AnimalsResultScreen() {
-  const score   = useQuizGameStore(s => s.score);
   const total   = useQuizGameStore(s => s.total);
-  const restart  = useAnimalsStore(s => s.restart);
+  const { score, restart } = useAnimalsSession();
   const pct = Math.round((score / total) * 100);
   return (
     <div className="min-h-screen bg-gradient-to-br from-green-50 to-teal-100 p-4 flex items-center" dir="rtl">

--- a/gamesformykids/app/games/animals/hooks/useAnimalsSession.ts
+++ b/gamesformykids/app/games/animals/hooks/useAnimalsSession.ts
@@ -1,0 +1,60 @@
+'use client';
+
+import { useCallback, useEffect } from 'react';
+import { useAnimalsStore, makeAnimalQuestion, buildAnimalPool, QUESTIONS_PER_GAME } from '@/lib/stores/animalsStore';
+import { useQuizGameStore } from '@/lib/stores/quizGameStore';
+import { useGameStore } from '@/lib/stores/gameStore';
+import { useGameProgressStore } from '@/lib/stores/gameProgressStore';
+import type { AnimalCategory } from '@/app/games/animals/data/animals';
+
+export function useAnimalsSession() {
+  const questions    = useAnimalsStore(s => s.questions);
+  const setQuestions = useAnimalsStore(s => s.setQuestions);
+
+  const phase    = useQuizGameStore(s => s.phase);
+  const index    = useQuizGameStore(s => s.index);
+  const selected = useQuizGameStore(s => s.selected);
+  const isCorrect = useQuizGameStore(s => s.isCorrect);
+  const score    = useQuizGameStore(s => s.score);
+
+  const current = questions[index] ?? null;
+
+  const startGame = useCallback((cat: AnimalCategory | 'all') => {
+    const qs = Array.from({ length: QUESTIONS_PER_GAME }, () =>
+      makeAnimalQuestion(buildAnimalPool(cat)),
+    );
+    setQuestions(cat, qs);
+    useQuizGameStore.getState().startQuiz('animals', QUESTIONS_PER_GAME);
+    useGameStore.getState().startGame('animals');
+    useGameProgressStore.getState().resetProgress();
+    useGameProgressStore.getState().setGameActive(true);
+  }, [setQuestions]);
+
+  const selectAnswer = useCallback((id: string) => {
+    if (selected !== null || !current) return;
+    const correct = id === current.animal.id;
+    useQuizGameStore.getState().selectAnswer(id, correct);
+    useGameProgressStore.getState().recordAttempt(correct);
+  }, [selected, current]);
+
+  const restart = useCallback(() => {
+    const cat = useAnimalsStore.getState().category;
+    const qs = Array.from({ length: QUESTIONS_PER_GAME }, () =>
+      makeAnimalQuestion(buildAnimalPool(cat)),
+    );
+    setQuestions(cat, qs);
+    useQuizGameStore.getState().restartQuiz();
+    useGameStore.getState().startGame('animals');
+    useGameProgressStore.getState().resetProgress();
+    useGameProgressStore.getState().setGameActive(true);
+  }, [setQuestions]);
+
+  useEffect(() => {
+    if (phase === 'result') {
+      useGameStore.getState().endGame();
+      useGameProgressStore.getState().setGameActive(false);
+    }
+  }, [phase]);
+
+  return { phase, index, selected, isCorrect, score, current, questions, startGame, selectAnswer, restart };
+}

--- a/gamesformykids/lib/stores/animalsStore.ts
+++ b/gamesformykids/lib/stores/animalsStore.ts
@@ -2,9 +2,6 @@ import { create } from 'zustand';
 import { devtools } from 'zustand/middleware';
 import { ANIMALS, type Animal, type AnimalCategory } from '@/app/games/animals/data/animals';
 import { shuffle } from '@/lib/utils';
-import { useQuizGameStore } from './quizGameStore';
-import { useGameStore } from './gameStore';
-import { useGameProgressStore } from './gameProgressStore';
 import { QUESTIONS_PER_GAME } from '@/lib/quiz/constants';
 
 export type QuestionMode = 'emoji-to-name' | 'name-to-emoji';
@@ -15,7 +12,7 @@ export interface AnimalQuestion {
   mode: QuestionMode;
 }
 
-function makeQuestion(pool: Animal[]): AnimalQuestion {
+export function makeAnimalQuestion(pool: Animal[]): AnimalQuestion {
   const animal = pool[Math.floor(Math.random() * pool.length)];
   const others = shuffle(pool.filter(a => a.id !== animal.id)).slice(0, 3);
   const choices = shuffle([animal, ...others]);
@@ -23,9 +20,11 @@ function makeQuestion(pool: Animal[]): AnimalQuestion {
   return { animal, choices, mode };
 }
 
-function buildPool(cat: AnimalCategory | 'all'): Animal[] {
+export function buildAnimalPool(cat: AnimalCategory | 'all'): Animal[] {
   return cat === 'all' ? ANIMALS : ANIMALS.filter(a => a.category === cat);
 }
+
+export { QUESTIONS_PER_GAME };
 
 export interface AnimalsState {
   category: AnimalCategory | 'all';
@@ -33,9 +32,7 @@ export interface AnimalsState {
 }
 
 export interface AnimalsActions {
-  startGame: (cat: AnimalCategory | 'all') => void;
-  selectAnswer: (id: string) => void;
-  restart: () => void;
+  setQuestions: (cat: AnimalCategory | 'all', questions: AnimalQuestion[]) => void;
   reset: () => void;
 }
 
@@ -46,43 +43,11 @@ const INITIAL_STATE: AnimalsState = {
 
 export const useAnimalsStore = create<AnimalsState & AnimalsActions>()(
   devtools(
-    (set, get) => ({
+    (set) => ({
       ...INITIAL_STATE,
 
-      startGame: (cat) => {
-        const questions = Array.from(
-          { length: QUESTIONS_PER_GAME },
-          () => makeQuestion(buildPool(cat)),
-        );
-        set({ category: cat, questions }, false, 'animals/startGame');
-        useQuizGameStore.getState().startQuiz('animals', QUESTIONS_PER_GAME);
-        useGameStore.getState().startGame('animals');
-        useGameProgressStore.getState().resetProgress();
-        useGameProgressStore.getState().setGameActive(true);
-      },
-
-      selectAnswer: (id) => {
-        const { questions } = get();
-        const { selected, index } = useQuizGameStore.getState();
-        const current = questions[index] ?? null;
-        if (selected || !current) return;
-        const isCorrect = id === current.animal.id;
-        useQuizGameStore.getState().selectAnswer(id, isCorrect);
-        useGameProgressStore.getState().recordAttempt(isCorrect);
-      },
-
-      restart: () => {
-        const { category } = get();
-        const questions = Array.from(
-          { length: QUESTIONS_PER_GAME },
-          () => makeQuestion(buildPool(category)),
-        );
-        set({ questions }, false, 'animals/restart');
-        useQuizGameStore.getState().restartQuiz();
-        useGameStore.getState().startGame('animals');
-        useGameProgressStore.getState().resetProgress();
-        useGameProgressStore.getState().setGameActive(true);
-      },
+      setQuestions: (category, questions) =>
+        set({ category, questions }, false, 'animals/setQuestions'),
 
       reset: () => set(INITIAL_STATE, false, 'animals/reset'),
     }),

--- a/gamesformykids/lib/stores/index.ts
+++ b/gamesformykids/lib/stores/index.ts
@@ -52,7 +52,7 @@ export { useHebrewLettersStore } from '@/app/games/hebrew-letters/store/hebrewLe
 
 // Animals (category / questions / game actions)
 export { useAnimalsStore } from './animalsStore';
-export type { QuestionMode } from './animalsStore';
+export type { AnimalsState, AnimalsActions, AnimalQuestion, QuestionMode } from './animalsStore';
 
 // Progress Tracking (allSessions — persisted)
 export { useProgressTrackingStore } from './progressTrackingStore';


### PR DESCRIPTION
Closes #84

## Summary
`animalsStore` had 11 cross-store `getState()` calls inside its actions, tightly coupling it to `quizGameStore`, `gameStore`, and `gameProgressStore`.

## Changes
- **`animalsStore`** — now pure: only manages `category` and `questions`. Single action: `setQuestions`
- **`useAnimalsSession`** (new hook) — orchestrates all cross-store coordination:
  - `startGame` / `restart` / `selectAnswer` with full lifecycle management
  - `useEffect` watching `phase === 'result'` to call `endGame()`
- **Components** — `AnimalsMenuScreen`, `AnimalsQuestionCard`, `AnimalsResultScreen` updated to use `useAnimalsSession`

## Verified
- `tsc --noEmit` ✅
- `npm run build` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)