### PR TITLE
cleanup: remove 80 unused exported types from lib/types/ (#52)

### DIFF
--- a/gamesformykids/components/shared/buttons/SimpleGameStartButton.tsx
+++ b/gamesformykids/components/shared/buttons/SimpleGameStartButton.tsx
@@ -1,7 +1,6 @@
 import { useGameActions } from '@/hooks';
-import { ComponentTypes } from '@/lib/types';
 
-type SimpleGameStartButtonProps = ComponentTypes.SimpleGameStartButtonProps & {
+type SimpleGameStartButtonProps = {
   fromColor?: string;
   toColor?: string;
   text?: string;

--- a/gamesformykids/lib/types/components/buttons.ts
+++ b/gamesformykids/lib/types/components/buttons.ts
@@ -5,12 +5,4 @@
  */
 
 // ייבוא מהטיפוסים המרכזיים
-export type { 
-  BaseButtonProps,
-  ButtonProps, 
-  GameStartButtonProps 
-} from '../ui/core';
-
-// אליאס לתאימות לאחור
-import type { GameStartButtonProps } from '../ui/core';
-export type SimpleGameStartButtonProps = GameStartButtonProps;
+export type { ButtonProps } from '../ui/core';

--- a/gamesformykids/lib/types/components/cards.ts
+++ b/gamesformykids/lib/types/components/cards.ts
@@ -5,32 +5,15 @@
  */
 
 import { BaseGameItem } from '../core/base';
-import { ColorItem, ShapeItem, NumberItem } from '../games/items';
-
-import type { Nameable, Translatable, Visualizable, Audioable } from '../core/base';
+import { ColorItem } from '../games/items';
 
 // ===== SOLID Principle: Single Responsibility =====
-// Using type aliases instead of empty interfaces for better DRY
 
-/**
- * תוכן טקסטואלי - type alias for clarity
- */
-export type ItemTextContent = Translatable;
+type ItemTextContent = { readonly hebrew: string; readonly english: string; readonly plural?: string; };
+type ItemVisuals = { readonly emoji: string; readonly color: string; };
+type ItemAudio = { readonly sound?: number[]; };
 
-/**
- * מאפיינים ויזואליים בסיסיים - type alias for clarity
- */
-export type ItemVisuals = Visualizable;
-
-/**
- * מאפיינים קוליים - type alias for clarity
- */
-export type ItemAudio = Audioable;
-
-/**
- * מאפיינים גיאומטריים - עקרון Single Responsibility
- */
-export interface ShapeProperties {
+interface ShapeProperties {
   readonly shape: string;
   readonly shapeHebrew: string;
   readonly svg: string;
@@ -39,7 +22,7 @@ export interface ShapeProperties {
 /**
  * מאפיינים של ערך - עקרון Single Responsibility
  */
-export interface ValueProperties {
+interface ValueProperties {
   readonly value: string;
   readonly tailwindClass?: string;
 }
@@ -47,13 +30,20 @@ export interface ValueProperties {
 /**
  * פריט צורה צבעונית - עקרון Interface Segregation
  */
-export interface ColoredShapeItem extends 
-  Nameable,
-  ItemTextContent,
-  ItemVisuals,
-  ItemAudio,
-  ShapeProperties,
-  ValueProperties {}
+export interface ColoredShapeItem {
+  readonly name: string;
+  readonly hebrew: string;
+  readonly english: string;
+  readonly plural?: string;
+  readonly emoji: string;
+  readonly color: string;
+  readonly sound?: number[];
+  readonly shape: string;
+  readonly shapeHebrew: string;
+  readonly svg: string;
+  readonly value: string;
+  readonly tailwindClass?: string;
+}
 
 // ===== SOLID Principle: Open/Closed =====
 
@@ -61,7 +51,7 @@ export interface ColoredShapeItem extends
  * טייפ union למיני פריטים - עקרון Open/Closed
  * ניתן להוסיף טייפים חדשים מבלי לשנות קוד קיים
  */
-export type GameItemType = BaseGameItem | ColorItem | ShapeItem | NumberItem | ColoredShapeItem;
+export type GameItemType = BaseGameItem | ColorItem | ColoredShapeItem;
 
 // ===== SOLID Principle: Interface Segregation =====
 
@@ -78,7 +68,7 @@ export interface CardContent {
 /**
  * עיצוב הכרטיס
  */
-export interface CardAppearance {
+interface CardAppearance {
   size?: "small" | "medium" | "large";
   shape?: "rounded" | "circle" | "square";
   variant?: 'default' | 'large' | 'compact' | 'simple' | 'advanced' | 'auto';
@@ -107,7 +97,7 @@ export interface CardAppearance {
 /**
  * התנהגות הכרטיס
  */
-export interface CardBehavior {
+interface CardBehavior {
   animationEnabled?: boolean;
   autoSpeak?: boolean;
   onSpeak?: () => void;
@@ -117,7 +107,7 @@ export interface CardBehavior {
 /**
  * תוכן מותאם אישית
  */
-export interface CardCustomContent {
+interface CardCustomContent {
   customContent?: React.ReactNode;
   customDecoration?: React.ReactNode;
   icon?: React.ReactNode;
@@ -132,7 +122,7 @@ export interface CardCustomContent {
 /**
  * Props בסיסיים לכל כרטיס
  */
-export interface BaseCardProps extends CardAppearance, CardBehavior, CardCustomContent {
+interface BaseCardProps extends CardAppearance, CardBehavior, CardCustomContent {
   className?: string;
   isSelected?: boolean;
 }

--- a/gamesformykids/lib/types/components/cards.ts
+++ b/gamesformykids/lib/types/components/cards.ts
@@ -7,26 +7,6 @@
 import { BaseGameItem } from '../core/base';
 import { ColorItem } from '../games/items';
 
-// ===== SOLID Principle: Single Responsibility =====
-
-type ItemTextContent = { readonly hebrew: string; readonly english: string; readonly plural?: string; };
-type ItemVisuals = { readonly emoji: string; readonly color: string; };
-type ItemAudio = { readonly sound?: number[]; };
-
-interface ShapeProperties {
-  readonly shape: string;
-  readonly shapeHebrew: string;
-  readonly svg: string;
-}
-
-/**
- * מאפיינים של ערך - עקרון Single Responsibility
- */
-interface ValueProperties {
-  readonly value: string;
-  readonly tailwindClass?: string;
-}
-
 /**
  * פריט צורה צבעונית - עקרון Interface Segregation
  */

--- a/gamesformykids/lib/types/components/displays.ts
+++ b/gamesformykids/lib/types/components/displays.ts
@@ -4,7 +4,7 @@
  * ===============================================
  */
 
-export interface GameProgressStats {
+interface GameProgressStats {
   totalItems: number;
   completedItems: number;
   averageTime: number;

--- a/gamesformykids/lib/types/components/feedback.ts
+++ b/gamesformykids/lib/types/components/feedback.ts
@@ -4,7 +4,7 @@
  * ===============================================
  */
 
-export interface Hint {
+interface Hint {
   id: string;
   text: string;
   type: 'tip' | 'warning' | 'info';

--- a/gamesformykids/lib/types/contexts/game-config.ts
+++ b/gamesformykids/lib/types/contexts/game-config.ts
@@ -14,7 +14,7 @@ export type { GameUIConfig } from '../../constants/ui/gameConfigs';
 /**
  * מידע משחק נוכחי - עקרון Single Responsibility
  */
-export interface CurrentGameInfo {
+interface CurrentGameInfo {
   readonly gameType: GameType | null;
   readonly config: GameUIConfig | null;
   readonly items: BaseGameItem[] | null;
@@ -25,7 +25,7 @@ export interface CurrentGameInfo {
 /**
  * מצב תקינות המשחק - עקרון Single Responsibility
  */
-export interface GameValidationStatus {
+interface GameValidationStatus {
   readonly isSupported: boolean;
   readonly isReady: boolean;
   readonly error: string | null;
@@ -38,12 +38,4 @@ export interface GameConfigContextValue extends
   CurrentGameInfo,
   GameValidationStatus {}
 
-/**
- * Props לProvider של GameConfig Context
- */
-export interface GameConfigProviderProps {
-  readonly children: React.ReactNode;
-  readonly gameType?: GameType;
-}
-
-// הערה: GameConfigProviderProps מוגדר כאן לפי עקרון DRY
+// GameConfigProviderProps removed (unused)

--- a/gamesformykids/lib/types/contexts/game-type.ts
+++ b/gamesformykids/lib/types/contexts/game-type.ts
@@ -6,12 +6,13 @@
 
 import type { GameStep } from '../components';
 import { GameType, BaseGameItem } from '../core/base';
-import type { TitledEntity } from '../core/base';
 
 /**
  * הגדרת תצורת UI למשחק - עקרון Single Responsibility + DRY
  */
-export interface GameUIConfiguration extends TitledEntity {
+interface GameUIConfiguration {
+  readonly title: string;
+  readonly description?: string;
   readonly instructions?: readonly string[];
   readonly subTitle?: string;
   readonly itemsTitle?: string;
@@ -60,7 +61,7 @@ export interface GameTypeActions {
 /**
  * כלים עזר לסוג משחק - עקרון Single Responsibility
  */
-export interface GameTypeUtilities {
+interface GameTypeUtilities {
   readonly isGameSupported: (gameType: string) => boolean;
   readonly getGameConfig: (gameType: GameType) => GameUIConfiguration | null;
   readonly getGameItems: (gameType: GameType) => readonly BaseGameItem[] | null;

--- a/gamesformykids/lib/types/contexts/index.ts
+++ b/gamesformykids/lib/types/contexts/index.ts
@@ -6,8 +6,7 @@
 
 // ייצוא ממשקים מתוקנים
 export type { 
-  GameConfigContextValue,
-  GameConfigProviderProps
+  GameConfigContextValue
 } from './game-config';
 
 export type {

--- a/gamesformykids/lib/types/contexts/universal-game.ts
+++ b/gamesformykids/lib/types/contexts/universal-game.ts
@@ -6,7 +6,6 @@
 
 import { ComponentType } from 'react';
 import { BaseGameItem, GameType } from '../core/base';
-import type { ProgressModalState } from '../core/base';
 
 // הערה: טיפוסים משותפים קיימים גם ב-hooks/game-state, יש להוסיף הפנייה מתאימה
 import { GameItemCardProps } from '../hooks/game-state';
@@ -21,7 +20,7 @@ import type { GameUIConfig } from './game-config';
 /**
  * מצב משחק עם סטטיסטיקות - עקרון Single Responsibility
  */
-export interface GameStatistics {
+interface GameStatistics {
   readonly score: number;
   readonly level: number;
   readonly currentAccuracy: number;
@@ -30,7 +29,7 @@ export interface GameStatistics {
 /**
  * מצב משחק נוכחי - עקרון Single Responsibility
  */
-export interface GameCurrentState {
+interface GameCurrentState {
   readonly isPlaying: boolean;
   readonly showCelebration: boolean;
   readonly currentChallenge: BaseGameItem | null;
@@ -41,7 +40,7 @@ export interface GameCurrentState {
 /**
  * מצב תקינות משחק - עקרון Single Responsibility
  */
-export interface GameReadinessState {
+interface GameReadinessState {
   readonly isReady: boolean;
   readonly error: string | null;
 }
@@ -49,7 +48,7 @@ export interface GameReadinessState {
 /**
  * פעולות משחק בסיסיות - עקרון Single Responsibility
  */
-export interface BasicGameActions {
+interface BasicGameActions {
   readonly startGame: () => void;
   readonly resetGame: () => void;
   readonly handleItemClick: (item: BaseGameItem) => void;
@@ -59,7 +58,7 @@ export interface BasicGameActions {
 /**
  * תצורת משחק בסיסית - Base interface לכל התצורות - עקרון DRY
  */
-export interface BaseGameConfiguration {
+interface BaseGameConfiguration {
   readonly config: GameUIConfig;
   readonly items: readonly BaseGameItem[];
   readonly CardComponent: ComponentType<GameItemCardProps>;
@@ -69,12 +68,12 @@ export interface BaseGameConfiguration {
 /**
  * תצורת משחק אוניברסלית - עקרון Single Responsibility
  */
-export type UniversalGameConfiguration = BaseGameConfiguration;
+type UniversalGameConfiguration = BaseGameConfiguration;
 
 /**
  * מערכת רמזים - עקרון Single Responsibility
  */
-export interface GameHintsSystem {
+interface GameHintsSystem {
   readonly hints: readonly string[];
   readonly hasMoreHints: boolean;
   readonly showNextHint: () => void;
@@ -83,7 +82,10 @@ export interface GameHintsSystem {
 /**
  * UI משחק - עקרון DRY, type alias
  */
-export type GameUI = ProgressModalState;
+type GameUI = {
+  readonly showProgressModal: boolean;
+  readonly setShowProgressModal: (show: boolean) => void;
+};
 
 /**
  * Value של UniversalGame Context - עקרון Interface Segregation
@@ -97,11 +99,4 @@ export interface UniversalGameContextValue extends
   GameHintsSystem,
   GameUI {}
 
-/**
- * Props לProvider של UniversalGame Context
- */
-export interface UniversalGameProviderProps {
-  readonly children: React.ReactNode;
-}
-
-// הערה: UniversalGameProviderProps מוגדר כאן לפי עקרון DRY
+// UniversalGameProviderProps removed (unused)

--- a/gamesformykids/lib/types/core/base.ts
+++ b/gamesformykids/lib/types/core/base.ts
@@ -5,40 +5,9 @@
  */
 
 import { ReactNode } from 'react';
-import type { DifficultyLevel } from '../games/base';
 
 interface Identifiable<TId = string> {
   readonly id: TId;
-}
-
-/**
- * שם בסיסי - עקרון Single Responsibility  
- */
-interface Nameable {
-  readonly name: string;
-}
-
-/**
- * מאפיינים בסיסיים עם כותרת ותיאור - עקרון DRY
- */
-interface TitledEntity {
-  readonly title: string;
-  readonly description?: string;
-}
-
-/**
- * זיהוי סוג משחק - עקרון DRY
- */
-interface GameTyped {
-  readonly gameType: string;
-}
-
-/**
- * ממשק לניהול modal התקדמות - עקרון DRY
- */
-interface ProgressModalState {
-  readonly showProgressModal: boolean;
-  readonly setShowProgressModal: (show: boolean) => void;
 }
 
 /**
@@ -48,21 +17,6 @@ interface Translatable {
   readonly hebrew: string;
   readonly english: string;
   readonly plural?: string;
-}
-
-/**
- * מאפיינים ויזואליים - עקרון Single Responsibility
- */
-interface Visualizable {
-  readonly emoji: string;
-  readonly color: string;
-}
-
-/**
- * מאפיינים קוליים - עקרון Single Responsibility
- */
-interface Audioable {
-  readonly sound?: number[];
 }
 
 /**

--- a/gamesformykids/lib/types/core/base.ts
+++ b/gamesformykids/lib/types/core/base.ts
@@ -5,23 +5,23 @@
  */
 
 import { ReactNode } from 'react';
-import type { GameAvailability, DifficultyLevel } from '../games/base';
+import type { DifficultyLevel } from '../games/base';
 
-export interface Identifiable<TId = string> {
+interface Identifiable<TId = string> {
   readonly id: TId;
 }
 
 /**
  * שם בסיסי - עקרון Single Responsibility  
  */
-export interface Nameable {
+interface Nameable {
   readonly name: string;
 }
 
 /**
  * מאפיינים בסיסיים עם כותרת ותיאור - עקרון DRY
  */
-export interface TitledEntity {
+interface TitledEntity {
   readonly title: string;
   readonly description?: string;
 }
@@ -29,29 +29,22 @@ export interface TitledEntity {
 /**
  * זיהוי סוג משחק - עקרון DRY
  */
-export interface GameTyped {
+interface GameTyped {
   readonly gameType: string;
 }
 
 /**
  * ממשק לניהול modal התקדמות - עקרון DRY
  */
-export interface ProgressModalState {
+interface ProgressModalState {
   readonly showProgressModal: boolean;
   readonly setShowProgressModal: (show: boolean) => void;
 }
 
 /**
- * ממשק בסיסי לרמת קושי - עקרון DRY
- */
-export interface BaseDifficultyConfig {
-  readonly difficulty?: DifficultyLevel;
-}
-
-/**
  * תרגום רב-לשוני - עקרון Single Responsibility
  */
-export interface Translatable {
+interface Translatable {
   readonly hebrew: string;
   readonly english: string;
   readonly plural?: string;
@@ -60,7 +53,7 @@ export interface Translatable {
 /**
  * מאפיינים ויזואליים - עקרון Single Responsibility
  */
-export interface Visualizable {
+interface Visualizable {
   readonly emoji: string;
   readonly color: string;
 }
@@ -68,27 +61,15 @@ export interface Visualizable {
 /**
  * מאפיינים קוליים - עקרון Single Responsibility
  */
-export interface Audioable {
+interface Audioable {
   readonly sound?: number[];
-}
-
-/**
- * גרסה מקוצרת של BaseGameItem לתאימות לאחור - ללא id חובה
- * להשתמש כאשר id לא נדרש
- */
-export interface BaseGameItemLegacy extends 
-  Nameable,
-  Translatable, 
-  Visualizable, 
-  Audioable {
-  readonly id?: string;
 }
 
 /**
  * טייפ לנתוני משחקים ללא ID - לתמיכה בקבצי קבועים קיימים
  * SOLID Principle: Single Responsibility - אחראי רק על נתוני פריט בסיסיים ללא מזהה
  */
-export interface GameDataItem {
+interface GameDataItem {
   readonly name: string;
   readonly hebrew: string;
   readonly english: string;
@@ -112,7 +93,7 @@ export type BaseGameItem = GameDataItem & {
  * מצב אתגר משחק בסיסי - עקרון Single Responsibility
  * מכיל רק מידע על מצב נוכחי
  */
-export interface GameChallengeState<T extends BaseGameItem = BaseGameItem> {
+interface GameChallengeState<T extends BaseGameItem = BaseGameItem> {
   readonly currentChallenge: T | null;
   readonly options: T[];
 }
@@ -120,7 +101,7 @@ export interface GameChallengeState<T extends BaseGameItem = BaseGameItem> {
 /**
  * מצב משחק עם ניקוד - עקרון Single Responsibility
  */
-export interface GameScoreState {
+interface GameScoreState {
   readonly score: number;
   readonly level: number;
 }
@@ -128,7 +109,7 @@ export interface GameScoreState {
 /**
  * מצב משחק עם סטטוס - עקרון Single Responsibility
  */
-export interface GamePlayState {
+interface GamePlayState {
   readonly isPlaying: boolean;
   readonly showCelebration: boolean;
 }
@@ -143,32 +124,9 @@ export interface BaseGameState<T extends BaseGameItem = BaseGameItem> extends
   GamePlayState {}
 
 /**
- * הגדרות בסיסיות למשחק - עקרון Single Responsibility
- */
-export interface BaseGameSettings {
-  readonly baseCount: number;
-  readonly increment: number;
-  readonly levelThreshold: number;
-}
-
-/**
- * הגדרות מתקדמות למשחק - עקרון Interface Segregation
- */
-export interface AdvancedGameSettings {
-  readonly maxCount?: number;
-  readonly timeLimit?: number;
-  readonly difficultyScaling?: boolean;
-}
-
-/**
- * הגדרות משחק מלאות - עקרון Open/Closed
- */
-export interface GameConfig extends BaseGameSettings, AdvancedGameSettings {}
-
-/**
  * מאפיינים בסיסיים למשחק - עקרון Single Responsibility
  */
-export interface GameBasicInfo extends Identifiable, Translatable {
+interface GameBasicInfo extends Identifiable, Translatable {
   readonly description: string;
   readonly href: string;
 }
@@ -176,7 +134,7 @@ export interface GameBasicInfo extends Identifiable, Translatable {
 /**
  * מאפיינים ויזואליים למשחק - עקרון Single Responsibility
  */
-export interface GameVisualInfo {
+interface GameVisualInfo {
   readonly icon: ReactNode;
   readonly color: string;
 }
@@ -186,13 +144,14 @@ export interface GameVisualInfo {
  */
 export interface Game extends 
   GameBasicInfo,
-  GameVisualInfo,
-  GameAvailability {}
+  GameVisualInfo {
+  readonly available: boolean;
+}
 
 /**
  * מצב כרטיס זיכרון - עקרון Single Responsibility
  */
-export interface CardState {
+interface CardState {
   readonly isFlipped: boolean;
   readonly isMatched: boolean;
 }
@@ -200,7 +159,7 @@ export interface CardState {
 /**
  * מידע כרטיס זיכרון - עקרון Single Responsibility
  */
-export interface CardInfo {
+interface CardInfo {
   readonly id: number;
   readonly emoji: string;
 }

--- a/gamesformykids/lib/types/events/game-events.ts
+++ b/gamesformykids/lib/types/events/game-events.ts
@@ -4,12 +4,10 @@
  * ===============================================
  */
 
-import type { GameTyped } from '../core/base';
-
 /**
  * אירועי מחזור חיים של משחק - עקרון Single Responsibility
  */
-export type GameLifecycleEvent = 
+type GameLifecycleEvent = 
   | 'game_start'
   | 'game_pause'
   | 'game_resume'
@@ -18,14 +16,14 @@ export type GameLifecycleEvent =
 /**
  * אירועי תגובת שחקן - עקרון Single Responsibility
  */
-export type PlayerResponseEvent = 
+type PlayerResponseEvent = 
   | 'correct_answer'
   | 'wrong_answer';
 
 /**
  * אירועי התקדמות במשחק - עקרון Single Responsibility
  */
-export type GameProgressEvent = 
+type GameProgressEvent = 
   | 'level_up'
   | 'new_high_score'
   | 'streak_milestone';
@@ -41,7 +39,7 @@ export type GameEvent =
 /**
  * מידע בסיסי לאירוע - עקרון Single Responsibility
  */
-export interface EventMetadata {
+interface EventMetadata {
   readonly event: GameEvent;
   readonly timestamp: number;
 }
@@ -51,7 +49,7 @@ export interface EventMetadata {
 /**
  * נתונים נוספים לאירוע - עקרון Single Responsibility
  */
-export interface EventPayload {
+interface EventPayload {
   readonly data?: Readonly<Record<string, unknown>>;
 }
 
@@ -60,8 +58,9 @@ export interface EventPayload {
  */
 export interface GameEventData extends 
   EventMetadata,
-  GameTyped,
-  EventPayload {}
+  EventPayload {
+  readonly gameType: string;
+}
 
 /**
  * הגדרת Window עבור gtag

--- a/gamesformykids/lib/types/games/base.ts
+++ b/gamesformykids/lib/types/games/base.ts
@@ -9,7 +9,7 @@ import type { ComponentType } from 'react';
 /**
  * רישום משחק בסיסי - עקרון Single Responsibility
  */
-export interface GameRegistrationBase {
+interface GameRegistrationBase {
   readonly id: string;
   readonly title: string;
   readonly description: string;
@@ -19,7 +19,7 @@ export interface GameRegistrationBase {
 /**
  * מאפיינים ויזואליים למשחק - עקרון Single Responsibility
  */
-export interface GameVisuals {
+interface GameVisuals {
   readonly color: string;
   readonly icon: ComponentType<{ className?: string }>;
   readonly emoji?: string;
@@ -28,7 +28,7 @@ export interface GameVisuals {
 /**
  * זמינות משחק - עקרון Single Responsibility
  */
-export interface GameAvailability {
+interface GameAvailability {
   readonly available: boolean;
 }
 
@@ -43,7 +43,7 @@ export interface GameRegistration extends
 /**
  * מידע בסיסי לקטגוריה - עקרון Single Responsibility
  */
-export interface CategoryInfo {
+interface CategoryInfo {
   readonly title: string;
   readonly description: string;
 }
@@ -51,7 +51,7 @@ export interface CategoryInfo {
 /**
  * מאפיינים ויזואליים לקטגוריה - עקרון Single Responsibility
  */
-export interface CategoryVisuals {
+interface CategoryVisuals {
   readonly icon: ComponentType<{ size?: number; className?: string }>;
   readonly gradient: string;
 }
@@ -59,7 +59,7 @@ export interface CategoryVisuals {
 /**
  * משחקים בקטגוריה - עקרון Single Responsibility
  */
-export interface CategoryGames {
+interface CategoryGames {
   readonly gameIds: ReadonlyArray<string>;
 }
 
@@ -72,61 +72,6 @@ export interface Category extends
   CategoryGames {}
 
 /**
- * מידע בסיסי לקבוצת גיל - עקרון Single Responsibility
- */
-export interface AgeGroupInfo {
-  readonly title: string;
-  readonly icon: string;
-  readonly description: string;
-}
-
-/**
- * משחקים מומלצים לקבוצת גיל - עקרון Single Responsibility
- */
-export interface AgeGroupRecommendations {
-  readonly recommendedGames: ReadonlyArray<GameRegistration>;
-}
-
-/**
- * קבוצת גיל מלאה - עקרון Interface Segregation
- */
-export interface AgeGroup extends 
-  AgeGroupInfo,
-  AgeGroupRecommendations {}
-
-/**
  * רמות קושי - עקרון Open/Closed
  */
 export type DifficultyLevel = 'easy' | 'medium' | 'hard';
-
-/**
- * מידע אתגר במשחק - עקרון Single Responsibility
- */
-export interface ChallengeInfo {
-  readonly id: string;
-  readonly title: string;
-  readonly description: string;
-}
-
-/**
- * מאפיינים לאתגר - עקרון Single Responsibility
- */
-export interface ChallengeProperties {
-  readonly difficulty: DifficultyLevel;
-  readonly points: number;
-}
-
-/**
- * מצב אתגר - עקרון Single Responsibility
- */
-export interface ChallengeState {
-  readonly completed: boolean;
-}
-
-/**
- * אתגר במשחק - עקרון Interface Segregation
- */
-export interface GameChallenge extends 
-  ChallengeInfo,
-  ChallengeProperties,
-  ChallengeState {}

--- a/gamesformykids/lib/types/games/index.ts
+++ b/gamesformykids/lib/types/games/index.ts
@@ -14,7 +14,6 @@ export * from './shared';
 // ייצוא טיפוסי הבסיס מ-core
 export type {
   BaseGameItem,
-  BaseGameItemLegacy,
   GameType
 } from '../core/base';
 

--- a/gamesformykids/lib/types/games/items.ts
+++ b/gamesformykids/lib/types/games/items.ts
@@ -11,12 +11,12 @@ import { BaseGameItem, BaseGameState } from '../core/base';
  */
 
 // צורות - מכיל SVG נוסף
-export interface ShapeItem extends BaseGameItem {
+interface ShapeItem extends BaseGameItem {
   svg: string;
 }
 
 // מספרים - מכיל ספרה נוספת
-export interface NumberItem extends BaseGameItem {
+interface NumberItem extends BaseGameItem {
   digit: string;
 }
 

--- a/gamesformykids/lib/types/games/items.ts
+++ b/gamesformykids/lib/types/games/items.ts
@@ -10,17 +10,9 @@ import { BaseGameItem, BaseGameState } from '../core/base';
  * פריטים ייחודיים למשחקים מיוחדים
  */
 
-// צורות - מכיל SVG נוסף
-interface ShapeItem extends BaseGameItem {
-  svg: string;
-}
-
-// מספרים - מכיל ספרה נוספת
-interface NumberItem extends BaseGameItem {
-  digit: string;
-}
-
-// מקצועות - מכיל תיאור נוסף
+/**
+ * מקצועות - מכיל תיאור נוסף
+ */
 export interface ProfessionItem extends BaseGameItem {
   id: string;
   description: string;

--- a/gamesformykids/lib/types/hooks/game-state.ts
+++ b/gamesformykids/lib/types/hooks/game-state.ts
@@ -4,9 +4,10 @@
  * ===============================================
  */
 
+import { ComponentType } from 'react';
 import { BaseGameItem, GameType } from '../core/base';
 import type { GameItemCardProps } from '../components/cards';
-import { UniversalGameConfiguration, GameUI } from '../contexts/universal-game';
+import type { GameUIConfig } from '../contexts/game-config';
 
 // ייצוא הטייפ למען תאימות - עקרון Liskov Substitution
 export type { GameItemCardProps };
@@ -25,7 +26,7 @@ export interface UseGameOptionsProps {
 /**
  * קבועי משחק - עקרון Single Responsibility
  */
-export interface GameConstants {
+interface GameConstants {
   readonly BASE_COUNT: number;
   readonly INCREMENT: number;
   readonly LEVEL_THRESHOLD: number;
@@ -67,7 +68,7 @@ export interface GameProgress {
 /**
  * תכונות מתקדמות של משחק - עקרון Single Responsibility
  */
-export interface GameEnhancements {
+interface GameEnhancements {
   readonly hints?: readonly string[];
   readonly hasMoreHints?: boolean;
   readonly showNextHint?: () => void;
@@ -90,7 +91,7 @@ export interface GameActions {
 /**
  * פעולות תגובה למשחק - עקרון Single Responsibility
  */
-export interface GameResponseActions {
+interface GameResponseActions {
   readonly handleCorrectAnswer: (data?: Record<string, unknown>) => void;
   readonly handleWrongAnswer: (data?: Record<string, unknown>) => void;
 }
@@ -98,13 +99,21 @@ export interface GameResponseActions {
 /**
  * מצב UI של משחק - עקרון DRY, type alias
  */
-export type GameUIState = GameUI;
+type GameUIState = {
+  readonly showProgressModal: boolean;
+  readonly setShowProgressModal: (show: boolean) => void;
+};
 
 /**
  * הגדרות משחק - עקרון Single Responsibility  
  * מרחיב את BaseGameConfiguration מ-universal-game
  */
-export type GameConfiguration = UniversalGameConfiguration;
+type GameConfiguration = {
+  readonly config: GameUIConfig;
+  readonly items: readonly BaseGameItem[];
+  readonly CardComponent: ComponentType<GameItemCardProps>;
+  readonly gameType: GameType;
+};
 
 /**
  * מצב משחק לוגי מלא - עקרון Interface Segregation
@@ -162,7 +171,7 @@ export interface GameTypeDbRecord {
 /**
  * מידע בסיסי על סוג משחק - עקרון Single Responsibility
  */
-export interface GameTypeInfo {
+interface GameTypeInfo {
   readonly gameType: string | null;
   readonly gameConfig: {
     readonly title: string;

--- a/gamesformykids/lib/types/hooks/progress.ts
+++ b/gamesformykids/lib/types/hooks/progress.ts
@@ -25,7 +25,7 @@ export interface GameSession {
   completed: boolean;
 }
 
-export interface UserProgressStats {
+export interface ProgressStats {
   totalSessions: number;
   totalTime: number;
   averageScore: number;
@@ -39,8 +39,5 @@ export interface UserProgressStats {
   improvementTrend: 'up' | 'down' | 'stable';
   recommendedPractice: string[];
 }
-
-// Alias for backward compatibility
-export type ProgressStats = UserProgressStats;
 
 

--- a/gamesformykids/lib/types/hooks/ui.ts
+++ b/gamesformykids/lib/types/hooks/ui.ts
@@ -42,7 +42,7 @@ export interface UseGameHintsReturn {
 /**
  * סוגי אירועי משחק מורחבים - עקרון DRY, uses existing types
  */
-export type ExtendedGameEvent = 
+type ExtendedGameEvent = 
   | GameEvent
   | 'streak_milestone';
 

--- a/gamesformykids/lib/types/index.ts
+++ b/gamesformykids/lib/types/index.ts
@@ -11,8 +11,6 @@ export * from './core';
 export type {
   GameRegistration,
   Category,
-  AgeGroup,
-  GameChallenge,
   DifficultyLevel
 } from './games/base';
 
@@ -37,7 +35,6 @@ export type {
   GameType,
   BaseGameItem,
   BaseGameState,
-  GameConfig,
   Game,
   Card
 } from './core/base';

--- a/gamesformykids/lib/types/ui/core.ts
+++ b/gamesformykids/lib/types/ui/core.ts
@@ -5,12 +5,11 @@
  */
 
 import { ReactNode } from 'react';
-import type { TitledEntity } from '../core/base';
 
 /**
  * מאפיינים בסיסיים לכל רכיב - עקרון Single Responsibility
  */
-export interface BaseComponentProps {
+interface BaseComponentProps {
   readonly children?: ReactNode;
   readonly className?: string;
 }
@@ -18,7 +17,7 @@ export interface BaseComponentProps {
 /**
  * Props בסיסיים לכפתור - עקרון Interface Segregation
  */
-export interface BaseButtonProps extends BaseComponentProps {
+interface BaseButtonProps extends BaseComponentProps {
   readonly onClick?: () => void;
   readonly disabled?: boolean;
   readonly loading?: boolean;
@@ -32,30 +31,12 @@ export type ButtonProps = BaseButtonProps;
 /**
  * סוגי וריאנטים לכפתור - עקרון Open/Closed
  */
-export type ButtonVariant = 'primary' | 'secondary' | 'danger' | 'success';
+type ButtonVariant = 'primary' | 'secondary' | 'danger' | 'success';
 
 /**
  * גדלים זמינים לכפתור - עקרון Open/Closed
  */
-export type ComponentSize = 'small' | 'medium' | 'large';
-
-/**
- * Props לכפתור התחלת משחק
- */
-export interface GameStartButtonProps extends BaseButtonProps {
-  readonly variant?: ButtonVariant;
-  readonly size?: ComponentSize;
-  readonly title?: string;
-  readonly text?: string;
-  readonly fromColor?: string;
-  readonly toColor?: string;
-  readonly customOnStart?: () => void;
-}
-
-/**
- * מאפיינים לכותרת - עקרון DRY, type alias
- */
-export type TitledComponent = TitledEntity;
+type ComponentSize = 'small' | 'medium' | 'large';
 
 /**
  * Props ל-Google Analytics - עקרון Single Responsibility

--- a/gamesformykids/lib/types/ui/core.ts
+++ b/gamesformykids/lib/types/ui/core.ts
@@ -29,16 +29,6 @@ interface BaseButtonProps extends BaseComponentProps {
 export type ButtonProps = BaseButtonProps;
 
 /**
- * סוגי וריאנטים לכפתור - עקרון Open/Closed
- */
-type ButtonVariant = 'primary' | 'secondary' | 'danger' | 'success';
-
-/**
- * גדלים זמינים לכפתור - עקרון Open/Closed
- */
-type ComponentSize = 'small' | 'medium' | 'large';
-
-/**
  * Props ל-Google Analytics - עקרון Single Responsibility
  */
 export interface GoogleAnalyticsProps {


### PR DESCRIPTION
Closes #52

## Summary
Removed all 80 unused exported types from `lib/types/`, reducing from 158 to 77 total exported types.

## Changes

### Deleted standalone unused types (18 types)
- `BaseDifficultyConfig`, `BaseGameItemLegacy`, `BaseGameSettings`, `AdvancedGameSettings`, `GameConfig`
- `AgeGroup`, `AgeGroupInfo`, `AgeGroupRecommendations`
- `ChallengeInfo`, `ChallengeProperties`, `ChallengeState`, `GameChallenge`
- `UserProgressStats` (consolidated into `ProgressStats`)
- `TitledComponent`, `GameConfigProviderProps`, `UniversalGameProviderProps`, `GameStartButtonProps`, `SimpleGameStartButtonProps`

### Unexported ~50 composition-base types
Types that are still needed internally by `lib/types/` for composition/inheritance had their `export` keyword removed. Examples: `Identifiable`, `GameDataItem`, `GameChallengeState`, `CardInfo`, `CardState`, `CategoryInfo`, `EventMetadata`, `BaseCardProps`, `Hint`, `ExtendedGameEvent`, etc.

### Structural improvements
- `ColoredShapeItem`: Inlined all base interface fields directly (removed dependency on `Nameable`/`Translatable`/`Visualizable`/`Audioable`)
- `GameItemType`: Simplified union — removed `ShapeItem`/`NumberItem` since `BaseGameItem` already has `svg?` and `digit?` as optional fields
- Cross-file composition chains inlined: `GameEventData.gameType`, `GameUIState`, `GameConfiguration`, `Game.available` all have their fields inlined
- `ProgressStats` converted from alias to standalone interface

## Verification
- `node scripts/find-unused-types.js` → **0 unused types** (was 80)
- `npx tsc --noEmit` → **0 errors**
- `npx vitest run` → **99/99 tests pass**