### PR TITLE
feat(reflex): migrate from useState/useEffect to Zustand store (#23)

### DIFF
--- a/gamesformykids/app/games/reflex/reflexStore.ts
+++ b/gamesformykids/app/games/reflex/reflexStore.ts
@@ -1,0 +1,91 @@
+import { makeStore } from '@/lib/stores/createStore';
+import type { PhaseResult as Phase } from '@/lib/types';
+import { TARGET_EMOJIS, GAME_DURATION, type Target, getLifetime, getSpawnInterval } from './data/targets';
+
+export type { Target } from './data/targets';
+
+// ── Store ──────────────────────────────────────────────────────────────────
+
+interface ReflexState {
+  phase:    Phase;
+  targets:  Target[];
+  score:    number;
+  missed:   number;
+  timeLeft: number;
+}
+
+interface ReflexActions {
+  startGame: () => void;
+  hitTarget: (id: number) => void;
+}
+
+const INITIAL: ReflexState = {
+  phase: 'menu', targets: [], score: 0, missed: 0, timeLeft: GAME_DURATION,
+};
+
+export const useReflexStore = makeStore<ReflexState & ReflexActions>(
+  'ReflexStore',
+  (set, get) => {
+    let nextId:  number = 0;
+    let spawnId: ReturnType<typeof setTimeout>  | null = null;
+    let tickId:  ReturnType<typeof setInterval> | null = null;
+
+    function clearTimers() {
+      if (spawnId) { clearTimeout(spawnId);  spawnId = null; }
+      if (tickId)  { clearInterval(tickId);  tickId  = null; }
+    }
+
+    function spawnTarget() {
+      if (get().phase !== 'playing') return;
+      const id = nextId++;
+      const target: Target = {
+        id,
+        x:        5 + Math.random() * 80,
+        y:        10 + Math.random() * 70,
+        emoji:    TARGET_EMOJIS[Math.floor(Math.random() * TARGET_EMOJIS.length)],
+        lifetime: getLifetime(get().score),
+        born:     Date.now(),
+      };
+      set({ targets: [...get().targets, target] }, false, 'reflex/spawn');
+
+      setTimeout(() => {
+        const { targets, missed } = get();
+        if (targets.find(t => t.id === id)) {
+          set({ targets: targets.filter(t => t.id !== id), missed: missed + 1 }, false, 'reflex/expire');
+        }
+      }, target.lifetime);
+
+      spawnId = setTimeout(spawnTarget, getSpawnInterval(get().score));
+    }
+
+    function startTick() {
+      tickId = setInterval(() => {
+        const { timeLeft } = get();
+        if (timeLeft <= 1) {
+          clearTimers();
+          set({ timeLeft: 0, phase: 'result' }, false, 'reflex/gameOver');
+        } else {
+          set({ timeLeft: timeLeft - 1 }, false, 'reflex/tick');
+        }
+      }, 1000);
+    }
+
+    return {
+      ...INITIAL,
+
+      startGame: () => {
+        clearTimers();
+        nextId = 0;
+        set({ ...INITIAL, phase: 'playing' }, false, 'reflex/startGame');
+        spawnId = setTimeout(spawnTarget, 600);
+        startTick();
+      },
+
+      hitTarget: (id: number) => {
+        const { targets, score } = get();
+        if (!targets.find(t => t.id === id)) return;
+        set({ targets: targets.filter(t => t.id !== id), score: score + 1 }, false, 'reflex/hit');
+      },
+    };
+  },
+);

--- a/gamesformykids/app/games/reflex/useReflexGame.ts
+++ b/gamesformykids/app/games/reflex/useReflexGame.ts
@@ -1,91 +1,11 @@
 'use client';
+import { useShallow } from 'zustand/react/shallow';
+import { useReflexStore } from './reflexStore';
 
-import { useState, useCallback, useEffect, useRef } from 'react';
-import { TARGET_EMOJIS, GAME_DURATION, Target, getLifetime, getSpawnInterval } from './data/targets';
-
-import type { PhaseResult as ReflexPhase } from '@/lib/types';
+export type { Target } from './reflexStore';
 
 export function useReflexGame() {
-  const [phase, setPhase] = useState<ReflexPhase>('menu');
-  const [targets, setTargets] = useState<Target[]>([]);
-  const [score, setScore] = useState(0);
-  const [missed, setMissed] = useState(0);
-  const [timeLeft, setTimeLeft] = useState(GAME_DURATION);
-  const nextIdRef = useRef(0);
-  const spawnRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const tickRef = useRef<ReturnType<typeof setInterval> | null>(null);
-  const scoreRef = useRef(0);
-
-  const clear = () => {
-    if (spawnRef.current) clearTimeout(spawnRef.current);
-    if (tickRef.current) clearInterval(tickRef.current);
-  };
-
-  const spawnTarget = useCallback(() => {
-    if (phase !== 'playing') return;
-    const id = nextIdRef.current++;
-    const t: Target = {
-      id,
-      x: 5 + Math.random() * 80,
-      y: 10 + Math.random() * 70,
-      emoji: TARGET_EMOJIS[Math.floor(Math.random() * TARGET_EMOJIS.length)],
-      lifetime: getLifetime(scoreRef.current),
-      born: Date.now(),
-    };
-    setTargets(prev => [...prev, t]);
-
-    // Auto-remove after lifetime
-    setTimeout(() => {
-      setTargets(prev => {
-        const still = prev.find(x => x.id === id);
-        if (still) setMissed(m => m + 1);
-        return prev.filter(x => x.id !== id);
-      });
-    }, t.lifetime);
-
-    // Schedule next spawn
-    spawnRef.current = setTimeout(spawnTarget, getSpawnInterval(scoreRef.current));
-  }, [phase]);
-
-  const startGame = useCallback(() => {
-    clear();
-    scoreRef.current = 0;
-    setScore(0);
-    setMissed(0);
-    setTargets([]);
-    setTimeLeft(GAME_DURATION);
-    nextIdRef.current = 0;
-    setPhase('playing');
-  }, []);
-
-  // Start spawning when phase becomes 'playing'
-  useEffect(() => {
-    if (phase !== 'playing') return;
-    spawnRef.current = setTimeout(spawnTarget, 600);
-    tickRef.current = setInterval(() => {
-      setTimeLeft(t => {
-        if (t <= 1) {
-          clear();
-          setPhase('result');
-          return 0;
-        }
-        return t - 1;
-      });
-    }, 1000);
-    return clear;
-  }, [phase, spawnTarget]);
-
-  const hitTarget = useCallback((id: number) => {
-    setTargets(prev => prev.filter(t => t.id !== id));
-    setScore(s => {
-      const next = s + 1;
-      scoreRef.current = next;
-      return next;
-    });
-  }, []);
-
-  return {
-    phase, targets, score, missed, timeLeft,
-    startGame, hitTarget,
-  };
+  const { phase, targets, score, missed, timeLeft, startGame, hitTarget } =
+    useReflexStore(useShallow((s) => s));
+  return { phase, targets, score, missed, timeLeft, startGame, hitTarget };
 }


### PR DESCRIPTION
## Summary
- Extract all state, spawn logic, and timer management from `useReflexGame` into a new `reflexStore.ts`
- Replace `useEffect` for spawn/tick startup with direct store action initialization
- Replace `useRef`/`scoreRef` stale closure workaround with `get()` in store actions
- `useReflexGame` is now a thin wrapper with `useShallow`

## Test plan
- [ ] `tsc --noEmit` passes (verified — pre-existing supabase errors unrelated)
- [ ] Game starts, targets spawn and disappear correctly
- [ ] Hitting a target increments score
- [ ] Missed targets increment missed counter
- [ ] 60s countdown ends game correctly

Closes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)