### PR TITLE
refactor: connect play-screen components directly to Zustand stores (#197)

### DIFF
--- a/gamesformykids/app/games/color-tap/ColorTapGame.tsx
+++ b/gamesformykids/app/games/color-tap/ColorTapGame.tsx
@@ -1,29 +1,13 @@
 'use client';
-import { useColorTapGame, TIME_PER_Q } from './useColorTapGame';
+import { useColorTapGame } from './useColorTapGame';
 import ColorTapMenuScreen from './components/ColorTapMenuScreen';
 import ColorTapGameOverScreen from './components/ColorTapGameOverScreen';
 import ColorTapPlayArea from './components/ColorTapPlayArea';
 
 export default function ColorTapGame() {
-  const { phase, score, best, lives, question, timeLeft, feedback, startGame, handleTap } = useColorTapGame();
+  const { phase, score, best, startGame } = useColorTapGame();
 
-  if (phase === 'menu') return (
-    <ColorTapMenuScreen best={best} onStart={startGame} />
-  );
-
-  if (phase === 'dead') return (
-    <ColorTapGameOverScreen score={score} best={best} onRestart={startGame} />
-  );
-
-  return (
-    <ColorTapPlayArea
-      question={question}
-      feedback={feedback}
-      timeLeft={timeLeft}
-      timePerQ={TIME_PER_Q}
-      score={score}
-      lives={lives}
-      onTap={handleTap}
-    />
-  );
+  if (phase === 'menu') return <ColorTapMenuScreen best={best} onStart={startGame} />;
+  if (phase === 'dead') return <ColorTapGameOverScreen score={score} best={best} onRestart={startGame} />;
+  return <ColorTapPlayArea />;
 }

--- a/gamesformykids/app/games/color-tap/components/ColorTapPlayArea.tsx
+++ b/gamesformykids/app/games/color-tap/components/ColorTapPlayArea.tsx
@@ -1,28 +1,11 @@
 'use client';
+import { useShallow } from 'zustand/react/shallow';
+import { useColorTapStore, TIME_PER_Q } from '../colorTapStore';
 
-interface Color {
-  name: string;
-  bg: string;
-  hex: string;
-  emoji: string;
-}
+export default function ColorTapPlayArea() {
+  const { question, feedback, timeLeft, score, lives, handleTap } =
+    useColorTapStore(useShallow((s) => s));
 
-interface Question {
-  target: Color;
-  options: Color[];
-}
-
-interface Props {
-  question: Question;
-  feedback: 'correct' | 'wrong' | null;
-  timeLeft: number;
-  timePerQ: number;
-  score: number;
-  lives: number;
-  onTap: (color: Color) => void;
-}
-
-export default function ColorTapPlayArea({ question, feedback, timeLeft, timePerQ, score, lives, onTap }: Props) {
   return (
     <div className="min-h-screen bg-gradient-to-br from-pink-100 to-purple-200 flex flex-col items-center justify-center p-4 select-none" dir="rtl">
       <div className="flex gap-8 mb-5 text-center">
@@ -53,7 +36,7 @@ export default function ColorTapPlayArea({ question, feedback, timeLeft, timePer
         <div className="bg-gray-100 rounded-full h-2 w-full mx-auto">
           <div
             className="bg-gradient-to-r from-pink-400 to-purple-500 h-2 rounded-full transition-all duration-1000"
-            style={{ width: `${(timeLeft / timePerQ) * 100}%` }}
+            style={{ width: `${(timeLeft / TIME_PER_Q) * 100}%` }}
           />
         </div>
       </div>
@@ -62,7 +45,7 @@ export default function ColorTapPlayArea({ question, feedback, timeLeft, timePer
         {question.options.map(color => (
           <button
             key={color.name}
-            onClick={() => onTap(color)}
+            onClick={() => handleTap(color)}
             disabled={!!feedback}
             className={`${color.bg} h-24 rounded-3xl shadow-xl font-black text-white text-lg flex items-center justify-center gap-2 active:scale-90 transition-all hover:brightness-110 disabled:opacity-80`}
           >

--- a/gamesformykids/app/games/emoji-math/EmojiMathGame.tsx
+++ b/gamesformykids/app/games/emoji-math/EmojiMathGame.tsx
@@ -1,31 +1,13 @@
 'use client';
-import { useEmojiMathGame, TIME_PER_Q } from './useEmojiMathGame';
+import { useEmojiMathGame } from './useEmojiMathGame';
 import EmojiMathMenuScreen from './components/EmojiMathMenuScreen';
 import EmojiMathGameOverScreen from './components/EmojiMathGameOverScreen';
 import EmojiMathPlayArea from './components/EmojiMathPlayArea';
 
 export default function EmojiMathGame() {
-  const { phase, q, score, best, lives, level, timeLeft, feedback, streak, startGame, tap } = useEmojiMathGame();
+  const { phase, score, best, startGame } = useEmojiMathGame();
 
-  if (phase === 'menu') return (
-    <EmojiMathMenuScreen best={best} onStart={startGame} />
-  );
-
-  if (phase === 'dead') return (
-    <EmojiMathGameOverScreen score={score} best={best} onRestart={startGame} />
-  );
-
-  return (
-    <EmojiMathPlayArea
-      q={q}
-      feedback={feedback}
-      level={level}
-      timeLeft={timeLeft}
-      timePerQ={TIME_PER_Q}
-      score={score}
-      lives={lives}
-      streak={streak}
-      onTap={tap}
-    />
-  );
+  if (phase === 'menu') return <EmojiMathMenuScreen best={best} onStart={startGame} />;
+  if (phase === 'dead') return <EmojiMathGameOverScreen score={score} best={best} onRestart={startGame} />;
+  return <EmojiMathPlayArea />;
 }

--- a/gamesformykids/app/games/emoji-math/components/EmojiMathPlayArea.tsx
+++ b/gamesformykids/app/games/emoji-math/components/EmojiMathPlayArea.tsx
@@ -1,25 +1,6 @@
 'use client';
-
-interface Question {
-  a: number;
-  b: number;
-  op: '+' | '-';
-  emojiA: string;
-  emojiB: string;
-  choices: number[];
-}
-
-interface Props {
-  q: Question;
-  feedback: 'correct' | 'wrong' | null;
-  level: number;
-  timeLeft: number;
-  timePerQ: number;
-  score: number;
-  lives: number;
-  streak: number;
-  onTap: (choice: number) => void;
-}
+import { useShallow } from 'zustand/react/shallow';
+import { useEmojiMathStore, TIME_PER_Q } from '../emojiMathStore';
 
 function renderEmojis(count: number, emoji: string) {
   return Array.from({ length: Math.min(count, 15) }, (_, i) => (
@@ -27,7 +8,10 @@ function renderEmojis(count: number, emoji: string) {
   ));
 }
 
-export default function EmojiMathPlayArea({ q, feedback, level, timeLeft, timePerQ, score, lives, streak, onTap }: Props) {
+export default function EmojiMathPlayArea() {
+  const { q, feedback, level, timeLeft, score, lives, streak, tap } =
+    useEmojiMathStore(useShallow((s) => s));
+
   return (
     <div className="min-h-screen bg-gradient-to-br from-yellow-100 to-orange-200 flex flex-col items-center justify-center p-4 select-none" dir="rtl">
       <div className="flex gap-5 mb-4 text-center">
@@ -70,7 +54,7 @@ export default function EmojiMathPlayArea({ q, feedback, level, timeLeft, timePe
         <div className="mt-3 bg-gray-100 rounded-full h-1.5">
           <div
             className="bg-gradient-to-r from-yellow-400 to-orange-500 h-1.5 rounded-full transition-all duration-1000"
-            style={{ width: `${(timeLeft / timePerQ) * 100}%` }}
+            style={{ width: `${(timeLeft / TIME_PER_Q) * 100}%` }}
           />
         </div>
       </div>
@@ -79,7 +63,7 @@ export default function EmojiMathPlayArea({ q, feedback, level, timeLeft, timePe
         {q.choices.map(c => (
           <button
             key={c}
-            onClick={() => onTap(c)}
+            onClick={() => tap(c)}
             disabled={!!feedback}
             className="py-5 rounded-3xl bg-white font-black text-3xl text-gray-700 shadow-xl border-2 border-orange-200 active:scale-90 hover:border-orange-400 transition-all disabled:opacity-60"
           >

--- a/gamesformykids/app/games/math-race/MathRaceGame.tsx
+++ b/gamesformykids/app/games/math-race/MathRaceGame.tsx
@@ -5,35 +5,13 @@ import MathRaceResultScreen from './components/MathRaceResultScreen';
 import MathRacePlayScreen from './components/MathRacePlayScreen';
 
 export default function MathRaceGame() {
-  const { phase, q, score, best, timeLeft, feedback, streak, total, correct, accuracy, startGame, tap } = useMathRaceGame();
+  const { phase, score, best, correct, total, accuracy, startGame } = useMathRaceGame();
 
-  if (phase === 'menu') return (
-    <MathRaceMenuScreen best={best} gameTime={GAME_TIME} onStart={startGame} />
-  );
-
+  if (phase === 'menu') return <MathRaceMenuScreen best={best} gameTime={GAME_TIME} onStart={startGame} />;
   if (phase === 'dead') return (
     <MathRaceResultScreen
-      score={score}
-      best={best}
-      correct={correct}
-      total={total}
-      accuracy={accuracy}
-      onRestart={startGame}
+      score={score} best={best} correct={correct} total={total} accuracy={accuracy} onRestart={startGame}
     />
   );
-
-  return (
-    <MathRacePlayScreen
-      q={q}
-      score={score}
-      timeLeft={timeLeft}
-      feedback={feedback}
-      streak={streak}
-      correct={correct}
-      total={total}
-      accuracy={accuracy}
-      gameTime={GAME_TIME}
-      onTap={tap}
-    />
-  );
+  return <MathRacePlayScreen />;
 }

--- a/gamesformykids/app/games/math-race/components/MathRacePlayScreen.tsx
+++ b/gamesformykids/app/games/math-race/components/MathRacePlayScreen.tsx
@@ -1,32 +1,18 @@
 'use client';
-
+import { useShallow } from 'zustand/react/shallow';
+import { useMathRaceStore, GAME_TIME } from '../mathRaceStore';
 import MathRaceProgressBar from './MathRaceProgressBar';
 import MathRaceQuestion from './MathRaceQuestion';
 
-interface Question {
-  text: string;
-  answer: number;
-  choices: number[];
-}
+export default function MathRacePlayScreen() {
+  const { q, score, timeLeft, feedback, streak, correct, total, tap } =
+    useMathRaceStore(useShallow((s) => s));
+  const accuracy = total > 0 ? Math.round((correct / total) * 100) : 0;
 
-interface Props {
-  q: Question;
-  score: number;
-  timeLeft: number;
-  feedback: 'correct' | 'wrong' | null;
-  streak: number;
-  correct: number;
-  total: number;
-  accuracy: number;
-  gameTime: number;
-  onTap: (choice: number) => void;
-}
-
-export default function MathRacePlayScreen({ q, score, timeLeft, feedback, streak, correct, total, accuracy, gameTime, onTap }: Props) {
   return (
     <div className="min-h-screen bg-gradient-to-br from-blue-100 to-indigo-200 flex flex-col items-center justify-center p-4 select-none" dir="rtl">
-      <MathRaceProgressBar timeLeft={timeLeft} score={score} streak={streak} gameTime={gameTime} />
-      <MathRaceQuestion q={q} feedback={feedback} streak={streak} onTap={onTap} />
+      <MathRaceProgressBar timeLeft={timeLeft} score={score} streak={streak} gameTime={GAME_TIME} />
+      <MathRaceQuestion q={q} feedback={feedback} streak={streak} onTap={tap} />
       <p className="mt-4 text-xs text-indigo-400">{correct}/{total} נכון · {accuracy}% דיוק</p>
     </div>
   );

--- a/gamesformykids/app/games/simon/SimonGame.tsx
+++ b/gamesformykids/app/games/simon/SimonGame.tsx
@@ -5,28 +5,13 @@ import SimonBoard from './components/SimonBoard';
 import SimonGameOverScreen from './components/SimonGameOverScreen';
 
 export default function SimonGame() {
-  const { phase, activeColor, playerIdx, best, roundScore, sequenceLength, startGame, handleTap } = useSimonGame();
+  const { phase, best, roundScore, startGame, handleTap } = useSimonGame();
 
   return (
     <div className="min-h-screen bg-gray-900 flex flex-col items-center justify-center p-4 select-none" dir="rtl">
-      {phase === 'menu' && (
-        <SimonMenuScreen best={best} onStart={startGame} />
-      )}
-
-      {(phase === 'showing' || phase === 'input') && (
-        <SimonBoard
-          phase={phase}
-          activeColor={activeColor}
-          playerIdx={playerIdx}
-          sequenceLength={sequenceLength}
-          best={best}
-          onTap={handleTap}
-        />
-      )}
-
-      {phase === 'dead' && (
-        <SimonGameOverScreen roundScore={roundScore} best={best} onRestart={startGame} />
-      )}
+      {phase === 'menu' && <SimonMenuScreen best={best} onStart={startGame} />}
+      {(phase === 'showing' || phase === 'input') && <SimonBoard onTap={handleTap} />}
+      {phase === 'dead' && <SimonGameOverScreen roundScore={roundScore} best={best} onRestart={startGame} />}
     </div>
   );
 }

--- a/gamesformykids/app/games/simon/components/SimonBoard.tsx
+++ b/gamesformykids/app/games/simon/components/SimonBoard.tsx
@@ -1,17 +1,17 @@
 'use client';
-
+import { useShallow } from 'zustand/react/shallow';
+import { useSimonStore } from '../simonStore';
 import { BUTTONS, type ButtonId } from '../useSimonGame';
 
 interface Props {
-  phase: 'showing' | 'input';
-  activeColor: ButtonId | null;
-  playerIdx: number;
-  sequenceLength: number;
-  best: number;
   onTap: (id: ButtonId) => void;
 }
 
-export default function SimonBoard({ phase, activeColor, playerIdx, sequenceLength, best, onTap }: Props) {
+export default function SimonBoard({ onTap }: Props) {
+  const { phase, activeColor, playerIdx, best, sequence } =
+    useSimonStore(useShallow((s) => s));
+  const sequenceLength = sequence.length;
+
   return (
     <div className="flex flex-col items-center gap-6">
       <div className="text-center">

--- a/gamesformykids/app/games/true-false/TrueFalseGame.tsx
+++ b/gamesformykids/app/games/true-false/TrueFalseGame.tsx
@@ -1,25 +1,13 @@
-﻿'use client';
+'use client';
 import { useTrueFalseGame, TIME_PER_Q } from './useTrueFalseGame';
 import TrueFalseMenuScreen from './components/TrueFalseMenuScreen';
 import TrueFalsePlayScreen from './components/TrueFalsePlayScreen';
 import TrueFalseResultScreen from './components/TrueFalseResultScreen';
 
 export default function TrueFalseGame() {
-  const { phase, q, score, best, lives, timeLeft, feedback, startGame, answer } = useTrueFalseGame();
+  const { phase, score, best, startGame } = useTrueFalseGame();
 
   if (phase === 'menu') return <TrueFalseMenuScreen best={best} timePer={TIME_PER_Q} onStart={startGame} />;
-
   if (phase === 'dead') return <TrueFalseResultScreen score={score} best={best} onRestart={startGame} />;
-
-  return (
-    <TrueFalsePlayScreen
-      score={score}
-      lives={lives}
-      timeLeft={timeLeft}
-      timePer={TIME_PER_Q}
-      q={q}
-      feedback={feedback}
-      onAnswer={answer}
-    />
-  );
+  return <TrueFalsePlayScreen />;
 }

--- a/gamesformykids/app/games/true-false/components/TrueFalsePlayScreen.tsx
+++ b/gamesformykids/app/games/true-false/components/TrueFalsePlayScreen.tsx
@@ -1,22 +1,12 @@
 'use client';
+import { useShallow } from 'zustand/react/shallow';
+import { useTrueFalseStore, TIME_PER_Q } from '../trueFalseStore';
 
-interface TrueFalseQuestion {
-  emoji: string;
-  fact: string;
-  answer: boolean;
-}
+export default function TrueFalsePlayScreen() {
+  const { score, lives, timeLeft, feedback, deck, idx, answer } =
+    useTrueFalseStore(useShallow((s) => s));
+  const q = deck[idx];
 
-interface Props {
-  score: number;
-  lives: number;
-  timeLeft: number;
-  timePer: number;
-  q: TrueFalseQuestion | null;
-  feedback: string | null;
-  onAnswer: (val: boolean) => void;
-}
-
-export default function TrueFalsePlayScreen({ score, lives, timeLeft, timePer, q, feedback, onAnswer }: Props) {
   return (
     <div className="min-h-screen bg-gradient-to-br from-teal-100 to-cyan-200 flex flex-col items-center justify-center p-4 select-none" dir="rtl">
       <div className="flex gap-6 mb-5 text-center">
@@ -43,18 +33,18 @@ export default function TrueFalsePlayScreen({ score, lives, timeLeft, timePer, q
         <div className="mt-4 bg-gray-100 rounded-full h-2">
           <div
             className="bg-gradient-to-r from-teal-400 to-cyan-500 h-2 rounded-full transition-all duration-1000"
-            style={{ width: `${(timeLeft / timePer) * 100}%` }}
+            style={{ width: `${(timeLeft / TIME_PER_Q) * 100}%` }}
           />
         </div>
       </div>
       <div className="flex gap-5 w-full max-w-sm">
         <button
-          onClick={() => onAnswer(true)}
+          onClick={() => answer(true)}
           disabled={!!feedback}
           className="flex-1 py-6 rounded-3xl bg-green-500 text-white font-black text-5xl shadow-xl active:scale-90 hover:bg-green-400 transition-all disabled:opacity-60"
         >✅</button>
         <button
-          onClick={() => onAnswer(false)}
+          onClick={() => answer(false)}
           disabled={!!feedback}
           className="flex-1 py-6 rounded-3xl bg-red-500 text-white font-black text-5xl shadow-xl active:scale-90 hover:bg-red-400 transition-all disabled:opacity-60"
         >❌</button>

--- a/gamesformykids/app/games/word-scramble/WordScrambleGame.tsx
+++ b/gamesformykids/app/games/word-scramble/WordScrambleGame.tsx
@@ -1,28 +1,13 @@
-﻿'use client';
+'use client';
 import { useWordScrambleGame } from './useWordScrambleGame';
 import WordScrambleMenuScreen from './components/WordScrambleMenuScreen';
 import WordScramblePlayScreen from './components/WordScramblePlayScreen';
 import WordScrambleResultScreen from './components/WordScrambleResultScreen';
 
 export default function WordScrambleGame() {
-  const { phase, words, wIdx, letters, picked, score, lives, shake, correct, startGame, pickLetter, unpick } = useWordScrambleGame();
+  const { phase, score, lives, startGame } = useWordScrambleGame();
 
   if (phase === 'menu') return <WordScrambleMenuScreen onStart={startGame} />;
-
   if (phase === 'results') return <WordScrambleResultScreen score={score} lives={lives} onRestart={startGame} />;
-
-  return (
-    <WordScramblePlayScreen
-      words={words}
-      wIdx={wIdx}
-      letters={letters}
-      picked={picked}
-      score={score}
-      lives={lives}
-      shake={shake}
-      correct={correct}
-      onPickLetter={pickLetter}
-      onUnpick={unpick}
-    />
-  );
+  return <WordScramblePlayScreen />;
 }

--- a/gamesformykids/app/games/word-scramble/components/WordScramblePlayScreen.tsx
+++ b/gamesformykids/app/games/word-scramble/components/WordScramblePlayScreen.tsx
@@ -1,38 +1,11 @@
 'use client';
+import { useShallow } from 'zustand/react/shallow';
+import { useWordScrambleStore } from '../wordScrambleStore';
 
-interface ScrambleLetter {
-  idx: number;
-  ch: string;
-  picked: boolean;
-}
-
-interface PickedLetter {
-  ch: string;
-}
-
-interface WordEntry {
-  emoji: string;
-  hint: string;
-  word: string;
-}
-
-interface Props {
-  words: WordEntry[];
-  wIdx: number;
-  letters: ScrambleLetter[];
-  picked: (PickedLetter | undefined)[];
-  score: number;
-  lives: number;
-  shake: boolean;
-  correct: boolean;
-  onPickLetter: (idx: number) => void;
-  onUnpick: (i: number) => void;
-}
-
-export default function WordScramblePlayScreen({
-  words, wIdx, letters, picked, score, lives, shake, correct, onPickLetter, onUnpick,
-}: Props) {
-  const entry = words[wIdx];
+export default function WordScramblePlayScreen() {
+  const { words, wIdx, letters, picked, score, lives, shake, correct, pickLetter, unpick } =
+    useWordScrambleStore(useShallow((s) => s));
+  const entry  = words[wIdx];
   const target = entry.word;
 
   return (
@@ -49,7 +22,7 @@ export default function WordScramblePlayScreen({
           {Array.from({ length: target.length }).map((_, i) => (
             <button
               key={i}
-              onClick={() => picked[i] && onUnpick(i)}
+              onClick={() => picked[i] && unpick(i)}
               className={`w-12 h-12 rounded-xl border-2 text-xl font-black transition-all
                 ${picked[i]
                   ? correct
@@ -66,7 +39,7 @@ export default function WordScramblePlayScreen({
           {letters.map(l => (
             <button
               key={l.idx}
-              onClick={() => onPickLetter(l.idx)}
+              onClick={() => pickLetter(l.idx)}
               disabled={l.picked}
               className={`w-12 h-12 rounded-xl text-xl font-black transition-all
                 ${l.picked


### PR DESCRIPTION
## Summary
- Play-screen components no longer receive game state as props — they subscribe to their Zustand store directly via `useShallow`
- `*Game.tsx` orchestrators are now pure phase routers: they only handle `menu` / `dead` / `results` routing and pass 0 state props to the play-screen
- Simon's `SimonBoard` retains only `onTap` as a prop (hook-level callback); all state fields now come from `useSimonStore`

## Games changed (12 files)
| Game | Play-screen props before → after |
|------|----------------------------------|
| emoji-math | 8 props → 0 |
| color-tap | 7 props → 0 |
| true-false | 7 props → 0 |
| math-race | 10 props → 0 |
| word-scramble | 10 props → 0 |
| simon (SimonBoard) | 6 props → 1 (onTap only) |

## Test plan
- [ ] `tsc --noEmit` passes (verified — pre-existing supabase errors unrelated)
- [ ] All 6 games start and play correctly
- [ ] Phase transitions (menu → playing → game over) work as expected

Closes #197

🤖 Generated with [Claude Code](https://claude.com/claude-code)