### PR TITLE
refactor(game-menu): migrate 9 MenuScreen components to GameMenuCard (#158)

### DIFF
--- a/gamesformykids/app/games/arithmetic/components/ArithmeticMenuScreen.tsx
+++ b/gamesformykids/app/games/arithmetic/components/ArithmeticMenuScreen.tsx
@@ -1,4 +1,6 @@
 'use client';
+
+import GameMenuCard from '@/components/game/shared/GameMenuCard';
 import { useArithmeticGameStore } from '../arithmeticGameStore';
 import { LEVELS, LEVEL_EMOJIS } from '../data/questions';
 
@@ -6,24 +8,22 @@ export default function ArithmeticMenuScreen() {
   const startGame = useArithmeticGameStore(s => s.startGame);
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-blue-50 to-indigo-100 p-4" dir="rtl">
-      <div className="max-w-xl mx-auto">
-        <div className="text-center mb-8">
-          <div className="text-6xl mb-3">➕</div>
-          <h1 className="text-3xl font-bold text-indigo-800 mb-2">חשבון מהיר</h1>
-          <p className="text-indigo-600">בחר רמה ותתחיל!</p>
-        </div>
-        <div className="grid grid-cols-2 gap-4">
-          {LEVELS.map(lv => (
-            <button key={lv.id} onClick={() => startGame(lv)}
-              className="p-5 rounded-2xl text-white font-bold text-lg shadow-lg hover:scale-105 active:scale-95 transition-all bg-gradient-to-br from-indigo-500 to-blue-600 text-right">
-              <div className="text-2xl mb-1">{LEVEL_EMOJIS[lv.id]}</div>
-              <div>{lv.label}</div>
-              <div className="text-xs opacity-70 mt-1 font-normal">עד {lv.maxNum}{lv.operations.includes('×') ? ' × ' + lv.maxNum : ''}</div>
-            </button>
-          ))}
-        </div>
+    <GameMenuCard
+      emoji="➕"
+      title="חשבון מהיר"
+      description="בחר רמה ותתחיל!"
+      gradientClass="from-blue-50 to-indigo-100"
+    >
+      <div className="grid grid-cols-2 gap-4">
+        {LEVELS.map(lv => (
+          <button key={lv.id} onClick={() => startGame(lv)}
+            className="p-5 rounded-2xl text-white font-bold text-lg shadow-lg hover:scale-105 active:scale-95 transition-all bg-gradient-to-br from-indigo-500 to-blue-600 text-right">
+            <div className="text-2xl mb-1">{LEVEL_EMOJIS[lv.id]}</div>
+            <div>{lv.label}</div>
+            <div className="text-xs opacity-70 mt-1 font-normal">עד {lv.maxNum}{lv.operations.includes('×') ? ' × ' + lv.maxNum : ''}</div>
+          </button>
+        ))}
       </div>
-    </div>
+    </GameMenuCard>
   );
 }

