### PR TITLE
cleanup: document all react-hooks/exhaustive-deps suppressions (#59)

### DIFF
--- a/gamesformykids/app/games/counting/useCountingGame.ts
+++ b/gamesformykids/app/games/counting/useCountingGame.ts
@@ -53,6 +53,8 @@ export function useCountingGame() {
     if (!audioContext && !speechEnabled) {
       initSpeechAndAudio(setSpeechEnabled, setAudioContext);
     }
+  // intentionally run only on mount — setSpeechEnabled/setAudioContext are stable Zustand
+  // actions; audioContext/speechEnabled are only checked once to avoid double-initialisation
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 

--- a/gamesformykids/app/games/hebrew-letters/hooks/useHebrewLetterPractice.ts
+++ b/gamesformykids/app/games/hebrew-letters/hooks/useHebrewLetterPractice.ts
@@ -33,6 +33,9 @@ export const useHebrewLetterPractice = (letterData: HebrewLetter) => {
     return () => {
       endPracticeSession();
     };
+    // intentionally omit selectLetter/startPracticeSession/endPracticeSession — they are
+    // stable Zustand store actions; letterData object is omitted to avoid re-running when
+    // other fields change — only the letter name triggers a new practice session
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [letterData.name]);
 

--- a/gamesformykids/app/games/snake/useSnakeGame.ts
+++ b/gamesformykids/app/games/snake/useSnakeGame.ts
@@ -116,6 +116,9 @@ export function useSnakeGame() {
     useGameStore.getState().startGame('snake');
     setPhase('playing');
     scheduleStep();
+    // intentionally omit all deps — all references are stable (st.current ref, Zustand
+    // getState() calls, and scheduleStep uses st.current internally); empty deps ensures
+    // a single stable callback identity for the game-start button
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 

--- a/gamesformykids/hooks/shared/game-state/useGameProgress.ts
+++ b/gamesformykids/hooks/shared/game-state/useGameProgress.ts
@@ -15,12 +15,14 @@ export function useGameProgress(maxLevel = 10, pointsPerCorrect = 10) {
 
   const incrementScore = useCallback(
     (points = pointsPerCorrect) => store.incrementScore(points),
+    // intentionally omit `store` — Zustand store actions are stable references
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [pointsPerCorrect],
   )
 
   const incrementLevel = useCallback(
     () => store.incrementLevel(maxLevel),
+    // intentionally omit `store` — Zustand store actions are stable references
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [maxLevel],
   )
@@ -37,6 +39,7 @@ export function useGameProgress(maxLevel = 10, pointsPerCorrect = 10) {
 
   const getProgressPercentage = useCallback(() => {
     return (useGameProgressStore.getState().level / maxLevel) * 100
+    // reads live state via getState() — no reactive dependency needed beyond maxLevel
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [maxLevel])
 

--- a/gamesformykids/lib/quiz/useGenericQuizGame.ts
+++ b/gamesformykids/lib/quiz/useGenericQuizGame.ts
@@ -10,6 +10,8 @@ export function useGenericQuizGame<Q>(config: QuizGameConfig<Q>) {
 
   const choices = useMemo(
     () => (current ? config.getChoices(current) : []),
+    // intentionally omit `config` — it is a static game-config object created outside the
+    // component and never changes; including it would cause unnecessary recomputation
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [current],
   );


### PR DESCRIPTION
## Changes

Reviewed all 7 \// eslint-disable-next-line react-hooks/exhaustive-deps\ suppressions across 5 files. All are intentional — each now has an explanatory comment documenting why the dependency is omitted.

### Files updated

| File | Suppressions | Reason |
|---|---|---|
| \hooks/shared/game-state/useGameProgress.ts\ | 3 | Zustand store actions are stable; \getState()\ reads live state without reactive dependency |
| \pp/games/counting/useCountingGame.ts\ | 1 | Run-once mount effect — store actions stable, checking flags once avoids double-initialisation |
| \pp/games/snake/useSnakeGame.ts\ | 1 | All refs are stable (\st.current\, Zustand \getState()\); empty deps gives stable callback identity |
| \pp/games/hebrew-letters/hooks/useHebrewLetterPractice.ts\ | 1 | Store actions stable; only \letterData.name\ should trigger a new session |
| \lib/quiz/useGenericQuizGame.ts\ | 1 | \config\ is a static object defined outside the component, never changes |

No logic changes — comments only.

Closes #59