### PR TITLE
chore: enable no-explicit-any ESLint rule (#93)

### DIFF
--- a/gamesformykids/eslint.config.mjs
+++ b/gamesformykids/eslint.config.mjs
@@ -13,6 +13,7 @@ const eslintConfig = [
   ...compat.extends("next/core-web-vitals", "next/typescript"),
   {
     rules: {
+      "@typescript-eslint/no-explicit-any": "error",
       "@typescript-eslint/no-unused-vars": [
         "error",
         {

--- a/gamesformykids/lib/stores/gameActionsStore.ts
+++ b/gamesformykids/lib/stores/gameActionsStore.ts
@@ -14,8 +14,7 @@ import { create } from 'zustand';
 import { devtools } from 'zustand/middleware';
 import type { BaseGameItem } from '@/lib/types/core/base';
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const NOOP = (): any => {};
+const NOOP = () => {};
 const ASYNC_NOOP = async (): Promise<void> => {};
 
 export interface GameActionsState {


### PR DESCRIPTION
## Summary
Closes #93

- Adds `"@typescript-eslint/no-explicit-any": "error"` to `eslint.config.mjs` — any new `any` introduced without a deliberate disable comment will now fail the build
- Removes the unnecessary `any` return annotation from `NOOP` in `gameActionsStore.ts` (implicit `void` is correct)
- The two remaining `any` usages both already had `// eslint-disable-next-line` comments and are legitimate:
  - `AnyGameHookFn = () => any` in `gameHooksMap.ts` — a heterogeneous registry of hooks with different return shapes; `unknown` would require callers to narrow the type on every use
  - `QuizGameConfig<any>` in `quizGameConfigs.tsx` — generic type erasure at the map level; `unknown` is not assignable due to function parameter contravariance

## Test plan
- [ ] `tsc --noEmit` passes
- [ ] `npm run build` passes
- [ ] Add a new `any` anywhere in the codebase → ESLint reports an error

🤖 Generated with [Claude Code](https://claude.com/claude-code)