### PR TITLE
refactor: consolidate Zustand stores with shared utilities

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -23,10 +23,12 @@
       "Bash(npm install *)",
       "Bash(cat vitest.config.ts)",
       "Bash(cat vitest.config.js)",
-      "Read(//c/Users/bensh/.claude/projects/c--Users-bensh-OneDrive--------------GamesForMyKids/memory/**)"
+      "Read(//c/Users/bensh/.claude/projects/c--Users-bensh-OneDrive--------------GamesForMyKids/memory/**)",
+      "Bash(git rm *)"
     ],
     "additionalDirectories": [
-      "c:\\Users\\bensh\\.claude\\projects\\c--Users-bensh-OneDrive--------------GamesForMyKids\\memory"
+      "c:\\Users\\bensh\\.claude\\projects\\c--Users-bensh-OneDrive--------------GamesForMyKids\\memory",
+      "c:\\Users\\bensh\\OneDrive\\שולחן העבודה\\GamesForMyKids\\gamesformykids\\hooks"
     ]
   }
 }

--- a/gamesformykids/lib/stores/achievementsStore.ts
+++ b/gamesformykids/lib/stores/achievementsStore.ts
@@ -11,13 +11,11 @@
 import { create } from 'zustand';
 import { devtools } from 'zustand/middleware';
 import type { Achievement } from '@/hooks/shared/progress/useAchievements';
+import { INITIAL_REMOTE_SLICE, type RemoteDataSlice } from './utils/RemoteDataSlice';
 
