### PR TITLE
feat(color-tap): migrate from useState/useRef to Zustand store

### DIFF
--- a/gamesformykids/app/games/color-tap/colorTapStore.ts
+++ b/gamesformykids/app/games/color-tap/colorTapStore.ts
@@ -1,0 +1,132 @@
+import { makeStore } from '@/lib/stores/createStore';
+import type { PhaseDead as Phase } from '@/lib/types';
+
+// ── Color data ──────────────────────────────────────────────────────────────
+
+export const COLORS = [
+  { name: 'אדום',  bg: 'bg-red-500',    hex: '#ef4444', emoji: '🔴' },
+  { name: 'כחול',  bg: 'bg-blue-500',   hex: '#3b82f6', emoji: '🔵' },
+  { name: 'ירוק',  bg: 'bg-green-500',  hex: '#22c55e', emoji: '🟢' },
+  { name: 'צהוב',  bg: 'bg-yellow-400', hex: '#facc15', emoji: '🟡' },
+  { name: 'סגול',  bg: 'bg-purple-500', hex: '#a855f7', emoji: '🟣' },
+  { name: 'כתום',  bg: 'bg-orange-500', hex: '#f97316', emoji: '🟠' },
+  { name: 'ורוד',  bg: 'bg-pink-400',   hex: '#f472b6', emoji: '🩷' },
+  { name: 'תכלת',  bg: 'bg-cyan-400',   hex: '#22d3ee', emoji: '🩵' },
+];
+
+export type ColorItem = typeof COLORS[number];
+
+export interface Question {
+  target:  ColorItem;
+  options: ColorItem[];
+}
+
+function makeQuestion(): Question {
+  const shuffled = [...COLORS].sort(() => Math.random() - 0.5) as ColorItem[];
+  const target  = shuffled[0];
+  const options = shuffled.slice(0, 4).sort(() => Math.random() - 0.5);
+  return { target, options };
+}
+
+// ── Store ───────────────────────────────────────────────────────────────────
+
+export const TIME_PER_Q   = 5;
+const        FEEDBACK_MS  = 700;
+const        INITIAL_LIVES = 3;
+
+interface ColorTapState {
+  phase:    Phase;
+  score:    number;
+  best:     number;
+  lives:    number;
+  timeLeft: number;
+  feedback: 'correct' | 'wrong' | null;
+  question: Question;
+}
+
+interface ColorTapActions {
+  startGame:  () => void;
+  handleTap:  (color: ColorItem) => void;
+}
+
+const INITIAL: ColorTapState = {
+  phase: 'menu', score: 0, best: 0, lives: INITIAL_LIVES,
+  timeLeft: TIME_PER_Q, feedback: null, question: makeQuestion(),
+};
+
+export const useColorTapStore = makeStore<ColorTapState & ColorTapActions>(
+  'ColorTapStore',
+  (set, get) => {
+    let countdownId: ReturnType<typeof setInterval> | null = null;
+    let feedbackId:  ReturnType<typeof setTimeout>  | null = null;
+
+    function clearCountdown()     { if (countdownId) { clearInterval(countdownId); countdownId = null; } }
+    function clearFeedbackTimer() { if (feedbackId)  { clearTimeout(feedbackId);   feedbackId  = null; } }
+
+    function advanceAfterFeedback() {
+      clearFeedbackTimer();
+      feedbackId = setTimeout(() => {
+        if (get().phase !== 'playing') return;
+        set({ feedback: null, timeLeft: TIME_PER_Q, question: makeQuestion() }, false, 'colorTap/nextQuestion');
+        startCountdown();
+      }, FEEDBACK_MS);
+    }
+
+    function startCountdown() {
+      clearCountdown();
+      if (typeof window === 'undefined') return;
+      countdownId = setInterval(() => {
+        const { phase, feedback, timeLeft, lives, score, best } = get();
+        if (phase !== 'playing' || feedback !== null) { clearCountdown(); return; }
+        if (timeLeft <= 1) {
+          clearCountdown();
+          const newLives = lives - 1;
+          const isDead   = newLives <= 0;
+          set(
+            isDead
+              ? { lives: newLives, feedback: 'wrong', timeLeft: TIME_PER_Q, phase: 'dead', best: Math.max(best, score) }
+              : { lives: newLives, feedback: 'wrong', timeLeft: TIME_PER_Q },
+            false,
+            'colorTap/timeout',
+          );
+          if (!isDead) advanceAfterFeedback();
+        } else {
+          set({ timeLeft: timeLeft - 1 }, false, 'colorTap/tick');
+        }
+      }, 1000);
+    }
+
+    return {
+      ...INITIAL,
+
+      startGame: () => {
+        clearCountdown();
+        clearFeedbackTimer();
+        set({ ...INITIAL, phase: 'playing', best: get().best, question: makeQuestion() }, false, 'colorTap/startGame');
+        startCountdown();
+      },
+
+      handleTap: (color: ColorItem) => {
+        const { phase, feedback, question, lives, score, best } = get();
+        if (phase !== 'playing' || feedback !== null) return;
+        clearCountdown();
+
+        if (color === question.target) {
+          set({ score: score + 10, feedback: 'correct' }, false, 'colorTap/correct');
+          advanceAfterFeedback();
+        } else {
+          const newLives = lives - 1;
+          const isDead   = newLives <= 0;
+          set(
+            isDead
+              ? { lives: newLives, feedback: 'wrong', phase: 'dead', best: Math.max(best, score) }
+              : { lives: newLives, feedback: 'wrong' },
+            false,
+            'colorTap/wrong',
+          );
+          if (!isDead) advanceAfterFeedback();
+        }
+      },
+    };
+  },
+);

