### PR TITLE
feat(true-false): migrate from useState/useRef to Zustand store

### DIFF
--- a/gamesformykids/app/games/true-false/trueFalseStore.ts
+++ b/gamesformykids/app/games/true-false/trueFalseStore.ts
@@ -1,0 +1,155 @@
+import { makeStore } from '@/lib/stores/createStore';
+import type { PhaseDead as Phase } from '@/lib/types';
+import { shuffle } from '@/lib/utils';
+
+// ── Facts data ──────────────────────────────────────────────────────────────
+
+export const FACTS = [
+  { fact: 'לכלב יש ארבע רגליים',          answer: true,  emoji: '🐕' },
+  { fact: 'השמש היא כוכב',                 answer: true,  emoji: '☀️' },
+  { fact: 'דגים נושמים בעזרת ריאות',       answer: false, emoji: '🐟' },
+  { fact: 'לעכביש יש שמונה רגליים',        answer: true,  emoji: '🕷️' },
+  { fact: 'הירח פולט אור עצמי',            answer: false, emoji: '🌙' },
+  { fact: 'לדולפין יש ריאות',              answer: true,  emoji: '🐬' },
+  { fact: 'לנחש יש רגליים',               answer: false, emoji: '🐍' },
+  { fact: 'עכביש הוא חרק',                answer: false, emoji: '🕷️' },
+  { fact: 'ענבים הם פרי',                 answer: true,  emoji: '🍇' },
+  { fact: 'זברה שייכת למשפחת הסוסים',     answer: true,  emoji: '🦓' },
+  { fact: 'פינגווין יכול לעוף',           answer: false, emoji: '🐧' },
+  { fact: 'תפוח גדל על עץ',              answer: true,  emoji: '🍎' },
+  { fact: 'לחתול יש שש רגליים',           answer: false, emoji: '🐈' },
+  { fact: 'השמיים כחולים ביום',           answer: true,  emoji: '🌤️' },
+  { fact: 'לדבורה יש כנפיים',            answer: true,  emoji: '🐝' },
+  { fact: 'בננה היא ירק',                answer: false, emoji: '🍌' },
+  { fact: 'ציפורים מטילות ביצים',         answer: true,  emoji: '🐦' },
+  { fact: 'לדג יש רגליים',               answer: false, emoji: '🐠' },
+  { fact: 'הלב שואב דם בגוף',            answer: true,  emoji: '❤️' },
+  { fact: 'ים שתייה מלוח',              answer: true,  emoji: '🌊' },
+  { fact: 'קוף אוהב בננות',             answer: true,  emoji: '🐒' },
+  { fact: 'לפרפר שלוש זוגות כנפיים',    answer: false, emoji: '🦋' },
+  { fact: 'אריה הוא חיית בית',           answer: false, emoji: '🦁' },
+  { fact: 'שלג צבעו לבן',              answer: true,  emoji: '❄️' },
+  { fact: 'תות שדה הוא פרי',            answer: true,  emoji: '🍓' },
+];
+
+export type Fact = typeof FACTS[number];
+
+// ── Store ───────────────────────────────────────────────────────────────────
+
+export const TIME_PER_Q   = 6;
+const        FEEDBACK_MS  = 800;
+const        INITIAL_LIVES = 3;
+
+interface TrueFalseState {
+  phase:    Phase;
+  score:    number;
+  best:     number;
+  lives:    number;
+  timeLeft: number;
+  feedback: 'correct' | 'wrong' | null;
+  deck:     Fact[];
+  idx:      number;
+}
+
+interface TrueFalseActions {
+  startGame: () => void;
+  answer:    (choice: boolean) => void;
+}
+
+const INITIAL_DECK = shuffle(FACTS);
+
+const INITIAL: TrueFalseState = {
+  phase: 'menu', score: 0, best: 0, lives: INITIAL_LIVES,
+  timeLeft: TIME_PER_Q, feedback: null, deck: INITIAL_DECK, idx: 0,
+};
+
+export const useTrueFalseStore = makeStore<TrueFalseState & TrueFalseActions>(
+  'TrueFalseStore',
+  (set, get) => {
+    let countdownId: ReturnType<typeof setInterval> | null = null;
+    let feedbackId:  ReturnType<typeof setTimeout>  | null = null;
+
+    function clearCountdown()     { if (countdownId) { clearInterval(countdownId); countdownId = null; } }
+    function clearFeedbackTimer() { if (feedbackId)  { clearTimeout(feedbackId);   feedbackId  = null; } }
+
+    function nextQuestion() {
+      const { deck, idx } = get();
+      const nextIdx = idx + 1;
+      if (nextIdx >= deck.length) {
+        const newDeck = shuffle(FACTS);
+        set({ deck: newDeck, idx: 0 }, false, 'trueFalse/reshuffleDeck');
+      } else {
+        set({ idx: nextIdx }, false, 'trueFalse/nextIdx');
+      }
+    }
+
+    function advanceAfterFeedback() {
+      clearFeedbackTimer();
+      feedbackId = setTimeout(() => {
+        if (get().phase !== 'playing') return;
+        nextQuestion();
+        set({ feedback: null, timeLeft: TIME_PER_Q }, false, 'trueFalse/nextQuestion');
+        startCountdown();
+      }, FEEDBACK_MS);
+    }
+
+    function startCountdown() {
+      clearCountdown();
+      if (typeof window === 'undefined') return;
+      countdownId = setInterval(() => {
+        const { phase, feedback, timeLeft, lives, score, best } = get();
+        if (phase !== 'playing' || feedback !== null) { clearCountdown(); return; }
+        if (timeLeft <= 1) {
+          clearCountdown();
+          const newLives = lives - 1;
+          const isDead   = newLives <= 0;
+          set(
+            isDead
+              ? { lives: newLives, feedback: 'wrong', timeLeft: TIME_PER_Q, phase: 'dead', best: Math.max(best, score) }
+              : { lives: newLives, feedback: 'wrong', timeLeft: TIME_PER_Q },
+            false,
+            'trueFalse/timeout',
+          );
+          if (!isDead) advanceAfterFeedback();
+        } else {
+          set({ timeLeft: timeLeft - 1 }, false, 'trueFalse/tick');
+        }
+      }, 1000);
+    }
+
+    return {
+      ...INITIAL,
+
+      startGame: () => {
+        clearCountdown();
+        clearFeedbackTimer();
+        const deck = shuffle(FACTS);
+        set({ ...INITIAL, phase: 'playing', best: get().best, deck, idx: 0 }, false, 'trueFalse/startGame');
+        startCountdown();
+      },
+
+      answer: (choice: boolean) => {
+        const { phase, feedback, deck, idx, lives, score, best } = get();
+        if (phase !== 'playing' || feedback !== null) return;
+        clearCountdown();
+
+        const correct = choice === deck[idx].answer;
+        if (correct) {
+          set({ score: score + 10, feedback: 'correct' }, false, 'trueFalse/correct');
+          advanceAfterFeedback();
+        } else {
+          const newLives = lives - 1;
+          const isDead   = newLives <= 0;
+          set(
+            isDead
+              ? { lives: newLives, feedback: 'wrong', phase: 'dead', best: Math.max(best, score) }
+              : { lives: newLives, feedback: 'wrong' },
+            false,
+            'trueFalse/wrong',
+          );
+          if (!isDead) advanceAfterFeedback();
+        }
+      },
+    };
+  },
+);

