### PR TITLE
refactor: consolidate quiz question components into QuizQuestionShell

### DIFF
--- a/gamesformykids/components/game/quiz/screens/ClockQuestion.tsx
+++ b/gamesformykids/components/game/quiz/screens/ClockQuestion.tsx
@@ -1,8 +1,7 @@
 'use client';
 
+import { QuizQuestionShell } from '@/components/game/quiz';
 import type { ClockQuestion as ClockQuestionType } from '@/lib/quiz/data/clock';
-import { answerButtonClass } from '@/lib/quiz/answerButtonClass';
-import { useQuizProgress } from '@/hooks/quiz/useQuizProgress';
 import ClockFace from './ClockFace';
 
 interface Props {
@@ -12,48 +11,28 @@ interface Props {
 }
 
 export default function ClockQuestion({ current, choices, onSelect }: Props) {
-  const { index, total, score, selected: rawSelected, isCorrect, next } = useQuizProgress();
-  const selected = rawSelected !== null ? Number(rawSelected) : null;
-
   return (
-    <div className="min-h-screen bg-gradient-to-br from-violet-50 to-indigo-100 p-4" dir="rtl">
-      <div className="max-w-lg mx-auto">
-        <div className="flex justify-between items-center mb-4">
-          <span className="font-bold text-indigo-700">{index + 1} / {total}</span>
-          <span className="font-bold text-indigo-700">⭐ {score * 10}</span>
-        </div>
-        <div className="h-2 bg-gray-200 rounded-full mb-5">
-          <div className="h-full bg-indigo-400 rounded-full transition-all" style={{ width: `${(index / total) * 100}%` }} />
-        </div>
-        <div className="bg-white rounded-3xl shadow-xl p-6 mb-5 text-center">
-          <p className="text-lg font-bold text-gray-600 mb-4">מה השעה?</p>
-          <div className="flex justify-center">
-            <ClockFace hour={current.hour} minute={current.minute} size={180} />
-          </div>
-        </div>
-        <div className="grid grid-cols-2 gap-3">
-          {choices.map(c => (
-            <button key={c.id} onClick={() => onSelect(c.id)} disabled={selected !== null}
-              className={`py-4 rounded-2xl font-bold text-lg transition-all active:scale-95 ${answerButtonClass(
-                c.id === current.id, c.id === selected, selected !== null,
-                'bg-white border-2 border-gray-200 text-gray-700 hover:border-indigo-400 hover:bg-indigo-50',
-              )}`}>
-              <div className="text-2xl font-black">{c.digital}</div>
-              <div className="text-sm opacity-75 mt-0.5">{c.description}</div>
-            </button>
-          ))}
-        </div>
-        {selected !== null && (
-          <div className="mt-4">
-            <div className={`rounded-2xl p-3 mb-3 text-center font-bold ${isCorrect ? 'bg-green-100 text-green-700' : 'bg-orange-100 text-orange-700'}`}>
-              {isCorrect ? `✅ נכון! ${current.digital} — ${current.description}` : `💙 ${current.digital} — ${current.description}`}
-            </div>
-            <button onClick={next} className="w-full py-4 rounded-2xl text-white font-bold text-xl bg-gradient-to-l from-violet-500 to-indigo-600 shadow-lg hover:opacity-90 active:scale-95 transition-all">
-              {index < total - 1 ? 'הבא ←' : 'תוצאות! 🎉'}
-            </button>
-          </div>
-        )}
+    <QuizQuestionShell
+      theme="indigo"
+      choices={choices.map(c => String(c.id))}
+      correctLabel={String(current.id)}
+      onSelect={(id) => onSelect(Number(id))}
+      renderChoice={(id) => {
+        const c = choices.find(ch => String(ch.id) === id)!;
+        return (
+          <>
+            <div className="text-2xl font-black">{c.digital}</div>
+            <div className="text-sm opacity-75 mt-0.5">{c.description}</div>
+          </>
+        );
+      }}
+      correctMsg={`✅ נכון! ${current.digital} — ${current.description}`}
+      wrongMsg={`💙 ${current.digital} — ${current.description}`}
+    >
+      <p className="text-lg font-bold text-gray-600 mb-4">מה השעה?</p>
+      <div className="flex justify-center">
+        <ClockFace hour={current.hour} minute={current.minute} size={180} />
       </div>
-    </div>
+    </QuizQuestionShell>
   );
 }

--- a/gamesformykids/components/game/quiz/screens/ColorMixQuestion.tsx
+++ b/gamesformykids/components/game/quiz/screens/ColorMixQuestion.tsx
@@ -1,8 +1,8 @@
 'use client';
 
+import { QuizQuestionShell } from '@/components/game/quiz';
+import { useQuizGameStore } from '@/lib/stores/quizGameStore';
 import type { ColorMix } from '@/lib/quiz/data/color-mix';
-import { answerButtonClass } from '@/lib/quiz/answerButtonClass';
-import { useQuizProgress } from '@/hooks/quiz/useQuizProgress';
 
 interface Props {
   mix: ColorMix;
@@ -10,63 +10,46 @@ interface Props {
   onSelect: (label: string) => void;
 }
 
-export default function ColorMixQuestion({ mix, choices, onSelect }: Props) {
-  const { index, total, score, selected, isCorrect, next } = useQuizProgress();
-
+function ResultCircle({ mix }: { mix: ColorMix }) {
+  const selected = useQuizGameStore(s => s.selected);
   return (
-    <div className="min-h-screen bg-gradient-to-br from-pink-50 via-purple-50 to-indigo-100 p-4" dir="rtl">
-      <div className="max-w-lg mx-auto">
-        <div className="flex justify-between items-center mb-4">
-          <span className="font-bold text-purple-700">{index + 1} / {total}</span>
-          <span className="font-bold text-purple-700">⭐ {score * 10}</span>
-        </div>
-        <div className="h-2 bg-gray-200 rounded-full mb-5">
-          <div className="h-full bg-purple-400 rounded-full transition-all" style={{ width: `${(index / total) * 100}%` }} />
-        </div>
-        <div className="bg-white rounded-3xl shadow-xl p-8 mb-5">
-          <p className="text-xl font-bold text-gray-700 text-center mb-5">מה מקבלים?</p>
-          <div className="flex items-center justify-center gap-4">
-            <div className="text-center">
-              <div className="w-20 h-20 rounded-full shadow-lg mx-auto mb-2 border-4 border-white ring-2 ring-gray-200" style={{ backgroundColor: mix.color1 }} />
-              <span className="text-sm font-bold text-gray-600">{mix.label1}</span>
-            </div>
-            <div className="text-4xl font-black text-gray-400">+</div>
-            <div className="text-center">
-              <div className="w-20 h-20 rounded-full shadow-lg mx-auto mb-2 border-4 border-white ring-2 ring-gray-200" style={{ backgroundColor: mix.color2 }} />
-              <span className="text-sm font-bold text-gray-600">{mix.label2}</span>
-            </div>
-            <div className="text-4xl font-black text-gray-400">=</div>
-            <div className="text-center">
-              <div className="w-20 h-20 rounded-full shadow-lg mx-auto mb-2 border-4 border-white ring-2 ring-gray-200 flex items-center justify-center"
-                style={{ backgroundColor: selected ? mix.result : '#f3f4f6' }}>
-                {!selected && <span className="text-3xl">❓</span>}
-              </div>
-              <span className="text-sm font-bold text-gray-600">{selected ? mix.resultLabel : '?'}</span>
-            </div>
-          </div>
-        </div>
-        <div className="grid grid-cols-2 gap-3">
-          {choices.map((label, i) => (
-            <button key={i} onClick={() => onSelect(label)} disabled={!!selected}
-              className={`py-4 px-3 rounded-2xl font-bold text-lg transition-all active:scale-95 ${answerButtonClass(
-                label === mix.resultLabel, label === selected, !!selected,
-                'bg-white border-2 border-gray-200 text-gray-700 hover:border-purple-400 hover:bg-purple-50',
-              )}`}>
-              {label}
-            </button>
-          ))}
-        </div>
-        {selected && (
-          <div className="mt-4">
-            <div className={`rounded-2xl p-3 mb-3 text-center font-bold ${isCorrect ? 'bg-green-100 text-green-700' : 'bg-orange-100 text-orange-700'}`}>
-              {isCorrect ? `✅ נכון! ${mix.label1} + ${mix.label2} = ${mix.resultLabel}` : `💙 ${mix.label1} + ${mix.label2} = ${mix.resultLabel}`}
-            </div>
-            <button onClick={next} className="w-full py-4 rounded-2xl text-white font-bold text-xl bg-gradient-to-l from-pink-500 via-purple-500 to-indigo-500 shadow-lg hover:opacity-90 active:scale-95 transition-all">
-              {index < total - 1 ? 'הבא ←' : 'תוצאות! 🎉'}
-            </button>
-          </div>
-        )}
+    <div className="text-center">
+      <div
+        className="w-20 h-20 rounded-full shadow-lg mx-auto mb-2 border-4 border-white ring-2 ring-gray-200 flex items-center justify-center"
+        style={{ backgroundColor: selected ? mix.result : '#f3f4f6' }}
+      >
+        {!selected && <span className="text-3xl">❓</span>}
       </div>
+      <span className="text-sm font-bold text-gray-600">{selected ? mix.resultLabel : '?'}</span>
     </div>
   );
 }
+
+export default function ColorMixQuestion({ mix, choices, onSelect }: Props) {
+  return (
+    <QuizQuestionShell
+      theme="purple"
+      choices={choices}
+      correctLabel={mix.resultLabel}
+      onSelect={onSelect}
+      correctMsg={`✅ נכון! ${mix.label1} + ${mix.label2} = ${mix.resultLabel}`}
+      wrongMsg={`💙 ${mix.label1} + ${mix.label2} = ${mix.resultLabel}`}
+    >
+      <p className="text-xl font-bold text-gray-700 text-center mb-5">מה מקבלים?</p>
+      <div className="flex items-center justify-center gap-4">
+        <div className="text-center">
+          <div className="w-20 h-20 rounded-full shadow-lg mx-auto mb-2 border-4 border-white ring-2 ring-gray-200" style={{ backgroundColor: mix.color1 }} />
+          <span className="text-sm font-bold text-gray-600">{mix.label1}</span>
+        </div>
+        <div className="text-4xl font-black text-gray-400">+</div>
+        <div className="text-center">
+          <div className="w-20 h-20 rounded-full shadow-lg mx-auto mb-2 border-4 border-white ring-2 ring-gray-200" style={{ backgroundColor: mix.color2 }} />
+          <span className="text-sm font-bold text-gray-600">{mix.label2}</span>
+        </div>
+        <div className="text-4xl font-black text-gray-400">=</div>
+        <ResultCircle mix={mix} />
+      </div>
+    </QuizQuestionShell>
+  );
+}
+

--- a/gamesformykids/components/game/quiz/screens/GeographyQuestion.tsx
+++ b/gamesformykids/components/game/quiz/screens/GeographyQuestion.tsx
@@ -1,9 +1,8 @@
 'use client';
 
+import { QuizQuestionShell } from '@/components/game/quiz';
 import type { GeoQuestion } from '@/lib/quiz/useGeographyGame';
 import { getGeoPrompt, getChoiceLabel } from '@/lib/quiz/data/geography';
-import { answerButtonClass } from '@/lib/quiz/answerButtonClass';
-import { useQuizProgress } from '@/hooks/quiz/useQuizProgress';
 
 interface Props {
   current: GeoQuestion;
@@ -11,48 +10,20 @@ interface Props {
 }
 
 export default function GeographyQuestion({ current, onSelect }: Props) {
-  const { index, total, score, selected, isCorrect, next } = useQuizProgress();
-
   const { country, mode, choices } = current;
-  const prompt = getGeoPrompt(country, mode);
-
   return (
-    <div className="min-h-screen bg-gradient-to-br from-teal-50 to-cyan-100 p-4" dir="rtl">
-      <div className="max-w-xl mx-auto">
-        <div className="flex justify-between items-center mb-4">
-          <span className="font-bold text-teal-700">שאלה {index + 1} / {total}</span>
-          <span className="font-bold text-teal-700">⭐ {score}</span>
-        </div>
-        <div className="h-2 bg-gray-200 rounded-full mb-5">
-          <div className="h-full bg-teal-400 rounded-full transition-all" style={{ width: `${(index / total) * 100}%` }} />
-        </div>
-        <div className="bg-white rounded-3xl shadow-xl p-6 mb-5 text-center">
-          <p className="text-xl font-bold text-gray-800">{prompt}</p>
-        </div>
-        <div className="grid grid-cols-2 gap-3">
-          {choices.map(c => (
-            <button key={c.id} onClick={() => onSelect(c.id)} disabled={!!selected}
-              className={`py-4 px-3 rounded-2xl font-semibold text-lg transition-all active:scale-95 ${answerButtonClass(
-                c.id === country.id,
-                c.id === selected,
-                !!selected,
-                'bg-white border-2 border-gray-200 text-gray-700 hover:border-teal-400',
-              )}`}>
-              {getChoiceLabel(c, mode)}
-            </button>
-          ))}
-        </div>
-        {selected && (
-          <div className="mt-4">
-            <div className={`rounded-2xl p-3 mb-3 text-center font-bold ${isCorrect ? 'bg-green-100 text-green-700' : 'bg-orange-100 text-orange-700'}`}>
-              {isCorrect ? `✅ נכון! ${country.flag} ${country.name} — ${country.capital}` : `💙 ${country.flag} ${country.name} — ${country.capital}, ${country.continent}`}
-            </div>
-            <button onClick={next} className="w-full py-4 rounded-2xl text-white font-bold text-xl bg-gradient-to-l from-teal-500 to-cyan-600 hover:opacity-90 active:scale-95 transition-all">
-              {index < total - 1 ? 'שאלה הבאה ←' : 'תוצאות! 🎉'}
-            </button>
-          </div>
-        )}
-      </div>
-    </div>
+    <QuizQuestionShell
+      theme="teal"
+      choices={choices.map(c => c.id)}
+      correctLabel={country.id}
+      onSelect={onSelect}
+      cols={2}
+      renderChoice={(id) => getChoiceLabel(choices.find(c => c.id === id)!, mode)}
+      correctMsg={`✅ נכון! ${country.flag} ${country.name} — ${country.capital}`}
+      wrongMsg={`💙 ${country.flag} ${country.name} — ${country.capital}, ${country.continent}`}
+    >
+      <p className="text-xl font-bold text-gray-800">{getGeoPrompt(country, mode)}</p>
+    </QuizQuestionShell>
   );
 }
+

--- a/gamesformykids/components/game/quiz/screens/HumanBodyQuestion.tsx
+++ b/gamesformykids/components/game/quiz/screens/HumanBodyQuestion.tsx
@@ -1,8 +1,7 @@
 'use client';
 
+import { QuizQuestionShell } from '@/components/game/quiz';
 import type { BodyQuestion } from '@/lib/quiz/data/body';
-import { answerButtonClass } from '@/lib/quiz/answerButtonClass';
-import { useQuizProgress } from '@/hooks/quiz/useQuizProgress';
 
 interface Props {
   currentQuestion: BodyQuestion;
@@ -11,43 +10,20 @@ interface Props {
 }
 
 export default function HumanBodyQuestion({ currentQuestion, choices, onSelect }: Props) {
-  const { index, total, score, selected, isCorrect, next } = useQuizProgress();
-
   return (
-    <div className="min-h-screen bg-gradient-to-br from-red-50 to-pink-100 flex flex-col p-4" dir="rtl">
-      <div className="flex justify-between items-center mb-4">
-        <span className="font-bold text-red-600">❤️ {score * 10} | שאלה {index + 1}/{total}</span>
-      </div>
-      <div className="flex-1 flex flex-col items-center justify-center">
-        <div className="bg-white rounded-2xl shadow-lg p-6 w-full max-w-md mb-6 text-center">
-          <div className="text-7xl mb-3">{currentQuestion.emoji}</div>
-          <div className="inline-block px-3 py-1 rounded-full text-sm font-bold text-white bg-red-400 mb-3">{currentQuestion.category}</div>
-          <p className="text-lg font-bold text-gray-800">מה התפקיד של: <span className="text-red-600">{currentQuestion.part}</span>?</p>
-          {selected !== null && (
-            <div className={`mt-4 p-3 rounded-xl text-sm font-bold ${isCorrect ? 'bg-green-100 text-green-700' : 'bg-red-100 text-red-700'}`}>
-              {isCorrect ? '✅ נכון!' : `❌ התשובה: ${currentQuestion.function}`}
-            </div>
-          )}
-        </div>
-        <div className="grid grid-cols-1 gap-3 w-full max-w-md">
-          {choices.map(choice => (
-            <button key={choice} onClick={() => onSelect(choice)} disabled={selected !== null}
-              className={`py-3 px-4 rounded-xl font-bold text-right shadow active:scale-95 transition-all ${answerButtonClass(
-                choice === currentQuestion.function,
-                choice === selected,
-                selected !== null,
-                'bg-white text-gray-800 border-2 border-red-200 hover:border-red-400',
-              )}`}>
-              {choice}
-            </button>
-          ))}
-        </div>
-        {selected !== null && (
-          <button onClick={next} className="mt-6 px-8 py-3 bg-red-500 text-white rounded-xl font-bold shadow-lg active:scale-95">
-            {index + 1 < total ? 'הבא ←' : 'סיום 🏁'}
-          </button>
-        )}
-      </div>
-    </div>
+    <QuizQuestionShell
+      theme="red"
+      choices={choices}
+      correctLabel={currentQuestion.function}
+      onSelect={onSelect}
+      cols={1}
+      correctMsg="✅ נכון!"
+      wrongMsg={`❌ התשובה: ${currentQuestion.function}`}
+    >
+      <div className="text-7xl mb-3">{currentQuestion.emoji}</div>
+      <div className="inline-block px-3 py-1 rounded-full text-sm font-bold text-white bg-red-400 mb-3">{currentQuestion.category}</div>
+      <p className="text-lg font-bold text-gray-800">מה התפקיד של: <span className="text-red-600">{currentQuestion.part}</span>?</p>
+    </QuizQuestionShell>
   );
 }
+

--- a/gamesformykids/components/game/quiz/screens/SequencesQuestion.tsx
+++ b/gamesformykids/components/game/quiz/screens/SequencesQuestion.tsx
@@ -1,8 +1,7 @@
 'use client';
 
+import { QuizQuestionShell } from '@/components/game/quiz';
 import type { SequenceLevel, SequenceQuestion } from '@/lib/quiz/data/sequences';
-import { answerButtonClass } from '@/lib/quiz/answerButtonClass';
-import { useQuizProgress } from '@/hooks/quiz/useQuizProgress';
 
 interface Props {
   level: SequenceLevel;
@@ -12,57 +11,29 @@ interface Props {
 }
 
 export default function SequencesQuestion({ level, current, choices, onSelect }: Props) {
-  const { index, total, score, selected: rawSelected, isCorrect, next } = useQuizProgress();
-  const selected = rawSelected !== null ? Number(rawSelected) : null;
-
   return (
-    <div className="min-h-screen bg-gradient-to-br from-sky-50 to-cyan-100 p-4" dir="rtl">
-      <div className="max-w-lg mx-auto">
-        <div className="flex justify-between items-center mb-4">
-          <span className="font-bold text-cyan-700">{level.label} | {index + 1} / {total}</span>
-          <span className="font-bold text-cyan-700">⭐ {score * 10}</span>
-        </div>
-        <div className="h-2 bg-gray-200 rounded-full mb-5">
-          <div className="h-full bg-cyan-400 rounded-full transition-all" style={{ width: `${(index / total) * 100}%` }} />
-        </div>
-        <div className="bg-white rounded-3xl shadow-xl p-6 mb-5">
-          <p className="text-sm font-semibold text-gray-400 text-center mb-4">מה המספר הבא?</p>
-          <div className="flex flex-wrap justify-center gap-3 items-center">
-            {current.sequence.map((n, i) => (
-              <div key={i} className="flex items-center gap-2">
-                <div className="w-14 h-14 rounded-2xl bg-cyan-100 border-2 border-cyan-300 flex items-center justify-center font-black text-xl text-cyan-800">{n}</div>
-                {i < current.sequence.length - 1 && <span className="text-gray-400 font-bold">،</span>}
-              </div>
-            ))}
-            <span className="text-gray-400 font-bold text-2xl">,</span>
-            <div className="w-14 h-14 rounded-2xl bg-indigo-100 border-2 border-indigo-300 flex items-center justify-center text-3xl">
-              {selected !== null ? (isCorrect ? '✅' : '❌') : '❓'}
-            </div>
+    <QuizQuestionShell
+      theme="sky"
+      choices={choices.map(String)}
+      correctLabel={String(current.next)}
+      onSelect={(v) => onSelect(Number(v))}
+      renderChoice={(v) => <span className="text-3xl font-black">{v}</span>}
+      correctMsg={`✅ נכון! הסדרה: ${[...current.sequence, current.next].join(', ')}`}
+      wrongMsg={`💙 הנכון: ${current.next}`}
+      funFact={`כלל: ${current.rule}`}
+    >
+      <p className="text-sm font-semibold text-gray-400 text-center mb-4">מה המספר הבא? <span className="text-xs text-indigo-400">{level.label}</span></p>
+      <div className="flex flex-wrap justify-center gap-3 items-center">
+        {current.sequence.map((n, i) => (
+          <div key={i} className="flex items-center gap-2">
+            <div className="w-14 h-14 rounded-2xl bg-cyan-100 border-2 border-cyan-300 flex items-center justify-center font-black text-xl text-cyan-800">{n}</div>
+            {i < current.sequence.length - 1 && <span className="text-gray-400 font-bold">،</span>}
           </div>
-          {selected !== null && <p className="text-center mt-3 text-sm text-gray-500">כלל: {current.rule}</p>}
-        </div>
-        <div className="grid grid-cols-2 gap-3">
-          {choices.map((n, i) => (
-            <button key={i} onClick={() => onSelect(n)} disabled={selected !== null}
-              className={`py-5 rounded-2xl font-black text-3xl transition-all active:scale-95 ${answerButtonClass(
-                n === current.next, n === selected, selected !== null,
-                'bg-white border-2 border-gray-200 text-gray-700 hover:border-cyan-400',
-              )}`}>
-              {n}
-            </button>
-          ))}
-        </div>
-        {selected !== null && (
-          <div className="mt-4">
-            <div className={`rounded-2xl p-3 mb-3 text-center font-bold ${isCorrect ? 'bg-green-100 text-green-700' : 'bg-orange-100 text-orange-700'}`}>
-              {isCorrect ? `✅ נכון! הסדרה: ${[...current.sequence, current.next].join(', ')}` : `💙 הנכון: ${current.next} (כלל: ${current.rule})`}
-            </div>
-            <button onClick={next} className="w-full py-4 rounded-2xl text-white font-bold text-xl bg-gradient-to-l from-cyan-500 to-sky-600 shadow-lg hover:opacity-90 active:scale-95 transition-all">
-              {index < total - 1 ? 'הבא ←' : 'תוצאות! 🎉'}
-            </button>
-          </div>
-        )}
+        ))}
+        <span className="text-gray-400 font-bold text-2xl">,</span>
+        <div className="w-14 h-14 rounded-2xl bg-indigo-100 border-2 border-indigo-300 flex items-center justify-center text-3xl">❓</div>
       </div>
-    </div>
+    </QuizQuestionShell>
   );
 }
+


### PR DESCRIPTION
Closes #116

Converts 5 custom quiz question components to use the shared QuizQuestionShell wrapper.

## Changes
- GeographyQuestion: teal theme, 2-col grid, custom choice labels
- HumanBodyQuestion: red theme, 1-col grid
- ClockQuestion: indigo theme, renderChoice shows digital + description, ClockFace in content
- ColorMixQuestion: purple theme, inner ResultCircle component reads store for live result reveal
- SequencesQuestion: sky theme, sequence display in content, rule shown as funFact

## Result
- TriviaQuestion and ScienceQuestion already used QuizQuestionShell
- All 7 quiz question components now use QuizQuestionShell
- Removed ~120 lines of duplicate layout (progress bar, gradient bg, answer buttons, next button)
- 71/71 tests pass