### PR TITLE
refactor: split settings/page.tsx into focused section components (#91)

### DIFF
--- a/gamesformykids/app/settings/page.tsx
+++ b/gamesformykids/app/settings/page.tsx
@@ -1,9 +1,12 @@
 'use client'
 
-import { useUserProfile } from '@/hooks'
-import { useAuth } from '@/hooks/shared/auth/useAuth'
 import { useState } from 'react'
 import Link from 'next/link'
+import { useUserProfile } from '@/hooks'
+import { useAuth } from '@/hooks/shared/auth/useAuth'
+import { AudioSection } from '@/components/settings/AudioSection'
+import { AppearanceSection } from '@/components/settings/AppearanceSection'
+import { AccountSection } from '@/components/settings/AccountSection'
 
 export default function SettingsPage() {
   const { user, loading: authLoading, signOut } = useAuth()
@@ -31,9 +34,9 @@ export default function SettingsPage() {
     )
   }
 
-  const handleSettingChange = async (setting: string, value: boolean | string) => {
+  const handleSettingChange = async (key: string, value: boolean | string) => {
     setSaving(true)
-    await updateSettings({ [setting]: value })
+    await updateSettings({ [key]: value })
     setSaving(false)
   }
 
@@ -48,7 +51,6 @@ export default function SettingsPage() {
   return (
     <div className="min-h-screen bg-gradient-to-br from-purple-100 to-blue-100 p-4">
       <div className="max-w-2xl mx-auto">
-        {/* Header */}
         <div className="text-center mb-8">
           <Link href="/" className="inline-flex items-center text-purple-600 hover:text-purple-800 mb-4">
             ← חזור לדף הבית
@@ -56,120 +58,22 @@ export default function SettingsPage() {
           <h1 className="text-3xl font-bold text-purple-800">הגדרות</h1>
         </div>
 
-        {/* Settings Sections */}
         <div className="space-y-6">
-          {/* Audio Settings */}
-          <div className="bg-white rounded-2xl shadow-lg p-6">
-            <h2 className="text-xl font-semibold text-gray-800 mb-4 flex items-center">
-              🔊 הגדרות שמע
-            </h2>
-            <div className="space-y-4">
-              <SettingToggle
-                label="צלילי משחק"
-                description="הפעלת צלילים במשחקים"
-                checked={settings?.sound_enabled ?? true}
-                onChange={(checked) => handleSettingChange('sound_enabled', checked)}
-                disabled={saving}
-              />
-              <SettingToggle
-                label="מוזיקת רקע"
-                description="הפעלת מוזיקה ברקע"
-                checked={settings?.music_enabled ?? true}
-                onChange={(checked) => handleSettingChange('music_enabled', checked)}
-                disabled={saving}
-              />
-            </div>
-          </div>
-
-          {/* Game Settings */}
-          <div className="bg-white rounded-2xl shadow-lg p-6">
-            <h2 className="text-xl font-semibold text-gray-800 mb-4 flex items-center">
-              🎮 הגדרות משחק
-            </h2>
-            <div className="space-y-4">
-              <SettingSelect
-                label="רמת קושי"
-                description="רמת הקושי הברירת מחדל"
-                value={settings?.difficulty_level ?? 'normal'}
-                options={[
-                  { value: 'easy', label: 'קל' },
-                  { value: 'normal', label: 'רגיל' },
-                  { value: 'hard', label: 'קשה' }
-                ]}
-                onChange={(value) => handleSettingChange('difficulty_level', value)}
-                disabled={saving}
-              />
-              <SettingSelect
-                label="ערכת נושא"
-                description="מראה האפליקציה"
-                value={settings?.theme ?? 'light'}
-                options={[
-                  { value: 'light', label: 'בהיר' },
-                  { value: 'dark', label: 'כהה' },
-                  { value: 'auto', label: 'אוטומטי' }
-                ]}
-                onChange={(value) => handleSettingChange('theme', value)}
-                disabled={saving}
-              />
-            </div>
-          </div>
-
-          {/* Notification Settings */}
-          <div className="bg-white rounded-2xl shadow-lg p-6">
-            <h2 className="text-xl font-semibold text-gray-800 mb-4 flex items-center">
-              🔔 הגדרות התראות
-            </h2>
-            <div className="space-y-4">
-              <SettingToggle
-                label="התראות משחק"
-                description="התראות על הישגים והתקדמות"
-                checked={settings?.notifications_enabled ?? true}
-                onChange={(checked) => handleSettingChange('notifications_enabled', checked)}
-                disabled={saving}
-              />
-            </div>
-          </div>
-
-          {/* Language Settings */}
-          <div className="bg-white rounded-2xl shadow-lg p-6">
-            <h2 className="text-xl font-semibold text-gray-800 mb-4 flex items-center">
-              🌐 שפה
-            </h2>
-            <div className="space-y-4">
-              <SettingSelect
-                label="שפת האפליקציה"
-                description="השפה העיקרית"
-                value={settings?.preferred_language ?? 'he'}
-                options={[
-                  { value: 'he', label: 'עברית' },
-                  { value: 'en', label: 'English' }
-                ]}
-                onChange={(value) => handleSettingChange('preferred_language', value)}
-                disabled={saving}
-              />
-            </div>
-          </div>
-
-          {/* Account Actions */}
-          <div className="bg-white rounded-2xl shadow-lg p-6">
-            <h2 className="text-xl font-semibold text-gray-800 mb-4 flex items-center">
-              👤 חשבון
-            </h2>
-            <div className="space-y-4">
-              <Link
-                href="/profile"
-                className="block w-full text-left p-3 text-purple-600 hover:bg-purple-50 rounded-lg transition-colors"
-              >
-                ערוך פרופיל
-              </Link>
-              <button
-                onClick={handleSignOut}
-                className="block w-full text-left p-3 text-red-600 hover:bg-red-50 rounded-lg transition-colors"
-              >
-                התנתק מהחשבון
-              </button>
-            </div>
-          </div>
+          <AudioSection
+            soundEnabled={settings?.sound_enabled ?? true}
+            musicEnabled={settings?.music_enabled ?? true}
+            notificationsEnabled={settings?.notifications_enabled ?? true}
+            onChange={handleSettingChange}
+            disabled={saving}
+          />
+          <AppearanceSection
+            difficulty={settings?.difficulty_level ?? 'normal'}
+            theme={settings?.theme ?? 'light'}
+            language={settings?.preferred_language ?? 'he'}
+            onChange={handleSettingChange}
+            disabled={saving}
+          />
+          <AccountSection onSignOut={handleSignOut} />
         </div>
 
         {saving && (
@@ -178,76 +82,6 @@ export default function SettingsPage() {
           </div>
         )}
       </div>
-    </div>
-  )
-}
-
-function SettingToggle({ 
-  label, 
-  description, 
-  checked, 
-  onChange, 
-  disabled 
-}: {
-  label: string
-  description: string
-  checked: boolean
-  onChange: (checked: boolean) => void
-  disabled?: boolean
-}) {
-  return (
-    <div className="flex items-center justify-between p-3 border border-gray-200 rounded-lg">
-      <div>
-        <h3 className="font-medium text-gray-800">{label}</h3>
-        <p className="text-sm text-gray-600">{description}</p>
-      </div>
-      <label className="relative inline-flex items-center cursor-pointer">
-        <input
-          type="checkbox"
-          checked={checked}
-          onChange={(e) => onChange(e.target.checked)}
-          disabled={disabled}
-          className="sr-only peer"
-        />
-        <div className="w-11 h-6 bg-gray-200 peer-focus:outline-none peer-focus:ring-4 peer-focus:ring-purple-300 rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-purple-600"></div>
-      </label>
-    </div>
-  )
-}
-
-function SettingSelect({ 
-  label, 
-  description, 
-  value, 
-  options, 
-  onChange, 
-  disabled 
-}: {
-  label: string
-  description: string
-  value: string
-  options: { value: string; label: string }[]
-  onChange: (value: string) => void
-  disabled?: boolean
-}) {
-  return (
-    <div className="p-3 border border-gray-200 rounded-lg">
-      <div className="mb-2">
-        <h3 className="font-medium text-gray-800">{label}</h3>
-        <p className="text-sm text-gray-600">{description}</p>
-      </div>
-      <select
-        value={value}
-        onChange={(e) => onChange(e.target.value)}
-        disabled={disabled}
-        className="w-full p-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-purple-500"
-      >
-        {options.map((option) => (
-          <option key={option.value} value={option.value}>
-            {option.label}
-          </option>
-        ))}
-      </select>
     </div>
   )
 }

--- a/gamesformykids/components/settings/AccountSection.tsx
+++ b/gamesformykids/components/settings/AccountSection.tsx
@@ -1,0 +1,29 @@
+import Link from 'next/link';
+
+interface Props {
+  onSignOut: () => void;
+}
+
+export function AccountSection({ onSignOut }: Props) {
+  return (
+    <div className="bg-white rounded-2xl shadow-lg p-6">
+      <h2 className="text-xl font-semibold text-gray-800 mb-4 flex items-center">
+        👤 חשבון
+      </h2>
+      <div className="space-y-4">
+        <Link
+          href="/profile"
+          className="block w-full text-left p-3 text-purple-600 hover:bg-purple-50 rounded-lg transition-colors"
+        >
+          ערוך פרופיל
+        </Link>
+        <button
+          onClick={onSignOut}
+          className="block w-full text-left p-3 text-red-600 hover:bg-red-50 rounded-lg transition-colors"
+        >
+          התנתק מהחשבון
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/gamesformykids/components/settings/AppearanceSection.tsx
+++ b/gamesformykids/components/settings/AppearanceSection.tsx
@@ -1,0 +1,66 @@
+import { SettingSelect } from './SettingSelect';
+
+interface Props {
+  difficulty: string;
+  theme: string;
+  language: string;
+  onChange: (key: string, value: string) => void;
+  disabled: boolean;
+}
+
+export function AppearanceSection({ difficulty, theme, language, onChange, disabled }: Props) {
+  return (
+    <>
+      <div className="bg-white rounded-2xl shadow-lg p-6">
+        <h2 className="text-xl font-semibold text-gray-800 mb-4 flex items-center">
+          🎮 הגדרות משחק
+        </h2>
+        <div className="space-y-4">
+          <SettingSelect
+            label="רמת קושי"
+            description="רמת הקושי הברירת מחדל"
+            value={difficulty}
+            options={[
+              { value: 'easy', label: 'קל' },
+              { value: 'normal', label: 'רגיל' },
+              { value: 'hard', label: 'קשה' },
+            ]}
+            onChange={(v) => onChange('difficulty_level', v)}
+            disabled={disabled}
+          />
+          <SettingSelect
+            label="ערכת נושא"
+            description="מראה האפליקציה"
+            value={theme}
+            options={[
+              { value: 'light', label: 'בהיר' },
+              { value: 'dark', label: 'כהה' },
+              { value: 'auto', label: 'אוטומטי' },
+            ]}
+            onChange={(v) => onChange('theme', v)}
+            disabled={disabled}
+          />
+        </div>
+      </div>
+
+      <div className="bg-white rounded-2xl shadow-lg p-6">
+        <h2 className="text-xl font-semibold text-gray-800 mb-4 flex items-center">
+          🌐 שפה
+        </h2>
+        <div className="space-y-4">
+          <SettingSelect
+            label="שפת האפליקציה"
+            description="השפה העיקרית"
+            value={language}
+            options={[
+              { value: 'he', label: 'עברית' },
+              { value: 'en', label: 'English' },
+            ]}
+            onChange={(v) => onChange('preferred_language', v)}
+            disabled={disabled}
+          />
+        </div>
+      </div>
+    </>
+  );
+}

--- a/gamesformykids/components/settings/AudioSection.tsx
+++ b/gamesformykids/components/settings/AudioSection.tsx
@@ -1,0 +1,52 @@
+import { SettingToggle } from './SettingToggle';
+
+interface Props {
+  soundEnabled: boolean;
+  musicEnabled: boolean;
+  notificationsEnabled: boolean;
+  onChange: (key: string, value: boolean) => void;
+  disabled: boolean;
+}
+
+export function AudioSection({ soundEnabled, musicEnabled, notificationsEnabled, onChange, disabled }: Props) {
+  return (
+    <>
+      <div className="bg-white rounded-2xl shadow-lg p-6">
+        <h2 className="text-xl font-semibold text-gray-800 mb-4 flex items-center">
+          🔊 הגדרות שמע
+        </h2>
+        <div className="space-y-4">
+          <SettingToggle
+            label="צלילי משחק"
+            description="הפעלת צלילים במשחקים"
+            checked={soundEnabled}
+            onChange={(v) => onChange('sound_enabled', v)}
+            disabled={disabled}
+          />
+          <SettingToggle
+            label="מוזיקת רקע"
+            description="הפעלת מוזיקה ברקע"
+            checked={musicEnabled}
+            onChange={(v) => onChange('music_enabled', v)}
+            disabled={disabled}
+          />
+        </div>
+      </div>
+
+      <div className="bg-white rounded-2xl shadow-lg p-6">
+        <h2 className="text-xl font-semibold text-gray-800 mb-4 flex items-center">
+          🔔 הגדרות התראות
+        </h2>
+        <div className="space-y-4">
+          <SettingToggle
+            label="התראות משחק"
+            description="התראות על הישגים והתקדמות"
+            checked={notificationsEnabled}
+            onChange={(v) => onChange('notifications_enabled', v)}
+            disabled={disabled}
+          />
+        </div>
+      </div>
+    </>
+  );
+}

--- a/gamesformykids/components/settings/SettingSelect.tsx
+++ b/gamesformykids/components/settings/SettingSelect.tsx
@@ -1,0 +1,31 @@
+interface Props {
+  label: string;
+  description: string;
+  value: string;
+  options: { value: string; label: string }[];
+  onChange: (value: string) => void;
+  disabled?: boolean;
+}
+
+export function SettingSelect({ label, description, value, options, onChange, disabled }: Props) {
+  return (
+    <div className="p-3 border border-gray-200 rounded-lg">
+      <div className="mb-2">
+        <h3 className="font-medium text-gray-800">{label}</h3>
+        <p className="text-sm text-gray-600">{description}</p>
+      </div>
+      <select
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        disabled={disabled}
+        className="w-full p-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-purple-500"
+      >
+        {options.map((option) => (
+          <option key={option.value} value={option.value}>
+            {option.label}
+          </option>
+        ))}
+      </select>
+    </div>
+  );
+}

--- a/gamesformykids/components/settings/SettingToggle.tsx
+++ b/gamesformykids/components/settings/SettingToggle.tsx
@@ -1,0 +1,28 @@
+interface Props {
+  label: string;
+  description: string;
+  checked: boolean;
+  onChange: (checked: boolean) => void;
+  disabled?: boolean;
+}
+
+export function SettingToggle({ label, description, checked, onChange, disabled }: Props) {
+  return (
+    <div className="flex items-center justify-between p-3 border border-gray-200 rounded-lg">
+      <div>
+        <h3 className="font-medium text-gray-800">{label}</h3>
+        <p className="text-sm text-gray-600">{description}</p>
+      </div>
+      <label className="relative inline-flex items-center cursor-pointer">
+        <input
+          type="checkbox"
+          checked={checked}
+          onChange={(e) => onChange(e.target.checked)}
+          disabled={disabled}
+          className="sr-only peer"
+        />
+        <div className="w-11 h-6 bg-gray-200 peer-focus:outline-none peer-focus:ring-4 peer-focus:ring-purple-300 rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-purple-600" />
+      </label>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
Closes #91

Extracts a 253-line monolith into:
- `components/settings/SettingToggle.tsx` — reusable toggle primitive
- `components/settings/SettingSelect.tsx` — reusable select primitive
- `components/settings/AudioSection.tsx` — 🔊 sound / music + 🔔 notifications
- `components/settings/AppearanceSection.tsx` — 🎮 difficulty / theme + 🌐 language
- `components/settings/AccountSection.tsx` — 👤 profile link + sign-out

`page.tsx` is now ~70 lines: auth guards, a single `handleSettingChange`, and three section components.

## Test plan
- [ ] Open `/settings` — all sections render correctly
- [ ] Toggle sound/music/notifications — saves and updates
- [ ] Change difficulty/theme/language — saves and updates
- [ ] Sign out — works
- [ ] Not logged in — shows login prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)