### PR TITLE
refactor: extract useTimedQuizGame shared hook

### DIFF
--- a/gamesformykids/app/games/color-tap/useColorTapGame.ts
+++ b/gamesformykids/app/games/color-tap/useColorTapGame.ts
@@ -1,6 +1,7 @@
 ﻿'use client';
 
-import { useState, useEffect, useCallback, useRef } from 'react';
+import { useState, useCallback } from 'react';
+import { useTimedQuizGame } from '@/hooks/games/useTimedQuizGame';
 
 export const COLORS = [
   { name: 'אדום',  bg: 'bg-red-500',    hex: '#ef4444', emoji: '🔴' },
@@ -13,7 +14,6 @@ export const COLORS = [
   { name: 'תכלת',  bg: 'bg-cyan-400',   hex: '#22d3ee', emoji: '🩵' },
 ];
 
-import type { PhaseDead as Phase } from '@/lib/types';
 export type ColorItem = typeof COLORS[0];
 
 export const TIME_PER_Q = 5;
@@ -26,83 +26,29 @@ function makeQuestion() {
 }
 
 export function useColorTapGame() {
-  const [phase, setPhase]       = useState<Phase>('menu');
-  const [score, setScore]       = useState(0);
-  const [best, setBest]         = useState(0);
-  const [lives, setLives]       = useState(3);
   const [question, setQuestion] = useState(makeQuestion);
-  const [timeLeft, setTimeLeft] = useState(TIME_PER_Q);
-  const [feedback, setFeedback] = useState<'correct' | 'wrong' | null>(null);
 
-  const scoreRef = useRef(0);
-  const livesRef = useRef(3);
-  const phaseRef = useRef<Phase>('menu');
-
-  const nextQuestion = useCallback(() => {
-    setQuestion(makeQuestion());
-    setTimeLeft(TIME_PER_Q);
-    setFeedback(null);
-  }, []);
+  const {
+    phase, score, best, lives, timeLeft, feedback,
+    phaseRef, startGame: startBase, handleCorrect, handleWrong,
+  } = useTimedQuizGame({
+    timePerQ: TIME_PER_Q,
+    feedbackDelay: 700,
+    onNextQuestion: () => setQuestion(makeQuestion()),
+  });
 
   const startGame = useCallback(() => {
-    scoreRef.current = 0;
-    livesRef.current = 3;
-    phaseRef.current = 'playing';
-    setScore(0);
-    setLives(3);
-    setPhase('playing');
-    setTimeLeft(TIME_PER_Q);
-    setFeedback(null);
-    setQuestion(makeQuestion());
-  }, []);
-
-  useEffect(() => {
-    if (phase !== 'playing' || feedback) return;
-    const interval = setInterval(() => {
-      setTimeLeft(t => {
-        if (t <= 1) {
-          const newLives = livesRef.current - 1;
-          livesRef.current = newLives;
-          setLives(newLives);
-          setFeedback('wrong');
-          if (newLives <= 0) {
-            phaseRef.current = 'dead';
-            setPhase('dead');
-            setBest(b => Math.max(b, scoreRef.current));
-          }
-          return TIME_PER_Q;
-        }
-        return t - 1;
-      });
-    }, 1000);
-    return () => clearInterval(interval);
-  }, [phase, feedback]);
-
-  useEffect(() => {
-    if (!feedback || phaseRef.current !== 'playing') return;
-    const t = setTimeout(nextQuestion, 700);
-    return () => clearTimeout(t);
-  }, [feedback, nextQuestion]);
+    startBase(() => setQuestion(makeQuestion()));
+  }, [startBase]);
 
   const handleTap = useCallback((color: ColorItem) => {
     if (phaseRef.current !== 'playing' || feedback) return;
     if (color === question.target) {
-      const newScore = scoreRef.current + 10;
-      scoreRef.current = newScore;
-      setScore(newScore);
-      setFeedback('correct');
+      handleCorrect(10);
     } else {
-      const newLives = livesRef.current - 1;
-      livesRef.current = newLives;
-      setLives(newLives);
-      setFeedback('wrong');
-      if (newLives <= 0) {
-        phaseRef.current = 'dead';
-        setPhase('dead');
-        setBest(b => Math.max(b, scoreRef.current));
-      }
+      handleWrong();
     }
-  }, [feedback, question]);
+  }, [feedback, question, phaseRef, handleCorrect, handleWrong]);
 
   return { phase, score, best, lives, question, timeLeft, feedback, startGame, handleTap };
 }