--- a/gamesformykids/app/games/checkers/components/DamkaMenuScreen.tsx
+++ b/gamesformykids/app/games/checkers/components/DamkaMenuScreen.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+import GameMenuCard from '@/components/game/shared/GameMenuCard';
+
 interface DamkaMenuScreenProps {
   playerScore: number;
   computerScore: number;
@@ -8,34 +10,29 @@ interface DamkaMenuScreenProps {
 
 export default function DamkaMenuScreen({ playerScore, computerScore, onStart }: DamkaMenuScreenProps) {
   return (
-    <div className="flex flex-col items-center gap-8 text-center">
-      <div className="text-8xl">♟️</div>
-      <h1 className="text-5xl font-extrabold text-white drop-shadow-lg">דמקה</h1>
-      <p className="text-amber-200 text-lg max-w-sm">
-        משחק הדמקה הקלאסי נגד המחשב!<br />
-        בחר האסימון האדום שלך וקפוץ מעל האסימונים הלבנים.<br />
-        מי שיישאר עם קלפים ינצח! 👑
-      </p>
+    <GameMenuCard
+      emoji="♟️"
+      title="דמקה"
+      description="משחק הדמקה הקלאסי נגד המחשב!"
+      gradientClass="from-amber-900 to-stone-950"
+      buttonClass="from-amber-400 to-amber-500"
+      onStart={onStart}
+      startLabel="🎮 התחל משחק"
+    >
       {(playerScore > 0 || computerScore > 0) && (
-        <div className="flex gap-6 text-white text-lg font-semibold">
+        <div className="flex justify-center gap-6 text-gray-700 text-lg font-semibold mb-2">
           <span>🔴 אתה: {playerScore}</span>
           <span>⚪ מחשב: {computerScore}</span>
         </div>
       )}
-      <button
-        onClick={onStart}
-        className="bg-amber-400 hover:bg-amber-300 text-gray-900 font-extrabold text-xl px-10 py-4 rounded-2xl shadow-xl transition-transform hover:scale-105 active:scale-95"
-      >
-        🎮 התחל משחק
-      </button>
-      <div className="bg-black/30 rounded-xl p-4 text-amber-200 text-sm max-w-sm text-right space-y-1">
-        <p className="font-bold text-white mb-2">כללים:</p>
+      <div className="bg-amber-50 rounded-xl p-4 text-gray-600 text-sm text-right space-y-1">
+        <p className="font-bold text-gray-700 mb-2">כללים:</p>
         <p>🔴 האסימונים שלך = אדום (מלמטה↑)</p>
         <p>⚪ המחשב = לבן (מלמעלה↓)</p>
         <p>👑 הגע לצד השני להפוך למלך (זז בכל כיוון)</p>
         <p>⚡ חובה לקפוץ כשיש הזדמנות!</p>
         <p>🏆 נצח כשלמחשב אין אסימונים או מהלכים</p>
       </div>
-    </div>
+    </GameMenuCard>
   );
 }

--- a/gamesformykids/app/games/color-tap/components/ColorTapMenuScreen.tsx
+++ b/gamesformykids/app/games/color-tap/components/ColorTapMenuScreen.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+import GameMenuCard from '@/components/game/shared/GameMenuCard';
+
 interface Props {
   best: number;
   onStart: () => void;
@@ -7,20 +9,16 @@ interface Props {
 
 export default function ColorTapMenuScreen({ best, onStart }: Props) {
   return (
-    <div className="min-h-screen bg-gradient-to-br from-pink-100 to-purple-200 flex items-center justify-center p-4" dir="rtl">
-      <div className="bg-white rounded-3xl p-8 text-center shadow-2xl max-w-sm w-full">
-        <div className="text-6xl mb-4">🎨</div>
-        <h1 className="text-3xl font-black text-gray-700 mb-2">צבע נכון</h1>
-        <p className="text-gray-500 mb-2 text-sm">בחר את הצבע הנכון לפני שהזמן נגמר!</p>
-        <p className="text-gray-400 mb-6 text-xs">3 חיים · 5 שניות לכל שאלה</p>
-        {best > 0 && <p className="text-yellow-600 font-bold mb-4">🏆 שיא: {best}</p>}
-        <button
-          onClick={onStart}
-          className="w-full py-4 rounded-2xl bg-gradient-to-r from-pink-500 to-purple-600 text-white font-black text-xl shadow-lg hover:opacity-90 active:scale-95 transition-all"
-        >
-          🎨 התחל!
-        </button>
-      </div>
-    </div>
+    <GameMenuCard
+      emoji="🎨"
+      title="צבע נכון"
+      description="בחר את הצבע הנכון לפני שהזמן נגמר!"
+      hint="3 חיים · 5 שניות לכל שאלה"
+      gradientClass="from-pink-100 to-purple-200"
+      buttonClass="from-pink-500 to-purple-600"
+      onStart={onStart}
+      startLabel="🎨 התחל!"
+      best={best}
+    />
   );
 }

--- a/gamesformykids/app/games/math-race/components/MathRaceMenuScreen.tsx
+++ b/gamesformykids/app/games/math-race/components/MathRaceMenuScreen.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+import GameMenuCard from '@/components/game/shared/GameMenuCard';
+
 interface Props {
   best: number;
   gameTime: number;
@@ -8,20 +10,16 @@ interface Props {
 
 export default function MathRaceMenuScreen({ best, gameTime, onStart }: Props) {
   return (
-    <div className="min-h-screen bg-gradient-to-br from-blue-100 to-indigo-200 flex items-center justify-center p-4" dir="rtl">
-      <div className="bg-white rounded-3xl p-8 text-center shadow-2xl max-w-sm w-full">
-        <div className="text-6xl mb-4">🏎️</div>
-        <h1 className="text-3xl font-black text-gray-700 mb-2">מרוץ מתמטיקה</h1>
-        <p className="text-gray-500 text-sm mb-2">פתור כמה שיותר תרגילים ב-{gameTime} שניות!</p>
-        <p className="text-gray-400 text-xs mb-6">רצף 3+ = 20 נקודות · הקושי עולה עם הניקוד</p>
-        {best > 0 && <p className="text-yellow-600 font-bold mb-4">🏆 שיא: {best}</p>}
-        <button
-          onClick={onStart}
-          className="w-full py-4 rounded-2xl bg-gradient-to-r from-blue-500 to-indigo-600 text-white font-black text-xl hover:opacity-90 active:scale-95 transition-all"
-        >
-          🏎️ התחל!
-        </button>
-      </div>
-    </div>
+    <GameMenuCard
+      emoji="🏎️"
+      title="מרוץ מתמטיקה"
+      description={`פתור כמה שיותר תרגילים ב-${gameTime} שניות!`}
+      hint="רצף 3+ = 20 נקודות · הקושי עולה עם הניקוד"
+      gradientClass="from-blue-100 to-indigo-200"
+      buttonClass="from-blue-500 to-indigo-600"
+      onStart={onStart}
+      startLabel="🏎️ התחל!"
+      best={best}
+    />
   );
 }

--- a/gamesformykids/app/games/multiplication/components/MultiplicationMenuScreen.tsx
+++ b/gamesformykids/app/games/multiplication/components/MultiplicationMenuScreen.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+import GameMenuCard from '@/components/game/shared/GameMenuCard';
+
 interface Props {
   levels: number[];
   questionsPerLevel: number;
@@ -9,25 +11,23 @@ interface Props {
 
 export default function MultiplicationMenuScreen({ levels, questionsPerLevel, timePerQuestion, onStart }: Props) {
   return (
-    <div className="min-h-screen bg-gradient-to-br from-violet-50 to-purple-100 p-4" dir="rtl">
-      <div className="max-w-xl mx-auto">
-        <div className="text-center mb-8">
-          <div className="text-6xl mb-3">✖️</div>
-          <h1 className="text-3xl font-bold text-purple-800 mb-2">לוח הכפל</h1>
-          <p className="text-purple-600">בחר לוח כפל ותתחיל!</p>
-        </div>
-        <div className="grid grid-cols-5 gap-3">
-          {levels.map(lv => (
-            <button key={lv} onClick={() => onStart(lv)}
-              className="aspect-square rounded-2xl text-2xl font-black text-white shadow-lg hover:scale-105 active:scale-95 transition-all bg-gradient-to-br from-purple-500 to-violet-600 hover:from-purple-400 hover:to-violet-500">
-              {lv}
-            </button>
-          ))}
-        </div>
-        <p className="text-center text-purple-500 text-sm mt-6">
-          {questionsPerLevel} שאלות ל-{timePerQuestion} שניות כל אחת
-        </p>
+    <GameMenuCard
+      emoji="✖️"
+      title="לוח הכפל"
+      description="בחר לוח כפל ותתחיל!"
+      gradientClass="from-violet-50 to-purple-100"
+    >
+      <div className="grid grid-cols-5 gap-3">
+        {levels.map(lv => (
+          <button key={lv} onClick={() => onStart(lv)}
+            className="aspect-square rounded-2xl text-2xl font-black text-white shadow-lg hover:scale-105 active:scale-95 transition-all bg-gradient-to-br from-purple-500 to-violet-600 hover:from-purple-400 hover:to-violet-500">
+            {lv}
+          </button>
+        ))}
       </div>
-    </div>
+      <p className="text-center text-purple-500 text-sm mt-4">
+        {questionsPerLevel} שאלות ל-{timePerQuestion} שניות כל אחת
+      </p>
+    </GameMenuCard>
   );
 }

--- a/gamesformykids/app/games/number-bubbles/components/NumberBubblesMenuScreen.tsx
+++ b/gamesformykids/app/games/number-bubbles/components/NumberBubblesMenuScreen.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+import GameMenuCard from '@/components/game/shared/GameMenuCard';
+
 interface Best {
   level: number;
   time: number;
@@ -12,20 +14,19 @@ interface Props {
 
 export default function NumberBubblesMenuScreen({ best, onStart }: Props) {
   return (
-    <div className="min-h-screen bg-gradient-to-br from-sky-100 to-blue-200 flex items-center justify-center p-4" dir="rtl">
-      <div className="bg-white rounded-3xl p-8 text-center shadow-2xl max-w-sm w-full">
-        <div className="text-6xl mb-4">🔢</div>
-        <h1 className="text-3xl font-black text-gray-700 mb-2">בועות מספרים</h1>
-        <p className="text-gray-500 text-sm mb-2">פוצץ את הבועות לפי הסדר: 1, 2, 3...</p>
-        <p className="text-gray-400 text-xs mb-6">כל רמה יש יותר מספרים!</p>
-        {best && <p className="text-yellow-600 font-bold mb-4">🏆 שיא: רמה {best.level} ב-{best.time}s</p>}
-        <button
-          onClick={onStart}
-          className="w-full py-4 rounded-2xl bg-gradient-to-r from-sky-500 to-blue-600 text-white font-black text-xl hover:opacity-90 active:scale-95 transition-all"
-        >
-          🔢 התחל!
-        </button>
-      </div>
-    </div>
+    <GameMenuCard
+      emoji="🔢"
+      title="בועות מספרים"
+      description="פוצץ את הבועות לפי הסדר: 1, 2, 3..."
+      hint="כל רמה יש יותר מספרים!"
+      gradientClass="from-sky-100 to-blue-200"
+      buttonClass="from-sky-500 to-blue-600"
+      onStart={onStart}
+      startLabel="🔢 התחל!"
+    >
+      {best && (
+        <p className="text-yellow-600 font-bold mb-2">🏆 שיא: רמה {best.level} ב-{best.time}s</p>
+      )}
+    </GameMenuCard>
   );
 }

--- a/gamesformykids/app/games/reflex/components/ReflexMenuScreen.tsx
+++ b/gamesformykids/app/games/reflex/components/ReflexMenuScreen.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+import GameMenuCard from '@/components/game/shared/GameMenuCard';
+
 interface Props {
   gameDuration: number;
   onStart: () => void;
@@ -7,23 +9,20 @@ interface Props {
 
 export default function ReflexMenuScreen({ gameDuration, onStart }: Props) {
   return (
-    <div className="min-h-screen bg-gradient-to-br from-rose-50 to-red-100 p-4 flex items-center" dir="rtl">
-      <div className="max-w-md mx-auto w-full text-center">
-        <div className="text-7xl mb-4">⚡</div>
-        <h1 className="text-3xl font-bold text-red-800 mb-3">מהירות תגובה</h1>
-        <p className="text-red-600 mb-3">לחץ על הסמלים לפני שהם נעלמים!</p>
-        <div className="bg-red-100 rounded-2xl p-4 mb-8 text-sm text-red-700 space-y-1 text-right">
-          <p>⏱️ {gameDuration} שניות משחק</p>
-          <p>⚡ ככל שאוספים יותר — הסמלים מהירים יותר</p>
-          <p>❌ סמל שנעלם = פספוס</p>
-        </div>
-        <button
-          onClick={onStart}
-          className="w-full py-5 rounded-2xl text-white font-bold text-2xl bg-gradient-to-l from-rose-500 to-red-600 shadow-xl hover:opacity-90 active:scale-95 transition-all"
-        >
-          🚀 התחל!
-        </button>
+    <GameMenuCard
+      emoji="⚡"
+      title="מהירות תגובה"
+      description="לחץ על הסמלים לפני שהם נעלמים!"
+      gradientClass="from-rose-50 to-red-100"
+      buttonClass="from-rose-500 to-red-600"
+      onStart={onStart}
+      startLabel="🚀 התחל!"
+    >
+      <div className="bg-red-100 rounded-2xl p-4 text-sm text-red-700 space-y-1 text-right">
+        <p>⏱️ {gameDuration} שניות משחק</p>
+        <p>⚡ ככל שאוספים יותר — הסמלים מהירים יותר</p>
+        <p>❌ סמל שנעלם = פספוס</p>
       </div>
-    </div>
+    </GameMenuCard>
   );
 }

--- a/gamesformykids/app/games/simon/components/SimonMenuScreen.tsx
+++ b/gamesformykids/app/games/simon/components/SimonMenuScreen.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+import GameMenuCard from '@/components/game/shared/GameMenuCard';
+
 interface Props {
   best: number;
   onStart: () => void;
@@ -7,18 +9,16 @@ interface Props {
 
 export default function SimonMenuScreen({ best, onStart }: Props) {
   return (
-    <div className="bg-white rounded-3xl p-8 text-center shadow-2xl max-w-xs w-full">
-      <div className="text-6xl mb-4">🔴</div>
-      <h1 className="text-3xl font-black text-gray-700 mb-2">שיימון אומר</h1>
-      <p className="text-gray-500 text-sm mb-2">צפה בסדר הצבעים וחזור עליהם בדיוק!</p>
-      <p className="text-gray-400 text-xs mb-5">כל סיבוב — עוד צבע אחד</p>
-      {best > 0 && <p className="text-yellow-600 font-bold mb-4">🏆 שיא: {best} צבעים</p>}
-      <button
-        onClick={onStart}
-        className="w-full py-4 rounded-2xl bg-gray-800 text-white font-black text-xl hover:bg-gray-700 active:scale-95 transition-all"
-      >
-        🔴 התחל!
-      </button>
-    </div>
+    <GameMenuCard
+      emoji="🔴"
+      title="שיימון אומר"
+      description="צפה בסדר הצבעים וחזור עליהם בדיוק!"
+      hint="כל סיבוב — עוד צבע אחד"
+      gradientClass="from-gray-800 to-gray-900"
+      buttonClass="from-gray-600 to-gray-800"
+      onStart={onStart}
+      startLabel="🔴 התחל!"
+      best={best}
+    />
   );
 }

--- a/gamesformykids/app/games/taki/components/TakiMenuScreen.tsx
+++ b/gamesformykids/app/games/taki/components/TakiMenuScreen.tsx
@@ -1,34 +1,31 @@
 'use client';
 
+import GameMenuCard from '@/components/game/shared/GameMenuCard';
 import { useTakiStore } from '../takiGameStore';
 
 export default function TakiMenuScreen() {
   const playerScore = useTakiStore(s => s.playerScore);
   const computerScore = useTakiStore(s => s.computerScore);
   const startGame = useTakiStore(s => s.startGame);
+
   return (
-    <div className="flex flex-col items-center justify-center min-h-screen gap-8 px-4 text-center">
-      <div className="text-8xl">🃏</div>
-      <h1 className="text-5xl font-extrabold text-white drop-shadow-lg">טאקי</h1>
-      <p className="text-green-200 text-lg max-w-sm">
-        משחק הקלפים הישראלי הקלאסי — שחק נגד המחשב!<br />
-        שחק קלפים באותו צבע או ערך, השתמש בקלפים מיוחדים,<br />
-        וריקן את היד ראשון כדי לנצח! 🏆
-      </p>
+    <GameMenuCard
+      emoji="🃏"
+      title="טאקי"
+      description="משחק הקלפים הישראלי הקלאסי — שחק נגד המחשב!"
+      gradientClass="from-green-50 to-teal-100"
+      buttonClass="from-teal-500 to-emerald-600"
+      onStart={startGame}
+      startLabel="🎮 התחל משחק"
+    >
       {(playerScore > 0 || computerScore > 0) && (
-        <div className="flex gap-6 text-white text-lg font-semibold">
+        <div className="flex justify-center gap-6 text-gray-700 text-lg font-semibold mb-2">
           <span>🧑 אתה: {playerScore}</span>
           <span>🤖 מחשב: {computerScore}</span>
         </div>
       )}
-      <button
-        onClick={startGame}
-        className="bg-yellow-400 hover:bg-yellow-300 text-gray-900 font-extrabold text-xl px-10 py-4 rounded-2xl shadow-xl transition-transform hover:scale-105 active:scale-95"
-      >
-        🎮 התחל משחק
-      </button>
-      <div className="bg-black/30 rounded-xl p-4 text-green-200 text-sm max-w-sm text-right space-y-1">
-        <p className="font-bold text-white mb-2">כללים בקצרה:</p>
+      <div className="bg-green-50 rounded-xl p-4 text-gray-600 text-sm text-right space-y-1">
+        <p className="font-bold text-gray-700 mb-2">כללים בקצרה:</p>
         <p>🃏 <strong>טאקי</strong> — שחק קלפים באותו צבע ולחץ &ldquo;סגור&rdquo;</p>
         <p>✋ <strong>עצור</strong> — המתנגד מדלג תור</p>
         <p>+2 <strong>פלוס</strong> — המתנגד מושך 2 קלפים</p>
@@ -36,6 +33,6 @@ export default function TakiMenuScreen() {
         <p>👑 <strong>מלך</strong> — שנה צבע + עצור</p>
         <p>⭐ <strong>סופר טאקי</strong> — טאקי עם כל צבע</p>
       </div>
-    </div>
+    </GameMenuCard>
   );
 }

--- a/gamesformykids/components/game/shared/GameMenuCard.tsx
+++ b/gamesformykids/components/game/shared/GameMenuCard.tsx
@@ -8,8 +8,8 @@ interface Props {
   /** Full Tailwind gradient classes, e.g. "from-green-50 to-teal-100" */
   gradientClass: string;
   /** Full Tailwind gradient classes for the start button, e.g. "from-blue-500 to-indigo-600" */
-  buttonClass: string;
-  onStart: () => void;
+  buttonClass?: string;
+  onStart?: () => void;
   startLabel?: string;
   animateEmoji?: boolean;
   /** Optional extra info line below description (e.g. rules, time per question) */
@@ -53,13 +53,15 @@ export default function GameMenuCard({
           <p className="text-yellow-600 font-bold mb-4">🏆 שיא: {best}</p>
         )}
         {children && <div className="mb-6">{children}</div>}
-        {!children && <div className="mb-2" />}
-        <button
-          onClick={onStart}
-          className={`w-full py-4 rounded-2xl bg-gradient-to-r ${buttonClass} text-white font-black text-xl hover:opacity-90 active:scale-95 transition-all`}
-        >
-          {startLabel ?? `${emoji} התחל!`}
-        </button>
+        {!children && onStart && <div className="mb-2" />}
+        {onStart && (
+          <button
+            onClick={onStart}
+            className={`w-full py-4 rounded-2xl bg-gradient-to-r ${buttonClass ?? ''} text-white font-black text-xl hover:opacity-90 active:scale-95 transition-all`}
+          >
+            {startLabel ?? `${emoji} התחל!`}
+          </button>
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- Make `GameMenuCard.onStart` and `buttonClass` optional so level-selection screens don't need a dummy start button
- Migrate 9 of 12 MenuScreen components to use `GameMenuCard`:
  - **ColorTap, NumberBubbles, MathRace** — direct fit (gradient + description + best + button)
  - **Simon** — dark gradient (`from-gray-800 to-gray-900`) to match parent's dark theme
  - **Reflex** — rules block passed as `children`
  - **Taki** — green theme (consistent with TakiResultScreen from #161), scores + rules in children
  - **Damka** — amber theme, scores + rules in children
  - **Arithmetic, Multiplication** — level selection grids as `children`, no start button

## Skipped (3 files — fundamentally different layouts)
- `shesh-besh/MenuScreen.tsx` — highly custom dark amber theme, gradient clip text, 3D button shadows
- `soccer/SoccerMenuScreen.tsx` — uses `PitchBackground` custom wrapper + `SoccerCategoryGrid`
- `animals/AnimalsMenuScreen.tsx` — file not found in filesystem

## Test plan
- [ ] ColorTap / NumberBubbles / MathRace menus show correct description and start correctly
- [ ] Simon menu displays on dark background, best score shows correctly
- [ ] Reflex menu shows rules box, game starts correctly
- [ ] Taki / Damka menus show previous scores and rules
- [ ] Arithmetic level grid starts game at selected level (no extra button)
- [ ] Multiplication table grid starts at selected table

Closes #158

🤖 Generated with [Claude Code](https://claude.com/claude-code)