### PR TITLE
feat(emoji-math): migrate from useState/useRef to Zustand store

### DIFF
--- a/gamesformykids/app/games/emoji-math/emojiMathStore.ts
+++ b/gamesformykids/app/games/emoji-math/emojiMathStore.ts
@@ -1,0 +1,60 @@
+import { makeStore } from '@/lib/stores/createStore';
+import type { PhaseDead as Phase } from '@/lib/types';
+import type { Question } from './useEmojiMathGame';
+
+interface EmojiMathState {
+  phase: Phase;
+  score: number;
+  best: number;
+  lives: number;
+  timeLeft: number;
+  feedback: 'correct' | 'wrong' | null;
+  q: Question;
+  level: number;
+  streak: number;
+}
+
+interface EmojiMathActions {
+  setPhase: (phase: Phase) => void;
+  setScore: (score: number) => void;
+  updateBest: (score: number) => void;
+  setLives: (lives: number) => void;
+  setTimeLeft: (t: number) => void;
+  setFeedback: (f: 'correct' | 'wrong' | null) => void;
+  setQ: (q: Question) => void;
+  setLevel: (level: number) => void;
+  setStreak: (streak: number) => void;
+}
+
+const INITIAL_Q: Question = {
+  a: 1, b: 1, op: '+', answer: 2,
+  choices: [2, 3, 4, 5], emojiA: '🍎', emojiB: '🍊',
+};
+
+const INITIAL: EmojiMathState = {
+  phase: 'menu',
+  score: 0,
+  best: 0,
+  lives: 3,
+  timeLeft: 8,
+  feedback: null,
+  q: INITIAL_Q,
+  level: 1,
+  streak: 0,
+};
+
+export const useEmojiMathStore = makeStore<EmojiMathState & EmojiMathActions>(
+  'EmojiMathStore',
+  (set) => ({
+    ...INITIAL,
+    setPhase:    (phase)    => set({ phase },                          false, 'emojiMath/setPhase'),
+    setScore:    (score)    => set({ score },                          false, 'emojiMath/setScore'),
+    updateBest:  (score)    => set((s) => ({ best: Math.max(s.best, score) }), false, 'emojiMath/updateBest'),
+    setLives:    (lives)    => set({ lives },                          false, 'emojiMath/setLives'),
+    setTimeLeft: (timeLeft) => set({ timeLeft },                       false, 'emojiMath/setTimeLeft'),
+    setFeedback: (feedback) => set({ feedback },                       false, 'emojiMath/setFeedback'),
+    setQ:        (q)        => set({ q },                              false, 'emojiMath/setQ'),
+    setLevel:    (level)    => set({ level },                          false, 'emojiMath/setLevel'),
+    setStreak:   (streak)   => set({ streak },                         false, 'emojiMath/setStreak'),
+  }),
+);

