### PR TITLE
feat(math-race): migrate from useState/useRef to Zustand store

### DIFF
--- a/gamesformykids/app/games/math-race/mathRaceStore.ts
+++ b/gamesformykids/app/games/math-race/mathRaceStore.ts
@@ -1,0 +1,116 @@
+import { makeStore } from '@/lib/stores/createStore';
+import type { ArithOp as Op, PhaseDead as Phase } from '@/lib/types';
+import { randInt as rnd } from '@/lib/utils';
+
+// ── Question helpers ────────────────────────────────────────────────────────
+
+export interface Question { text: string; answer: number; choices: number[]; }
+
+export function makeQ(score: number): Question {
+  const level = Math.floor(score / 30);
+  let a: number, b: number, op: Op, answer: number;
+  if (level < 3) {
+    op = '+'; a = rnd(1, 10 + level * 5); b = rnd(1, 10 + level * 3);
+    answer = a + b;
+  } else if (level < 6) {
+    op = Math.random() < 0.5 ? '+' : '-';
+    a = rnd(5, 20); b = rnd(1, op === '-' ? a : 15);
+    answer = op === '+' ? a + b : a - b;
+  } else {
+    op = Math.random() < 0.4 ? '×' : (Math.random() < 0.5 ? '+' : '-');
+    if (op === '×') { a = rnd(2, 9); b = rnd(2, 9); answer = a * b; }
+    else if (op === '+') { a = rnd(10, 50); b = rnd(10, 50); answer = a + b; }
+    else { a = rnd(20, 60); b = rnd(1, a); answer = a - b; }
+  }
+  const text = `${a} ${op} ${b} = ?`;
+  const wrong = new Set<number>();
+  while (wrong.size < 3) {
+    const w = answer + rnd(-5, 5) * (level < 3 ? 1 : 2);
+    if (w !== answer && w >= 0) wrong.add(w);
+  }
+  return { text, answer, choices: [...wrong, answer].sort(() => Math.random() - 0.5) };
+}
+
+// ── Store ───────────────────────────────────────────────────────────────────
+
+export const GAME_TIME = 30;
+
+interface MathRaceState {
+  phase:    Phase;
+  q:        Question;
+  score:    number;
+  best:     number;
+  timeLeft: number;
+  feedback: 'correct' | 'wrong' | null;
+  streak:   number;
+  total:    number;
+  correct:  number;
+}
+
+interface MathRaceActions {
+  startGame: () => void;
+  tap:       (choice: number) => void;
+}
+
+const INITIAL: MathRaceState = {
+  phase: 'menu', q: makeQ(0), score: 0, best: 0,
+  timeLeft: GAME_TIME, feedback: null, streak: 0, total: 0, correct: 0,
+};
+
+export const useMathRaceStore = makeStore<MathRaceState & MathRaceActions>(
+  'MathRaceStore',
+  (set, get) => {
+    let gameTimerId:  ReturnType<typeof setInterval> | null = null;
+    let feedbackId:   ReturnType<typeof setTimeout>  | null = null;
+
+    function clearTimers() {
+      if (gameTimerId) { clearInterval(gameTimerId); gameTimerId = null; }
+      if (feedbackId)  { clearTimeout(feedbackId);   feedbackId  = null; }
+    }
+
+    function startGameTimer() {
+      if (typeof window === 'undefined') return;
+      gameTimerId = setInterval(() => {
+        const { timeLeft, score, best } = get();
+        if (timeLeft <= 1) {
+          clearTimers();
+          set({ timeLeft: 0, phase: 'dead', best: Math.max(best, score) }, false, 'mathRace/gameOver');
+        } else {
+          set({ timeLeft: timeLeft - 1 }, false, 'mathRace/tick');
+        }
+      }, 1000);
+    }
+
+    return {
+      ...INITIAL,
+
+      startGame: () => {
+        clearTimers();
+        set({ ...INITIAL, phase: 'playing', best: get().best, q: makeQ(0) }, false, 'mathRace/startGame');
+        startGameTimer();
+      },
+
+      tap: (choice: number) => {
+        const { phase, feedback, q, score, streak, total, correct } = get();
+        if (phase !== 'playing' || feedback !== null) return;
+
+        const newTotal = total + 1;
+        if (choice === q.answer) {
+          const newStreak  = streak + 1;
+          const pts        = newStreak >= 3 ? 20 : 10;
+          const newScore   = score + pts;
+          const newCorrect = correct + 1;
+          set({ score: newScore, streak: newStreak, total: newTotal, correct: newCorrect, feedback: 'correct' }, false, 'mathRace/correct');
+          feedbackId = setTimeout(() => {
+            set({ feedback: null, q: makeQ(get().score) }, false, 'mathRace/nextQ');
+          }, 500);
+        } else {
+          set({ streak: 0, total: newTotal, feedback: 'wrong' }, false, 'mathRace/wrong');
+          feedbackId = setTimeout(() => {
+            set({ feedback: null, q: makeQ(get().score) }, false, 'mathRace/nextQ');
+          }, 500);
+        }
+      },
+    };
+  },
+);

--- a/gamesformykids/app/games/math-race/useMathRaceGame.ts
+++ b/gamesformykids/app/games/math-race/useMathRaceGame.ts
@@ -1,104 +1,21 @@
 'use client';
-import { useState, useEffect, useCallback, useRef } from 'react';
+import { useMathRaceStore } from './mathRaceStore';
 