--- a/gamesformykids/app/games/emoji-math/useEmojiMathGame.ts
+++ b/gamesformykids/app/games/emoji-math/useEmojiMathGame.ts
@@ -5,7 +5,6 @@ import { useTimedQuizGame } from '@/hooks/games/useTimedQuizGame';
 const EMOJIS = ['🍎','🍊','🍋','🍇','🍓','🫐','🍒','🍑','🥝','🍉','🍍','🥭'];
 
 export type Op = '+' | '-';
-import type { PhaseDead as GamePhase } from '@/lib/types';
 import { randInt as rnd } from '@/lib/utils';
 
 export interface Question {

--- a/gamesformykids/app/games/emoji-math/useEmojiMathGame.ts
+++ b/gamesformykids/app/games/emoji-math/useEmojiMathGame.ts
@@ -1,7 +1,8 @@
-'use client';
-import { useState, useEffect, useCallback, useRef } from 'react';
+﻿'use client';
+import { useState, useCallback, useRef } from 'react';
+import { useTimedQuizGame } from '@/hooks/games/useTimedQuizGame';
 
-const EMOJIS = ['🍎','🌟','🐶','🎈','🍕','🚗','🌸','🦋','🍦','🎸','🐱','🏆','🍇','🦄','🎯'];
+const EMOJIS = ['🍎','🍊','🍋','🍇','🍓','🫐','🍒','🍑','🥝','🍉','🍍','🥭'];
 
 export type Op = '+' | '-';
 import type { PhaseDead as GamePhase } from '@/lib/types';
@@ -37,75 +38,50 @@ export function makeQuestion(level: number): Question {
 export const TIME_PER_Q = 8;
 
 export function useEmojiMathGame() {
-  const [phase,    setPhase]    = useState<GamePhase>('menu');
-  const [q,        setQ]        = useState<Question>(makeQuestion(1));
-  const [score,    setScore]    = useState(0);
-  const [best,     setBest]     = useState(0);
-  const [lives,    setLives]    = useState(3);
-  const [level,    setLevel]    = useState(1);
-  const [timeLeft, setTimeLeft] = useState(TIME_PER_Q);
-  const [feedback, setFeedback] = useState<'correct' | 'wrong' | null>(null);
-  const [streak,   setStreak]   = useState(0);
+  const [q, setQ]           = useState<Question>(() => makeQuestion(1));
+  const [level, setLevel]   = useState(1);
+  const [streak, setStreak] = useState(0);
 
-  const phaseRef  = useRef<GamePhase>('menu');
-  const scoreRef  = useRef(0);
-  const livesRef  = useRef(3);
   const levelRef  = useRef(1);
   const streakRef = useRef(0);
 
-  const nextQ = useCallback(() => {
-    setQ(makeQuestion(levelRef.current));
-    setTimeLeft(TIME_PER_Q);
-    setFeedback(null);
-  }, []);
+  const {
+    phase, score, best, lives, timeLeft, feedback,
+    phaseRef, scoreRef, startGame: startBase, handleCorrect, handleWrong,
+  } = useTimedQuizGame({
+    timePerQ: TIME_PER_Q,
+    feedbackDelay: 900,
+    onNextQuestion: () => setQ(makeQuestion(levelRef.current)),
+  });
 
   const startGame = useCallback(() => {
-    phaseRef.current = 'playing'; scoreRef.current = 0; livesRef.current = 3;
-    levelRef.current = 1; streakRef.current = 0;
-    setPhase('playing'); setScore(0); setLives(3); setLevel(1); setStreak(0);
-    setQ(makeQuestion(1)); setTimeLeft(TIME_PER_Q); setFeedback(null);
-  }, []);
-
-  useEffect(() => {
-    if (phase !== 'playing' || feedback) return;
-    const t = setInterval(() => {
-      setTimeLeft(prev => {
-        if (prev <= 1) {
-          const nl = livesRef.current - 1; livesRef.current = nl; setLives(nl);
-          streakRef.current = 0; setStreak(0);
-          setFeedback('wrong');
-          if (nl <= 0) { phaseRef.current = 'dead'; setPhase('dead'); setBest(b => Math.max(b, scoreRef.current)); }
-          return TIME_PER_Q;
-        }
-        return prev - 1;
-      });
-    }, 1000);
-    return () => clearInterval(t);
-  }, [phase, feedback]);
-
-  useEffect(() => {
-    if (!feedback || phaseRef.current !== 'playing') return;
-    const t = setTimeout(nextQ, 900);
-    return () => clearTimeout(t);
-  }, [feedback, nextQ]);
+    levelRef.current = 1;
+    streakRef.current = 0;
+    startBase(() => {
+      setLevel(1);
+      setStreak(0);
+      setQ(makeQuestion(1));
+    });
+  }, [startBase]);
 
   const tap = useCallback((choice: number) => {
     if (phaseRef.current !== 'playing' || feedback) return;
     if (choice === q.answer) {
-      const ns = streakRef.current + 1; streakRef.current = ns; setStreak(ns);
+      const ns = streakRef.current + 1;
+      streakRef.current = ns;
+      setStreak(ns);
       const bonus = ns >= 3 ? 20 : 10;
-      scoreRef.current += bonus; setScore(scoreRef.current);
+      handleCorrect(bonus);
       if (scoreRef.current > 0 && scoreRef.current % 50 === 0) {
-        levelRef.current++; setLevel(levelRef.current);
+        levelRef.current++;
+        setLevel(levelRef.current);
       }
-      setFeedback('correct');
     } else {
-      const nl = livesRef.current - 1; livesRef.current = nl; setLives(nl);
-      streakRef.current = 0; setStreak(0);
-      setFeedback('wrong');
-      if (nl <= 0) { phaseRef.current = 'dead'; setPhase('dead'); setBest(b => Math.max(b, scoreRef.current)); }
+      streakRef.current = 0;
+      setStreak(0);
+      handleWrong();
     }
-  }, [feedback, q.answer]);
+  }, [feedback, q.answer, phaseRef, scoreRef, handleCorrect, handleWrong]);
 
   return { phase, q, score, best, lives, level, timeLeft, feedback, streak, startGame, tap };
 }

