### PR TITLE
refactor(stores): extract makeStore factory, migrate 17 stores (#171)

### DIFF
--- a/gamesformykids/lib/stores/achievementsStore.ts
+++ b/gamesformykids/lib/stores/achievementsStore.ts
@@ -8,8 +8,7 @@
  * מחליף את useState ב-useAchievements.ts.
  */
 
-import { create } from 'zustand';
-import { devtools } from 'zustand/middleware';
+import { makeStore } from './createStore';
 import type { Achievement } from '@/hooks/shared/progress/useAchievements';
 import { INITIAL_REMOTE_SLICE, type RemoteDataSlice } from './utils/RemoteDataSlice';
 
@@ -34,9 +33,7 @@ const initialState: AchievementsState = {
 };
 
 // ── Store ──────────────────────────────────────────────────
-export const useAchievementsStore = create<AchievementsState & AchievementsStoreActions>()(
-  devtools(
-    (set) => ({
+export const useAchievementsStore = makeStore<AchievementsState & AchievementsStoreActions>('AchievementsStore', (set) => ({
       ...initialState,
 
       setAchievements: (achievements) =>
@@ -57,7 +54,4 @@ export const useAchievementsStore = create<AchievementsState & AchievementsStore
         set({ loadedForUserId: userId }, false, 'achievements/setLoadedForUserId'),
 
       reset: () => set(initialState, false, 'achievements/reset'),
-    }),
-    { name: 'AchievementsStore' },
-  ),
-);
+    }));

--- a/gamesformykids/lib/stores/animalsStore.ts
+++ b/gamesformykids/lib/stores/animalsStore.ts
@@ -1,5 +1,4 @@
-import { create } from 'zustand';
-import { devtools } from 'zustand/middleware';
+import { makeStore } from './createStore';
 import { ANIMALS, type Animal, type AnimalCategory } from '@/app/games/animals/data/animals';
 import { shuffle } from '@/lib/utils';
 import { QUESTIONS_PER_GAME } from '@/lib/quiz/constants';
@@ -41,16 +40,11 @@ const INITIAL_STATE: AnimalsState = {
   questions: [],
 };
 
-export const useAnimalsStore = create<AnimalsState & AnimalsActions>()(
-  devtools(
-    (set) => ({
+export const useAnimalsStore = makeStore<AnimalsState & AnimalsActions>('AnimalsStore', (set) => ({
       ...INITIAL_STATE,
 
       setQuestions: (category, questions) =>
         set({ category, questions }, false, 'animals/setQuestions'),
 
       reset: () => set(INITIAL_STATE, false, 'animals/reset'),
-    }),
-    { name: 'AnimalsStore' },
-  ),
-);
+    }));

--- a/gamesformykids/lib/stores/authStore.ts
+++ b/gamesformykids/lib/stores/authStore.ts
@@ -7,8 +7,7 @@
  * ומעדכן את ה-store — כל שאר הקומפוננטות קוראות מהסטור ישירות.
  */
 
-import { create } from 'zustand';
-import { devtools } from 'zustand/middleware';
+import { makeStore } from './createStore';
 import type { User, Session } from '@supabase/supabase-js';
 import { supabase, isSupabaseConfigured } from '@/lib/supabase/client';
 
@@ -38,9 +37,7 @@ const INITIAL_STATE: AuthState = {
   isGuest: false,
 };
 
-export const useAuthStore = create<AuthState & AuthActions>()(
-  devtools(
-    (set) => ({
+export const useAuthStore = makeStore<AuthState & AuthActions>('AuthStore', (set) => ({
       ...INITIAL_STATE,
 
       setUser: (user) => set({ user }, false, 'auth/setUser'),
@@ -57,8 +54,5 @@ export const useAuthStore = create<AuthState & AuthActions>()(
       },
 
       reset: () => set(INITIAL_STATE, false, 'auth/reset'),
-    }),
-    { name: 'AuthStore' }
-  )
-);
+    }));
 

--- a/gamesformykids/lib/stores/createStore.ts
+++ b/gamesformykids/lib/stores/createStore.ts
@@ -1,0 +1,19 @@
+import { create, type StateCreator } from 'zustand';
+import { devtools } from 'zustand/middleware';
+
+/**
+ * Wraps create<T>()(devtools(creator, { name })) to reduce per-store boilerplate.
+ * Named `makeStore` to avoid shadowing Zustand v5's own `createStore` export.
+ *
+ * Usage:
+ *   export const useFooStore = makeStore<FooState & FooActions>('FooStore', (set, get) => ({
+ *     ...INITIAL_STATE,
+ *     action: () => set({...}, false, 'foo/action'),
+ *   }));
+ */
+export function makeStore<T extends object>(
+  name: string,
+  creator: StateCreator<T, [['zustand/devtools', never]]>,
+) {
+  return create<T>()(devtools(creator, { name }));
+}

--- a/gamesformykids/lib/stores/featuredGameStore.ts
+++ b/gamesformykids/lib/stores/featuredGameStore.ts
@@ -1,5 +1,4 @@
-import { create } from 'zustand';
-import { devtools } from 'zustand/middleware';
+import { makeStore } from './createStore';
 import { GamesRegistry, GameRegistration } from '@/lib/registry/gamesRegistry';
 
 export interface AgeGroupData {
@@ -46,9 +45,7 @@ function computeAgeGroups(allGames: GameRegistration[]): Record<string, AgeGroup
   };
 }
 
