### PR TITLE
refactor: create shared GameResultCard component

### DIFF
--- a/gamesformykids/app/games/animals/components/AnimalsResultScreen.tsx
+++ b/gamesformykids/app/games/animals/components/AnimalsResultScreen.tsx
@@ -1,27 +1,27 @@
 'use client';
 import { useQuizGameStore } from '@/lib/stores/quizGameStore';
 import { useAnimalsSession } from '../hooks/useAnimalsSession';
+import GameResultCard from '@/components/game/shared/GameResultCard';
 
 export default function AnimalsResultScreen() {
-  const total   = useQuizGameStore(s => s.total);
+  const total = useQuizGameStore(s => s.total);
   const { score, restart } = useAnimalsSession();
   const pct = Math.round((score / total) * 100);
   return (
-    <div className="min-h-screen bg-gradient-to-br from-green-50 to-teal-100 p-4 flex items-center" dir="rtl">
-      <div className="max-w-md mx-auto w-full bg-white rounded-3xl shadow-xl p-8 text-center">
-        <div className="text-6xl mb-3 animate-bounce">🐘</div>
-        <h1 className="text-2xl font-bold text-gray-800 mb-4">כל הכבוד!</h1>
-        <div className="bg-green-50 rounded-2xl p-5 mb-6">
-          <p className="text-4xl font-black text-green-700">{score} / {total}</p>
-          <div className="mt-2 h-3 bg-green-100 rounded-full">
-            <div className="h-full bg-green-400 rounded-full" style={{ width: `${pct}%` }} />
-          </div>
-          <p className="text-green-500 text-sm mt-1">{pct}%</p>
+    <GameResultCard
+      emoji="🐘"
+      title="כל הכבוד!"
+      gradientClass="from-green-50 to-teal-100"
+      buttonClass="from-green-500 to-teal-600"
+      onRestart={restart}
+    >
+      <div className="bg-green-50 rounded-2xl p-5">
+        <p className="text-4xl font-black text-green-700">{score} / {total}</p>
+        <div className="mt-2 h-3 bg-green-100 rounded-full">
+          <div className="h-full bg-green-400 rounded-full" style={{ width: `${pct}%` }} />
         </div>
-        <div className="flex gap-3">
-          <button onClick={restart} className="flex-1 py-4 rounded-2xl text-white font-bold bg-gradient-to-l from-green-500 to-teal-600 hover:opacity-90 active:scale-95 transition-all">🔄 שוב</button>
-        </div>
+        <p className="text-green-500 text-sm mt-1">{pct}%</p>
       </div>
-    </div>
+    </GameResultCard>
   );
 }

--- a/gamesformykids/app/games/arithmetic/components/ArithmeticResultScreen.tsx
+++ b/gamesformykids/app/games/arithmetic/components/ArithmeticResultScreen.tsx
@@ -1,33 +1,32 @@
 'use client';
 import { useArithmeticGameStore } from '../arithmeticGameStore';
 import { QUESTIONS_PER_GAME } from '@/lib/quiz/constants';