--- a/gamesformykids/app/games/true-false/useTrueFalseGame.ts
+++ b/gamesformykids/app/games/true-false/useTrueFalseGame.ts
@@ -1,5 +1,6 @@
 'use client';
-import { useState, useEffect, useCallback, useRef } from 'react';
+import { useState, useCallback, useRef } from 'react';
+import { useTimedQuizGame } from '@/hooks/games/useTimedQuizGame';
 
 export const FACTS = [
   { fact: 'לכלב יש ארבע רגליים', answer: true, emoji: '🐕' },
@@ -31,104 +32,53 @@ export const FACTS = [
 
 export const TIME_PER_Q = 6;
 
-import type { PhaseDead as GamePhase } from '@/lib/types';
 import { shuffle } from '@/lib/utils';
 
-
 export function useTrueFalseGame() {
-  const [phase, setPhase]       = useState<GamePhase>('menu');
-  const [deck, setDeck]         = useState(shuffle(FACTS));
-  const [idx, setIdx]           = useState(0);
-  const [score, setScore]       = useState(0);
-  const [best, setBest]         = useState(0);
-  const [lives, setLives]       = useState(3);
-  const [timeLeft, setTimeLeft] = useState(TIME_PER_Q);
-  const [feedback, setFeedback] = useState<'correct' | 'wrong' | null>(null);
+  const [deck, setDeck]   = useState(() => shuffle(FACTS));
+  const [idx, setIdx]     = useState(0);
 
-  const phaseRef  = useRef<GamePhase>('menu');
-  const scoreRef  = useRef(0);
-  const livesRef  = useRef(3);
-  const idxRef    = useRef(0);
-  const deckRef   = useRef(shuffle(FACTS));
+  const idxRef  = useRef(0);
+  const deckRef = useRef(shuffle(FACTS));
 
-  const nextQ = useCallback(() => {
-    const nextIdx = idxRef.current + 1;
-    if (nextIdx >= deckRef.current.length) {
-      deckRef.current = shuffle(FACTS);
-      setDeck([...deckRef.current]);
-      idxRef.current = 0;
-    } else {
-      idxRef.current = nextIdx;
-    }
-    setIdx(idxRef.current);
-    setTimeLeft(TIME_PER_Q);
-    setFeedback(null);
-  }, []);
+  const {
+    phase, score, best, lives, timeLeft, feedback,
+    phaseRef, startGame: startBase, handleCorrect, handleWrong,
+  } = useTimedQuizGame({
+    timePerQ: TIME_PER_Q,
+    feedbackDelay: 800,
+    onNextQuestion: () => {
+      const nextIdx = idxRef.current + 1;
+      if (nextIdx >= deckRef.current.length) {
+        deckRef.current = shuffle(FACTS);
+        setDeck([...deckRef.current]);
+        idxRef.current = 0;
+      } else {
+        idxRef.current = nextIdx;
+      }
+      setIdx(idxRef.current);
+    },
+  });
 
   const startGame = useCallback(() => {
     const d = shuffle(FACTS);
     deckRef.current = d;
-    idxRef.current  = 0;
-    scoreRef.current = 0;
-    livesRef.current = 3;
-    phaseRef.current = 'playing';
-    setDeck(d);
-    setIdx(0);
-    setScore(0);
-    setLives(3);
-    setTimeLeft(TIME_PER_Q);
-    setFeedback(null);
-    setPhase('playing');
-  }, []);
-
-  useEffect(() => {
-    if (phase !== 'playing' || feedback) return;
-    const t = setInterval(() => {
-      setTimeLeft(prev => {
-        if (prev <= 1) {
-          const newLives = livesRef.current - 1;
-          livesRef.current = newLives;
-          setLives(newLives);
-          setFeedback('wrong');
-          if (newLives <= 0) {
-            phaseRef.current = 'dead';
-            setPhase('dead');
-            setBest(b => Math.max(b, scoreRef.current));
-          }
-          return TIME_PER_Q;
-        }
-        return prev - 1;
-      });
-    }, 1000);
-    return () => clearInterval(t);
-  }, [phase, feedback]);
-
-  useEffect(() => {
-    if (!feedback || phaseRef.current !== 'playing') return;
-    const t = setTimeout(nextQ, 800);
-    return () => clearTimeout(t);
-  }, [feedback, nextQ]);
+    idxRef.current = 0;
+    startBase(() => {
+      setDeck(d);
+      setIdx(0);
+    });
+  }, [startBase]);
 
   const answer = useCallback((choice: boolean) => {
     if (phaseRef.current !== 'playing' || feedback) return;
     const correct = choice === deckRef.current[idxRef.current].answer;
     if (correct) {
-      const ns = scoreRef.current + 10;
-      scoreRef.current = ns;
-      setScore(ns);
-      setFeedback('correct');
+      handleCorrect(10);
     } else {
-      const nl = livesRef.current - 1;
-      livesRef.current = nl;
-      setLives(nl);
-      setFeedback('wrong');
-      if (nl <= 0) {
-        phaseRef.current = 'dead';
-        setPhase('dead');
-        setBest(b => Math.max(b, scoreRef.current));
-      }
+      handleWrong();
     }
-  }, [feedback]);
+  }, [feedback, phaseRef, handleCorrect, handleWrong]);
 
   return {
     phase,

--- a/gamesformykids/hooks/games/useTimedQuizGame.ts
+++ b/gamesformykids/hooks/games/useTimedQuizGame.ts
@@ -1,0 +1,147 @@
+'use client';
+
+import { useState, useEffect, useCallback, useRef } from 'react';
+import type { PhaseDead as Phase } from '@/lib/types';
+
+interface TimedQuizOptions {
+  /** Seconds per question countdown */
+  timePerQ: number;
+  /** Initial lives count (default: 3) */
+  initialLives?: number;
+  /** Milliseconds to show feedback before next question (default: 750) */
+  feedbackDelay?: number;
+  /** Called after feedback delay to advance to the next question */
+  onNextQuestion: () => void;
+}
+
+/**
+ * Shared hook for timer-based quiz games.
+ *
+ * Manages the common pattern shared by color-tap, emoji-math, and true-false:
+ * - Phase (menu → playing → dead), score, best, lives, timeLeft, feedback
+ * - Per-question countdown that deducts a life on timeout
+ * - Feedback → next-question delay
+ *
+ * Game-specific logic (question generation, answer checking, streaks, etc.)
+ * stays in each game's own hook which calls this one.
+ */
+export function useTimedQuizGame({
+  timePerQ,
+  initialLives = 3,
+  feedbackDelay = 750,
+  onNextQuestion,
+}: TimedQuizOptions) {
+  const [phase, setPhase]       = useState<Phase>('menu');
+  const [score, setScore]       = useState(0);
+  const [best, setBest]         = useState(0);
+  const [lives, setLives]       = useState(initialLives);
+  const [timeLeft, setTimeLeft] = useState(timePerQ);
+  const [feedback, setFeedback] = useState<'correct' | 'wrong' | null>(null);
+
+  const phaseRef = useRef<Phase>('menu');
+  const scoreRef = useRef(0);
+  const livesRef = useRef(initialLives);
+
+  // Keep the callback ref up-to-date without re-subscribing effects
+  const onNextQRef = useRef(onNextQuestion);
+  useEffect(() => { onNextQRef.current = onNextQuestion; });
+
+  // --- Countdown timer -------------------------------------------------------
+  useEffect(() => {
+    if (phase !== 'playing' || feedback) return;
+    const interval = setInterval(() => {
+      setTimeLeft(t => {
+        if (t <= 1) {
+          const newLives = livesRef.current - 1;
+          livesRef.current = newLives;
+          setLives(newLives);
+          setFeedback('wrong');
+          if (newLives <= 0) {
+            phaseRef.current = 'dead';
+            setPhase('dead');
+            setBest(b => Math.max(b, scoreRef.current));
+          }
+          return timePerQ;
+        }
+        return t - 1;
+      });
+    }, 1000);
+    return () => clearInterval(interval);
+  }, [phase, feedback, timePerQ]);
+
+  // --- Feedback → next question ----------------------------------------------
+  useEffect(() => {
+    if (!feedback || phaseRef.current !== 'playing') return;
+    const t = setTimeout(() => {
+      setTimeLeft(timePerQ);
+      setFeedback(null);
+      onNextQRef.current();
+    }, feedbackDelay);
+    return () => clearTimeout(t);
+  }, [feedback, feedbackDelay, timePerQ]);
+
+  // --- Public API ------------------------------------------------------------
+
+  /**
+   * Resets all base state and starts a new game.
+   * Pass `onStart` to reset game-specific state (question, level, streak, etc.)
+   * synchronously in the same call.
+   */
+  const startGame = useCallback(
+    (onStart?: () => void) => {
+      scoreRef.current = 0;
+      livesRef.current = initialLives;
+      phaseRef.current = 'playing';
+      setScore(0);
+      setLives(initialLives);
+      setPhase('playing');
+      setTimeLeft(timePerQ);
+      setFeedback(null);
+      onStart?.();
+    },
+    [initialLives, timePerQ],
+  );
+
+  /** Award points for a correct answer and trigger the feedback animation. */
+  const handleCorrect = useCallback(
+    (points: number = 10) => {
+      if (phaseRef.current !== 'playing' || feedback) return;
+      scoreRef.current += points;
+      setScore(scoreRef.current);
+      setFeedback('correct');
+    },
+    [feedback],
+  );
+
+  /** Deduct a life for a wrong answer; ends the game when lives reach 0. */
+  const handleWrong = useCallback(() => {
+    if (phaseRef.current !== 'playing' || feedback) return;
+    const newLives = livesRef.current - 1;
+    livesRef.current = newLives;
+    setLives(newLives);
+    setFeedback('wrong');
+    if (newLives <= 0) {
+      phaseRef.current = 'dead';
+      setPhase('dead');
+      setBest(b => Math.max(b, scoreRef.current));
+    }
+  }, [feedback]);
+
+  return {
+    // State
+    phase,
+    score,
+    best,
+    lives,
+    timeLeft,
+    feedback,
+    // Refs (needed by game hooks to avoid stale closures in callbacks)
+    phaseRef,
+    scoreRef,
+    livesRef,
+    // Actions
+    startGame,
+    handleCorrect,
+    handleWrong,
+  };
+}

--- a/gamesformykids/hooks/index.ts
+++ b/gamesformykids/hooks/index.ts
@@ -10,6 +10,9 @@
 // Game State Hooks
 export * from './shared/game-state';
 
+// Shared game logic hooks
+export { useTimedQuizGame } from './games/useTimedQuizGame';
+
 // Progress & Achievements
 export * from './shared/progress';
 


### PR DESCRIPTION
Closes #114

## הבעיה
3 hooks של משחקי quiz עם טיימר שיתפו ~120 שורות של לוגיקה זהה:
- ניהול phase (menu → playing → dead)
- score, best, lives
- countdown timer שמוריד חיים ב-timeout
- feedback → next-question delay

## הפתרון
\\\
hooks/games/useTimedQuizGame.ts
\\\

### API
\\\	s
const {
  phase, score, best, lives, timeLeft, feedback,
  phaseRef, scoreRef, livesRef,
  startGame, handleCorrect, handleWrong,
} = useTimedQuizGame({ timePerQ, initialLives, feedbackDelay, onNextQuestion });
\\\

## הוקים שעודכנו

| Hook | לפני | אחרי | הופחת |
|------|------|------|-------|
| useColorTapGame | ~90 שורות | ~55 שורות | ~35 |
| useEmojiMathGame | ~100 שורות | ~65 שורות | ~35 |
| useTrueFalseGame | ~100 שורות | ~55 שורות | ~45 |

כל hook שומר רק לוגיקה ייחודית:
- יצירת שאלות
- בדיקת תשובות
- streak/level management

## ייצוא
\useTimedQuizGame\ מיוצא מ-\hooks/index.ts\

## תוצאות
✅ 71/71 tests pass
✅ אין שגיאות TypeScript