### PR TITLE
refactor(hooks): replace individual selectors with useShallow (#189)

### DIFF
--- a/gamesformykids/app/games/color-tap/useColorTapGame.ts
+++ b/gamesformykids/app/games/color-tap/useColorTapGame.ts
@@ -1,19 +1,12 @@
 'use client';
+import { useShallow } from 'zustand/react/shallow';
 import { useColorTapStore } from './colorTapStore';
 
 export type { ColorItem, Question } from './colorTapStore';
 export { COLORS, TIME_PER_Q }       from './colorTapStore';
 
 export function useColorTapGame() {
-  const phase     = useColorTapStore((s) => s.phase);
-  const score     = useColorTapStore((s) => s.score);
-  const best      = useColorTapStore((s) => s.best);
-  const lives     = useColorTapStore((s) => s.lives);
-  const timeLeft  = useColorTapStore((s) => s.timeLeft);
-  const feedback  = useColorTapStore((s) => s.feedback);
-  const question  = useColorTapStore((s) => s.question);
-  const startGame = useColorTapStore((s) => s.startGame);
-  const handleTap = useColorTapStore((s) => s.handleTap);
-
+  const { phase, score, best, lives, timeLeft, feedback, question, startGame, handleTap } =
+    useColorTapStore(useShallow((s) => s));
   return { phase, score, best, lives, question, timeLeft, feedback, startGame, handleTap };
 }

--- a/gamesformykids/app/games/emoji-math/useEmojiMathGame.ts
+++ b/gamesformykids/app/games/emoji-math/useEmojiMathGame.ts
@@ -1,21 +1,12 @@
 'use client';
+import { useShallow } from 'zustand/react/shallow';
 import { useEmojiMathStore } from './emojiMathStore';
 
 export type { Op, Question } from './emojiMathStore';
-export { makeQuestion, TIME_PER_Q }  from './emojiMathStore';
+export { makeQuestion, TIME_PER_Q } from './emojiMathStore';
 
 export function useEmojiMathGame() {
-  const phase    = useEmojiMathStore((s) => s.phase);
-  const score    = useEmojiMathStore((s) => s.score);
-  const best     = useEmojiMathStore((s) => s.best);
-  const lives    = useEmojiMathStore((s) => s.lives);
-  const timeLeft = useEmojiMathStore((s) => s.timeLeft);
-  const feedback = useEmojiMathStore((s) => s.feedback);
-  const q        = useEmojiMathStore((s) => s.q);
-  const level    = useEmojiMathStore((s) => s.level);
-  const streak   = useEmojiMathStore((s) => s.streak);
-  const startGame = useEmojiMathStore((s) => s.startGame);
-  const tap       = useEmojiMathStore((s) => s.tap);
-
+  const { phase, q, score, best, lives, level, timeLeft, feedback, streak, startGame, tap } =
+    useEmojiMathStore(useShallow((s) => s));
   return { phase, q, score, best, lives, level, timeLeft, feedback, streak, startGame, tap };
 }

--- a/gamesformykids/app/games/math-race/useMathRaceGame.ts
+++ b/gamesformykids/app/games/math-race/useMathRaceGame.ts
@@ -1,23 +1,13 @@
 'use client';
+import { useShallow } from 'zustand/react/shallow';
 import { useMathRaceStore } from './mathRaceStore';
 
 export type { Question } from './mathRaceStore';
 export { makeQ, GAME_TIME } from './mathRaceStore';
 
 export function useMathRaceGame() {
-  const phase    = useMathRaceStore((s) => s.phase);
-  const q        = useMathRaceStore((s) => s.q);
-  const score    = useMathRaceStore((s) => s.score);
-  const best     = useMathRaceStore((s) => s.best);
-  const timeLeft = useMathRaceStore((s) => s.timeLeft);
-  const feedback = useMathRaceStore((s) => s.feedback);
-  const streak   = useMathRaceStore((s) => s.streak);
-  const total    = useMathRaceStore((s) => s.total);
-  const correct  = useMathRaceStore((s) => s.correct);
-  const startGame = useMathRaceStore((s) => s.startGame);
-  const tap       = useMathRaceStore((s) => s.tap);
-
+  const { phase, q, score, best, timeLeft, feedback, streak, total, correct, startGame, tap } =
+    useMathRaceStore(useShallow((s) => s));
   const accuracy = total > 0 ? Math.round((correct / total) * 100) : 0;
-
   return { phase, q, score, best, timeLeft, feedback, streak, total, correct, accuracy, startGame, tap };
 }

--- a/gamesformykids/app/games/simon/useSimonGame.ts
+++ b/gamesformykids/app/games/simon/useSimonGame.ts
@@ -1,6 +1,7 @@
 'use client';
 
 import { useCallback } from 'react';
+import { useShallow } from 'zustand/react/shallow';
 import { useSimonStore } from './simonStore';
 
 export const BUTTONS = [
@@ -14,12 +15,11 @@ export type ButtonId = typeof BUTTONS[number]['id'];
 import type { PhaseSimon as Phase } from '@/lib/types';
 
 export function useSimonGame() {
-  const phase       = useSimonStore((s) => s.phase);
-  const activeColor = useSimonStore((s) => s.activeColor);
-  const playerIdx   = useSimonStore((s) => s.playerIdx);
-  const best        = useSimonStore((s) => s.best);
-  const roundScore  = useSimonStore((s) => s.roundScore);
-  const sequence    = useSimonStore((s) => s.sequence);
+  const { phase, activeColor, playerIdx, best, roundScore, sequence } =
+    useSimonStore(useShallow((s) => ({
+      phase: s.phase, activeColor: s.activeColor, playerIdx: s.playerIdx,
+      best: s.best, roundScore: s.roundScore, sequence: s.sequence,
+    })));
 
   const flash = useCallback((id: ButtonId, ms: number) =>
     new Promise<void>(resolve => {

--- a/gamesformykids/app/games/simon/useSimonGame.ts
+++ b/gamesformykids/app/games/simon/useSimonGame.ts
@@ -16,10 +16,7 @@ import type { PhaseSimon as Phase } from '@/lib/types';
 
 export function useSimonGame() {
   const { phase, activeColor, playerIdx, best, roundScore, sequence } =
-    useSimonStore(useShallow((s) => ({
-      phase: s.phase, activeColor: s.activeColor, playerIdx: s.playerIdx,
-      best: s.best, roundScore: s.roundScore, sequence: s.sequence,
-    })));
+    useSimonStore(useShallow((s) => s));
 
   const flash = useCallback((id: ButtonId, ms: number) =>
     new Promise<void>(resolve => {

--- a/gamesformykids/app/games/true-false/useTrueFalseGame.ts
+++ b/gamesformykids/app/games/true-false/useTrueFalseGame.ts
@@ -1,20 +1,12 @@
 'use client';
+import { useShallow } from 'zustand/react/shallow';
 import { useTrueFalseStore } from './trueFalseStore';
 
 export type { Fact } from './trueFalseStore';
 export { FACTS, TIME_PER_Q } from './trueFalseStore';
 
 export function useTrueFalseGame() {
-  const phase    = useTrueFalseStore((s) => s.phase);
-  const score    = useTrueFalseStore((s) => s.score);
-  const best     = useTrueFalseStore((s) => s.best);
-  const lives    = useTrueFalseStore((s) => s.lives);
-  const timeLeft = useTrueFalseStore((s) => s.timeLeft);
-  const feedback = useTrueFalseStore((s) => s.feedback);
-  const deck     = useTrueFalseStore((s) => s.deck);
-  const idx      = useTrueFalseStore((s) => s.idx);
-  const startGame = useTrueFalseStore((s) => s.startGame);
-  const answer    = useTrueFalseStore((s) => s.answer);
-
+  const { phase, score, best, lives, timeLeft, feedback, deck, idx, startGame, answer } =
+    useTrueFalseStore(useShallow((s) => s));
   return { phase, q: deck[idx], score, best, lives, timeLeft, feedback, startGame, answer };
 }


### PR DESCRIPTION
## Summary
- Replace 6 individual `useSimonStore((s) => s.field)` calls in `useSimonGame` with a single `useShallow` selector
- Apply `useShallow` pattern uniformly across all 5 game hooks: emoji-math, color-tap, true-false, math-race, simon

## Test plan
- [ ] `tsc --noEmit` passes (verified)
- [ ] All games still start and play correctly
- [ ] No extra re-renders from multiple individual selectors

Closes #189

🤖 Generated with [Claude Code](https://claude.com/claude-code)