--- a/gamesformykids/app/games/color-tap/useColorTapGame.ts
+++ b/gamesformykids/app/games/color-tap/useColorTapGame.ts
@@ -1,54 +1,19 @@
-﻿'use client';
+'use client';
+import { useColorTapStore } from './colorTapStore';
 
-import { useState, useCallback } from 'react';
-import { useTimedQuizGame } from '@/hooks/games/useTimedQuizGame';
-
-export const COLORS = [
-  { name: 'אדום',  bg: 'bg-red-500',    hex: '#ef4444', emoji: '🔴' },
-  { name: 'כחול',  bg: 'bg-blue-500',   hex: '#3b82f6', emoji: '🔵' },
-  { name: 'ירוק',  bg: 'bg-green-500',  hex: '#22c55e', emoji: '🟢' },
-  { name: 'צהוב',  bg: 'bg-yellow-400', hex: '#facc15', emoji: '🟡' },
-  { name: 'סגול',  bg: 'bg-purple-500', hex: '#a855f7', emoji: '🟣' },
-  { name: 'כתום',  bg: 'bg-orange-500', hex: '#f97316', emoji: '🟠' },
-  { name: 'ורוד',  bg: 'bg-pink-400',   hex: '#f472b6', emoji: '🩷' },
-  { name: 'תכלת',  bg: 'bg-cyan-400',   hex: '#22d3ee', emoji: '🩵' },
-];
-
-export type ColorItem = typeof COLORS[0];
-
-export const TIME_PER_Q = 5;
-
-function makeQuestion() {
-  const shuffled = [...COLORS].sort(() => Math.random() - 0.5);
-  const target = shuffled[0];
-  const options = shuffled.slice(0, 4).sort(() => Math.random() - 0.5);
-  return { target, options };
-}
+export type { ColorItem, Question } from './colorTapStore';
+export { COLORS, TIME_PER_Q }       from './colorTapStore';
 
 export function useColorTapGame() {
-  const [question, setQuestion] = useState(makeQuestion);
-
-  const {
-    phase, score, best, lives, timeLeft, feedback,
-    phaseRef, startGame: startBase, handleCorrect, handleWrong,
-  } = useTimedQuizGame({
-    timePerQ: TIME_PER_Q,
-    feedbackDelay: 700,
-    onNextQuestion: () => setQuestion(makeQuestion()),
-  });
-
-  const startGame = useCallback(() => {
-    startBase(() => setQuestion(makeQuestion()));
-  }, [startBase]);
-
-  const handleTap = useCallback((color: ColorItem) => {
-    if (phaseRef.current !== 'playing' || feedback) return;
-    if (color === question.target) {
-      handleCorrect(10);
-    } else {
-      handleWrong();
-    }
-  }, [feedback, question, phaseRef, handleCorrect, handleWrong]);
+  const phase     = useColorTapStore((s) => s.phase);
+  const score     = useColorTapStore((s) => s.score);
+  const best      = useColorTapStore((s) => s.best);
+  const lives     = useColorTapStore((s) => s.lives);
+  const timeLeft  = useColorTapStore((s) => s.timeLeft);
+  const feedback  = useColorTapStore((s) => s.feedback);
+  const question  = useColorTapStore((s) => s.question);
+  const startGame = useColorTapStore((s) => s.startGame);
+  const handleTap = useColorTapStore((s) => s.handleTap);
 
   return { phase, score, best, lives, question, timeLeft, feedback, startGame, handleTap };
 }


### PR DESCRIPTION
Closes #19

## Summary
- Add `colorTapStore.ts` using `makeStore` factory — all game state + timer logic in one place
- Timer managed via module-level `setInterval`/`setTimeout` refs inside store creator closure (same pattern as `emojiMathStore`)
- `startGame` and `handleTap` are complete store actions; no React lifecycle needed
- `useColorTapGame.ts` reduced to 12 lines of pure Zustand selectors

## Test plan
- [ ] Game starts from menu, countdown runs from 5→0
- [ ] Correct tap: score +10, green feedback, next question after 700ms
- [ ] Wrong tap: life deducted, red feedback, next question after 700ms
- [ ] Timer expiry: deducts life, shows wrong feedback
- [ ] 3 wrong answers → game over screen with best score
- [ ] Restart resets all state except best

🤖 Generated with [Claude Code](https://claude.com/claude-code)