-// ── State ──────────────────────────────────────────────────
-export interface AchievementsState {
+// ── State ────────────────────────────────────────────────────────────
+export interface AchievementsState extends RemoteDataSlice {
   achievements: Achievement[];
-  loading: boolean;
-  error: string | null;
-  loadedForUserId: string | null;
 }
 
 // ── Actions ────────────────────────────────────────────────
@@ -32,9 +30,7 @@ export interface AchievementsStoreActions {
 
 const initialState: AchievementsState = {
   achievements: [],
-  loading: true,
-  error: null,
-  loadedForUserId: null,
+  ...INITIAL_REMOTE_SLICE,
 };
 
 // ── Store ──────────────────────────────────────────────────

--- a/gamesformykids/lib/stores/countingChallengeStore.ts
+++ b/gamesformykids/lib/stores/countingChallengeStore.ts
@@ -2,22 +2,7 @@
  * countingChallengeStore — stores the current CountingChallenge for visual rendering.
  * Written by useCountingGame; read by CountingChallengeBox.
  */
-import { create } from 'zustand';
-import { devtools } from 'zustand/middleware';
 import type { CountingChallenge } from '@/lib/types';
+import { createChallengeStore } from './utils/createChallengeStore';
 
-interface CountingChallengeState {
-  challenge: CountingChallenge | null;
-  setChallenge: (challenge: CountingChallenge | null) => void;
-}
-
-export const useCountingChallengeStore = create<CountingChallengeState>()(
-  devtools(
-    (set) => ({
-      challenge: null,
-      setChallenge: (challenge) =>
-        set({ challenge }, false, 'countingChallenge/setChallenge'),
-    }),
-    { name: 'CountingChallengeStore' },
-  ),
-);
+export const useCountingChallengeStore = createChallengeStore<CountingChallenge>('countingChallenge');

--- a/gamesformykids/lib/stores/gameProgressDataStore.ts
+++ b/gamesformykids/lib/stores/gameProgressDataStore.ts
@@ -11,13 +11,11 @@
 import { create } from 'zustand';
 import { devtools } from 'zustand/middleware';
 import type { GameProgress } from '@/hooks/shared/progress/useGameProgress';
+import { INITIAL_REMOTE_SLICE, type RemoteDataSlice } from './utils/RemoteDataSlice';
 
-// ── State ──────────────────────────────────────────────────
-export interface GameProgressDataState {
+// ── State ────────────────────────────────────────────────────────────
+export interface GameProgressDataState extends RemoteDataSlice {
   progress: GameProgress[];
-  loading: boolean;
-  error: string | null;
-  loadedForUserId: string | null;
 }
 
 // ── Actions ────────────────────────────────────────────────
@@ -32,9 +30,7 @@ export interface GameProgressDataActions {
 
 const initialState: GameProgressDataState = {
   progress: [],
-  loading: true,
-  error: null,
-  loadedForUserId: null,
+  ...INITIAL_REMOTE_SLICE,
 };
 
 // ── Store ──────────────────────────────────────────────────

--- a/gamesformykids/lib/stores/index.ts
+++ b/gamesformykids/lib/stores/index.ts
@@ -80,3 +80,11 @@ export { useGameAudioStore } from './gameAudioStore';
 
 // Favorites (favoriteIds — persisted in localStorage)
 export { useFavoritesStore } from './favoritesStore';
+
+// Challenge Stores (current challenge for visual rendering)
+export { useCountingChallengeStore } from './countingChallengeStore';
+export { useMathChallengeStore } from './mathChallengeStore';
+
+// Store utilities
+export type { RemoteDataSlice } from './utils/RemoteDataSlice';
+export type { ChallengeStoreState } from './utils/createChallengeStore';

--- a/gamesformykids/lib/stores/mathChallengeStore.ts
+++ b/gamesformykids/lib/stores/mathChallengeStore.ts
@@ -2,22 +2,7 @@
  * mathChallengeStore — stores the current MathChallenge for visual rendering.
  * Written by useMathGame; read by MathChallengeBox.
  */
-import { create } from 'zustand';
-import { devtools } from 'zustand/middleware';
 import type { MathChallenge } from '@/lib/types';
+import { createChallengeStore } from './utils/createChallengeStore';
 
-interface MathChallengeState {
-  challenge: MathChallenge | null;
-  setChallenge: (challenge: MathChallenge | null) => void;
-}
-
-export const useMathChallengeStore = create<MathChallengeState>()(
-  devtools(
-    (set) => ({
-      challenge: null,
-      setChallenge: (challenge) =>
-        set({ challenge }, false, 'mathChallenge/setChallenge'),
-    }),
-    { name: 'MathChallengeStore' },
-  ),
-);
+export const useMathChallengeStore = createChallengeStore<MathChallenge>('mathChallenge');

--- a/gamesformykids/lib/stores/userProfileStore.ts
+++ b/gamesformykids/lib/stores/userProfileStore.ts
@@ -12,15 +12,12 @@
 import { create } from 'zustand';
 import { devtools } from 'zustand/middleware';
 import type { UserProfile, UserSettings } from '@/hooks/shared/user/useUserProfile';
+import { INITIAL_REMOTE_SLICE, type RemoteDataSlice } from './utils/RemoteDataSlice';
 
-// ── State ──────────────────────────────────────────────────
-export interface UserProfileState {
+// ── State ────────────────────────────────────────────────────────────
+export interface UserProfileState extends RemoteDataSlice {
   profile: UserProfile | null;
   settings: UserSettings | null;
-  loading: boolean;
-  error: string | null;
-  /** tracks which userId's data is currently loaded */
-  loadedForUserId: string | null;
 }
 
 // ── Actions ────────────────────────────────────────────────
@@ -36,9 +33,7 @@ export interface UserProfileStoreActions {
 const initialState: UserProfileState = {
   profile: null,
   settings: null,
-  loading: true,
-  error: null,
-  loadedForUserId: null,
+  ...INITIAL_REMOTE_SLICE,
 };
 
 // ── Store ──────────────────────────────────────────────────

--- a/gamesformykids/lib/stores/utils/RemoteDataSlice.ts
+++ b/gamesformykids/lib/stores/utils/RemoteDataSlice.ts
@@ -1,0 +1,18 @@
+/**
+ * RemoteDataSlice — shared state shape for stores that fetch data
+ * from Supabase on behalf of a specific user.
+ *
+ * Used by: achievementsStore, gameProgressDataStore, userProfileStore
+ */
+export interface RemoteDataSlice {
+  loading: boolean;
+  error: string | null;
+  /** Tracks which userId's data is currently loaded — prevents duplicate fetches. */
+  loadedForUserId: string | null;
+}
+
+export const INITIAL_REMOTE_SLICE: RemoteDataSlice = {
+  loading: true,
+  error: null,
+  loadedForUserId: null,
+};

--- a/gamesformykids/lib/stores/utils/createChallengeStore.ts
+++ b/gamesformykids/lib/stores/utils/createChallengeStore.ts
@@ -1,0 +1,27 @@
+/**
+ * createChallengeStore — factory function for single-challenge stores.
+ *
+ * Usage:
+ *   export const useCountingChallengeStore = createChallengeStore<CountingChallenge>('countingChallenge');
+ *   export const useMathChallengeStore     = createChallengeStore<MathChallenge>('mathChallenge');
+ */
+import { create } from 'zustand';
+import { devtools } from 'zustand/middleware';
+
+export interface ChallengeStoreState<T> {
+  challenge: T | null;
+  setChallenge: (challenge: T | null) => void;
+}
+
+export function createChallengeStore<T>(storeName: string) {
+  return create<ChallengeStoreState<T>>()(
+    devtools(
+      (set) => ({
+        challenge: null,
+        setChallenge: (challenge) =>
+          set({ challenge }, false, `${storeName}/setChallenge`),
+      }),
+      { name: `${storeName}Store` },
+    ),
+  );
+}


### PR DESCRIPTION
Closes #115

Extracts shared patterns from 24 stores into reusable utilities.

changes:
- createChallengeStore factory for countingChallengeStore and mathChallengeStore
- RemoteDataSlice interface for achievementsStore, gameProgressDataStore, userProfileStore
- Added missing exports in index.ts

71/71 tests pass