### PR TITLE
refactor(UnifiedCard): extract SimpleCard and AdvancedCard (#135)

### DIFF
--- a/gamesformykids/components/shared/cards/AdvancedCard.tsx
+++ b/gamesformykids/components/shared/cards/AdvancedCard.tsx
@@ -1,0 +1,197 @@
+import { Volume2 } from "lucide-react";
+import { ComponentTypes } from "@/lib/types";
+
+type AdvancedCardProps = Pick<
+  ComponentTypes.UnifiedCardProps,
+  | 'item'
+  | 'hebrewText'
+  | 'secondaryText'
+  | 'name'
+  | 'icon'
+  | 'color'
+  | 'gradientFrom'
+  | 'gradientTo'
+  | 'hoverFrom'
+  | 'hoverTo'
+  | 'borderColor'
+  | 'borderWidth'
+  | 'size'
+  | 'aspectRatio'
+  | 'borderRadius'
+  | 'showEmoji'
+  | 'showHebrew'
+  | 'showEnglish'
+  | 'animation'
+  | 'shadow'
+  | 'hoverEffect'
+  | 'backgroundPattern'
+  | 'description'
+  | 'digit'
+  | 'customDecoration'
+  | 'customContent'
+  | 'className'
+> & {
+  finalShowSoundIcon: boolean;
+  handleClick: () => void;
+};
+
+export function AdvancedCard({
+  item,
+  hebrewText,
+  secondaryText,
+  name,
+  icon,
+  color = "bg-blue-500",
+  gradientFrom = "blue-400",
+  gradientTo = "blue-600",
+  hoverFrom = "blue-500",
+  hoverTo = "blue-700",
+  borderColor = "border-white/70",
+  borderWidth = "4",
+  size = "medium",
+  aspectRatio = "square",
+  borderRadius = "xl",
+  showEmoji = true,
+  showHebrew = true,
+  showEnglish = false,
+  animation = "none",
+  shadow = "lg",
+  hoverEffect = "scale",
+  backgroundPattern = "none",
+  description,
+  digit,
+  customDecoration,
+  customContent,
+  className = "",
+  finalShowSoundIcon,
+  handleClick,
+}: AdvancedCardProps) {
+  const advancedSizeClasses = {
+    small: "text-4xl md:text-5xl",
+    medium: "text-6xl md:text-8xl",
+    large: "text-7xl md:text-9xl",
+  };
+
+  const aspectClasses = {
+    square: "aspect-square",
+    wide: "aspect-[4/3]",
+    tall: "aspect-[3/4]",
+  };
+
+  const animationClasses = {
+    bounce: "animate-bounce-in",
+    pulse: "animate-pulse",
+    none: "",
+  };
+
+  const hoverClasses = {
+    scale: "hover:scale-110",
+    lift: "hover:-translate-y-2",
+    glow: "hover:shadow-2xl",
+    none: "",
+  };
+
+  const shadowClasses: Record<string, string> = {
+    sm: "shadow-sm",
+    md: "shadow-md",
+    lg: "shadow-lg",
+    xl: "shadow-xl",
+    "2xl": "shadow-2xl",
+    none: "",
+  };
+
+  const backgroundClass =
+    gradientFrom === gradientTo && hoverFrom === hoverTo
+      ? `${color || `bg-${gradientFrom}`}`
+      : `bg-gradient-to-br from-${gradientFrom} to-${gradientTo} hover:from-${hoverFrom} hover:to-${hoverTo}`;
+
+  const ariaLabel =
+    hebrewText || item?.hebrew || name || (digit ? String(digit) : undefined);
+
+  return (
+    <button
+      type="button"
+      onClick={handleClick}
+      aria-label={ariaLabel}
+      className={`
+        ${aspectClasses[aspectRatio]}
+        rounded-${borderRadius}
+        cursor-pointer transition-all duration-300 transform
+        ${hoverClasses[hoverEffect]}
+        ${shadowClasses[shadow]} hover:shadow-2xl
+        ${backgroundClass}
+        border-${borderWidth} ${borderColor}
+        relative overflow-hidden
+        ${className}
+      `}
+    >
+      {backgroundPattern === "stars" && (
+        <div className="absolute inset-0 overflow-hidden pointer-events-none opacity-20">
+          <div className="absolute top-2 left-2 w-1 h-1 bg-white rounded-full animate-pulse"></div>
+          <div className="absolute top-4 right-4 w-1 h-1 bg-white rounded-full animate-pulse delay-100"></div>
+          <div className="absolute bottom-3 left-1/3 w-1 h-1 bg-white rounded-full animate-pulse delay-200"></div>
+        </div>
+      )}
+
+      {backgroundPattern === "dots" && (
+        <div className="absolute inset-0 bg-gradient-to-br from-white/10 to-white/5">
+          <div className="absolute top-2 right-2 w-3 h-3 bg-white/30 rounded-full"></div>
+          <div className="absolute bottom-3 left-3 w-2 h-2 bg-white/20 rounded-full"></div>
+          <div className="absolute top-1/2 left-2 w-1 h-1 bg-white/40 rounded-full"></div>
+        </div>
+      )}
+
+      {customDecoration}
+
+      <div className="w-full h-full flex flex-col items-center justify-center text-white relative z-10">
+        {customContent || (
+          <>
+            {showEmoji && item?.emoji && (
+              <div className={`${advancedSizeClasses[size]} mb-2 ${animationClasses[animation]}`}>
+                {item.emoji}
+              </div>
+            )}
+
+            {icon && !item?.emoji && (
+              <div className="text-3xl mb-2">{icon}</div>
+            )}
+
+            {digit && (
+              <div className={`${advancedSizeClasses[size]} font-bold mb-2`}>
+                {digit}
+              </div>
+            )}
+
+            {showHebrew && (
+              <div className="text-xl md:text-2xl font-bold text-center px-2">
+                {hebrewText || item?.hebrew}
+              </div>
+            )}
+
+            {showEnglish && item?.english && (
+              <div className="text-lg md:text-xl font-semibold mt-1">
+                {item.english}
+              </div>
+            )}
+
+            {description && (
+              <div className="text-sm text-center mt-2 px-2 opacity-90">
+                {description}
+              </div>
+            )}
+
+            {secondaryText && (
+              <div className="text-sm text-center mt-1 px-2 opacity-80">
+                {secondaryText}
+              </div>
+            )}
+
+            {finalShowSoundIcon && (
+              <Volume2 className="w-4 h-4 opacity-70 mt-2" aria-hidden="true" />
+            )}
+          </>
+        )}
+      </div>
+    </button>
+  );
+}

--- a/gamesformykids/components/shared/cards/SimpleCard.tsx
+++ b/gamesformykids/components/shared/cards/SimpleCard.tsx
@@ -1,0 +1,81 @@
+import { Volume2 } from "lucide-react";
+import { ComponentTypes } from "@/lib/types";
+
+type SimpleCardProps = Pick<
+  ComponentTypes.UnifiedCardProps,
+  | 'item'
+  | 'hebrewText'
+  | 'secondaryText'
+  | 'name'
+  | 'icon'
+  | 'color'
+  | 'borderColor'
+  | 'borderWidth'
+  | 'textColor'
+  | 'size'
+  | 'shape'
+  | 'shadow'
+  | 'hoverEffect'
+  | 'className'
+> & {
+  finalShowSoundIcon: boolean;
+  handleClick: () => void;
+};
+
+export function SimpleCard({
+  item,
+  hebrewText,
+  secondaryText,
+  name,
+  icon,
+  color = "bg-blue-500",
+  borderColor = "border-white/70",
+  borderWidth = "4",
+  textColor = "text-white",
+  size = "medium",
+  shape = "rounded",
+  shadow = "lg",
+  hoverEffect = "scale",
+  className = "",
+  finalShowSoundIcon,
+  handleClick,
+}: SimpleCardProps) {
+  const shapeClasses = {
+    rounded: "rounded-xl",
+    circle: "rounded-full",
+    square: "rounded-md",
+  };
+
+  const sizeClasses = {
+    small: "w-14 h-14 text-xs",
+    medium: "w-16 h-16 text-sm",
+    large: "w-20 h-20 text-base",
+  };
+
+  const ariaLabel = hebrewText || item?.hebrew || name || undefined;
+
+  return (
+    <button
+      type="button"
+      className={`
+        ${sizeClasses[size]} ${shapeClasses[shape]}
+        shadow-${shadow} ${color} ${textColor} border-${borderWidth} ${borderColor}
+        transform ${hoverEffect === "scale" ? "hover:scale-110" : ""}
+        transition-all duration-300 cursor-pointer
+        flex flex-col items-center justify-center p-2
+        ${className}
+      `}
+      onClick={handleClick}
+      aria-label={ariaLabel}
+    >
+      {icon && <div className="mb-1">{icon}</div>}
+      <div className="font-bold text-center">
+        {hebrewText || item?.hebrew}
+      </div>
+      {secondaryText && (
+        <div className="text-xs opacity-80 mt-0.5">{secondaryText}</div>
+      )}
+      {finalShowSoundIcon && <Volume2 className="w-3 h-3 opacity-70 mt-1" aria-hidden="true" />}
+    </button>
+  );
+}

--- a/gamesformykids/components/shared/cards/UnifiedCard.tsx
+++ b/gamesformykids/components/shared/cards/UnifiedCard.tsx
@@ -1,88 +1,38 @@
-import { Volume2 } from "lucide-react";
-import { ComponentTypes } from "@/lib/types";
+﻿import { ComponentTypes } from "@/lib/types";
 import { speakHebrew } from "@/lib/utils/speech/enhancedSpeechUtils";
+import { SimpleCard } from "./SimpleCard";
+import { AdvancedCard } from "./AdvancedCard";
 
-/**
- * UnifiedCard - קומפוננט Card אחוד שמחליף:
- * - BaseGameCard (variant="advanced") 
- * - GameItem (variant="simple")
- * 
- * מתאים עצמו אוטומטית לפי הפרמטרים שמועברים
- */
 export default function UnifiedCard({
-  // Data
-  item,
-  onClick,
-  
-  // Simple mode
-  hebrewText,
-  secondaryText,
-  name,
-  icon,
-  
-  // Advanced mode
-  customContent,
-  
-  // Colors - defaults for backward compatibility
-  color = "bg-blue-500",
-  gradientFrom = "blue-400",
-  gradientTo = "blue-600", 
-  hoverFrom = "blue-500",
-  hoverTo = "blue-700",
-  borderColor = "border-white/70",
-  borderWidth = "4",
-  textColor = "text-white",
-  
-  // Layout
-  variant = "auto", // Auto-detect based on props
-  size = "medium",
-  shape = "rounded",
-  aspectRatio = "square",
-  borderRadius = "xl",
-  
-  // Content
-  showEmoji = true,
-  showHebrew = true,
-  showEnglish = false,
+  variant = "auto",
   showSoundIcon,
   hideSoundIcon = true,
-  
-  // Effects
-  animation = "none",
-  shadow = "lg",
-  hoverEffect = "scale",
-  backgroundPattern = "none",
-  
-  // Special
-  description,
-  digit,
-  customDecoration,
-  
-  // Audio
-  onSpeak,
   autoSpeak = false,
-  
-  className = "",
+  onSpeak,
+  onClick,
+  item,
+  backgroundPattern = "none",
+  customContent,
+  hebrewText,
+  ...rest
 }: ComponentTypes.UnifiedCardProps) {
-  
-  // Auto-detect variant if not specified
   let actualVariant = variant;
   if (variant === "auto") {
-    actualVariant = (item && !hebrewText) || customContent || backgroundPattern !== "none" 
-      ? "advanced" 
-      : "simple";
+    actualVariant =
+      (item && !hebrewText) || customContent || backgroundPattern !== "none"
+        ? "advanced"
+        : "simple";
   }
-  
-  // Handle audio
+
+  const finalShowSoundIcon =
+    showSoundIcon !== undefined ? showSoundIcon : !hideSoundIcon;
+
   const handleAudioClick = async () => {
-    const textToSpeak = hebrewText || item?.hebrew || name;
-    if (textToSpeak && autoSpeak) {
-      await speakHebrew(textToSpeak);
-    }
+    const textToSpeak = hebrewText || item?.hebrew || rest.name;
+    if (textToSpeak && autoSpeak) await speakHebrew(textToSpeak);
     if (onSpeak) onSpeak();
   };
-  
-  // Handle main click
+
   const handleClick = async () => {
     if (autoSpeak) await handleAudioClick();
     if (onClick) {
@@ -90,199 +40,28 @@ export default function UnifiedCard({
       else onClick();
     }
   };
-  
-  // Determine final showSoundIcon value
-  const finalShowSoundIcon = showSoundIcon !== undefined 
-    ? showSoundIcon 
-    : !hideSoundIcon;
-  
-  // === SIMPLE VARIANT (like GameItem) ===
+
   if (actualVariant === "simple") {
-    const shapeClasses = {
-      rounded: "rounded-xl",
-      circle: "rounded-full", 
-      square: "rounded-md"
-    };
-    
-    const sizeClasses = {
-      small: "w-14 h-14 text-xs",
-      medium: "w-16 h-16 text-sm",
-      large: "w-20 h-20 text-base"
-    };
-    
-    const ariaLabel = hebrewText || item?.hebrew || name || undefined;
     return (
-      <button
-        type="button"
-        className={`
-          ${sizeClasses[size]} ${shapeClasses[shape]}
-          shadow-${shadow} ${color} ${textColor} border-${borderWidth} ${borderColor}
-          transform ${hoverEffect === "scale" ? "hover:scale-110" : ""}
-          transition-all duration-300 cursor-pointer
-          flex flex-col items-center justify-center p-2
-          ${className}
-        `}
-        onClick={handleClick}
-        aria-label={ariaLabel}
-      >
-        {icon && <div className="mb-1">{icon}</div>}
-        <div className="font-bold text-center">
-          {hebrewText || item?.hebrew}
-        </div>
-        {secondaryText && (
-          <div className="text-xs opacity-80 mt-0.5">
-            {secondaryText}
-          </div>
-        )}
-        {finalShowSoundIcon && <Volume2 className="w-3 h-3 opacity-70 mt-1" aria-hidden="true" />}
-      </button>
+      <SimpleCard
+        {...rest}
+        item={item}
+        hebrewText={hebrewText}
+        finalShowSoundIcon={finalShowSoundIcon}
+        handleClick={handleClick}
+      />
     );
   }
-  
-  // === ADVANCED VARIANT (like BaseGameCard) ===
-  
-  // Size classes for advanced mode
-  const advancedSizeClasses = {
-    small: "text-4xl md:text-5xl",
-    medium: "text-6xl md:text-8xl",
-    large: "text-7xl md:text-9xl"
-  };
-  
-  // Aspect ratio classes
-  const aspectClasses = {
-    square: "aspect-square",
-    wide: "aspect-[4/3]",
-    tall: "aspect-[3/4]"
-  };
-  
-  // Animation classes
-  const animationClasses = {
-    bounce: "animate-bounce-in",
-    pulse: "animate-pulse", 
-    none: ""
-  };
-  
-  // Hover effect classes
-  const hoverClasses = {
-    scale: "hover:scale-110",
-    lift: "hover:-translate-y-2",
-    glow: "hover:shadow-2xl",
-    none: ""
-  };
-  
-  // Shadow classes
-  const shadowClasses = {
-    sm: "shadow-sm",
-    md: "shadow-md",
-    lg: "shadow-lg", 
-    xl: "shadow-xl",
-    "2xl": "shadow-2xl",
-    none: ""
-  };
-  
-  // Background class
-  const backgroundClass = gradientFrom === gradientTo && hoverFrom === hoverTo
-    ? `${color || `bg-${gradientFrom}`}`
-    : `bg-gradient-to-br from-${gradientFrom} to-${gradientTo} hover:from-${hoverFrom} hover:to-${hoverTo}`;
-  
-  const advancedAriaLabel = hebrewText || item?.hebrew || name || (digit ? String(digit) : undefined);
+
   return (
-    <button
-      type="button"
-      onClick={handleClick}
-      aria-label={advancedAriaLabel}
-      className={`
-        ${aspectClasses[aspectRatio]}
-        rounded-${borderRadius}
-        cursor-pointer transition-all duration-300 transform
-        ${hoverClasses[hoverEffect]}
-        ${shadowClasses[shadow]} hover:shadow-2xl
-        ${backgroundClass}
-        border-${borderWidth} ${borderColor}
-        relative overflow-hidden
-        ${className}
-      `}
-    >
-      {/* Background patterns */}
-      {backgroundPattern === "stars" && (
-        <div className="absolute inset-0 overflow-hidden pointer-events-none opacity-20">
-          <div className="absolute top-2 left-2 w-1 h-1 bg-white rounded-full animate-pulse"></div>
-          <div className="absolute top-4 right-4 w-1 h-1 bg-white rounded-full animate-pulse delay-100"></div>
-          <div className="absolute bottom-3 left-1/3 w-1 h-1 bg-white rounded-full animate-pulse delay-200"></div>
-        </div>
-      )}
-      
-      {backgroundPattern === "dots" && (
-        <div className="absolute inset-0 bg-gradient-to-br from-white/10 to-white/5">
-          <div className="absolute top-2 right-2 w-3 h-3 bg-white/30 rounded-full"></div>
-          <div className="absolute bottom-3 left-3 w-2 h-2 bg-white/20 rounded-full"></div>
-          <div className="absolute top-1/2 left-2 w-1 h-1 bg-white/40 rounded-full"></div>
-        </div>
-      )}
-      
-      {/* Custom decoration */}
-      {customDecoration}
-      
-      {/* Card content */}
-      <div className="w-full h-full flex flex-col items-center justify-center text-white relative z-10">
-        {customContent || (
-          <>
-            {/* Emoji */}
-            {showEmoji && item?.emoji && (
-              <div className={`${advancedSizeClasses[size]} mb-2 ${animationClasses[animation]}`}>
-                {item.emoji}
-              </div>
-            )}
-            
-            {/* Icon (for simple mode compatibility) */}
-            {icon && !item?.emoji && (
-              <div className="text-3xl mb-2">
-                {icon}
-              </div>
-            )}
-            
-            {/* Digit */}
-            {digit && (
-              <div className={`${advancedSizeClasses[size]} font-bold mb-2`}>
-                {digit}
-              </div>
-            )}
-            
-            {/* Hebrew text */}
-            {showHebrew && (
-              <div className="text-xl md:text-2xl font-bold text-center px-2">
-                {hebrewText || item?.hebrew}
-              </div>
-            )}
-            
-            {/* English text */}
-            {showEnglish && item?.english && (
-              <div className="text-lg md:text-xl font-semibold mt-1">
-                {item.english}
-              </div>
-            )}
-            
-            {/* Description */}
-            {description && (
-              <div className="text-sm text-center mt-2 px-2 opacity-90">
-                {description}
-              </div>
-            )}
-            
-            {/* Secondary text */}
-            {secondaryText && (
-              <div className="text-sm text-center mt-1 px-2 opacity-80">
-                {secondaryText}
-              </div>
-            )}
-            
-            {/* Sound icon */}
-            {finalShowSoundIcon && (
-              <Volume2 className="w-4 h-4 opacity-70 mt-2" aria-hidden="true" />
-            )}
-          </>
-        )}
-      </div>
-    </button>
+    <AdvancedCard
+      {...rest}
+      item={item}
+      hebrewText={hebrewText}
+      backgroundPattern={backgroundPattern}
+      customContent={customContent}
+      finalShowSoundIcon={finalShowSoundIcon}
+      handleClick={handleClick}
+    />
   );
 }


### PR DESCRIPTION
## Changes

Splits 288-line \UnifiedCard.tsx\ into two focused rendering components.

### New files
| File | Contents |
|---|---|
| \SimpleCard.tsx\ | Button-based small card (former simple variant) |
| \AdvancedCard.tsx\ | Gradient card with patterns/decorations (former advanced variant) |

### Updated files
- \UnifiedCard.tsx\ — thin facade: detects variant, wires click/audio handlers, delegates to SimpleCard or AdvancedCard; reduced from 288 to ~65 lines

No breaking changes. Lint clean.

Closes #135