-export const useFeaturedGameStore = create<FeaturedGameState>()(
-  devtools(
-    (set, get) => ({
+export const useFeaturedGameStore = makeStore<FeaturedGameState>('FeaturedGameStore', (set, get) => ({
       featuredGame: null,
       ageGroups: {},
       ageGroupKeys: [],
@@ -73,7 +70,4 @@ export const useFeaturedGameStore = create<FeaturedGameState>()(
           'featuredGame/initialize'
         );
       },
-    }),
-    { name: 'FeaturedGameStore' }
-  )
-);
+    }));

--- a/gamesformykids/lib/stores/gameActionsStore.ts
+++ b/gamesformykids/lib/stores/gameActionsStore.ts
@@ -10,8 +10,7 @@
  * המשחק ללא props drilling.
  */
 
-import { create } from 'zustand';
-import { devtools } from 'zustand/middleware';
+import { makeStore } from './createStore';
 import type { BaseGameItem } from '@/lib/types/core/base';
 
 const NOOP = () => {};
@@ -32,9 +31,7 @@ export interface GameActionsStoreActions {
   setGameActions: (actions: Partial<GameActionsState>) => void;
 }
 
-export const useGameActionsStore = create<GameActionsState & GameActionsStoreActions>()(
-  devtools(
-    (set) => ({
+export const useGameActionsStore = makeStore<GameActionsState & GameActionsStoreActions>('GameActionsStore', (set) => ({
       startGame: ASYNC_NOOP,
       resetGame: NOOP,
       handleItemClick: ASYNC_NOOP,
@@ -45,7 +42,4 @@ export const useGameActionsStore = create<GameActionsState & GameActionsStoreAct
       currentAccuracy: 0,
 
       setGameActions: (actions) => set(actions, false, 'gameActions/setGameActions'),
-    }),
-    { name: 'GameActionsStore' },
-  ),
-);
+    }));

