### PR TITLE
refactor: verify and finalize canvas game standardization

### DIFF
--- a/gamesformykids/app/games/math-race/MathRaceGame.tsx
+++ b/gamesformykids/app/games/math-race/MathRaceGame.tsx
@@ -2,8 +2,7 @@
 import { useMathRaceGame, GAME_TIME } from './useMathRaceGame';
 import MathRaceMenuScreen from './components/MathRaceMenuScreen';
 import MathRaceResultScreen from './components/MathRaceResultScreen';
-import MathRaceProgressBar from './components/MathRaceProgressBar';
-import MathRaceQuestion from './components/MathRaceQuestion';
+import MathRacePlayScreen from './components/MathRacePlayScreen';
 
 export default function MathRaceGame() {
   const { phase, q, score, best, timeLeft, feedback, streak, total, correct, accuracy, startGame, tap } = useMathRaceGame();
@@ -24,10 +23,17 @@ export default function MathRaceGame() {
   );
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-blue-100 to-indigo-200 flex flex-col items-center justify-center p-4 select-none" dir="rtl">
-      <MathRaceProgressBar timeLeft={timeLeft} score={score} streak={streak} gameTime={GAME_TIME} />
-      <MathRaceQuestion q={q} feedback={feedback} streak={streak} onTap={tap} />
-      <p className="mt-4 text-xs text-indigo-400">{correct}/{total} נכון · {accuracy}% דיוק</p>
-    </div>
+    <MathRacePlayScreen
+      q={q}
+      score={score}
+      timeLeft={timeLeft}
+      feedback={feedback}
+      streak={streak}
+      correct={correct}
+      total={total}
+      accuracy={accuracy}
+      gameTime={GAME_TIME}
+      onTap={tap}
+    />
   );
 }

--- a/gamesformykids/app/games/math-race/components/MathRacePlayScreen.tsx
+++ b/gamesformykids/app/games/math-race/components/MathRacePlayScreen.tsx
@@ -1,0 +1,33 @@
+'use client';
+
+import MathRaceProgressBar from './MathRaceProgressBar';
+import MathRaceQuestion from './MathRaceQuestion';
+
+interface Question {
+  text: string;
+  answer: number;
+  choices: number[];
+}
+
+interface Props {
+  q: Question;
+  score: number;
+  timeLeft: number;
+  feedback: 'correct' | 'wrong' | null;
+  streak: number;
+  correct: number;
+  total: number;
+  accuracy: number;
+  gameTime: number;
+  onTap: (choice: number) => void;
+}
+
+export default function MathRacePlayScreen({ q, score, timeLeft, feedback, streak, correct, total, accuracy, gameTime, onTap }: Props) {
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-blue-100 to-indigo-200 flex flex-col items-center justify-center p-4 select-none" dir="rtl">
+      <MathRaceProgressBar timeLeft={timeLeft} score={score} streak={streak} gameTime={gameTime} />
+      <MathRaceQuestion q={q} feedback={feedback} streak={streak} onTap={onTap} />
+      <p className="mt-4 text-xs text-indigo-400">{correct}/{total} נכון · {accuracy}% דיוק</p>
+    </div>
+  );
+}


### PR DESCRIPTION
Closes #113

## ממצאים

לאחר בדיקת כל קבצי \*Game.tsx\ בפרויקט:

### ✅ 11 Canvas games — כבר מסוכמות לחלוטין
כל המשחקים המשתמשים ב-HTML5 Canvas כבר עוקבים אחר הדפוס הזהה עם \CanvasGameShell\:

| משחק | שורות |
|------|-------|
| BrickBreakerGame | 31 |
| CatchFruitGame | 27 |
| DinoRunnerGame | 28 |
| FlappyBirdGame | 25 |
| FroggerGame | 29 |
| JumperGame | 31 |
| MeteorDodgeGame | 29 |
| PongGame | 31 |
| SnakeGame | 29 |
| SpaceDefenderGame | 33 |
| StackGame | 27 |

כל אחד: \const { canvasRef, ui, ... } = useXxxGame(); return <CanvasGameShell ... />\

### ✅ React games — דפוס phase-based אחיד
כל המשחקים שאינם Canvas עוקבים אחר דפוס phase-based עקבי (15-35 שורות):
\\\	sx
if (phase === 'menu') return <MenuScreen .../>;
if (phase === 'dead') return <ResultScreen .../>;
return <PlayScreen .../>;
\\\

## שינויים

### Extract \MathRacePlayScreen\
\MathRaceGame\ היה **היחיד** עם play area inline (div + raw \<p>\) במקום קומפוננטה ייעודית.
- נוצר \pp/games/math-race/components/MathRacePlayScreen.tsx\
- \MathRaceGame.tsx\ עודכן לעקוב אחר הדפוס הסטנדרטי

## תוצאות
✅ 71/71 tests pass