### PR TITLE
refactor(game-result): migrate 4 GameOverScreen components to GameResultCard (#161)

### DIFF
--- a/gamesformykids/app/games/color-tap/components/ColorTapGameOverScreen.tsx
+++ b/gamesformykids/app/games/color-tap/components/ColorTapGameOverScreen.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+import GameResultCard from '@/components/game/shared/GameResultCard';
+
 interface Props {
   score: number;
   best: number;
@@ -8,27 +10,24 @@ interface Props {
 
 export default function ColorTapGameOverScreen({ score, best, onRestart }: Props) {
   return (
-    <div className="min-h-screen bg-gradient-to-br from-pink-100 to-purple-200 flex items-center justify-center p-4" dir="rtl">
-      <div className="bg-white rounded-3xl p-8 text-center shadow-2xl max-w-sm w-full">
-        <div className="text-6xl mb-3">😢</div>
-        <h2 className="text-2xl font-black text-gray-700 mb-4">נגמרו החיים!</h2>
-        <div className="grid grid-cols-2 gap-4 mb-6">
-          <div className="bg-pink-50 rounded-2xl p-3">
-            <p className="text-3xl font-black text-pink-600">{score}</p>
-            <p className="text-xs text-pink-400">ניקוד</p>
-          </div>
-          <div className="bg-yellow-50 rounded-2xl p-3">
-            <p className="text-3xl font-black text-yellow-500">{best}</p>
-            <p className="text-xs text-yellow-400">שיא</p>
-          </div>
+    <GameResultCard
+      emoji="😢"
+      title="נגמרו החיים!"
+      gradientClass="from-pink-100 to-purple-200"
+      buttonClass="from-pink-500 to-purple-600"
+      onRestart={onRestart}
+      restartLabel="🔄 שוב!"
+    >
+      <div className="grid grid-cols-2 gap-4">
+        <div className="bg-pink-50 rounded-2xl p-3">
+          <p className="text-3xl font-black text-pink-600">{score}</p>
+          <p className="text-xs text-pink-400">ניקוד</p>
         </div>
-        <button
-          onClick={onRestart}
-          className="w-full py-4 rounded-2xl bg-gradient-to-r from-pink-500 to-purple-600 text-white font-black text-xl hover:opacity-90 active:scale-95 transition-all"
-        >
-          🔄 שוב!
-        </button>
+        <div className="bg-yellow-50 rounded-2xl p-3">
+          <p className="text-3xl font-black text-yellow-500">{best}</p>
+          <p className="text-xs text-yellow-400">שיא</p>
+        </div>
       </div>
-    </div>
+    </GameResultCard>
   );
 }

--- a/gamesformykids/app/games/emoji-math/components/EmojiMathGameOverScreen.tsx
+++ b/gamesformykids/app/games/emoji-math/components/EmojiMathGameOverScreen.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+import GameResultCard from '@/components/game/shared/GameResultCard';
+
 interface Props {
   score: number;
   best: number;
@@ -8,27 +10,24 @@ interface Props {
 
 export default function EmojiMathGameOverScreen({ score, best, onRestart }: Props) {
   return (
-    <div className="min-h-screen bg-gradient-to-br from-yellow-100 to-orange-200 flex items-center justify-center p-4" dir="rtl">
-      <div className="bg-white rounded-3xl p-8 text-center shadow-2xl max-w-sm w-full">
-        <div className="text-6xl mb-3">🤓</div>
-        <h2 className="text-2xl font-black text-gray-700 mb-4">כל הכבוד על המאמץ!</h2>
-        <div className="grid grid-cols-2 gap-4 mb-6">
-          <div className="bg-orange-50 rounded-2xl p-3">
-            <p className="text-3xl font-black text-orange-600">{score}</p>
-            <p className="text-xs text-orange-400">ניקוד</p>
-          </div>
-          <div className="bg-yellow-50 rounded-2xl p-3">
-            <p className="text-3xl font-black text-yellow-500">{best}</p>
-            <p className="text-xs text-yellow-400">שיא</p>
-          </div>
+    <GameResultCard
+      emoji="🤓"
+      title="כל הכבוד על המאמץ!"
+      gradientClass="from-yellow-100 to-orange-200"
+      buttonClass="from-yellow-400 to-orange-500"
+      onRestart={onRestart}
+      restartLabel="🔄 שוב!"
+    >
+      <div className="grid grid-cols-2 gap-4">
+        <div className="bg-orange-50 rounded-2xl p-3">
+          <p className="text-3xl font-black text-orange-600">{score}</p>
+          <p className="text-xs text-orange-400">ניקוד</p>
         </div>
-        <button
-          onClick={onRestart}
-          className="w-full py-4 rounded-2xl bg-gradient-to-r from-yellow-400 to-orange-500 text-white font-black text-xl hover:opacity-90 active:scale-95 transition-all"
-        >
-          🔄 שוב!
-        </button>
+        <div className="bg-yellow-50 rounded-2xl p-3">
+          <p className="text-3xl font-black text-yellow-500">{best}</p>
+          <p className="text-xs text-yellow-400">שיא</p>
+        </div>
       </div>
-    </div>
+    </GameResultCard>
   );
 }

--- a/gamesformykids/app/games/simon/components/SimonGameOverScreen.tsx
+++ b/gamesformykids/app/games/simon/components/SimonGameOverScreen.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+import GameResultCard from '@/components/game/shared/GameResultCard';
+
 interface Props {
   roundScore: number;
   best: number;
@@ -8,11 +10,16 @@ interface Props {
 
 export default function SimonGameOverScreen({ roundScore, best, onRestart }: Props) {
   return (
-    <div className="bg-white rounded-3xl p-8 text-center shadow-2xl max-w-xs w-full">
-      <div className="text-6xl mb-3">😵</div>
-      <h2 className="text-2xl font-black text-gray-700 mb-2">טעית!</h2>
-      <p className="text-gray-500 text-sm mb-4">הגעת לרצף של {roundScore} צבעים</p>
-      <div className="grid grid-cols-2 gap-4 mb-6">
+    <GameResultCard
+      emoji="😵"
+      title="טעית!"
+      gradientClass="from-gray-800 to-gray-900"
+      buttonClass="from-gray-600 to-gray-800"
+      onRestart={onRestart}
+      restartLabel="🔄 שוב!"
+    >
+      <p className="text-gray-400 text-sm mb-4">הגעת לרצף של {roundScore} צבעים</p>
+      <div className="grid grid-cols-2 gap-4">
         <div className="bg-gray-50 rounded-2xl p-3">
           <p className="text-3xl font-black text-gray-700">{roundScore}</p>
           <p className="text-xs text-gray-400">סיבובים</p>
@@ -22,12 +29,6 @@ export default function SimonGameOverScreen({ roundScore, best, onRestart }: Pro
           <p className="text-xs text-yellow-400">שיא</p>
         </div>
       </div>
-      <button
-        onClick={onRestart}
-        className="w-full py-4 rounded-2xl bg-gray-800 text-white font-black text-xl hover:bg-gray-700 active:scale-95 transition-all"
-      >
-        🔄 שוב!
-      </button>
-    </div>
+    </GameResultCard>
   );
 }

--- a/gamesformykids/app/games/taki/components/TakiResultScreen.tsx
+++ b/gamesformykids/app/games/taki/components/TakiResultScreen.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import GameResultCard from '@/components/game/shared/GameResultCard';
 import { useTakiStore } from '../takiGameStore';
 
 export default function TakiResultScreen() {
@@ -8,23 +9,21 @@ export default function TakiResultScreen() {
   const playerScore = useTakiStore(s => s.playerScore);
   const computerScore = useTakiStore(s => s.computerScore);
   const startGame = useTakiStore(s => s.startGame);
+
   return (
-    <div className="flex flex-col items-center justify-center min-h-screen gap-6 px-4 text-center">
-      <div className="text-8xl">{phase === 'won' ? '🎉' : '😢'}</div>
-      <h2 className="text-4xl font-extrabold text-white drop-shadow-lg">
-        {phase === 'won' ? 'ניצחת!' : 'המחשב ניצח!'}
-      </h2>
-      <p className="text-green-200 text-xl">{message}</p>
-      <div className="flex gap-6 text-white text-xl font-semibold">
+    <GameResultCard
+      emoji={phase === 'won' ? '🎉' : '😢'}
+      title={phase === 'won' ? 'ניצחת!' : 'המחשב ניצח!'}
+      gradientClass="from-green-50 to-teal-100"
+      buttonClass="from-teal-500 to-emerald-600"
+      onRestart={startGame}
+      restartLabel="🔄 שחק שוב"
+    >
+      {message && <p className="text-gray-500 text-base mb-3">{message}</p>}
+      <div className="flex justify-center gap-6 text-gray-700 text-xl font-semibold">
         <span>🧑 אתה: {playerScore}</span>
         <span>🤖 מחשב: {computerScore}</span>
       </div>
-      <button
-        onClick={startGame}
-        className="bg-yellow-400 hover:bg-yellow-300 text-gray-900 font-extrabold text-xl px-10 py-4 rounded-2xl shadow-xl transition-transform hover:scale-105 active:scale-95 mt-2"
-      >
-        🔄 שחק שוב
-      </button>
-    </div>
+    </GameResultCard>
   );
 }


### PR DESCRIPTION
## Summary
- Migrate `ColorTapGameOverScreen`, `EmojiMathGameOverScreen`, `SimonGameOverScreen`, and `TakiResultScreen` to use the shared `GameResultCard` shell
- ColorTap & EmojiMath: direct mechanical replacement (identical structure)
- Simon: uses dark gradient (`from-gray-800 to-gray-900`) to match parent's dark theme
- Taki: uses light green gradient (`from-green-50 to-teal-100`); Zustand store reads preserved as-is

## Test plan
- [ ] ColorTap game over screen displays score + best correctly
- [ ] EmojiMath game over screen displays score + best correctly
- [ ] Simon "טעית!" screen shows round score + best, dark background
- [ ] Taki result screen shows win/lose, player/computer scores, message if present
- [ ] All restart buttons work

Closes #161

🤖 Generated with [Claude Code](https://claude.com/claude-code)