-import type { ArithOp as Op, PhaseDead as GamePhase } from '@/lib/types';
-import { randInt as rnd } from '@/lib/utils';
-
-export interface Question { text: string; answer: number; choices: number[]; }
-
-export const GAME_TIME = 30;
-
-
-export function makeQ(score: number): Question {
-  const level = Math.floor(score / 30);
-  let a: number, b: number, op: Op, answer: number;
-  if (level < 3) {
-    op = '+'; a = rnd(1, 10 + level * 5); b = rnd(1, 10 + level * 3);
-    answer = a + b;
-  } else if (level < 6) {
-    op = Math.random() < 0.5 ? '+' : '-';
-    a = rnd(5, 20); b = rnd(1, op === '-' ? a : 15);
-    answer = op === '+' ? a + b : a - b;
-  } else {
-    op = Math.random() < 0.4 ? '×' : (Math.random() < 0.5 ? '+' : '-');
-    if (op === '×') { a = rnd(2, 9); b = rnd(2, 9); answer = a * b; }
-    else if (op === '+') { a = rnd(10, 50); b = rnd(10, 50); answer = a + b; }
-    else { a = rnd(20, 60); b = rnd(1, a); answer = a - b; }
-  }
-  const text = `${a} ${op} ${b} = ?`;
-  const wrong = new Set<number>();
-  while (wrong.size < 3) {
-    const w = answer + rnd(-5, 5) * (level < 3 ? 1 : 2);
-    if (w !== answer && w >= 0) wrong.add(w);
-  }
-  return { text, answer, choices: [...wrong, answer].sort(() => Math.random() - 0.5) };
-}
+export type { Question } from './mathRaceStore';
+export { makeQ, GAME_TIME } from './mathRaceStore';
 
 export function useMathRaceGame() {
-  const [phase,    setPhase]    = useState<GamePhase>('menu');
-  const [q,        setQ]        = useState<Question>(makeQ(0));
-  const [score,    setScore]    = useState(0);
-  const [best,     setBest]     = useState(0);
-  const [timeLeft, setTimeLeft] = useState(GAME_TIME);
-  const [feedback, setFeedback] = useState<'correct' | 'wrong' | null>(null);
-  const [streak,   setStreak]   = useState(0);
-  const [total,    setTotal]    = useState(0);
-  const [correct,  setCorrect]  = useState(0);
-
-  const phaseRef   = useRef<GamePhase>('menu');
-  const scoreRef   = useRef(0);
-  const streakRef  = useRef(0);
-  const totalRef   = useRef(0);
-  const correctRef = useRef(0);
-
-  const nextQ = useCallback(() => {
-    setQ(makeQ(scoreRef.current));
-    setFeedback(null);
-  }, []);
-
-  const startGame = useCallback(() => {
-    phaseRef.current = 'playing'; scoreRef.current = 0; streakRef.current = 0;
-    totalRef.current = 0; correctRef.current = 0;
-    setPhase('playing'); setScore(0); setStreak(0); setTotal(0); setCorrect(0);
-    setTimeLeft(GAME_TIME); setFeedback(null); setQ(makeQ(0));
-  }, []);
-
-  useEffect(() => {
-    if (phase !== 'playing') return;
-    const t = setInterval(() => {
-      setTimeLeft(prev => {
-        if (prev <= 1) {
-          phaseRef.current = 'dead';
-          setPhase('dead');
-          setBest(b => Math.max(b, scoreRef.current));
-          return 0;
-        }
-        return prev - 1;
-      });
-    }, 1000);
-    return () => clearInterval(t);
-  }, [phase]);
-
-  useEffect(() => {
-    if (!feedback) return;
-    const t = setTimeout(nextQ, 500);
-    return () => clearTimeout(t);
-  }, [feedback, nextQ]);
-
-  const tap = useCallback((choice: number) => {
-    if (phaseRef.current !== 'playing' || feedback) return;
-    totalRef.current++; setTotal(totalRef.current);
-    if (choice === q.answer) {
-      correctRef.current++; setCorrect(correctRef.current);
-      streakRef.current++; setStreak(streakRef.current);
-      const pts = streakRef.current >= 3 ? 20 : 10;
-      scoreRef.current += pts; setScore(scoreRef.current);
-      setFeedback('correct');
-    } else {
-      streakRef.current = 0; setStreak(0);
-      setFeedback('wrong');
-    }
-  }, [feedback, q.answer]);
+  const phase    = useMathRaceStore((s) => s.phase);
+  const q        = useMathRaceStore((s) => s.q);
+  const score    = useMathRaceStore((s) => s.score);
+  const best     = useMathRaceStore((s) => s.best);
+  const timeLeft = useMathRaceStore((s) => s.timeLeft);
+  const feedback = useMathRaceStore((s) => s.feedback);
+  const streak   = useMathRaceStore((s) => s.streak);
+  const total    = useMathRaceStore((s) => s.total);
+  const correct  = useMathRaceStore((s) => s.correct);
+  const startGame = useMathRaceStore((s) => s.startGame);
+  const tap       = useMathRaceStore((s) => s.tap);
 
   const accuracy = total > 0 ? Math.round((correct / total) * 100) : 0;
 


### PR DESCRIPTION
Closes #22

## Summary
- Add `mathRaceStore.ts` using `makeStore` factory — all state + timer logic
- 30s game countdown managed via module-level `setInterval` ref in store closure
- Feedback delay (500ms) managed via `setTimeout` ref — no `useEffect`
- `startGame` and `tap` are complete store actions
- `useMathRaceGame.ts` reduced to pure selectors; `accuracy` derived in hook
- 5 refs eliminated: `phaseRef`, `scoreRef`, `streakRef`, `totalRef`, `correctRef`

## Test plan
- [ ] Game starts, 30s countdown runs
- [ ] Correct tap: score updates, streak increments, ×3 streak gives 20pts, next Q after 500ms
- [ ] Wrong tap: streak resets, next Q after 500ms
- [ ] Timer hits 0 → dead screen with best score
- [ ] Accuracy % correct on game over

🤖 Generated with [Claude Code](https://claude.com/claude-code)