### PR TITLE
refactor(HebrewLettersStatsPanel): extract sub-components (#144)

### DIFF
--- a/gamesformykids/app/games/hebrew-letters/components/stats/HebrewLettersStatsPanel.tsx
+++ b/gamesformykids/app/games/hebrew-letters/components/stats/HebrewLettersStatsPanel.tsx
@@ -4,32 +4,13 @@ import { motion } from 'framer-motion';
 import { useHebrewLettersStats } from '@/app/games/hebrew-letters/hooks/useHebrewLettersStats';
 import { FADE_UP_ANIMATION } from '@/app/games/hebrew-letters/constants/hebrewLettersConstants';
 import { Button } from '@/components/ui/button';
-import { Download, RotateCcw, BarChart3, Timer, Trophy, type LucideIcon } from 'lucide-react';
+import { Download, RotateCcw, BarChart3, Timer, Trophy } from 'lucide-react';
+import { StatPanelCard } from './StatPanelCard';
+import { LetterSpecificStats } from './LetterSpecificStats';
+import { PracticeHistoryList } from './PracticeHistoryList';
 
 interface HebrewLettersStatsProps {
   letterName?: string;
-}
-
-interface StatPanelCardProps {
-  icon: LucideIcon;
-  label: string;
-  value: React.ReactNode;
-  gradientClass: string;
-  iconClass: string;
-  labelClass: string;
-  valueClass: string;
-}
-
-function StatPanelCard({ icon: Icon, label, value, gradientClass, iconClass, labelClass, valueClass }: StatPanelCardProps) {
-  return (
-    <div className={`${gradientClass} p-4 rounded-lg`}>
-      <div className="flex items-center gap-2 mb-2">
-        <Icon className={`w-4 h-4 ${iconClass}`} />
-        <span className={`text-sm font-medium ${labelClass}`}>{label}</span>
-      </div>
-      <p className={`text-2xl font-bold ${valueClass}`}>{value}</p>
-    </div>
-  );
 }
 
 export default function HebrewLettersStatsPanel({ letterName }: HebrewLettersStatsProps) {
@@ -90,27 +71,11 @@ export default function HebrewLettersStatsPanel({ letterName }: HebrewLettersSta
 
       {/* סטטיסטיקות ספציפיות לאות */}
       {letterStats && letterName && (
-        <div className="bg-gray-50 p-4 rounded-lg mb-4">
-          <h4 className="font-bold text-gray-800 mb-3">פרטים עבור האות {letterName}:</h4>
-          <div className="grid grid-cols-2 gap-4 text-sm">
-            <div>
-              <span className="text-gray-600">פעמים שהתחלתי:</span>
-              <span className="font-bold mr-2">{letterStats.timesStarted}</span>
-            </div>
-            <div>
-              <span className="text-gray-600">פעמים שהשלמתי:</span>
-              <span className="font-bold mr-2">{letterStats.timesCompleted}</span>
-            </div>
-            <div>
-              <span className="text-gray-600">זמן כולל:</span>
-              <span className="font-bold mr-2">{formatTime(letterStats.totalTimeSpent)}</span>
-            </div>
-            <div>
-              <span className="text-gray-600">ממוצע לשלב:</span>
-              <span className="font-bold mr-2">{formatTime(letterStats.averageTimePerStep)}</span>
-            </div>
-          </div>
-        </div>
+        <LetterSpecificStats
+          letterName={letterName}
+          letterStats={letterStats}
+          formatTime={formatTime}
+        />
       )}
 
       {/* כפתורי פעולה */}
@@ -137,21 +102,10 @@ export default function HebrewLettersStatsPanel({ letterName }: HebrewLettersSta
       </div>
 
       {/* היסטוריית תרגולים אחרונה */}
-      {learningStats.practiceHistory.length > 0 && (
-        <div className="mt-6 pt-4 border-t border-gray-200">
-          <h4 className="font-bold text-gray-800 mb-3">תרגולים אחרונים:</h4>
-          <div className="space-y-2 max-h-40 overflow-y-auto">
-            {learningStats.practiceHistory.slice(-5).reverse().map((activity, index) => (
-              <div key={index} className="text-sm bg-gray-50 p-2 rounded flex justify-between">
-                <span>האות {activity.letter} - שלב {activity.stepCompleted + 1}</span>
-                <span className="text-gray-600">
-                  {formatTime(activity.timeSpent)} | {new Date(activity.timestamp).toLocaleTimeString('he-IL')}
-                </span>
-              </div>
-            ))}
-          </div>
-        </div>
-      )}
+      <PracticeHistoryList
+        practiceHistory={learningStats.practiceHistory}
+        formatTime={formatTime}
+      />
     </motion.div>
   );
 }

--- a/gamesformykids/app/games/hebrew-letters/components/stats/LetterSpecificStats.tsx
+++ b/gamesformykids/app/games/hebrew-letters/components/stats/LetterSpecificStats.tsx
@@ -1,0 +1,40 @@
+'use client';
+
+interface LetterStats {
+  timesStarted: number;
+  timesCompleted: number;
+  totalTimeSpent: number;
+  averageTimePerStep: number;
+}
+
+interface LetterSpecificStatsProps {
+  letterName: string;
+  letterStats: LetterStats;
+  formatTime: (ms: number) => string;
+}
+
+export function LetterSpecificStats({ letterName, letterStats, formatTime }: LetterSpecificStatsProps) {
+  return (
+    <div className="bg-gray-50 p-4 rounded-lg mb-4">
+      <h4 className="font-bold text-gray-800 mb-3">פרטים עבור האות {letterName}:</h4>
+      <div className="grid grid-cols-2 gap-4 text-sm">
+        <div>
+          <span className="text-gray-600">פעמים שהתחלתי:</span>
+          <span className="font-bold mr-2">{letterStats.timesStarted}</span>
+        </div>
+        <div>
+          <span className="text-gray-600">פעמים שהשלמתי:</span>
+          <span className="font-bold mr-2">{letterStats.timesCompleted}</span>
+        </div>
+        <div>
+          <span className="text-gray-600">זמן כולל:</span>
+          <span className="font-bold mr-2">{formatTime(letterStats.totalTimeSpent)}</span>
+        </div>
+        <div>
+          <span className="text-gray-600">ממוצע לשלב:</span>
+          <span className="font-bold mr-2">{formatTime(letterStats.averageTimePerStep)}</span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/gamesformykids/app/games/hebrew-letters/components/stats/PracticeHistoryList.tsx
+++ b/gamesformykids/app/games/hebrew-letters/components/stats/PracticeHistoryList.tsx
@@ -1,0 +1,33 @@
+'use client';
+
+interface PracticeActivity {
+  letter: string;
+  stepCompleted: number;
+  timeSpent: number;
+  timestamp: number;
+}
+
+interface PracticeHistoryListProps {
+  practiceHistory: PracticeActivity[];
+  formatTime: (ms: number) => string;
+}
+
+export function PracticeHistoryList({ practiceHistory, formatTime }: PracticeHistoryListProps) {
+  if (practiceHistory.length === 0) return null;
+
+  return (
+    <div className="mt-6 pt-4 border-t border-gray-200">
+      <h4 className="font-bold text-gray-800 mb-3">תרגולים אחרונים:</h4>
+      <div className="space-y-2 max-h-40 overflow-y-auto">
+        {practiceHistory.slice(-5).reverse().map((activity, index) => (
+          <div key={index} className="text-sm bg-gray-50 p-2 rounded flex justify-between">
+            <span>האות {activity.letter} - שלב {activity.stepCompleted + 1}</span>
+            <span className="text-gray-600">
+              {formatTime(activity.timeSpent)} | {new Date(activity.timestamp).toLocaleTimeString('he-IL')}
+            </span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/gamesformykids/app/games/hebrew-letters/components/stats/StatPanelCard.tsx
+++ b/gamesformykids/app/games/hebrew-letters/components/stats/StatPanelCard.tsx
@@ -1,0 +1,33 @@
+'use client';
+
+import type { LucideIcon } from 'lucide-react';
+
+interface StatPanelCardProps {
+  icon: LucideIcon;
+  label: string;
+  value: React.ReactNode;
+  gradientClass: string;
+  iconClass: string;
+  labelClass: string;
+  valueClass: string;
+}
+
+export function StatPanelCard({
+  icon: Icon,
+  label,
+  value,
+  gradientClass,
+  iconClass,
+  labelClass,
+  valueClass,
+}: StatPanelCardProps) {
+  return (
+    <div className={`${gradientClass} p-4 rounded-lg`}>
+      <div className="flex items-center gap-2 mb-2">
+        <Icon className={`w-4 h-4 ${iconClass}`} />
+        <span className={`text-sm font-medium ${labelClass}`}>{label}</span>
+      </div>
+      <p className={`text-2xl font-bold ${valueClass}`}>{value}</p>
+    </div>
+  );
+}


### PR DESCRIPTION
## Changes

Splits HebrewLettersStatsPanel.tsx from 157 lines into focused components.

### New files
| File | Contents |
|---|---|
| \StatPanelCard.tsx\ | Reusable stat card (icon + label + value) |
| \LetterSpecificStats.tsx\ | Letter-level stat grid block |
| \PracticeHistoryList.tsx\ | Recent practice history list |

### Updated files
- \HebrewLettersStatsPanel.tsx\ — now uses the extracted components; reduced from 157 to ~70 lines

No breaking changes. Lint clean.

Closes #144