--- a/gamesformykids/app/games/true-false/useTrueFalseGame.ts
+++ b/gamesformykids/app/games/true-false/useTrueFalseGame.ts
@@ -1,94 +1,20 @@
 'use client';
-import { useState, useCallback, useRef } from 'react';
-import { useTimedQuizGame } from '@/hooks/games/useTimedQuizGame';
+import { useTrueFalseStore } from './trueFalseStore';
 
-export const FACTS = [
-  { fact: 'לכלב יש ארבע רגליים', answer: true, emoji: '🐕' },
-  { fact: 'השמש היא כוכב', answer: true, emoji: '☀️' },
-  { fact: 'דגים נושמים בעזרת ריאות', answer: false, emoji: '🐟' },
-  { fact: 'לעכביש יש שמונה רגליים', answer: true, emoji: '🕷️' },
-  { fact: 'הירח פולט אור עצמי', answer: false, emoji: '🌙' },
-  { fact: 'לדולפין יש ריאות', answer: true, emoji: '🐬' },
-  { fact: 'לנחש יש רגליים', answer: false, emoji: '🐍' },
-  { fact: 'עכביש הוא חרק', answer: false, emoji: '🕷️' },
-  { fact: 'ענבים הם פרי', answer: true, emoji: '🍇' },
-  { fact: 'זברה שייכת למשפחת הסוסים', answer: true, emoji: '🦓' },
-  { fact: 'פינגווין יכול לעוף', answer: false, emoji: '🐧' },
-  { fact: 'תפוח גדל על עץ', answer: true, emoji: '🍎' },
-  { fact: 'לחתול יש שש רגליים', answer: false, emoji: '🐈' },
-  { fact: 'השמיים כחולים ביום', answer: true, emoji: '🌤️' },
-  { fact: 'לדבורה יש כנפיים', answer: true, emoji: '🐝' },
-  { fact: 'בננה היא ירק', answer: false, emoji: '🍌' },
-  { fact: 'ציפורים מטילות ביצים', answer: true, emoji: '🐦' },
-  { fact: 'לדג יש רגליים', answer: false, emoji: '🐠' },
-  { fact: 'הלב שואב דם בגוף', answer: true, emoji: '❤️' },
-  { fact: 'ים שתייה מלוח', answer: true, emoji: '🌊' },
-  { fact: 'קוף אוהב בננות', answer: true, emoji: '🐒' },
-  { fact: 'לפרפר שלוש זוגות כנפיים', answer: false, emoji: '🦋' },
-  { fact: 'אריה הוא חיית בית', answer: false, emoji: '🦁' },
-  { fact: 'שלג צבעו לבן', answer: true, emoji: '❄️' },
-  { fact: 'תות שדה הוא פרי', answer: true, emoji: '🍓' },
-];
-
-export const TIME_PER_Q = 6;
-
-import { shuffle } from '@/lib/utils';
+export type { Fact } from './trueFalseStore';
+export { FACTS, TIME_PER_Q } from './trueFalseStore';
 
 export function useTrueFalseGame() {
-  const [deck, setDeck]   = useState(() => shuffle(FACTS));
-  const [idx, setIdx]     = useState(0);
+  const phase    = useTrueFalseStore((s) => s.phase);
+  const score    = useTrueFalseStore((s) => s.score);
+  const best     = useTrueFalseStore((s) => s.best);
+  const lives    = useTrueFalseStore((s) => s.lives);
+  const timeLeft = useTrueFalseStore((s) => s.timeLeft);
+  const feedback = useTrueFalseStore((s) => s.feedback);
+  const deck     = useTrueFalseStore((s) => s.deck);
+  const idx      = useTrueFalseStore((s) => s.idx);
+  const startGame = useTrueFalseStore((s) => s.startGame);
+  const answer    = useTrueFalseStore((s) => s.answer);
 
-  const idxRef  = useRef(0);
-  const deckRef = useRef(shuffle(FACTS));
-
-  const {
-    phase, score, best, lives, timeLeft, feedback,
-    phaseRef, startGame: startBase, handleCorrect, handleWrong,
-  } = useTimedQuizGame({
-    timePerQ: TIME_PER_Q,
-    feedbackDelay: 800,
-    onNextQuestion: () => {
-      const nextIdx = idxRef.current + 1;
-      if (nextIdx >= deckRef.current.length) {
-        deckRef.current = shuffle(FACTS);
-        setDeck([...deckRef.current]);
-        idxRef.current = 0;
-      } else {
-        idxRef.current = nextIdx;
-      }
-      setIdx(idxRef.current);
-    },
-  });
-
-  const startGame = useCallback(() => {
-    const d = shuffle(FACTS);
-    deckRef.current = d;
-    idxRef.current = 0;
-    startBase(() => {
-      setDeck(d);
-      setIdx(0);
-    });
-  }, [startBase]);
-
-  const answer = useCallback((choice: boolean) => {
-    if (phaseRef.current !== 'playing' || feedback) return;
-    const correct = choice === deckRef.current[idxRef.current].answer;
-    if (correct) {
-      handleCorrect(10);
-    } else {
-      handleWrong();
-    }
-  }, [feedback, phaseRef, handleCorrect, handleWrong]);
-
-  return {
-    phase,
-    q: deck[idx],
-    score,
-    best,
-    lives,
-    timeLeft,
-    feedback,
-    startGame,
-    answer,
-  };
+  return { phase, q: deck[idx], score, best, lives, timeLeft, feedback, startGame, answer };
 }


### PR DESCRIPTION
Closes #21

## Summary
- Add `trueFalseStore.ts` using `makeStore` factory — all game state, deck management, and timer logic
- Deck of facts shuffles on `startGame` and reshuffles automatically when exhausted, all inside store actions
- Timer and feedback-advance managed via module-level `setInterval`/`setTimeout` refs in store closure
- `useTrueFalseGame.ts` reduced to pure selectors — no `useState`, `useRef`, or `useCallback`

## Test plan
- [ ] Game starts, countdown runs from 6→0
- [ ] Correct answer: score +10, green feedback, next fact after 800ms
- [ ] Wrong answer: life deducted, red feedback, next fact after 800ms
- [ ] Timer expiry: deducts life, shows wrong feedback
- [ ] Deck reshuffles when all 25 facts are shown
- [ ] 3 lives lost → game over with best score
- [ ] Restart resets all state except best

🤖 Generated with [Claude Code](https://claude.com/claude-code)