### PR TITLE
perf: apply React.memo to pure display components (#81)

### DIFF
--- a/gamesformykids/components/game/quiz/FractionBar.tsx
+++ b/gamesformykids/components/game/quiz/FractionBar.tsx
@@ -1,12 +1,14 @@
 'use client';
 
+import { memo } from 'react';
+
 interface Props {
   numerator: number;
   denominator: number;
   color?: string;
 }
 
-export default function FractionBar({ numerator, denominator, color = '#7c3aed' }: Props) {
+function FractionBar({ numerator, denominator, color = '#7c3aed' }: Props) {
   return (
     <div className="flex gap-1 justify-center my-2">
       {Array.from({ length: denominator }).map((_, i) => (
@@ -22,3 +24,5 @@ export default function FractionBar({ numerator, denominator, color = '#7c3aed' 
     </div>
   );
 }
+
+export default memo(FractionBar);

--- a/gamesformykids/components/game/quiz/QuizProgress.tsx
+++ b/gamesformykids/components/game/quiz/QuizProgress.tsx
@@ -1,9 +1,10 @@
 'use client';
 
+import { memo } from 'react';
 import { useQuizGameStore } from '@/lib/stores/quizGameStore';
 import { QUIZ_THEMES, type QuizTheme } from './quizTheme';
 
-export function QuizProgress({ theme }: { theme: QuizTheme }) {
+function QuizProgressInner({ theme }: { theme: QuizTheme }) {
   const index = useQuizGameStore(s => s.index);
   const total = useQuizGameStore(s => s.total);
   const score = useQuizGameStore(s => s.score);
@@ -23,3 +24,5 @@ export function QuizProgress({ theme }: { theme: QuizTheme }) {
     </>
   );
 }
+
+export const QuizProgress = memo(QuizProgressInner);

--- a/gamesformykids/components/shared/cards/UnifiedCard.tsx
+++ b/gamesformykids/components/shared/cards/UnifiedCard.tsx
@@ -1,3 +1,4 @@
+import { memo } from "react";
 import { Volume2 } from "lucide-react";
 import { ComponentTypes } from "@/lib/types";
 import { speakHebrew } from "@/lib/utils/speech/enhancedSpeechUtils";
@@ -9,7 +10,7 @@ import { speakHebrew } from "@/lib/utils/speech/enhancedSpeechUtils";
  * 
  * מתאים עצמו אוטומטית לפי הפרמטרים שמועברים
  */
-export default function UnifiedCard({
+function UnifiedCard({
   // Data
   item,
   onClick,
@@ -286,3 +287,5 @@ export default function UnifiedCard({
     </button>
   );
 }
+
+export default memo(UnifiedCard);


### PR DESCRIPTION
## Summary
- Wrap `FractionBar` with `memo` — pure display component, only primitive props (`number`, `string`)
- Wrap `QuizProgress` with `memo` — only receives `theme: string` which is stable per game session; prevents re-renders when parent updates for unrelated reasons
- Wrap `UnifiedCard` with `memo` — rendered in grids of 4–10 items; prevents unnecessary re-renders when parent state changes (e.g., score updates, notifications) but card props are unchanged

## Test plan
- [ ] TypeScript: `npx tsc --noEmit` — clean
- [ ] Build: `npm run build` — clean
- [ ] Manual: game grids still render correctly, cards are clickable

Closes #81

🤖 Generated with [Claude Code](https://claude.com/claude-code)