--- a/gamesformykids/lib/stores/gameAudioStore.ts
+++ b/gamesformykids/lib/stores/gameAudioStore.ts
@@ -1,5 +1,4 @@
-import { create } from 'zustand';
-import { devtools } from 'zustand/middleware';
+import { makeStore } from './createStore';
 
 interface GameAudioState {
   audioContext: AudioContext | null;
@@ -8,14 +7,9 @@ interface GameAudioState {
   setSpeechEnabled: (enabled: boolean) => void;
 }
 
-export const useGameAudioStore = create<GameAudioState>()(
-  devtools(
-    (set) => ({
+export const useGameAudioStore = makeStore<GameAudioState>('GameAudioStore', (set) => ({
       audioContext: null,
       speechEnabled: false,
       setAudioContext: (ctx) => set({ audioContext: ctx }),
       setSpeechEnabled: (enabled) => set({ speechEnabled: enabled }),
-    }),
-    { name: 'GameAudioStore' }
-  )
-);
+    }));

--- a/gamesformykids/lib/stores/gameDataStore.ts
+++ b/gamesformykids/lib/stores/gameDataStore.ts
@@ -1,5 +1,4 @@
-import { create } from 'zustand';
-import { devtools } from 'zustand/middleware';
+import { makeStore } from './createStore';
 import { GameItem, GameTypeDbRecord } from '@/lib/types/hooks/game-state';
 
 interface GameDataState {
@@ -14,9 +13,7 @@ interface GameDataState {
   reset: () => void;
 }
 
-export const useGameDataStore = create<GameDataState>()(
-  devtools(
-    (set) => ({
+export const useGameDataStore = makeStore<GameDataState>('GameDataStore', (set) => ({
       gameItems: [],
       gameTypes: [],
       loading: false,
@@ -26,7 +23,4 @@ export const useGameDataStore = create<GameDataState>()(
       setLoading: (loading) => set({ loading }),
       setError: (error) => set({ error }),
       reset: () => set({ gameItems: [], gameTypes: [], loading: false, error: null, loaded: false }),
-    }),
-    { name: 'GameDataStore' }
-  )
-);
+    }));

--- a/gamesformykids/lib/stores/gameHintsStore.ts
+++ b/gamesformykids/lib/stores/gameHintsStore.ts
@@ -8,8 +8,7 @@
  * מחליף את useState ב-useGameHints.ts.
  */
 
-import { create } from 'zustand';
-import { devtools } from 'zustand/middleware';
+import { makeStore } from './createStore';
 import type { GameHint } from '@/lib/types/hooks/ui';
 
 // ── State ──────────────────────────────────────────────────
@@ -26,9 +25,7 @@ export interface GameHintsActions {
 }
 
 // ── Store ──────────────────────────────────────────────────
-export const useGameHintsStore = create<GameHintsState & GameHintsActions>()(
-  devtools(
-    (set, get) => ({
+export const useGameHintsStore = makeStore<GameHintsState & GameHintsActions>('GameHintsStore', (set, get) => ({
       hints: [],
       revealedHintsCount: 0,
 
@@ -52,7 +49,4 @@ export const useGameHintsStore = create<GameHintsState & GameHintsActions>()(
 
       resetHints: () =>
         set({ hints: [], revealedHintsCount: 0 }, false, 'hints/reset'),
-    }),
-    { name: 'GameHintsStore' },
-  ),
-);
+    }));

--- a/gamesformykids/lib/stores/gameProgressDataStore.ts
+++ b/gamesformykids/lib/stores/gameProgressDataStore.ts
@@ -8,8 +8,7 @@
  * מחליף את useState ב-useGameProgress.ts.
  */
 
-import { create } from 'zustand';
-import { devtools } from 'zustand/middleware';
+import { makeStore } from './createStore';
 import type { GameProgress } from '@/hooks/shared/progress/useGameProgress';
 import { INITIAL_REMOTE_SLICE, type RemoteDataSlice } from './utils/RemoteDataSlice';
 
@@ -34,9 +33,7 @@ const initialState: GameProgressDataState = {
 };
 
 // ── Store ──────────────────────────────────────────────────
-export const useGameProgressDataStore = create<GameProgressDataState & GameProgressDataActions>()(
-  devtools(
-    (set) => ({
+export const useGameProgressDataStore = makeStore<GameProgressDataState & GameProgressDataActions>('GameProgressDataStore', (set) => ({
       ...initialState,
 
       setProgress: (progress) =>
@@ -64,7 +61,4 @@ export const useGameProgressDataStore = create<GameProgressDataState & GameProgr
         set({ loadedForUserId: userId }, false, 'gameProgressData/setLoadedForUserId'),
 
       reset: () => set(initialState, false, 'gameProgressData/reset'),
-    }),
-    { name: 'GameProgressDataStore' },
-  ),
-);
+    }));

--- a/gamesformykids/lib/stores/gameProgressStore.ts
+++ b/gamesformykids/lib/stores/gameProgressStore.ts
@@ -10,8 +10,7 @@
  *   - איפוס ההתקדמות כשמשתנה סוג המשחק
  */
 
-import { create } from 'zustand';
-import { devtools } from 'zustand/middleware';
+import { makeStore } from './createStore';
 
 export interface GameProgressState {
   score: number;
@@ -53,9 +52,7 @@ const INITIAL_STATE: GameProgressState = {
   timerPaused: false,
 };
 
-export const useGameProgressStore = create<GameProgressState & GameProgressActions>()(
-  devtools(
-    (set) => ({
+export const useGameProgressStore = makeStore<GameProgressState & GameProgressActions>('GameProgressStore', (set) => ({
       ...INITIAL_STATE,
 
       incrementScore: (points = 10) =>
@@ -115,8 +112,5 @@ export const useGameProgressStore = create<GameProgressState & GameProgressActio
 
       updateProgress: (updates) =>
         set(updates as Partial<GameProgressState>, false, 'progress/updateProgress'),
-    }),
-    { name: 'GameProgressStore' },
-  ),
-);
+    }));
 

--- a/gamesformykids/lib/stores/gameSessionStore.ts
+++ b/gamesformykids/lib/stores/gameSessionStore.ts
@@ -13,8 +13,7 @@
  * יכול לגשת לנתוני הסשן ישירות ללא props drilling.
  */
 
-import { create } from 'zustand';
-import { devtools } from 'zustand/middleware';
+import { makeStore } from './createStore';
 import type { BaseGameItem } from '@/lib/types/core/base';
 
 // ── State ──────────────────────────────────────────────────
@@ -43,9 +42,7 @@ const INITIAL_STATE: GameSessionState = {
   wrongAttempts: 0,
 };
 
-export const useGameSessionStore = create<GameSessionState & GameSessionActions>()(
-  devtools(
-    (set) => ({
+export const useGameSessionStore = makeStore<GameSessionState & GameSessionActions>('GameSessionStore', (set) => ({
       ...INITIAL_STATE,
 
       setChallenge: (challenge) =>
@@ -68,7 +65,4 @@ export const useGameSessionStore = create<GameSessionState & GameSessionActions>
 
       resetSession: () =>
         set({ ...INITIAL_STATE }, false, 'session/resetSession'),
-    }),
-    { name: 'GameSessionStore' },
-  ),
-);
+    }));

--- a/gamesformykids/lib/stores/gameTypeStore.ts
+++ b/gamesformykids/lib/stores/gameTypeStore.ts
@@ -8,8 +8,7 @@
  * כיוון שהוא דורש useRouter מ-React.
  */
 
-import { create } from 'zustand';
-import { devtools } from 'zustand/middleware';
+import { makeStore } from './createStore';
 import { GameType } from '@/lib/types/core/base';
 
 export interface GameTypeState {
@@ -29,9 +28,7 @@ const INITIAL_STATE: GameTypeState = {
   gameHistory: [],
 };
 
-export const useGameTypeStore = create<GameTypeState & GameTypeActions>()(
-  devtools(
-    (set) => ({
+export const useGameTypeStore = makeStore<GameTypeState & GameTypeActions>('GameTypeStore', (set) => ({
       ...INITIAL_STATE,
 
       setCurrentGameType: (gameType) =>
@@ -56,8 +53,5 @@ export const useGameTypeStore = create<GameTypeState & GameTypeActions>()(
           false,
           'gameType/clearGameHistory',
         ),
-    }),
-    { name: 'GameTypeStore' },
-  ),
-);
+    }));
 

--- a/gamesformykids/lib/stores/homePageStore.ts
+++ b/gamesformykids/lib/stores/homePageStore.ts
@@ -10,8 +10,7 @@
  * כך שמצב הניווט נשמר גם אם הקומפוננט מתרנדר מחדש.
  */
 
-import { create } from 'zustand';
-import { devtools } from 'zustand/middleware';
+import { makeStore } from './createStore';
 
 // ── State ──────────────────────────────────────────────────
 export interface HomePageState {
@@ -33,9 +32,7 @@ export interface HomePageActions {
   setShouldShowLoader: (show: boolean) => void;
 }
 
-export const useHomePageStore = create<HomePageState & HomePageActions>()(
-  devtools(
-    (set) => ({
+export const useHomePageStore = makeStore<HomePageState & HomePageActions>('HomePageStore', (set) => ({
       selectedCategory: null,
       showAllGames: false,
       showFavorites: false,
@@ -60,7 +57,4 @@ export const useHomePageStore = create<HomePageState & HomePageActions>()(
 
       backToCategories: () =>
         set({ selectedCategory: null, showFavorites: false }, false, 'homePage/backToCategories'),
-    }),
-    { name: 'HomePageStore' },
-  ),
-);
+    }));

--- a/gamesformykids/lib/stores/quizGameStore.ts
+++ b/gamesformykids/lib/stores/quizGameStore.ts
@@ -1,5 +1,4 @@
-import { create } from 'zustand';
-import { devtools } from 'zustand/middleware';
+import { makeStore } from './createStore';
 
 export type QuizPhase = 'menu' | 'playing' | 'result';
 
@@ -31,9 +30,7 @@ const INITIAL_STATE: QuizGameState = {
   isCorrect: null,
 };
 
-export const useQuizGameStore = create<QuizGameState & QuizGameActions>()(
-  devtools(
-    (set, get) => ({
+export const useQuizGameStore = makeStore<QuizGameState & QuizGameActions>('QuizGameStore', (set, get) => ({
       ...INITIAL_STATE,
 
       startQuiz: (gameType, total) =>
@@ -68,7 +65,4 @@ export const useQuizGameStore = create<QuizGameState & QuizGameActions>()(
           false,
           'quiz/restartQuiz',
         ),
-    }),
-    { name: 'QuizGameStore' },
-  ),
-);
+    }));

--- a/gamesformykids/lib/stores/tetrisStore.ts
+++ b/gamesformykids/lib/stores/tetrisStore.ts
@@ -9,8 +9,7 @@
  * כאן עם get() כדי להמנע מ-stale closures.
  */
 
-import { create } from 'zustand';
-import { devtools } from 'zustand/middleware';
+import { makeStore } from './createStore';
 import { Board, Piece, Position, TetrisGameState } from '@/app/games/tetris/types';
 import {
   BOARD_WIDTH,
@@ -101,9 +100,7 @@ const INITIAL_STATE: TetrisGameState = {
 
 // ── Store ──────────────────────────────────────────────────────────────────────
 
-export const useTetrisStore = create<TetrisGameState & TetrisActions>()(
-  devtools(
-    (set, get) => ({
+export const useTetrisStore = makeStore<TetrisGameState & TetrisActions>('TetrisStore', (set, get) => ({
       ...INITIAL_STATE,
 
       setLoaded: () => set({ isLoading: false }),
@@ -187,7 +184,4 @@ export const useTetrisStore = create<TetrisGameState & TetrisActions>()(
         }
         return displayBoard;
       },
-    }),
-    { name: 'TetrisStore' }
-  )
-);
+    }));

--- a/gamesformykids/lib/stores/uiStore.ts
+++ b/gamesformykids/lib/stores/uiStore.ts
@@ -14,8 +14,7 @@
  *   useUIStore.getState().addNotification('שגיאה כלשהי', 'error');
  */
 
-import { create } from 'zustand';
-import { devtools } from 'zustand/middleware';
+import { makeStore } from './createStore';
 
 // ── Types ──────────────────────────────────────────────────
 export type NotificationType = 'success' | 'error' | 'info' | 'warning';
@@ -60,9 +59,7 @@ let _counter = 0;
 const genId = () => `notif_${Date.now()}_${++_counter}`;
 
 // ── Store ──────────────────────────────────────────────────
-export const useUIStore = create<UIState & UIActions>()(
-  devtools(
-    (set, get) => ({
+export const useUIStore = makeStore<UIState & UIActions>('UIStore', (set, get) => ({
       notifications: [],
       sidebarOpen: false,
       showProgressModal: false,
@@ -112,10 +109,7 @@ export const useUIStore = create<UIState & UIActions>()(
       closeUserMenu: () => set({ isUserMenuOpen: false }, false, 'ui/closeUserMenu'),
       toggleUserMenu: () =>
         set((s) => ({ isUserMenuOpen: !s.isUserMenuOpen }), false, 'ui/toggleUserMenu'),
-    }),
-    { name: 'UIStore' }
-  )
-);
+    }));
 
 // ── Convenience Selectors ──────────────────────────────────
 /** שמישה ישירות בתוך קומפוננט הצגת Toasts */

--- a/gamesformykids/lib/stores/userProfileStore.ts
+++ b/gamesformykids/lib/stores/userProfileStore.ts
@@ -9,8 +9,7 @@
  * מחליף את useState ב-useUserProfile.ts.
  */
 
-import { create } from 'zustand';
-import { devtools } from 'zustand/middleware';
+import { makeStore } from './createStore';
 import type { UserProfile, UserSettings } from '@/hooks/shared/user/useUserProfile';
 import { INITIAL_REMOTE_SLICE, type RemoteDataSlice } from './utils/RemoteDataSlice';
 
@@ -37,9 +36,7 @@ const initialState: UserProfileState = {
 };
 
 // ── Store ──────────────────────────────────────────────────
-export const useUserProfileStore = create<UserProfileState & UserProfileStoreActions>()(
-  devtools(
-    (set) => ({
+export const useUserProfileStore = makeStore<UserProfileState & UserProfileStoreActions>('UserProfileStore', (set) => ({
       ...initialState,
 
       setProfile: (profile) => set({ profile }, false, 'userProfile/setProfile'),
@@ -54,7 +51,4 @@ export const useUserProfileStore = create<UserProfileState & UserProfileStoreAct
         set({ loadedForUserId: userId }, false, 'userProfile/setLoadedForUserId'),
 
       reset: () => set(initialState, false, 'userProfile/reset'),
-    }),
-    { name: 'UserProfileStore' },
-  ),
-);
+    }));


### PR DESCRIPTION
## Summary

- Add `makeStore<T>(name, creator)` in `lib/stores/createStore.ts` — wraps `create<T>()(devtools(creator, { name }))` with `StateCreator<T, [['zustand/devtools', never]]>` so functional updater callbacks retain full type inference
- Migrate 17 non-persist Zustand stores to use `makeStore`, removing the repetitive `create()(devtools(..., { name }))` boilerplate from each
- 4 persist stores (`audioSettings`, `favorites`, `game`, `progressTracking`) are intentionally skipped — they compose persist + devtools and can't use this factory

**Before (per store):**
```ts
import { create } from 'zustand';
import { devtools } from 'zustand/middleware';
export const useFooStore = create<FooState>()(
  devtools((set) => ({ ... }), { name: 'FooStore' }),
);
```

**After:**
```ts
import { makeStore } from './createStore';
export const useFooStore = makeStore<FooState>('FooStore', (set) => ({ ... }));
```

Net: −102 lines across 17 files.

## Test plan

- [x] `tsc --noEmit` passes with zero errors
- [ ] Verify devtools Redux DevTools extension still shows correct store names at runtime

Closes #171

🤖 Generated with [Claude Code](https://claude.ai/claude-code)