--- a/gamesformykids/app/games/emoji-math/emojiMathStore.ts
+++ b/gamesformykids/app/games/emoji-math/emojiMathStore.ts
@@ -111,7 +111,7 @@ export const useEmojiMathStore = makeStore<EmojiMathState & EmojiMathActions>(
       startGame: () => {
         clearCountdown();
         clearFeedbackTimer();
-        set({ ...INITIAL, best: get().best, q: makeQuestion(1) }, false, 'emojiMath/startGame');
+        set({ ...INITIAL, phase: 'playing', best: get().best, q: makeQuestion(1) }, false, 'emojiMath/startGame');
         startCountdown();
       },
 

--- a/gamesformykids/app/games/emoji-math/emojiMathStore.ts
+++ b/gamesformykids/app/games/emoji-math/emojiMathStore.ts
@@ -1,60 +1,145 @@
 import { makeStore } from '@/lib/stores/createStore';
 import type { PhaseDead as Phase } from '@/lib/types';
-import type { Question } from './useEmojiMathGame';
+import { randInt as rnd } from '@/lib/utils';
+
+// ── Question helpers ────────────────────────────────────────────────────────
+
+const EMOJIS = ['🍎','🍊','🍋','🍇','🍓','🫐','🍒','🍑','🥝','🍉','🍍','🥭'];
+
+export type Op = '+' | '-';
+
+export interface Question {
+  a: number; b: number; op: Op; answer: number;
+  choices: number[]; emojiA: string; emojiB: string;
+}
+
+function pickEmoji() { return EMOJIS[Math.floor(Math.random() * EMOJIS.length)]; }
+
+export function makeQuestion(level: number): Question {
+  const maxNum = Math.min(5 + level * 2, 15);
+  const op: Op = level < 3 ? '+' : (Math.random() < 0.6 ? '+' : '-');
+  let a: number, b: number;
+  if (op === '+') {
+    a = rnd(1, maxNum); b = rnd(1, maxNum - a + 1);
+  } else {
+    a = rnd(2, maxNum); b = rnd(1, a);
+  }
+  const answer = op === '+' ? a + b : a - b;
+  const wrong = new Set<number>();
+  while (wrong.size < 3) {
+    const w = answer + rnd(-3, 3);
+    if (w !== answer && w >= 0 && w <= 20) wrong.add(w);
+  }
+  const choices = [...wrong, answer].sort(() => Math.random() - 0.5);
+  const e1 = pickEmoji(), e2 = op === '+' ? pickEmoji() : e1;
+  return { a, b, op, answer, choices, emojiA: e1, emojiB: e2 };
+}
+
+// ── Store ───────────────────────────────────────────────────────────────────
+
+export const TIME_PER_Q  = 8;
+const        INITIAL_LIVES = 3;
 
 interface EmojiMathState {
-  phase: Phase;
-  score: number;
-  best: number;
-  lives: number;
+  phase:    Phase;
+  score:    number;
+  best:     number;
+  lives:    number;
   timeLeft: number;
   feedback: 'correct' | 'wrong' | null;
-  q: Question;
-  level: number;
-  streak: number;
+  q:        Question;
+  level:    number;
+  streak:   number;
 }
 
 interface EmojiMathActions {
-  setPhase: (phase: Phase) => void;
-  setScore: (score: number) => void;
-  updateBest: (score: number) => void;
-  setLives: (lives: number) => void;
-  setTimeLeft: (t: number) => void;
-  setFeedback: (f: 'correct' | 'wrong' | null) => void;
-  setQ: (q: Question) => void;
-  setLevel: (level: number) => void;
-  setStreak: (streak: number) => void;
+  startGame: () => void;
+  tap:       (choice: number) => void;
 }
 
-const INITIAL_Q: Question = {
-  a: 1, b: 1, op: '+', answer: 2,
-  choices: [2, 3, 4, 5], emojiA: '🍎', emojiB: '🍊',
-};
-
 const INITIAL: EmojiMathState = {
-  phase: 'menu',
-  score: 0,
-  best: 0,
-  lives: 3,
-  timeLeft: 8,
-  feedback: null,
-  q: INITIAL_Q,
-  level: 1,
-  streak: 0,
+  phase: 'menu', score: 0, best: 0, lives: INITIAL_LIVES,
+  timeLeft: TIME_PER_Q, feedback: null, q: makeQuestion(1), level: 1, streak: 0,
 };
 
 export const useEmojiMathStore = makeStore<EmojiMathState & EmojiMathActions>(
   'EmojiMathStore',
-  (set) => ({
-    ...INITIAL,
-    setPhase:    (phase)    => set({ phase },                          false, 'emojiMath/setPhase'),
-    setScore:    (score)    => set({ score },                          false, 'emojiMath/setScore'),
-    updateBest:  (score)    => set((s) => ({ best: Math.max(s.best, score) }), false, 'emojiMath/updateBest'),
-    setLives:    (lives)    => set({ lives },                          false, 'emojiMath/setLives'),
-    setTimeLeft: (timeLeft) => set({ timeLeft },                       false, 'emojiMath/setTimeLeft'),
-    setFeedback: (feedback) => set({ feedback },                       false, 'emojiMath/setFeedback'),
-    setQ:        (q)        => set({ q },                              false, 'emojiMath/setQ'),
-    setLevel:    (level)    => set({ level },                          false, 'emojiMath/setLevel'),
-    setStreak:   (streak)   => set({ streak },                         false, 'emojiMath/setStreak'),
-  }),
+  (set, get) => {
+    let countdownId: ReturnType<typeof setInterval> | null = null;
+    let feedbackId:  ReturnType<typeof setTimeout>  | null = null;
+
+    function clearCountdown()    { if (countdownId) { clearInterval(countdownId); countdownId = null; } }
+    function clearFeedbackTimer(){ if (feedbackId)  { clearTimeout(feedbackId);   feedbackId  = null; } }
+
+    function advanceAfterFeedback() {
+      clearFeedbackTimer();
+      feedbackId = setTimeout(() => {
+        if (get().phase !== 'playing') return;
+        const level = get().level;
+        set({ feedback: null, timeLeft: TIME_PER_Q, q: makeQuestion(level) }, false, 'emojiMath/nextQuestion');
+        startCountdown();
+      }, 900);
+    }
+
+    function startCountdown() {
+      clearCountdown();
+      if (typeof window === 'undefined') return;
+      countdownId = setInterval(() => {
+        const { phase, feedback, timeLeft, lives, score, best } = get();
+        if (phase !== 'playing' || feedback !== null) { clearCountdown(); return; }
+        if (timeLeft <= 1) {
+          clearCountdown();
+          const newLives = lives - 1;
+          const isDead   = newLives <= 0;
+          set(
+            isDead
+              ? { lives: newLives, feedback: 'wrong', timeLeft: TIME_PER_Q, phase: 'dead', best: Math.max(best, score) }
+              : { lives: newLives, feedback: 'wrong', timeLeft: TIME_PER_Q },
+            false,
+            'emojiMath/timeout',
+          );
+          if (!isDead) advanceAfterFeedback();
+        } else {
+          set({ timeLeft: timeLeft - 1 }, false, 'emojiMath/tick');
+        }
+      }, 1000);
+    }
+
+    return {
+      ...INITIAL,
+
+      startGame: () => {
+        clearCountdown();
+        clearFeedbackTimer();
+        set({ ...INITIAL, best: get().best, q: makeQuestion(1) }, false, 'emojiMath/startGame');
+        startCountdown();
+      },
+
+      tap: (choice: number) => {
+        const { phase, feedback, q, streak, score, lives, level, best } = get();
+        if (phase !== 'playing' || feedback !== null) return;
+        clearCountdown();
+
+        if (choice === q.answer) {
+          const newStreak = streak + 1;
+          const bonus     = newStreak >= 3 ? 20 : 10;
+          const newScore  = score + bonus;
+          const newLevel  = newScore > 0 && newScore % 50 === 0 ? level + 1 : level;
+          set({ streak: newStreak, score: newScore, level: newLevel, feedback: 'correct' }, false, 'emojiMath/correct');
+          advanceAfterFeedback();
+        } else {
+          const newLives = lives - 1;
+          const isDead   = newLives <= 0;
+          set(
+            isDead
+              ? { streak: 0, lives: newLives, feedback: 'wrong', phase: 'dead', best: Math.max(best, score) }
+              : { streak: 0, lives: newLives, feedback: 'wrong' },
+            false,
+            'emojiMath/wrong',
+          );
+          if (!isDead) advanceAfterFeedback();
+        }
+      },
+    };
+  },
 );

--- a/gamesformykids/app/games/emoji-math/useEmojiMathGame.ts
+++ b/gamesformykids/app/games/emoji-math/useEmojiMathGame.ts
@@ -1,41 +1,8 @@
 'use client';
-import { useEffect, useCallback } from 'react';
 import { useEmojiMathStore } from './emojiMathStore';
 
-const EMOJIS = ['🍎','🍊','🍋','🍇','🍓','🫐','🍒','🍑','🥝','🍉','🍍','🥭'];
-
-export type Op = '+' | '-';
-import { randInt as rnd } from '@/lib/utils';
-
-export interface Question {
-  a: number; b: number; op: Op; answer: number;
-  choices: number[]; emojiA: string; emojiB: string;
-}
-
-function pickEmoji() { return EMOJIS[Math.floor(Math.random() * EMOJIS.length)]; }
-
-export function makeQuestion(level: number): Question {
-  const maxNum = Math.min(5 + level * 2, 15);
-  const op: Op = level < 3 ? '+' : (Math.random() < 0.6 ? '+' : '-');
-  let a: number, b: number;
-  if (op === '+') {
-    a = rnd(1, maxNum); b = rnd(1, maxNum - a + 1);
-  } else {
-    a = rnd(2, maxNum); b = rnd(1, a);
-  }
-  const answer = op === '+' ? a + b : a - b;
-  const wrong = new Set<number>();
-  while (wrong.size < 3) {
-    const w = answer + rnd(-3, 3);
-    if (w !== answer && w >= 0 && w <= 20) wrong.add(w);
-  }
-  const choices = [...wrong, answer].sort(() => Math.random() - 0.5);
-  const e1 = pickEmoji(), e2 = op === '+' ? pickEmoji() : e1;
-  return { a, b, op, answer, choices, emojiA: e1, emojiB: e2 };
-}
-
-export const TIME_PER_Q = 8;
-const INITIAL_LIVES = 3;
+export type { Op, Question } from './emojiMathStore';
+export { makeQuestion, TIME_PER_Q }  from './emojiMathStore';
 
 export function useEmojiMathGame() {
   const phase    = useEmojiMathStore((s) => s.phase);
@@ -47,79 +14,8 @@ export function useEmojiMathGame() {
   const q        = useEmojiMathStore((s) => s.q);
   const level    = useEmojiMathStore((s) => s.level);
   const streak   = useEmojiMathStore((s) => s.streak);
-
-  // Countdown timer — runs while playing and no feedback showing
-  useEffect(() => {
-    if (phase !== 'playing' || feedback !== null) return;
-    const interval = setInterval(() => {
-      const store = useEmojiMathStore.getState();
-      if (store.phase !== 'playing' || store.feedback !== null) return;
-      if (store.timeLeft <= 1) {
-        const newLives = store.lives - 1;
-        store.setLives(newLives);
-        store.setFeedback('wrong');
-        store.setTimeLeft(TIME_PER_Q);
-        if (newLives <= 0) {
-          store.setPhase('dead');
-          store.updateBest(store.score);
-        }
-      } else {
-        store.setTimeLeft(store.timeLeft - 1);
-      }
-    }, 1000);
-    return () => clearInterval(interval);
-  }, [phase, feedback]);
-
-  // Advance to next question after feedback delay
-  useEffect(() => {
-    if (feedback === null || phase !== 'playing') return;
-    const t = setTimeout(() => {
-      const store = useEmojiMathStore.getState();
-      if (store.phase !== 'playing') return;
-      store.setFeedback(null);
-      store.setTimeLeft(TIME_PER_Q);
-      store.setQ(makeQuestion(store.level));
-    }, 900);
-    return () => clearTimeout(t);
-  }, [feedback, phase]);
-
-  const startGame = useCallback(() => {
-    const store = useEmojiMathStore.getState();
-    store.setPhase('playing');
-    store.setScore(0);
-    store.setLives(INITIAL_LIVES);
-    store.setTimeLeft(TIME_PER_Q);
-    store.setFeedback(null);
-    store.setLevel(1);
-    store.setStreak(0);
-    store.setQ(makeQuestion(1));
-  }, []);
-
-  const tap = useCallback((choice: number) => {
-    const store = useEmojiMathStore.getState();
-    if (store.phase !== 'playing' || store.feedback !== null) return;
-
-    if (choice === store.q.answer) {
-      const newStreak = store.streak + 1;
-      const bonus = newStreak >= 3 ? 20 : 10;
-      const newScore = store.score + bonus;
-      store.setStreak(newStreak);
-      store.setScore(newScore);
-      store.setFeedback('correct');
-      if (newScore > 0 && newScore % 50 === 0) {
-        store.setLevel(store.level + 1);
-      }
-    } else {
-      const newLives = store.lives - 1;
-      store.setStreak(0);
-      store.setLives(newLives);
-      store.setFeedback('wrong');
-      if (newLives <= 0) {
-        store.setPhase('dead');
-        store.updateBest(store.score);
-      }
-    }
-  }, []);
+  const startGame = useEmojiMathStore((s) => s.startGame);
+  const tap       = useEmojiMathStore((s) => s.tap);
 
   return { phase, q, score, best, lives, level, timeLeft, feedback, streak, startGame, tap };
 }

--- a/gamesformykids/app/games/emoji-math/useEmojiMathGame.ts
+++ b/gamesformykids/app/games/emoji-math/useEmojiMathGame.ts
@@ -1,6 +1,6 @@
-﻿'use client';
-import { useState, useCallback, useRef } from 'react';
-import { useTimedQuizGame } from '@/hooks/games/useTimedQuizGame';
+'use client';
+import { useEffect, useCallback } from 'react';
+import { useEmojiMathStore } from './emojiMathStore';
 
 const EMOJIS = ['🍎','🍊','🍋','🍇','🍓','🫐','🍒','🍑','🥝','🍉','🍍','🥭'];
 
@@ -35,52 +35,91 @@ export function makeQuestion(level: number): Question {
 }
 
 export const TIME_PER_Q = 8;
+const INITIAL_LIVES = 3;
 
 export function useEmojiMathGame() {
-  const [q, setQ]           = useState<Question>(() => makeQuestion(1));
-  const [level, setLevel]   = useState(1);
-  const [streak, setStreak] = useState(0);
+  const phase    = useEmojiMathStore((s) => s.phase);
+  const score    = useEmojiMathStore((s) => s.score);
+  const best     = useEmojiMathStore((s) => s.best);
+  const lives    = useEmojiMathStore((s) => s.lives);
+  const timeLeft = useEmojiMathStore((s) => s.timeLeft);
+  const feedback = useEmojiMathStore((s) => s.feedback);
+  const q        = useEmojiMathStore((s) => s.q);
+  const level    = useEmojiMathStore((s) => s.level);
+  const streak   = useEmojiMathStore((s) => s.streak);
 
-  const levelRef  = useRef(1);
-  const streakRef = useRef(0);
+  // Countdown timer — runs while playing and no feedback showing
+  useEffect(() => {
+    if (phase !== 'playing' || feedback !== null) return;
+    const interval = setInterval(() => {
+      const store = useEmojiMathStore.getState();
+      if (store.phase !== 'playing' || store.feedback !== null) return;
+      if (store.timeLeft <= 1) {
+        const newLives = store.lives - 1;
+        store.setLives(newLives);
+        store.setFeedback('wrong');
+        store.setTimeLeft(TIME_PER_Q);
+        if (newLives <= 0) {
+          store.setPhase('dead');
+          store.updateBest(store.score);
+        }
+      } else {
+        store.setTimeLeft(store.timeLeft - 1);
+      }
+    }, 1000);
+    return () => clearInterval(interval);
+  }, [phase, feedback]);
 
-  const {
-    phase, score, best, lives, timeLeft, feedback,
-    phaseRef, scoreRef, startGame: startBase, handleCorrect, handleWrong,
-  } = useTimedQuizGame({
-    timePerQ: TIME_PER_Q,
-    feedbackDelay: 900,
-    onNextQuestion: () => setQ(makeQuestion(levelRef.current)),
-  });
+  // Advance to next question after feedback delay
+  useEffect(() => {
+    if (feedback === null || phase !== 'playing') return;
+    const t = setTimeout(() => {
+      const store = useEmojiMathStore.getState();
+      if (store.phase !== 'playing') return;
+      store.setFeedback(null);
+      store.setTimeLeft(TIME_PER_Q);
+      store.setQ(makeQuestion(store.level));
+    }, 900);
+    return () => clearTimeout(t);
+  }, [feedback, phase]);
 
   const startGame = useCallback(() => {
-    levelRef.current = 1;
-    streakRef.current = 0;
-    startBase(() => {
-      setLevel(1);
-      setStreak(0);
-      setQ(makeQuestion(1));
-    });
-  }, [startBase]);
+    const store = useEmojiMathStore.getState();
+    store.setPhase('playing');
+    store.setScore(0);
+    store.setLives(INITIAL_LIVES);
+    store.setTimeLeft(TIME_PER_Q);
+    store.setFeedback(null);
+    store.setLevel(1);
+    store.setStreak(0);
+    store.setQ(makeQuestion(1));
+  }, []);
 
   const tap = useCallback((choice: number) => {
-    if (phaseRef.current !== 'playing' || feedback) return;
-    if (choice === q.answer) {
-      const ns = streakRef.current + 1;
-      streakRef.current = ns;
-      setStreak(ns);
-      const bonus = ns >= 3 ? 20 : 10;
-      handleCorrect(bonus);
-      if (scoreRef.current > 0 && scoreRef.current % 50 === 0) {
-        levelRef.current++;
-        setLevel(levelRef.current);
+    const store = useEmojiMathStore.getState();
+    if (store.phase !== 'playing' || store.feedback !== null) return;
+
+    if (choice === store.q.answer) {
+      const newStreak = store.streak + 1;
+      const bonus = newStreak >= 3 ? 20 : 10;
+      const newScore = store.score + bonus;
+      store.setStreak(newStreak);
+      store.setScore(newScore);
+      store.setFeedback('correct');
+      if (newScore > 0 && newScore % 50 === 0) {
+        store.setLevel(store.level + 1);
       }
     } else {
-      streakRef.current = 0;
-      setStreak(0);
-      handleWrong();
+      const newLives = store.lives - 1;
+      store.setStreak(0);
+      store.setLives(newLives);
+      store.setFeedback('wrong');
+      if (newLives <= 0) {
+        store.setPhase('dead');
+        store.updateBest(store.score);
+      }
     }
-  }, [feedback, q.answer, phaseRef, scoreRef, handleCorrect, handleWrong]);
+  }, []);
 
   return { phase, q, score, best, lives, level, timeLeft, feedback, streak, startGame, tap };
 }


### PR DESCRIPTION
Closes #18

## Summary
- Add `emojiMathStore.ts` using `makeStore` factory with all game state (phase, score, best, lives, timeLeft, feedback, q, level, streak)
- Rewrite `useEmojiMathGame.ts` to use Zustand selectors — no more `useState` or `useRef`
- Remove dependency on shared `useTimedQuizGame` hook; timer and feedback-advance logic inline with `getState()` for stale-closure safety
- 5 refs eliminated: `phaseRef`, `scoreRef`, `levelRef`, `streakRef`, `livesRef`

## Test plan
- [ ] Game starts from menu, timer counts down correctly
- [ ] Correct tap: streak increments, bonus 10 (×3 streak → 20), level-up at multiples of 50 score
- [ ] Wrong tap: life deducted, feedback shows, next question loads after 900ms
- [ ] Timer expiry: deducts life, shows wrong feedback
- [ ] Game over when lives reach 0 → dead screen with best score
- [ ] Restart resets all state

🤖 Generated with [Claude Code](https://claude.com/claude-code)