### PR TITLE
test: add unit tests for game utilities and useGameOptions hook (#61)

### DIFF
--- a/gamesformykids/__tests__/hooks/useGameOptions.test.ts
+++ b/gamesformykids/__tests__/hooks/useGameOptions.test.ts
@@ -1,0 +1,76 @@
+// @vitest-environment jsdom
+import { describe, it, expect } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { useGameOptions } from '@/hooks/shared/game-state/useGameOptions';
+import type { BaseGameItem } from '@/lib/types/core/base';
+
+const makeItems = (count: number): BaseGameItem[] =>
+  Array.from({ length: count }, (_, i) => ({
+    name: `item${i}`,
+    hebrew: `פריט${i}`,
+    english: `item${i}`,
+    emoji: '🔵',
+    color: 'blue',
+  }));
+
+describe('useGameOptions', () => {
+  describe('availableItems', () => {
+    it('starts with baseCount items at level 1', () => {
+      const items = makeItems(10);
+      const { result } = renderHook(() =>
+        useGameOptions({ allItems: items, level: 1, baseCount: 4 })
+      );
+      expect(result.current.availableItems).toHaveLength(4);
+    });
+
+    it('adds items as level increases past levelThreshold', () => {
+      const items = makeItems(10);
+      const { result: r1 } = renderHook(() =>
+        useGameOptions({ allItems: items, level: 4, baseCount: 4, increment: 1, levelThreshold: 3 })
+      );
+      expect(r1.current.availableItems).toHaveLength(5);
+    });
+
+    it('never exceeds the total number of items', () => {
+      const items = makeItems(3);
+      const { result } = renderHook(() =>
+        useGameOptions({ allItems: items, level: 100, baseCount: 10 })
+      );
+      expect(result.current.availableItems).toHaveLength(3);
+    });
+  });
+
+  describe('getRandomChallenge', () => {
+    it('returns an item from availableItems', () => {
+      const items = makeItems(6);
+      const { result } = renderHook(() =>
+        useGameOptions({ allItems: items, level: 1, baseCount: 4 })
+      );
+      const challenge = result.current.getRandomChallenge();
+      expect(result.current.availableItems).toContainEqual(challenge);
+    });
+  });
+
+  describe('getOptionsForChallenge', () => {
+    it('always includes the correct challenge in options', () => {
+      const items = makeItems(8);
+      const { result } = renderHook(() =>
+        useGameOptions({ allItems: items, level: 1, baseCount: 6 })
+      );
+      const challenge = result.current.availableItems[0];
+      const options = result.current.getOptionsForChallenge(challenge);
+      expect(options).toContainEqual(challenge);
+    });
+
+    it('returns no duplicate names in options', () => {
+      const items = makeItems(8);
+      const { result } = renderHook(() =>
+        useGameOptions({ allItems: items, level: 1, baseCount: 6 })
+      );
+      const challenge = result.current.availableItems[0];
+      const options = result.current.getOptionsForChallenge(challenge);
+      const names = options.map((o) => o.name);
+      expect(new Set(names).size).toBe(names.length);
+    });
+  });
+});

--- a/gamesformykids/__tests__/utils/errorUtils.test.ts
+++ b/gamesformykids/__tests__/utils/errorUtils.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { logError, logWarning } from '@/lib/utils/errorUtils';
+
+describe('logError', () => {
+  beforeEach(() => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+  afterEach(() => vi.restoreAllMocks());
+
+  it('calls console.error in development', () => {
+    vi.stubEnv('NODE_ENV', 'development');
+    logError('test error', new Error('boom'));
+    expect(console.error).toHaveBeenCalledWith('test error', expect.any(Error));
+    vi.unstubAllEnvs();
+  });
+
+  it('does not call console.error in production', () => {
+    vi.stubEnv('NODE_ENV', 'production');
+    logError('test error');
+    expect(console.error).not.toHaveBeenCalled();
+    vi.unstubAllEnvs();
+  });
+
+  it('works with no error argument', () => {
+    vi.stubEnv('NODE_ENV', 'development');
+    logError('message only');
+    expect(console.error).toHaveBeenCalledWith('message only', undefined);
+    vi.unstubAllEnvs();
+  });
+});
+
+describe('logWarning', () => {
+  beforeEach(() => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+  afterEach(() => vi.restoreAllMocks());
+
+  it('calls console.warn in development', () => {
+    vi.stubEnv('NODE_ENV', 'development');
+    logWarning('watch out', { detail: 42 });
+    expect(console.warn).toHaveBeenCalledWith('watch out', { detail: 42 });
+    vi.unstubAllEnvs();
+  });
+
+  it('does not call console.warn in production', () => {
+    vi.stubEnv('NODE_ENV', 'production');
+    logWarning('watch out');
+    expect(console.warn).not.toHaveBeenCalled();
+    vi.unstubAllEnvs();
+  });
+
+  it('works with no data argument', () => {
+    vi.stubEnv('NODE_ENV', 'development');
+    logWarning('message only');
+    expect(console.warn).toHaveBeenCalledWith('message only', undefined);
+    vi.unstubAllEnvs();
+  });
+});

--- a/gamesformykids/__tests__/utils/gameUtils.test.ts
+++ b/gamesformykids/__tests__/utils/gameUtils.test.ts
@@ -1,0 +1,194 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  shuffleArray,
+  randInt,
+  getRandomItem,
+  generateOptions,
+  delay,
+  getRandomFeedbackMessage,
+} from '@/lib/utils/game/gameUtils';
+
+// ── shuffleArray ──────────────────────────────────────────────────────────────
+
+describe('shuffleArray', () => {
+  it('returns a new array with the same elements', () => {
+    const input = [1, 2, 3, 4, 5];
+    const result = shuffleArray(input);
+    expect(result).toHaveLength(input.length);
+    expect(result).toEqual(expect.arrayContaining(input));
+  });
+
+  it('does not mutate the original array', () => {
+    const input = [1, 2, 3];
+    const copy = [...input];
+    shuffleArray(input);
+    expect(input).toEqual(copy);
+  });
+
+  it('returns an empty array when given an empty array', () => {
+    expect(shuffleArray([])).toEqual([]);
+  });
+
+  it('returns a single-element array unchanged', () => {
+    expect(shuffleArray([42])).toEqual([42]);
+  });
+
+  it('works with strings', () => {
+    const input = ['a', 'b', 'c'];
+    const result = shuffleArray(input);
+    expect(result).toHaveLength(3);
+    expect(result).toEqual(expect.arrayContaining(['a', 'b', 'c']));
+  });
+});
+
+// ── randInt ───────────────────────────────────────────────────────────────────
+
+describe('randInt', () => {
+  it('returns a value within [min, max]', () => {
+    for (let i = 0; i < 100; i++) {
+      const value = randInt(1, 10);
+      expect(value).toBeGreaterThanOrEqual(1);
+      expect(value).toBeLessThanOrEqual(10);
+    }
+  });
+
+  it('returns exactly min when Math.random returns 0', () => {
+    vi.spyOn(Math, 'random').mockReturnValue(0);
+    expect(randInt(5, 10)).toBe(5);
+    vi.restoreAllMocks();
+  });
+
+  it('returns exactly max when Math.random returns close to 1', () => {
+    vi.spyOn(Math, 'random').mockReturnValue(0.9999);
+    expect(randInt(5, 10)).toBe(10);
+    vi.restoreAllMocks();
+  });
+
+  it('works when min equals max', () => {
+    expect(randInt(7, 7)).toBe(7);
+  });
+
+  it('returns an integer', () => {
+    for (let i = 0; i < 20; i++) {
+      expect(Number.isInteger(randInt(0, 100))).toBe(true);
+    }
+  });
+});
+
+// ── getRandomItem ─────────────────────────────────────────────────────────────
+
+describe('getRandomItem', () => {
+  it('returns an element from the array', () => {
+    const items = ['apple', 'banana', 'cherry'];
+    const result = getRandomItem(items);
+    expect(items).toContain(result);
+  });
+
+  it('returns the only element of a single-item array', () => {
+    expect(getRandomItem([99])).toBe(99);
+  });
+
+  it('throws when the array is empty', () => {
+    expect(() => getRandomItem([])).toThrow();
+  });
+
+  it('works with objects', () => {
+    const items = [{ id: 1 }, { id: 2 }, { id: 3 }];
+    const result = getRandomItem(items);
+    expect(items).toContain(result);
+  });
+});
+
+// ── generateOptions ───────────────────────────────────────────────────────────
+
+describe('generateOptions', () => {
+  const allItems = [
+    { name: 'cat' },
+    { name: 'dog' },
+    { name: 'fish' },
+    { name: 'bird' },
+    { name: 'lion' },
+  ];
+
+  it('always includes the correct item', () => {
+    const correct = allItems[0];
+    const options = generateOptions(correct, allItems, 4);
+    expect(options).toContainEqual(correct);
+  });
+
+  it('returns exactly `count` items', () => {
+    const correct = allItems[0];
+    const options = generateOptions(correct, allItems, 3);
+    expect(options).toHaveLength(3);
+  });
+
+  it('returns no duplicate items', () => {
+    const correct = allItems[0];
+    const options = generateOptions(correct, allItems, 4);
+    const names = options.map((o) => o.name);
+    expect(new Set(names).size).toBe(names.length);
+  });
+
+  it('uses a custom idField', () => {
+    const customItems = [
+      { id: 'a', label: 'A' },
+      { id: 'b', label: 'B' },
+      { id: 'c', label: 'C' },
+    ];
+    const correct = customItems[0];
+    const options = generateOptions(correct, customItems, 2, 'id' as keyof typeof correct);
+    expect(options).toContainEqual(correct);
+  });
+
+  it('returns all items when count equals total items', () => {
+    const correct = allItems[0];
+    const options = generateOptions(correct, allItems, allItems.length);
+    expect(options).toHaveLength(allItems.length);
+  });
+});
+
+// ── delay ─────────────────────────────────────────────────────────────────────
+
+describe('delay', () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  it('resolves after the specified milliseconds', async () => {
+    let resolved = false;
+    const promise = delay(500).then(() => { resolved = true; });
+    expect(resolved).toBe(false);
+    await vi.advanceTimersByTimeAsync(500);
+    await promise;
+    expect(resolved).toBe(true);
+  });
+
+  it('resolves immediately for 0ms', async () => {
+    let resolved = false;
+    const promise = delay(0).then(() => { resolved = true; });
+    await vi.advanceTimersByTimeAsync(0);
+    await promise;
+    expect(resolved).toBe(true);
+  });
+});
+
+// ── getRandomFeedbackMessage ──────────────────────────────────────────────────
+
+describe('getRandomFeedbackMessage', () => {
+  it('returns a non-empty string for SUCCESS', () => {
+    const msg = getRandomFeedbackMessage('SUCCESS');
+    expect(typeof msg).toBe('string');
+    expect(msg.length).toBeGreaterThan(0);
+  });
+
+  it('returns a non-empty string for WRONG', () => {
+    const msg = getRandomFeedbackMessage('WRONG');
+    expect(typeof msg).toBe('string');
+    expect(msg.length).toBeGreaterThan(0);
+  });
+
+  it('returns a non-empty string for START', () => {
+    const msg = getRandomFeedbackMessage('START');
+    expect(typeof msg).toBe('string');
+    expect(msg.length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Changes

Adds 36 new unit tests across 3 new test files, bringing total coverage to **135 tests** (was 99):

### New test files
- \__tests__/utils/gameUtils.test.ts\ — 24 tests covering:
  - \shuffleArray\: immutability, element preservation, edge cases
  - \andInt\: range bounds, integer output, edge cases
  - \getRandomItem\: correct selection, empty array throws
  - \generateOptions\: always includes correct item, no duplicates, custom idField
  - \delay\: resolves after specified ms (fake timers)
  - \getRandomFeedbackMessage\: returns non-empty string for all types

- \__tests__/utils/errorUtils.test.ts\ — 6 tests covering:
  - \logError\: logs in dev, silent in production
  - \logWarning\: logs in dev, silent in production

- \__tests__/hooks/useGameOptions.test.ts\ — 6 tests covering:
  - \vailableItems\: respects baseCount, grows with level, capped at total items
  - \getRandomChallenge\: returns item from available pool
  - \getOptionsForChallenge\: always includes correct answer, no duplicate names

Closes #61