### PR TITLE
refactor: extract setupLivesTimer helper to eliminate timer boilerplate

### DIFF
--- a/gamesformykids/app/games/color-tap/colorTapStore.ts
+++ b/gamesformykids/app/games/color-tap/colorTapStore.ts
@@ -1,4 +1,5 @@
 import { makeStore } from '@/lib/stores/createStore';
+import { setupLivesTimer } from '@/lib/stores/livesTimerHelpers';
 import type { PhaseDead as Phase } from '@/lib/types';
 
 // ── Color data ──────────────────────────────────────────────────────────────
@@ -23,16 +24,12 @@ export interface Question {
 
 function makeQuestion(): Question {
   const shuffled = [...COLORS].sort(() => Math.random() - 0.5) as ColorItem[];
-  const target  = shuffled[0];
-  const options = shuffled.slice(0, 4).sort(() => Math.random() - 0.5);
-  return { target, options };
+  return { target: shuffled[0], options: shuffled.slice(0, 4).sort(() => Math.random() - 0.5) };
 }
 
 // ── Store ───────────────────────────────────────────────────────────────────
 
-export const TIME_PER_Q   = 5;
-const        FEEDBACK_MS  = 700;
-const        INITIAL_LIVES = 3;
+export const TIME_PER_Q = 5;
 
 interface ColorTapState {
   phase:    Phase;
@@ -45,87 +42,34 @@ interface ColorTapState {
 }
 
 interface ColorTapActions {
-  startGame:  () => void;
-  handleTap:  (color: ColorItem) => void;
+  startGame: () => void;
+  handleTap: (color: ColorItem) => void;
 }
 
 const INITIAL: ColorTapState = {
-  phase: 'menu', score: 0, best: 0, lives: INITIAL_LIVES,
+  phase: 'menu', score: 0, best: 0, lives: 3,
   timeLeft: TIME_PER_Q, feedback: null, question: makeQuestion(),
 };
 
 export const useColorTapStore = makeStore<ColorTapState & ColorTapActions>(
   'ColorTapStore',
   (set, get) => {
-    let countdownId: ReturnType<typeof setInterval> | null = null;
-    let feedbackId:  ReturnType<typeof setTimeout>  | null = null;
-
-    function clearCountdown()     { if (countdownId) { clearInterval(countdownId); countdownId = null; } }
-    function clearFeedbackTimer() { if (feedbackId)  { clearTimeout(feedbackId);   feedbackId  = null; } }
-
-    function advanceAfterFeedback() {
-      clearFeedbackTimer();
-      feedbackId = setTimeout(() => {
-        if (get().phase !== 'playing') return;
-        set({ feedback: null, timeLeft: TIME_PER_Q, question: makeQuestion() }, false, 'colorTap/nextQuestion');
-        startCountdown();
-      }, FEEDBACK_MS);
-    }
-
-    function startCountdown() {
-      clearCountdown();
-      if (typeof window === 'undefined') return;
-      countdownId = setInterval(() => {
-        const { phase, feedback, timeLeft, lives, score, best } = get();
-        if (phase !== 'playing' || feedback !== null) { clearCountdown(); return; }
-        if (timeLeft <= 1) {
-          clearCountdown();
-          const newLives = lives - 1;
-          const isDead   = newLives <= 0;
-          set(
-            isDead
-              ? { lives: newLives, feedback: 'wrong', timeLeft: TIME_PER_Q, phase: 'dead', best: Math.max(best, score) }
-              : { lives: newLives, feedback: 'wrong', timeLeft: TIME_PER_Q },
-            false,
-            'colorTap/timeout',
-          );
-          if (!isDead) advanceAfterFeedback();
-        } else {
-          set({ timeLeft: timeLeft - 1 }, false, 'colorTap/tick');
-        }
-      }, 1000);
-    }
+    const timer = setupLivesTimer({
+      name: 'ColorTapStore', timePerQ: TIME_PER_Q, feedbackMs: 700, initialLives: 3,
+      set, get,
+      getNextUpdates: () => ({ question: makeQuestion() }),
+    });
 
     return {
       ...INITIAL,
 
-      startGame: () => {
-        clearCountdown();
-        clearFeedbackTimer();
-        set({ ...INITIAL, phase: 'playing', best: get().best, question: makeQuestion() }, false, 'colorTap/startGame');
-        startCountdown();
-      },
+      startGame: () => timer.startGame(() => ({ question: makeQuestion() })),
 
       handleTap: (color: ColorItem) => {
-        const { phase, feedback, question, lives, score, best } = get();
+        const { phase, feedback, question } = get();
         if (phase !== 'playing' || feedback !== null) return;
-        clearCountdown();
-
-        if (color === question.target) {
-          set({ score: score + 10, feedback: 'correct' }, false, 'colorTap/correct');
-          advanceAfterFeedback();
-        } else {
-          const newLives = lives - 1;
-          const isDead   = newLives <= 0;
-          set(
-            isDead
-              ? { lives: newLives, feedback: 'wrong', phase: 'dead', best: Math.max(best, score) }
-              : { lives: newLives, feedback: 'wrong' },
-            false,
-            'colorTap/wrong',
-          );
-          if (!isDead) advanceAfterFeedback();
-        }
+        if (color === question.target) timer.correct(10);
+        else timer.wrong();
       },
     };
   },

--- a/gamesformykids/app/games/emoji-math/emojiMathStore.ts
+++ b/gamesformykids/app/games/emoji-math/emojiMathStore.ts
@@ -1,4 +1,5 @@
 import { makeStore } from '@/lib/stores/createStore';
+import { setupLivesTimer } from '@/lib/stores/livesTimerHelpers';
 import type { PhaseDead as Phase } from '@/lib/types';
 import { randInt as rnd } from '@/lib/utils';
 
@@ -37,8 +38,7 @@ export function makeQuestion(level: number): Question {
 
 // ── Store ───────────────────────────────────────────────────────────────────
 
-export const TIME_PER_Q  = 8;
-const        INITIAL_LIVES = 3;
+export const TIME_PER_Q = 8;
 
 interface EmojiMathState {
   phase:    Phase;
@@ -58,86 +58,36 @@ interface EmojiMathActions {
 }
 
 const INITIAL: EmojiMathState = {
-  phase: 'menu', score: 0, best: 0, lives: INITIAL_LIVES,
+  phase: 'menu', score: 0, best: 0, lives: 3,
   timeLeft: TIME_PER_Q, feedback: null, q: makeQuestion(1), level: 1, streak: 0,
 };
 
 export const useEmojiMathStore = makeStore<EmojiMathState & EmojiMathActions>(
   'EmojiMathStore',
   (set, get) => {
-    let countdownId: ReturnType<typeof setInterval> | null = null;
-    let feedbackId:  ReturnType<typeof setTimeout>  | null = null;
-
-    function clearCountdown()    { if (countdownId) { clearInterval(countdownId); countdownId = null; } }
-    function clearFeedbackTimer(){ if (feedbackId)  { clearTimeout(feedbackId);   feedbackId  = null; } }
-
-    function advanceAfterFeedback() {
-      clearFeedbackTimer();
-      feedbackId = setTimeout(() => {
-        if (get().phase !== 'playing') return;
-        const level = get().level;
-        set({ feedback: null, timeLeft: TIME_PER_Q, q: makeQuestion(level) }, false, 'emojiMath/nextQuestion');
-        startCountdown();
-      }, 900);
-    }
-
-    function startCountdown() {
-      clearCountdown();
-      if (typeof window === 'undefined') return;
-      countdownId = setInterval(() => {
-        const { phase, feedback, timeLeft, lives, score, best } = get();
-        if (phase !== 'playing' || feedback !== null) { clearCountdown(); return; }
-        if (timeLeft <= 1) {
-          clearCountdown();
-          const newLives = lives - 1;
-          const isDead   = newLives <= 0;
-          set(
-            isDead
-              ? { lives: newLives, feedback: 'wrong', timeLeft: TIME_PER_Q, phase: 'dead', best: Math.max(best, score) }
-              : { lives: newLives, feedback: 'wrong', timeLeft: TIME_PER_Q },
-            false,
-            'emojiMath/timeout',
-          );
-          if (!isDead) advanceAfterFeedback();
-        } else {
-          set({ timeLeft: timeLeft - 1 }, false, 'emojiMath/tick');
-        }
-      }, 1000);
-    }
+    const timer = setupLivesTimer({
+      name: 'EmojiMathStore', timePerQ: TIME_PER_Q, feedbackMs: 900, initialLives: 3,
+      set, get,
+      getNextUpdates: () => ({ q: makeQuestion(get().level) }),
+    });
 
     return {
       ...INITIAL,
 
-      startGame: () => {
-        clearCountdown();
-        clearFeedbackTimer();
-        set({ ...INITIAL, phase: 'playing', best: get().best, q: makeQuestion(1) }, false, 'emojiMath/startGame');
-        startCountdown();
-      },
+      startGame: () => timer.startGame(() => ({ q: makeQuestion(1), level: 1, streak: 0 })),
 
       tap: (choice: number) => {
-        const { phase, feedback, q, streak, score, lives, level, best } = get();
+        const { phase, feedback, q, streak, score, level } = get();
         if (phase !== 'playing' || feedback !== null) return;
-        clearCountdown();
 
         if (choice === q.answer) {
           const newStreak = streak + 1;
           const bonus     = newStreak >= 3 ? 20 : 10;
           const newScore  = score + bonus;
           const newLevel  = newScore > 0 && newScore % 50 === 0 ? level + 1 : level;
-          set({ streak: newStreak, score: newScore, level: newLevel, feedback: 'correct' }, false, 'emojiMath/correct');
-          advanceAfterFeedback();
+          timer.correct(bonus, { streak: newStreak, level: newLevel });
         } else {
-          const newLives = lives - 1;
-          const isDead   = newLives <= 0;
-          set(
-            isDead
-              ? { streak: 0, lives: newLives, feedback: 'wrong', phase: 'dead', best: Math.max(best, score) }
-              : { streak: 0, lives: newLives, feedback: 'wrong' },
-            false,
-            'emojiMath/wrong',
-          );
-          if (!isDead) advanceAfterFeedback();
+          timer.wrong({ streak: 0 });
         }
       },
     };

--- a/gamesformykids/app/games/true-false/trueFalseStore.ts
+++ b/gamesformykids/app/games/true-false/trueFalseStore.ts
@@ -1,4 +1,5 @@
 import { makeStore } from '@/lib/stores/createStore';
+import { setupLivesTimer } from '@/lib/stores/livesTimerHelpers';
 import type { PhaseDead as Phase } from '@/lib/types';
 import { shuffle } from '@/lib/utils';
 
@@ -36,9 +37,7 @@ export type Fact = typeof FACTS[number];
 
 // ── Store ───────────────────────────────────────────────────────────────────
 
-export const TIME_PER_Q   = 6;
-const        FEEDBACK_MS  = 800;
-const        INITIAL_LIVES = 3;
+export const TIME_PER_Q = 6;
 
 interface TrueFalseState {
   phase:    Phase;
@@ -56,99 +55,41 @@ interface TrueFalseActions {
   answer:    (choice: boolean) => void;
 }
 
-const INITIAL_DECK = shuffle(FACTS);
-
 const INITIAL: TrueFalseState = {
-  phase: 'menu', score: 0, best: 0, lives: INITIAL_LIVES,
-  timeLeft: TIME_PER_Q, feedback: null, deck: INITIAL_DECK, idx: 0,
+  phase: 'menu', score: 0, best: 0, lives: 3,
+  timeLeft: TIME_PER_Q, feedback: null, deck: shuffle(FACTS), idx: 0,
 };
 
 export const useTrueFalseStore = makeStore<TrueFalseState & TrueFalseActions>(
   'TrueFalseStore',
   (set, get) => {
-    let countdownId: ReturnType<typeof setInterval> | null = null;
-    let feedbackId:  ReturnType<typeof setTimeout>  | null = null;
-
-    function clearCountdown()     { if (countdownId) { clearInterval(countdownId); countdownId = null; } }
-    function clearFeedbackTimer() { if (feedbackId)  { clearTimeout(feedbackId);   feedbackId  = null; } }
-
-    function nextQuestion() {
-      const { deck, idx } = get();
-      const nextIdx = idx + 1;
-      if (nextIdx >= deck.length) {
-        const newDeck = shuffle(FACTS);
-        set({ deck: newDeck, idx: 0 }, false, 'trueFalse/reshuffleDeck');
-      } else {
-        set({ idx: nextIdx }, false, 'trueFalse/nextIdx');
-      }
-    }
-
-    function advanceAfterFeedback() {
-      clearFeedbackTimer();
-      feedbackId = setTimeout(() => {
-        if (get().phase !== 'playing') return;
-        nextQuestion();
-        set({ feedback: null, timeLeft: TIME_PER_Q }, false, 'trueFalse/nextQuestion');
-        startCountdown();
-      }, FEEDBACK_MS);
-    }
-
-    function startCountdown() {
-      clearCountdown();
-      if (typeof window === 'undefined') return;
-      countdownId = setInterval(() => {
-        const { phase, feedback, timeLeft, lives, score, best } = get();
-        if (phase !== 'playing' || feedback !== null) { clearCountdown(); return; }
-        if (timeLeft <= 1) {
-          clearCountdown();
-          const newLives = lives - 1;
-          const isDead   = newLives <= 0;
-          set(
-            isDead
-              ? { lives: newLives, feedback: 'wrong', timeLeft: TIME_PER_Q, phase: 'dead', best: Math.max(best, score) }
-              : { lives: newLives, feedback: 'wrong', timeLeft: TIME_PER_Q },
-            false,
-            'trueFalse/timeout',
-          );
-          if (!isDead) advanceAfterFeedback();
-        } else {
-          set({ timeLeft: timeLeft - 1 }, false, 'trueFalse/tick');
+    const timer = setupLivesTimer({
+      name: 'TrueFalseStore', timePerQ: TIME_PER_Q, feedbackMs: 800, initialLives: 3,
+      set, get,
+      getNextUpdates: () => {
+        const { deck, idx } = get();
+        const nextIdx = idx + 1;
+        if (nextIdx >= deck.length) {
+          const newDeck = shuffle(FACTS);
+          return { deck: newDeck, idx: 0 };
         }
-      }, 1000);
-    }
+        return { idx: nextIdx };
+      },
+    });
 
     return {
       ...INITIAL,
 
       startGame: () => {
-        clearCountdown();
-        clearFeedbackTimer();
         const deck = shuffle(FACTS);
-        set({ ...INITIAL, phase: 'playing', best: get().best, deck, idx: 0 }, false, 'trueFalse/startGame');
-        startCountdown();
+        timer.startGame(() => ({ deck, idx: 0 }));
       },
 
       answer: (choice: boolean) => {
-        const { phase, feedback, deck, idx, lives, score, best } = get();
+        const { phase, feedback, deck, idx } = get();
         if (phase !== 'playing' || feedback !== null) return;
-        clearCountdown();
-
-        const correct = choice === deck[idx].answer;
-        if (correct) {
-          set({ score: score + 10, feedback: 'correct' }, false, 'trueFalse/correct');
-          advanceAfterFeedback();
-        } else {
-          const newLives = lives - 1;
-          const isDead   = newLives <= 0;
-          set(
-            isDead
-              ? { lives: newLives, feedback: 'wrong', phase: 'dead', best: Math.max(best, score) }
-              : { lives: newLives, feedback: 'wrong' },
-            false,
-            'trueFalse/wrong',
-          );
-          if (!isDead) advanceAfterFeedback();
-        }
+        if (choice === deck[idx].answer) timer.correct(10);
+        else timer.wrong();
       },
     };
   },

--- a/gamesformykids/lib/stores/livesTimerHelpers.ts
+++ b/gamesformykids/lib/stores/livesTimerHelpers.ts
@@ -1,0 +1,113 @@
+/**
+ * Shared timer infrastructure for lives-based quiz games
+ * (color-tap, emoji-math, true-false, and future games with the same pattern).
+ *
+ * Call inside a makeStore creator to get startGame / correct / wrong helpers
+ * that handle countdown, feedback delay, and game-over logic.
+ */
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type AnySet = (partial: any, replace?: false, name?: string) => void;
+type AnyGet = () => { phase: string; lives: number; score: number; best: number; timeLeft: number; feedback: unknown };
+
+export interface LivesTimerConfig {
+  /** DevTools store name prefix used in action labels */
+  name:         string;
+  timePerQ:     number;
+  feedbackMs:   number;
+  initialLives: number;
+  set:          AnySet;
+  get:          AnyGet;
+  /**
+   * Returns the state updates needed to show the next question.
+   * Called when the feedback delay expires. May return any store keys
+   * (e.g. `{ q }` for emoji-math, `{ question }` for color-tap, `{ idx }` for true-false).
+   */
+  getNextUpdates: () => Record<string, unknown>;
+}
+
+export function setupLivesTimer(cfg: LivesTimerConfig) {
+  const { name, timePerQ, feedbackMs, initialLives, set, get, getNextUpdates } = cfg;
+
+  let countdownId: ReturnType<typeof setInterval> | null = null;
+  let feedbackId:  ReturnType<typeof setTimeout>  | null = null;
+
+  function clearCountdown()     { if (countdownId) { clearInterval(countdownId); countdownId = null; } }
+  function clearFeedbackTimer() { if (feedbackId)  { clearTimeout(feedbackId);   feedbackId  = null; } }
+
+  function advanceAfterFeedback() {
+    clearFeedbackTimer();
+    feedbackId = setTimeout(() => {
+      if (get().phase !== 'playing') return;
+      set({ feedback: null, timeLeft: timePerQ, ...getNextUpdates() }, false, `${name}/nextQuestion`);
+      startCountdown();
+    }, feedbackMs);
+  }
+
+  function startCountdown() {
+    clearCountdown();
+    if (typeof window === 'undefined') return;
+    countdownId = setInterval(() => {
+      const { phase, feedback, timeLeft, lives, score, best } = get();
+      if (phase !== 'playing' || feedback !== null) { clearCountdown(); return; }
+      if (timeLeft <= 1) {
+        clearCountdown();
+        const newLives = lives - 1;
+        const isDead   = newLives <= 0;
+        set(
+          isDead
+            ? { lives: newLives, feedback: 'wrong', timeLeft: timePerQ, phase: 'dead', best: Math.max(best, score) }
+            : { lives: newLives, feedback: 'wrong', timeLeft: timePerQ },
+          false,
+          `${name}/timeout`,
+        );
+        if (!isDead) advanceAfterFeedback();
+      } else {
+        set({ timeLeft: timeLeft - 1 }, false, `${name}/tick`);
+      }
+    }, 1000);
+  }
+
+  return {
+    /**
+     * Resets shared state to initial values and starts the countdown.
+     * Pass `getInitialUpdates` to also reset game-specific state
+     * (e.g. `{ q, level: 1, streak: 0 }` for emoji-math).
+     */
+    startGame(getInitialUpdates: () => Record<string, unknown>) {
+      clearCountdown();
+      clearFeedbackTimer();
+      const { best } = get();
+      set(
+        { phase: 'playing', score: 0, lives: initialLives, timeLeft: timePerQ, feedback: null, best, ...getInitialUpdates() },
+        false,
+        `${name}/startGame`,
+      );
+      startCountdown();
+    },
+
+    /** Mark a correct answer: add points, set feedback, schedule next question. */
+    correct(points = 10, extra: Record<string, unknown> = {}) {
+      clearCountdown();
+      const { score } = get();
+      set({ score: score + points, feedback: 'correct', ...extra }, false, `${name}/correct`);
+      advanceAfterFeedback();
+    },
+
+    /** Mark a wrong answer: deduct a life, set feedback, end or schedule next question. */
+    wrong(extra: Record<string, unknown> = {}) {
+      clearCountdown();
+      const { lives, score, best } = get();
+      const newLives = lives - 1;
+      const isDead   = newLives <= 0;
+      set(
+        isDead
+          ? { lives: newLives, feedback: 'wrong', phase: 'dead', best: Math.max(best, score), ...extra }
+          : { lives: newLives, feedback: 'wrong', ...extra },
+        false,
+        `${name}/wrong`,
+      );
+      if (!isDead) advanceAfterFeedback();
+    },
+  };
+}


### PR DESCRIPTION
Closes #186

## Summary
- Add `lib/stores/livesTimerHelpers.ts` — `setupLivesTimer()` encapsulates the repeated timer pattern shared by all lives-based quiz games
- Refactor `emojiMathStore`, `colorTapStore`, `trueFalseStore` to use the helper
- Each store drops ~60 lines of identical boilerplate; total: -212 lines / +160 lines across 4 files

## What the helper provides
- `startGame(getInitialUpdates)` — resets phase/score/lives/timeLeft/feedback/best, then starts countdown
- `correct(points, extra?)` — stops countdown, sets feedback, schedules next question
- `wrong(extra?)` — stops countdown, deducts life, ends game or schedules next question
- Internal: `startCountdown` / `advanceAfterFeedback` with module-level timer refs per call

## Future games to use this (#20, #22, #23, #24)
word-scramble, math-race, reflex, whack-a-mole will all call `setupLivesTimer` instead of duplicating the pattern.

## Test plan
- [ ] emoji-math: game starts, correct/wrong/timeout all work, streak & level-up still function
- [ ] color-tap: correct/wrong/timeout work, timer runs at 5s
- [ ] true-false: deck advances and reshuffles correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)