+import GameResultCard from '@/components/game/shared/GameResultCard';
 
 export default function ArithmeticResultScreen() {
-  const level   = useArithmeticGameStore(s => s.level);
-  const correct = useArithmeticGameStore(s => s.correct);
-  const score   = useArithmeticGameStore(s => s.score);
+  const level     = useArithmeticGameStore(s => s.level);
+  const correct   = useArithmeticGameStore(s => s.correct);
+  const score     = useArithmeticGameStore(s => s.score);
   const startGame = useArithmeticGameStore(s => s.startGame);
   const goMenu    = useArithmeticGameStore(s => s.goMenu);
-
   const pct = Math.round((correct / QUESTIONS_PER_GAME) * 100);
   return (
-    <div className="min-h-screen bg-gradient-to-br from-blue-50 to-indigo-100 p-4 flex items-center" dir="rtl">
-      <div className="max-w-md mx-auto w-full bg-white rounded-3xl shadow-xl p-8 text-center">
-        <div className="text-6xl mb-3">{pct >= 80 ? '🏆' : pct >= 50 ? '😊' : '💪'}</div>
-        <h1 className="text-2xl font-bold mb-4">{level.label} — סיום!</h1>
-        <div className="bg-indigo-50 rounded-2xl p-5 mb-6">
-          <p className="text-4xl font-black text-indigo-700">{correct} / {QUESTIONS_PER_GAME}</p>
-          <p className="text-indigo-500 text-sm mt-1">תשובות נכונות</p>
-          <p className="text-xl font-bold text-indigo-600 mt-2">⭐ {score} נקודות</p>
-          <div className="mt-2 h-3 bg-indigo-100 rounded-full">
-            <div className="h-full bg-indigo-400 rounded-full" style={{ width: `${pct}%` }} />
-          </div>
-        </div>
-        <div className="flex gap-3">
-          <button onClick={() => startGame(level)} className="flex-1 py-4 rounded-2xl text-white font-bold bg-gradient-to-l from-indigo-500 to-blue-600 hover:opacity-90 active:scale-95 transition-all">🔄 שוב</button>
-          <button onClick={goMenu} className="flex-1 py-4 rounded-2xl border-2 border-gray-200 text-gray-600 font-semibold hover:bg-gray-50 transition-all">📋 רמות</button>
+    <GameResultCard
+      emoji={pct >= 80 ? '🏆' : pct >= 50 ? '😊' : '💪'}
+      title={`${level.label} — סיום!`}
+      gradientClass="from-blue-50 to-indigo-100"
+      buttonClass="from-indigo-500 to-blue-600"
+      onRestart={() => startGame(level)}
+      secondaryAction={{ label: '📋 רמות', onClick: goMenu }}
+    >
+      <div className="bg-indigo-50 rounded-2xl p-5">
+        <p className="text-4xl font-black text-indigo-700">{correct} / {QUESTIONS_PER_GAME}</p>
+        <p className="text-indigo-500 text-sm mt-1">תשובות נכונות</p>
+        <p className="text-xl font-bold text-indigo-600 mt-2">⭐ {score} נקודות</p>
+        <div className="mt-2 h-3 bg-indigo-100 rounded-full">
+          <div className="h-full bg-indigo-400 rounded-full" style={{ width: `${pct}%` }} />
         </div>
       </div>
-    </div>
+    </GameResultCard>
   );
 }

--- a/gamesformykids/app/games/balloon-pop/components/BalloonResultScreen.tsx
+++ b/gamesformykids/app/games/balloon-pop/components/BalloonResultScreen.tsx
@@ -1,34 +1,31 @@
 'use client';
 import { useBalloonPopStore } from '../balloonPopStore';
