### PR TITLE
feat(simon): migrate to Zustand store (#25)

### DIFF
--- a/gamesformykids/app/games/simon/SimonGame.tsx
+++ b/gamesformykids/app/games/simon/SimonGame.tsx
@@ -5,7 +5,7 @@ import SimonBoard from './components/SimonBoard';
 import SimonGameOverScreen from './components/SimonGameOverScreen';
 
 export default function SimonGame() {
-  const { phase, activeColor, playerIdx, best, roundScore, sequenceRef, startGame, handleTap } = useSimonGame();
+  const { phase, activeColor, playerIdx, best, roundScore, sequenceLength, startGame, handleTap } = useSimonGame();
 
   return (
     <div className="min-h-screen bg-gray-900 flex flex-col items-center justify-center p-4 select-none" dir="rtl">
@@ -18,7 +18,7 @@ export default function SimonGame() {
           phase={phase}
           activeColor={activeColor}
           playerIdx={playerIdx}
-          sequenceLength={sequenceRef.current.length}
+          sequenceLength={sequenceLength}
           best={best}
           onTap={handleTap}
         />

--- a/gamesformykids/app/games/simon/simonStore.ts
+++ b/gamesformykids/app/games/simon/simonStore.ts
@@ -1,0 +1,40 @@
+import { makeStore } from '@/lib/stores/createStore';
+import type { PhaseSimon as Phase } from '@/lib/types';
+import type { ButtonId } from './useSimonGame';
+
+interface SimonState {
+  phase: Phase;
+  activeColor: ButtonId | null;
+  playerIdx: number;
+  best: number;
+  roundScore: number;
+  sequence: ButtonId[];
+}
+
+interface SimonActions {
+  setPhase: (phase: Phase) => void;
+  setActiveColor: (color: ButtonId | null) => void;
+  setPlayerIdx: (idx: number) => void;
+  updateBest: (score: number) => void;
+  setRoundScore: (score: number) => void;
+  setSequence: (seq: ButtonId[]) => void;
+}
+
+const INITIAL: SimonState = {
+  phase: 'menu',
+  activeColor: null,
+  playerIdx: 0,
+  best: 0,
+  roundScore: 0,
+  sequence: [],
+};
+
+export const useSimonStore = makeStore<SimonState & SimonActions>('SimonStore', (set) => ({
+  ...INITIAL,
+  setPhase: (phase) => set({ phase }, false, 'simon/setPhase'),
+  setActiveColor: (color) => set({ activeColor: color }, false, 'simon/setActiveColor'),
+  setPlayerIdx: (idx) => set({ playerIdx: idx }, false, 'simon/setPlayerIdx'),
+  updateBest: (score) => set((s) => ({ best: Math.max(s.best, score) }), false, 'simon/updateBest'),
+  setRoundScore: (score) => set({ roundScore: score }, false, 'simon/setRoundScore'),
+  setSequence: (seq) => set({ sequence: seq }, false, 'simon/setSequence'),
+}));

--- a/gamesformykids/app/games/simon/useSimonGame.ts
+++ b/gamesformykids/app/games/simon/useSimonGame.ts
@@ -1,6 +1,7 @@
-﻿'use client';
+'use client';
 
-import { useState, useCallback, useRef } from 'react';
+import { useCallback } from 'react';
+import { useSimonStore } from './simonStore';
 
 export const BUTTONS = [
   { id: 'red',    bg: 'bg-red-500',    active: 'bg-red-200',    label: '' },
@@ -13,75 +14,70 @@ export type ButtonId = typeof BUTTONS[number]['id'];
 import type { PhaseSimon as Phase } from '@/lib/types';
 
 export function useSimonGame() {
-  const [phase, setPhase]             = useState<Phase>('menu');
-  const [activeColor, setActiveColor] = useState<ButtonId | null>(null);
-  const [playerIdx, setPlayerIdx]     = useState(0);
-  const [best, setBest]               = useState(0);
-  const [roundScore, setRoundScore]   = useState(0);
-
-  const phaseRef     = useRef<Phase>('menu');
-  const sequenceRef  = useRef<ButtonId[]>([]);
-  const playerIdxRef = useRef(0);
+  const phase       = useSimonStore((s) => s.phase);
+  const activeColor = useSimonStore((s) => s.activeColor);
+  const playerIdx   = useSimonStore((s) => s.playerIdx);
+  const best        = useSimonStore((s) => s.best);
+  const roundScore  = useSimonStore((s) => s.roundScore);
+  const sequence    = useSimonStore((s) => s.sequence);
 
   const flash = useCallback((id: ButtonId, ms: number) =>
     new Promise<void>(resolve => {
-      setActiveColor(id);
-      setTimeout(() => { setActiveColor(null); setTimeout(resolve, 120); }, ms);
+      useSimonStore.getState().setActiveColor(id);
+      setTimeout(() => { useSimonStore.getState().setActiveColor(null); setTimeout(resolve, 120); }, ms);
     }), []);
 
   const showSequence = useCallback(async (seq: ButtonId[]) => {
-    phaseRef.current = 'showing';
-    setPhase('showing');
-    setPlayerIdx(0);
+    const store = useSimonStore.getState();
+    store.setPhase('showing');
+    store.setPlayerIdx(0);
     await new Promise(r => setTimeout(r, 500));
     const speed = Math.max(280, 650 - seq.length * 25);
     for (const id of seq) {
-      if (phaseRef.current !== 'showing') return;
+      if (useSimonStore.getState().phase !== 'showing') return;
       await flash(id, speed);
     }
-    if (phaseRef.current !== 'showing') return;
-    phaseRef.current = 'input';
-    setPhase('input');
-    playerIdxRef.current = 0;
-    setPlayerIdx(0);
+    if (useSimonStore.getState().phase !== 'showing') return;
+    useSimonStore.getState().setPhase('input');
+    useSimonStore.getState().setPlayerIdx(0);
   }, [flash]);
 
   const startGame = useCallback(() => {
     const first = BUTTONS[Math.floor(Math.random() * BUTTONS.length)].id;
     const seq: ButtonId[] = [first];
-    sequenceRef.current = seq;
-    setRoundScore(0);
+    useSimonStore.getState().setSequence(seq);
+    useSimonStore.getState().setRoundScore(0);
     showSequence(seq);
   }, [showSequence]);
 
   const handleTap = useCallback((id: ButtonId) => {
-    if (phaseRef.current !== 'input') return;
-    setActiveColor(id);
-    setTimeout(() => setActiveColor(null), 180);
+    const { phase: currentPhase, playerIdx: idx, sequence: seq } = useSimonStore.getState();
+    if (currentPhase !== 'input') return;
 
-    const seq = sequenceRef.current;
-    const idx = playerIdxRef.current;
+    useSimonStore.getState().setActiveColor(id);
+    setTimeout(() => useSimonStore.getState().setActiveColor(null), 180);
 
     if (id !== seq[idx]) {
-      phaseRef.current = 'dead';
-      setPhase('dead');
-      setBest(b => Math.max(b, seq.length - 1));
-      setRoundScore(seq.length - 1);
+      useSimonStore.getState().setPhase('dead');
+      useSimonStore.getState().updateBest(seq.length - 1);
+      useSimonStore.getState().setRoundScore(seq.length - 1);
       return;
     }
 
     const next = idx + 1;
-    playerIdxRef.current = next;
-    setPlayerIdx(next);
+    useSimonStore.getState().setPlayerIdx(next);
 
     if (next >= seq.length) {
-      setRoundScore(seq.length);
+      useSimonStore.getState().setRoundScore(seq.length);
       const nextBtn = BUTTONS[Math.floor(Math.random() * BUTTONS.length)].id;
       const newSeq: ButtonId[] = [...seq, nextBtn];
-      sequenceRef.current = newSeq;
+      useSimonStore.getState().setSequence(newSeq);
       setTimeout(() => showSequence(newSeq), 900);
     }
   }, [showSequence]);
 
-  return { phase, activeColor, playerIdx, best, roundScore, sequenceRef, startGame, handleTap };
+  return { phase, activeColor, playerIdx, best, roundScore, sequenceLength: sequence.length, startGame, handleTap };
 }
+
+// keep Phase exported for consumers
+export type { Phase };


### PR DESCRIPTION
## Summary

- Add `simonStore.ts` using `makeStore` factory with `SimonState` (phase, activeColor, playerIdx, best, roundScore, sequence)
- Rewrite `useSimonGame.ts` to read from the store via selectors and write via `useSimonStore.getState()` inside async functions — this eliminates all three refs (`phaseRef`, `playerIdxRef`, `sequenceRef`) that existed only to avoid stale closures
- Update `SimonGame.tsx` to use `sequenceLength` from hook return instead of `sequenceRef.current.length`

**Key insight:** Zustand's `getState()` always returns the current state synchronously, making it a drop-in replacement for `useRef` in async game logic.

## Test plan

- [x] `tsc --noEmit` passes with zero errors
- [ ] Simon game plays correctly — sequence shows, player input works, best score persists across rounds
- [ ] Redux DevTools shows `SimonStore` with correct action names

Closes #25

🤖 Generated with [Claude Code](https://claude.ai/claude-code)