### PR TITLE
perf: enable React Compiler (#105)

### DIFF
--- a/gamesformykids/next.config.ts
+++ b/gamesformykids/next.config.ts
@@ -2,6 +2,9 @@ import type { NextConfig } from "next";
 
 // Bundle analyzer configuration - disabled by default
 const nextConfig: NextConfig = {
+  experimental: {
+    reactCompiler: true,
+  },
   images: {
     unoptimized: true,
   },

--- a/gamesformykids/package-lock.json
+++ b/gamesformykids/package-lock.json
@@ -33,6 +33,7 @@
         "@types/react-dom": "^19",
         "@vitejs/plugin-react": "^6.0.1",
         "@vitest/coverage-v8": "^4.1.4",
+        "babel-plugin-react-compiler": "^1.0.0",
         "dotenv": "^17.4.2",
         "eslint": "^9",
         "eslint-config-next": "15.3.5",
@@ -146,7 +147,7 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
       "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -156,7 +157,7 @@
       "version": "7.28.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
       "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -192,7 +193,7 @@
       "version": "7.29.0",
       "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
       "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-string-parser": "^7.27.1",
@@ -3346,6 +3347,17 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/babel-plugin-react-compiler": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-react-compiler/-/babel-plugin-react-compiler-1.0.0.tgz",
+      "integrity": "sha512-Ixm8tFfoKKIPYdCCKYTsqv+Fd4IJ0DQqMyEimo+pxUOMUR9cVPlwTrFt9Avu+3cb6Zp3mAzl+t1MrG2fxxKsxw==",
+      "devOptional": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/types": "^7.26.0"
       }
     },
     "node_modules/balanced-match": {

--- a/gamesformykids/package.json
+++ b/gamesformykids/package.json
@@ -45,6 +45,7 @@
     "@types/react-dom": "^19",
     "@vitejs/plugin-react": "^6.0.1",
     "@vitest/coverage-v8": "^4.1.4",
+    "babel-plugin-react-compiler": "^1.0.0",
     "dotenv": "^17.4.2",
     "eslint": "^9",
     "eslint-config-next": "15.3.5",


### PR DESCRIPTION
## Summary
- Install `babel-plugin-react-compiler@^1.0.0`
- Add `experimental: { reactCompiler: true }` to `next.config.ts`

The React Compiler automatically memoizes all components and hooks — it replaces the need for any manual `React.memo`, `useMemo`, or `useCallback`. It's smarter than manual memoization because it can't accidentally miss a component or forget to stabilize a callback reference.

## Verification
- `npx tsc --noEmit` — clean
- `npm run build` — clean, build output shows `✓ reactCompiler`

Closes #105

🤖 Generated with [Claude Code](https://claude.com/claude-code)