+import GameResultCard from '@/components/game/shared/GameResultCard';
 
 export default function BalloonResultScreen() {
   const score     = useBalloonPopStore(s => s.score);
   const best      = useBalloonPopStore(s => s.best);
   const lives     = useBalloonPopStore(s => s.lives);
   const startGame = useBalloonPopStore(s => s.startGame);
-
   return (
-    <div className="min-h-screen bg-gradient-to-b from-sky-200 to-blue-400 flex items-center justify-center p-4" dir="rtl">
-      <div className="bg-white rounded-3xl shadow-2xl p-8 max-w-sm w-full text-center">
-        <div className="text-6xl mb-3">{lives <= 0 ? '💔' : '🎉'}</div>
-        <h2 className="text-3xl font-black text-gray-800 mb-5">{lives <= 0 ? 'נגמרו החיים!' : 'הזמן נגמר!'}</h2>
-        <div className="grid grid-cols-2 gap-3 mb-6">
-          <div className="bg-pink-50 rounded-2xl p-4">
-            <p className="text-4xl font-black text-pink-500">{score}</p>
-            <p className="text-xs text-pink-400">ניקוד</p>
-          </div>
-          <div className="bg-yellow-50 rounded-2xl p-4">
-            <p className="text-4xl font-black text-yellow-500">{best}</p>
-            <p className="text-xs text-yellow-400">שיא</p>
-          </div>
+    <GameResultCard
+      emoji={lives <= 0 ? '💔' : '🎉'}
+      title={lives <= 0 ? 'נגמרו החיים!' : 'הזמן נגמר!'}
+      gradientClass="from-sky-200 to-blue-400"
+      buttonClass="from-pink-500 to-rose-500"
+      onRestart={startGame}
+      restartLabel="🔄 שוב!"
+    >
+      <div className="grid grid-cols-2 gap-3">
+        <div className="bg-pink-50 rounded-2xl p-4">
+          <p className="text-4xl font-black text-pink-500">{score}</p>
+          <p className="text-xs text-pink-400">ניקוד</p>
         </div>
-        <button
-          onClick={startGame}
-          className="w-full py-4 rounded-2xl bg-gradient-to-l from-pink-500 to-rose-500 text-white font-black text-xl shadow-lg hover:opacity-90 active:scale-95 transition-all"
-        >
-          🔄 שוב!
-        </button>
+        <div className="bg-yellow-50 rounded-2xl p-4">
+          <p className="text-4xl font-black text-yellow-500">{best}</p>
+          <p className="text-xs text-yellow-400">שיא</p>
+        </div>
       </div>
-    </div>
+    </GameResultCard>
   );
 }

--- a/gamesformykids/app/games/math-race/components/MathRaceResultScreen.tsx
+++ b/gamesformykids/app/games/math-race/components/MathRaceResultScreen.tsx
@@ -1,4 +1,5 @@
 'use client';
