### PR TITLE
refactor: replace direct initSpeechAndAudio calls with useGameAudio hook (#159)

### DIFF
--- a/gamesformykids/app/games/bubbles/hooks/useBubbleGame.ts
+++ b/gamesformykids/app/games/bubbles/hooks/useBubbleGame.ts
@@ -1,5 +1,5 @@
 import { useState, useEffect, useRef, useCallback, useMemo } from 'react';
-import { initSpeechAndAudio } from '@/lib/utils/speech/enhancedSpeechUtils';
+import { useGameAudio } from '@/hooks/shared/audio/useGameAudio';
 
 interface BubbleData {
   id: number;
@@ -28,15 +28,10 @@ export function useBubbleGame() {
     poppedCount: 0,
   });
 
-  const [audioContext, setAudioContext] = useState<AudioContext | null>(null);
+  const { audioContext } = useGameAudio();
   const nextBubbleId = useRef(0);
   const bubbleCreationInterval = useRef<NodeJS.Timeout | null>(null);
   const gameContainerRef = useRef<HTMLDivElement>(null);
-
-  // אתחול מערכת השמע
-  useEffect(() => {
-    initSpeechAndAudio(() => {}, setAudioContext);
-  }, []);
 
   // צבעים ותדרים לבועות
   const bubbleTypes = useMemo(() => [

--- a/gamesformykids/app/games/counting/useCountingGame.ts
+++ b/gamesformykids/app/games/counting/useCountingGame.ts
@@ -3,7 +3,8 @@
 import { useState, useEffect } from "react";
 import { CountingChallenge, CountingGameState } from "@/lib/types/games";
 import { BaseGameItem } from "@/lib/types/core/base";
-import { initSpeechAndAudio, speakHebrew } from "@/lib/utils/speech/enhancedSpeechUtils";
+import { speakHebrew } from "@/lib/utils/speech/enhancedSpeechUtils";
+import { useGameAudio } from "@/hooks/shared/audio/useGameAudio";
 import { 
   delay, 
   playSuccessSound as playSound, 
@@ -13,7 +14,6 @@ import {
   speakStartMessage
 } from "@/lib/utils/game/gameUtils";
 import { GAME_CONSTANTS, COUNTING_GAME_CONSTANTS } from "@/lib/constants";
-import { useGameAudioStore } from "@/lib/stores/gameAudioStore";
 import { useGameProgressStore } from "@/lib/stores/gameProgressStore";
 import { useGameSessionStore } from "@/lib/stores/gameSessionStore";
 import { useCountingChallengeStore } from "@/lib/stores/countingChallengeStore";
@@ -44,19 +44,7 @@ export function useCountingGame() {
     options: [],
   });
 
-  const audioContext = useGameAudioStore((s) => s.audioContext);
-  const speechEnabled = useGameAudioStore((s) => s.speechEnabled);
-  const setAudioContext = useGameAudioStore((s) => s.setAudioContext);
-  const setSpeechEnabled = useGameAudioStore((s) => s.setSpeechEnabled);
-
-  useEffect(() => {
-    if (!audioContext && !speechEnabled) {
-      initSpeechAndAudio(setSpeechEnabled, setAudioContext);
-    }
-  // intentionally run only on mount — setSpeechEnabled/setAudioContext are stable Zustand
-  // actions; audioContext/speechEnabled are only checked once to avoid double-initialisation
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  const { audioContext, speechEnabled } = useGameAudio();
 
   // --- Utility Functions ---
 

--- a/gamesformykids/app/games/counting/useCountingGame.ts
+++ b/gamesformykids/app/games/counting/useCountingGame.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect } from "react";
+import { useState } from "react";
 import { CountingChallenge, CountingGameState } from "@/lib/types/games";
 import { BaseGameItem } from "@/lib/types/core/base";
 import { speakHebrew } from "@/lib/utils/speech/enhancedSpeechUtils";

--- a/gamesformykids/app/games/math/hooks/useMathGame.ts
+++ b/gamesformykids/app/games/math/hooks/useMathGame.ts
@@ -1,9 +1,10 @@
 'use client';
 
-import { useState, useEffect } from "react";
+import { useState } from "react";
 import { MathChallenge } from "@/lib/types";
 import { BaseGameItem } from "@/lib/types/core/base";
-import { initSpeechAndAudio, speakHebrew } from "@/lib/utils/speech/enhancedSpeechUtils";
+import { speakHebrew } from "@/lib/utils/speech/enhancedSpeechUtils";
+import { useGameAudio } from "@/hooks/shared/audio/useGameAudio";
 import { 
   delay, 
   playSuccessSound as playSound, 
@@ -72,12 +73,7 @@ export function useMathGame() {
     options: [],
   });
 
-  const [audioContext, setAudioContext] = useState<AudioContext | null>(null);
-  const [speechEnabled, setSpeechEnabled] = useState(false);
-
-  useEffect(() => {
-    initSpeechAndAudio(setSpeechEnabled, setAudioContext);
-  }, []);
+  const { audioContext, speechEnabled } = useGameAudio();
 
   // --- Utility Functions ---
 

--- a/gamesformykids/app/games/puzzles/store/slices/feedbackSlice.ts
+++ b/gamesformykids/app/games/puzzles/store/slices/feedbackSlice.ts
@@ -1,42 +1,31 @@
 import type { StateCreator } from 'zustand';
-import { speakHebrew, initSpeechAndAudio } from '@/lib/utils/speech/enhancedSpeechUtils';
+import { speakHebrew } from '@/lib/utils/speech/enhancedSpeechUtils';
 import { playSuccessSound } from '@/lib/utils/game/gameUtils';
+import { useGameAudioStore } from '@/lib/stores/gameAudioStore';
 import type { PuzzleStore } from '../puzzleStore';
 
 export interface FeedbackSlice {
   feedbackMessage: string;
   feedbackType: 'success' | 'error' | '';
-  _audioContext: AudioContext | null;
-  _speechEnabled: boolean;
-  initAudio: () => void;
   showFeedback: (message: string, type: 'success' | 'error') => void;
   speak: (message: string) => Promise<void>;
 }
 
-export const createFeedbackSlice: StateCreator<PuzzleStore, [], [], FeedbackSlice> = (set, get) => ({
+export const createFeedbackSlice: StateCreator<PuzzleStore, [], [], FeedbackSlice> = (set) => ({
   feedbackMessage: '',
   feedbackType: '',
-  _audioContext: null,
-  _speechEnabled: false,
-
-  initAudio: () => {
-    initSpeechAndAudio(
-      (enabled) => set({ _speechEnabled: enabled }),
-      (ctx) => set({ _audioContext: ctx }),
-    );
-  },
 
   showFeedback: (message, type) => {
     set({ feedbackMessage: message, feedbackType: type });
-    const { _audioContext } = get();
-    if (type === 'success') playSuccessSound(_audioContext);
+    const { audioContext } = useGameAudioStore.getState();
+    if (type === 'success') playSuccessSound(audioContext);
     setTimeout(() => {
       set({ feedbackMessage: '', feedbackType: '' });
     }, type === 'success' ? 2000 : 1500);
   },
 
   speak: async (message) => {
-    if (get()._speechEnabled) {
+    if (useGameAudioStore.getState().speechEnabled) {
       await speakHebrew(message);
     }
   },

--- a/gamesformykids/app/games/puzzles/usePuzzleSetup.ts
+++ b/gamesformykids/app/games/puzzles/usePuzzleSetup.ts
@@ -2,15 +2,10 @@
 
 import { useEffect } from 'react';
 import { usePuzzleStore } from './store/puzzleStore';
+import { useGameAudio } from '@/hooks/shared/audio/useGameAudio';
 
 function useRouterBridge() {
   // bridge removed — UniversalGameNavigation handles routing
-}
-
-function useAudioInit() {
-  useEffect(() => {
-    usePuzzleStore.getState().initAudio();
-  }, []);
 }
 
 function usePuzzleTimer() {
@@ -45,7 +40,7 @@ function useKeyboardShortcuts() {
 
 export function usePuzzleSetup() {
   useRouterBridge();
-  useAudioInit();
+  useGameAudio();
   usePuzzleTimer();
   useKeyboardShortcuts();
 }


### PR DESCRIPTION
## Summary

- **3 React hooks** (`useCountingGame`, `useMathGame`, `useBubbleGame`): replace local `useState`/`useEffect` audio init with `useGameAudio()`, which centralises initialisation in `useGameAudioStore`
- **`feedbackSlice.ts`** (Zustand slice, can't use hooks): remove `_audioContext`, `_speechEnabled`, and `initAudio` from slice state; read `useGameAudioStore.getState()` directly at call-time in `showFeedback` and `speak`
- **`usePuzzleSetup.ts`**: replace the `useAudioInit` bridge function (which imperatively called `initAudio()`) with a direct `useGameAudio()` call

Net: −37 lines, 0 duplicated init patterns remaining.

## Test plan

- [x] `tsc --noEmit` passes with zero errors
- [ ] Verify audio/speech works in counting, math, bubbles, and puzzles games

Closes #159

🤖 Generated with [Claude Code](https://claude.ai/claude-code)