### PR TITLE
fix: replace any type in gameHooksMap with proper typed interface

### DIFF
--- a/gamesformykids/components/game/universal/ultimate-game/GameLogicSync.tsx
+++ b/gamesformykids/components/game/universal/ultimate-game/GameLogicSync.tsx
@@ -21,9 +21,10 @@ function GameLogicSyncInner() {
       resetGame: gameHookResult.resetGame,
       handleItemClick: gameHookResult.handleItemClick,
       speakItemName: gameHookResult.speakItemName,
-      hints: gameHookResult.hints?.map(
-        (h: string | { text?: string }) => (typeof h === 'string' ? h : h.text || ''),
-      ) ?? [],
+      hints: gameHookResult.hints?.map((h) => {
+        const hint = h as string | { text?: string };
+        return typeof hint === 'string' ? hint : hint.text ?? '';
+      }) ?? [],
       hasMoreHints: gameHookResult.hasMoreHints ?? false,
       showNextHint: gameHookResult.showNextHint ?? (() => {}),
       currentAccuracy: gameHookResult.currentAccuracy ?? 0,

--- a/gamesformykids/hooks/shared/game-state/useAutoGame.ts
+++ b/gamesformykids/hooks/shared/game-state/useAutoGame.ts
@@ -69,13 +69,13 @@ export function useAutoGame(): GameLogicState {
     timeSpent: 0,
     totalQuestions: 0,
     correctAnswers: 0,
-    currentAccuracy,
+    currentAccuracy: currentAccuracy ?? 0,
 
     // Game Actions
-    startGame,
-    resetGame,
-    handleItemClick,
-    speakItemName,
+    startGame: startGame ?? (() => {}),
+    resetGame: resetGame ?? (() => {}),
+    handleItemClick: handleItemClick ?? (() => {}),
+    speakItemName: speakItemName ?? (() => {}),
     pauseGame: () => {},
     resumeGame: () => {},
     resetProgress: () => {},
@@ -84,9 +84,10 @@ export function useAutoGame(): GameLogicState {
     handleWrongAnswer: () => {},
 
     // Enhanced Features
-    hints: hints?.map((hint: string | { text?: string }) =>
-      typeof hint === 'string' ? hint : hint.text || '',
-    ),
+    hints: hints?.map((hint) => {
+      const h = hint as string | { text?: string };
+      return typeof h === 'string' ? h : h.text ?? '';
+    }),
     hasMoreHints,
     showNextHint,
     progressStats: progressStats ? (progressStats as unknown as Record<string, unknown>) : undefined,

--- a/gamesformykids/lib/constants/gameHooksMap.ts
+++ b/gamesformykids/lib/constants/gameHooksMap.ts
@@ -9,9 +9,20 @@ import { GAME_ITEMS_MAP } from "./gameItemsMap";
 
 import { useMathGame } from "@/app/games/math/hooks/useMathGame";
 import { useCountingGame } from "@/app/games/counting/useCountingGame";
+import type { BaseGameItem } from "@/lib/types/core/base";
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-type AnyGameHookFn = () => any;
+type AnyGameHookFn = () => {
+  startGame?: () => void | Promise<void>;
+  resetGame?: () => void;
+  handleItemClick?: (item: BaseGameItem) => void | Promise<void>;
+  speakItemName?: (name: string) => void | Promise<void>;
+  hints?: unknown[];
+  hasMoreHints?: boolean;
+  showNextHint?: () => void;
+  currentAccuracy?: number;
+  progressStats?: unknown;
+  [key: string]: unknown;
+};
 
 // טיפוס עבור משחקים שתומכים ב-AutoGamePage בלבד
 export type AutoGameType =


### PR DESCRIPTION
Closes #58`n`nReplaces `any` return type in `gameHooksMap.ts` with a proper typed interface.`n`n## Changes`n- `gameHooksMap.ts`: removed `eslint-disable-next-line @typescript-eslint/no-explicit-any` + replaced `() => any` with a typed interface containing known hook return fields + index signature`n- `useAutoGame.ts`: added `?? fallbacks` for optional hook fields (startGame, resetGame, handleItemClick, speakItemName, currentAccuracy)`n- `GameLogicSync.tsx`: cast hints elements to `string | { text?: string }` via `as``n`n## Note`nThe `any` was used as a catch-all for heterogeneous game hooks. The fix uses an explicit interface with `[key: string]: unknown` index signature + typed known fields — no `eslint-disable` needed.`n`n71/71 tests pass