+import GameResultCard from '@/components/game/shared/GameResultCard';
 
 interface Props {
   score: number;
@@ -11,35 +12,32 @@ interface Props {
 
 export default function MathRaceResultScreen({ score, best, correct, total, accuracy, onRestart }: Props) {
   return (
-    <div className="min-h-screen bg-gradient-to-br from-blue-100 to-indigo-200 flex items-center justify-center p-4" dir="rtl">
-      <div className="bg-white rounded-3xl p-8 text-center shadow-2xl max-w-sm w-full">
-        <div className="text-6xl mb-3">🏁</div>
-        <h2 className="text-2xl font-black text-gray-700 mb-4">הסיום!</h2>
-        <div className="grid grid-cols-2 gap-3 mb-2">
-          <div className="bg-blue-50 rounded-2xl p-3">
-            <p className="text-3xl font-black text-blue-600">{score}</p>
-            <p className="text-xs text-blue-400">ניקוד</p>
-          </div>
-          <div className="bg-yellow-50 rounded-2xl p-3">
-            <p className="text-3xl font-black text-yellow-500">{best}</p>
-            <p className="text-xs text-yellow-400">שיא</p>
-          </div>
-          <div className="bg-green-50 rounded-2xl p-3">
-            <p className="text-3xl font-black text-green-600">{correct}/{total}</p>
-            <p className="text-xs text-green-400">נכון/סה&quot;כ</p>
-          </div>
-          <div className="bg-purple-50 rounded-2xl p-3">
-            <p className="text-3xl font-black text-purple-600">{accuracy}%</p>
-            <p className="text-xs text-purple-400">דיוק</p>
-          </div>
+    <GameResultCard
+      emoji="🏁"
+      title="הסיום!"
+      gradientClass="from-blue-100 to-indigo-200"
+      buttonClass="from-blue-500 to-indigo-600"
+      onRestart={onRestart}
+      restartLabel="🔄 שוב!"
+    >
+      <div className="grid grid-cols-2 gap-3">
+        <div className="bg-blue-50 rounded-2xl p-3">
+          <p className="text-3xl font-black text-blue-600">{score}</p>
+          <p className="text-xs text-blue-400">ניקוד</p>
         </div>
-        <button
-          onClick={onRestart}
-          className="w-full mt-4 py-4 rounded-2xl bg-gradient-to-r from-blue-500 to-indigo-600 text-white font-black text-xl hover:opacity-90 active:scale-95 transition-all"
-        >
-          🔄 שוב!
-        </button>
+        <div className="bg-yellow-50 rounded-2xl p-3">
+          <p className="text-3xl font-black text-yellow-500">{best}</p>
+          <p className="text-xs text-yellow-400">שיא</p>
+        </div>
+        <div className="bg-green-50 rounded-2xl p-3">
+          <p className="text-3xl font-black text-green-600">{correct}/{total}</p>
+          <p className="text-xs text-green-400">נכון/סה&quot;כ</p>
+        </div>
+        <div className="bg-purple-50 rounded-2xl p-3">
+          <p className="text-3xl font-black text-purple-600">{accuracy}%</p>
+          <p className="text-xs text-purple-400">דיוק</p>
+        </div>
       </div>
-    </div>
+    </GameResultCard>
   );
 }

--- a/gamesformykids/app/games/number-bubbles/components/NumberBubblesResultScreen.tsx
+++ b/gamesformykids/app/games/number-bubbles/components/NumberBubblesResultScreen.tsx
@@ -1,4 +1,5 @@
 'use client';
+import GameResultCard from '@/components/game/shared/GameResultCard';
 
 interface Props {
   level: number;
@@ -9,36 +10,26 @@ interface Props {
 
 export default function NumberBubblesResultScreen({ level, elapsed, onNextLevel, onRestart }: Props) {
   return (
-    <div className="min-h-screen bg-gradient-to-br from-sky-100 to-blue-200 flex items-center justify-center p-4" dir="rtl">
-      <div className="bg-white rounded-3xl p-8 text-center shadow-2xl max-w-sm w-full">
-        <div className="text-6xl mb-3">🎉</div>
-        <h2 className="text-2xl font-black text-gray-700 mb-1">כל הכבוד!</h2>
-        <p className="text-gray-500 mb-4">סיימת רמה {level} ב-{elapsed} שניות</p>
-        <div className="grid grid-cols-2 gap-4 mb-6">
-          <div className="bg-sky-50 rounded-2xl p-3">
-            <p className="text-3xl font-black text-sky-600">{level}</p>
-            <p className="text-xs text-sky-400">רמה</p>
-          </div>
-          <div className="bg-green-50 rounded-2xl p-3">
-            <p className="text-3xl font-black text-green-600">{elapsed}s</p>
-            <p className="text-xs text-green-400">זמן</p>
-          </div>
+    <GameResultCard
+      emoji="🎉"
+      title="כל הכבוד!"
+      gradientClass="from-sky-100 to-blue-200"
+      buttonClass="from-sky-500 to-blue-600"
+      onRestart={() => onNextLevel(level)}
+      restartLabel={`➡️ רמה ${level + 1}`}
+      secondaryAction={{ label: '🔄 מחדש', onClick: onRestart }}
+    >
+      <p className="text-gray-500 mb-2">סיימת רמה {level} ב-{elapsed} שניות</p>
+      <div className="grid grid-cols-2 gap-4">
+        <div className="bg-sky-50 rounded-2xl p-3">
+          <p className="text-3xl font-black text-sky-600">{level}</p>
+          <p className="text-xs text-sky-400">רמה</p>
         </div>
-        <div className="flex gap-3">
-          <button
-            onClick={() => onNextLevel(level)}
-            className="flex-1 py-4 rounded-2xl bg-gradient-to-r from-sky-500 to-blue-600 text-white font-black text-lg hover:opacity-90 active:scale-95 transition-all"
-          >
-            ➡️ רמה {level + 1}
-          </button>
-          <button
-            onClick={onRestart}
-            className="flex-1 py-4 rounded-2xl bg-gray-200 text-gray-700 font-black text-lg hover:bg-gray-300 active:scale-95 transition-all"
-          >
-            🔄 מחדש
-          </button>
+        <div className="bg-green-50 rounded-2xl p-3">
+          <p className="text-3xl font-black text-green-600">{elapsed}s</p>
+          <p className="text-xs text-green-400">זמן</p>
         </div>
       </div>
-    </div>
+    </GameResultCard>
   );
 }

--- a/gamesformykids/app/games/reflex/components/ReflexResultScreen.tsx
+++ b/gamesformykids/app/games/reflex/components/ReflexResultScreen.tsx
@@ -1,4 +1,5 @@
 'use client';
+import GameResultCard from '@/components/game/shared/GameResultCard';
 
 interface Props {
   score: number;
@@ -8,30 +9,29 @@ interface Props {
 
 export default function ReflexResultScreen({ score, missed, onRestart }: Props) {
   const accuracy = score + missed > 0 ? Math.round((score / (score + missed)) * 100) : 0;
-
   return (
-    <div className="min-h-screen bg-gradient-to-br from-rose-50 to-red-100 p-4 flex items-center" dir="rtl">
-      <div className="max-w-md mx-auto w-full bg-white rounded-3xl shadow-xl p-8 text-center">
-        <div className="text-6xl mb-3 animate-bounce">⚡</div>
-        <h1 className="text-2xl font-bold text-gray-800 mb-5">הסתיים!</h1>
-        <div className="grid grid-cols-3 gap-3 mb-6">
-          <div className="bg-yellow-50 rounded-2xl p-4">
-            <p className="text-3xl font-black text-yellow-600">{score}</p>
-            <p className="text-xs text-yellow-500">לחיצות</p>
-          </div>
-          <div className="bg-red-50 rounded-2xl p-4">
-            <p className="text-3xl font-black text-red-500">{missed}</p>
-            <p className="text-xs text-red-400">פספוסים</p>
-          </div>
-          <div className="bg-blue-50 rounded-2xl p-4">
-            <p className="text-3xl font-black text-blue-600">{accuracy}%</p>
-            <p className="text-xs text-blue-400">דיוק</p>
-          </div>
+    <GameResultCard
+      emoji="⚡"
+      title="הסתיים!"
+      gradientClass="from-rose-50 to-red-100"
+      buttonClass="from-rose-500 to-red-600"
+      onRestart={onRestart}
+      animateEmoji
+    >
+      <div className="grid grid-cols-3 gap-3">
+        <div className="bg-yellow-50 rounded-2xl p-4">
+          <p className="text-3xl font-black text-yellow-600">{score}</p>
+          <p className="text-xs text-yellow-500">לחיצות</p>
         </div>
-        <div className="flex gap-3">
-          <button onClick={onRestart} className="flex-1 py-4 rounded-2xl text-white font-bold bg-gradient-to-l from-rose-500 to-red-600 hover:opacity-90 active:scale-95 transition-all">🔄 שוב</button>
+        <div className="bg-red-50 rounded-2xl p-4">
+          <p className="text-3xl font-black text-red-500">{missed}</p>
+          <p className="text-xs text-red-400">פספוסים</p>
+        </div>
+        <div className="bg-blue-50 rounded-2xl p-4">
+          <p className="text-3xl font-black text-blue-600">{accuracy}%</p>
+          <p className="text-xs text-blue-400">דיוק</p>
         </div>
       </div>
-    </div>
+    </GameResultCard>
   );
 }

--- a/gamesformykids/app/games/true-false/components/TrueFalseResultScreen.tsx
+++ b/gamesformykids/app/games/true-false/components/TrueFalseResultScreen.tsx
@@ -1,4 +1,5 @@
 'use client';
+import GameResultCard from '@/components/game/shared/GameResultCard';
 
 interface Props {
   score: number;
@@ -8,27 +9,24 @@ interface Props {
 
 export default function TrueFalseResultScreen({ score, best, onRestart }: Props) {
   return (
-    <div className="min-h-screen bg-gradient-to-br from-teal-100 to-cyan-200 flex items-center justify-center p-4" dir="rtl">
-      <div className="bg-white rounded-3xl p-8 text-center shadow-2xl max-w-sm w-full">
-        <div className="text-6xl mb-3">🧠</div>
-        <h2 className="text-2xl font-black text-gray-700 mb-4">כל הכבוד על הניסיון!</h2>
-        <div className="grid grid-cols-2 gap-4 mb-6">
-          <div className="bg-teal-50 rounded-2xl p-3">
-            <p className="text-3xl font-black text-teal-600">{score}</p>
-            <p className="text-xs text-teal-400">ניקוד</p>
-          </div>
-          <div className="bg-yellow-50 rounded-2xl p-3">
-            <p className="text-3xl font-black text-yellow-500">{best}</p>
-            <p className="text-xs text-yellow-400">שיא</p>
-          </div>
+    <GameResultCard
+      emoji="🧠"
+      title="כל הכבוד על הניסיון!"
+      gradientClass="from-teal-100 to-cyan-200"
+      buttonClass="from-teal-500 to-cyan-600"
+      onRestart={onRestart}
+      restartLabel="🔄 שוב!"
+    >
+      <div className="grid grid-cols-2 gap-4">
+        <div className="bg-teal-50 rounded-2xl p-3">
+          <p className="text-3xl font-black text-teal-600">{score}</p>
+          <p className="text-xs text-teal-400">ניקוד</p>
         </div>
-        <button
-          onClick={onRestart}
-          className="w-full py-4 rounded-2xl bg-gradient-to-r from-teal-500 to-cyan-600 text-white font-black text-xl hover:opacity-90 active:scale-95 transition-all"
-        >
-          🔄 שוב!
-        </button>
+        <div className="bg-yellow-50 rounded-2xl p-3">
+          <p className="text-3xl font-black text-yellow-500">{best}</p>
+          <p className="text-xs text-yellow-400">שיא</p>
+        </div>
       </div>
-    </div>
+    </GameResultCard>
   );
 }

--- a/gamesformykids/app/games/whack-a-mole/components/WhackResultScreen.tsx
+++ b/gamesformykids/app/games/whack-a-mole/components/WhackResultScreen.tsx
@@ -1,4 +1,5 @@
 'use client';
+import GameResultCard from '@/components/game/shared/GameResultCard';
 
 interface Props {
   score: number;
@@ -8,29 +9,23 @@ interface Props {
 
 export default function WhackResultScreen({ score, best, onRestart }: Props) {
   return (
-    <div className="min-h-screen bg-gradient-to-br from-yellow-50 to-amber-100 flex items-center justify-center p-4" dir="rtl">
-      <div className="bg-white rounded-3xl shadow-2xl p-8 max-w-sm w-full text-center">
-        <div className="text-6xl mb-3">🔨</div>
-        <h2 className="text-3xl font-black text-gray-800 mb-5">הזמן נגמר!</h2>
-        <div className="grid grid-cols-2 gap-3 mb-6">
-          <div className="bg-amber-50 rounded-2xl p-4">
-            <p className="text-4xl font-black text-amber-600">{score}</p>
-            <p className="text-xs text-amber-400">ניקוד</p>
-          </div>
-          <div className="bg-yellow-50 rounded-2xl p-4">
-            <p className="text-4xl font-black text-yellow-500">{best}</p>
-            <p className="text-xs text-yellow-400">שיא</p>
-          </div>
+    <GameResultCard
+      emoji="🔨"
+      title="הזמן נגמר!"
+      gradientClass="from-yellow-50 to-amber-100"
+      buttonClass="from-amber-500 to-orange-500"
+      onRestart={onRestart}
+    >
+      <div className="grid grid-cols-2 gap-3">
+        <div className="bg-amber-50 rounded-2xl p-4">
+          <p className="text-4xl font-black text-amber-600">{score}</p>
+          <p className="text-xs text-amber-400">ניקוד</p>
         </div>
-        <div className="flex gap-3">
-          <button
-            onClick={onRestart}
-            className="flex-1 py-4 rounded-2xl bg-gradient-to-l from-amber-500 to-orange-500 text-white font-black text-xl shadow-lg hover:opacity-90 active:scale-95 transition-all"
-          >
-            🔄 שוב
-          </button>
+        <div className="bg-yellow-50 rounded-2xl p-4">
+          <p className="text-4xl font-black text-yellow-500">{best}</p>
+          <p className="text-xs text-yellow-400">שיא</p>
         </div>
       </div>
-    </div>
+    </GameResultCard>
   );
 }

--- a/gamesformykids/app/games/word-scramble/components/WordScrambleResultScreen.tsx
+++ b/gamesformykids/app/games/word-scramble/components/WordScrambleResultScreen.tsx
@@ -1,4 +1,5 @@
 'use client';
+import GameResultCard from '@/components/game/shared/GameResultCard';
 
 interface Props {
   score: number;
@@ -7,30 +8,27 @@ interface Props {
 }
 
 export default function WordScrambleResultScreen({ score, lives, onRestart }: Props) {
+  const emoji = score >= 100 ? '🏆' : score >= 60 ? '🎉' : '😊';
+  const title = score >= 100 ? 'מדהים!' : score >= 60 ? 'כל הכבוד!' : 'ניסיון טוב!';
   return (
-    <div className="min-h-screen bg-gradient-to-br from-green-100 to-emerald-200 flex items-center justify-center p-4" dir="rtl">
-      <div className="bg-white rounded-3xl p-8 text-center shadow-2xl max-w-sm w-full">
-        <div className="text-6xl mb-3">{score >= 100 ? '🏆' : score >= 60 ? '🎉' : '😊'}</div>
-        <h2 className="text-2xl font-black text-gray-700 mb-4">
-          {score >= 100 ? 'מדהים!' : score >= 60 ? 'כל הכבוד!' : 'ניסיון טוב!'}
-        </h2>
-        <div className="grid grid-cols-2 gap-4 mb-6">
-          <div className="bg-green-50 rounded-2xl p-3">
-            <p className="text-3xl font-black text-green-600">{score}</p>
-            <p className="text-xs text-green-400">ניקוד</p>
-          </div>
-          <div className="bg-red-50 rounded-2xl p-3">
-            <p className="text-3xl font-black text-red-500">{3 - lives}</p>
-            <p className="text-xs text-red-400">טעויות</p>
-          </div>
+    <GameResultCard
+      emoji={emoji}
+      title={title}
+      gradientClass="from-green-100 to-emerald-200"
+      buttonClass="from-green-500 to-emerald-600"
+      onRestart={onRestart}
+      restartLabel="🔄 שחק שוב"
+    >
+      <div className="grid grid-cols-2 gap-4">
+        <div className="bg-green-50 rounded-2xl p-3">
+          <p className="text-3xl font-black text-green-600">{score}</p>
+          <p className="text-xs text-green-400">ניקוד</p>
         </div>
-        <button
-          onClick={onRestart}
-          className="w-full py-4 rounded-2xl bg-gradient-to-r from-green-500 to-emerald-600 text-white font-black text-xl hover:opacity-90 active:scale-95 transition-all"
-        >
-          🔄 שחק שוב
-        </button>
+        <div className="bg-red-50 rounded-2xl p-3">
+          <p className="text-3xl font-black text-red-500">{3 - lives}</p>
+          <p className="text-xs text-red-400">טעויות</p>
+        </div>
       </div>
-    </div>
+    </GameResultCard>
   );
 }

--- a/gamesformykids/components/game/shared/GameResultCard.tsx
+++ b/gamesformykids/components/game/shared/GameResultCard.tsx
@@ -1,0 +1,67 @@
+'use client';
+import { ReactNode } from 'react';
+
+interface SecondaryAction {
+  label: string;
+  onClick: () => void;
+}
+
+interface Props {
+  emoji: string;
+  title: string;
+  /** Full Tailwind gradient classes, e.g. "from-green-50 to-teal-100" */
+  gradientClass: string;
+  /** Full Tailwind gradient classes for the restart button, e.g. "from-blue-500 to-indigo-600" */
+  buttonClass: string;
+  onRestart: () => void;
+  restartLabel?: string;
+  secondaryAction?: SecondaryAction;
+  animateEmoji?: boolean;
+  children: ReactNode;
+}
+
+/**
+ * Shared shell for game result screens.
+ * Provides the outer gradient background, white card, emoji, title, and restart button.
+ * Pass game-specific metrics as `children`.
+ */
+export default function GameResultCard({
+  emoji,
+  title,
+  gradientClass,
+  buttonClass,
+  onRestart,
+  restartLabel = '🔄 שוב',
+  secondaryAction,
+  animateEmoji = false,
+  children,
+}: Props) {
+  return (
+    <div
+      className={`min-h-screen bg-gradient-to-br ${gradientClass} flex items-center justify-center p-4`}
+      dir="rtl"
+    >
+      <div className="bg-white rounded-3xl shadow-2xl p-8 text-center max-w-sm w-full">
+        <div className={`text-6xl mb-3 ${animateEmoji ? 'animate-bounce' : ''}`}>{emoji}</div>
+        <h2 className="text-2xl font-bold text-gray-800 mb-4">{title}</h2>
+        <div className="mb-6">{children}</div>
+        <div className="flex gap-3">
+          <button
+            onClick={onRestart}
+            className={`flex-1 py-4 rounded-2xl bg-gradient-to-l ${buttonClass} text-white font-bold hover:opacity-90 active:scale-95 transition-all`}
+          >
+            {restartLabel}
+          </button>
+          {secondaryAction && (
+            <button
+              onClick={secondaryAction.onClick}
+              className="flex-1 py-4 rounded-2xl border-2 border-gray-200 text-gray-600 font-semibold hover:bg-gray-50 transition-all"
+            >
+              {secondaryAction.label}
+            </button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
Closes #110

## מה השתנה
יצירת קומפוננטת \GameResultCard\ משותפת ב-\components/game/shared/\ שמספקת:
- מכל גרדיאנט רקע + כרטיס לבן + emoji + כותרת + כפתורי פעולה
- slot ל-\children\ לתצוגת המדדים הספציפיים למשחק
- תמיכה ב-\secondaryAction\ ו-\nimateEmoji\

## קבצים שעודכנו (9)
| קובץ | שינוי |
|------|-------|
| \AnimalsResultScreen\ | עבר ל-GameResultCard |
| \ArithmeticResultScreen\ | עבר ל-GameResultCard |
| \BalloonResultScreen\ | עבר ל-GameResultCard |
| \MathRaceResultScreen\ | עבר ל-GameResultCard |
| \NumberBubblesResultScreen\ | עבר ל-GameResultCard |
| \ReflexResultScreen\ | עבר ל-GameResultCard |
| \TrueFalseResultScreen\ | עבר ל-GameResultCard |
| \WhackResultScreen\ | עבר ל-GameResultCard |
| \WordScrambleResultScreen\ | עבר ל-GameResultCard |

## קבצים שנשמרו כמו שהם
- **כבר משתמשים ב-QuizResultScreen**: Multiplication, WordBuilder, Transport
- **עיצוב ייחודי**: Soccer, Damka, Taki, Holidays, Clock

## תוצאות
✅ 71/71 tests pass