### PR TITLE
feat(word-builder, number-bubbles): migrate from useState to Zustand stores (#33)

### DIFF
--- a/gamesformykids/app/games/number-bubbles/NumberBubblesGame.tsx
+++ b/gamesformykids/app/games/number-bubbles/NumberBubblesGame.tsx
@@ -25,7 +25,7 @@ export default function NumberBubblesGame() {
         elapsed={elapsed}
         next={next}
       />
-      <NumberBubbleGrid bubbles={bubbles} next={next} level={level} onTap={tap} />
+      <NumberBubbleGrid bubbles={bubbles} next={next} onTap={tap} />
     </div>
   );
 }

--- a/gamesformykids/app/games/number-bubbles/components/NumberBubbleGrid.tsx
+++ b/gamesformykids/app/games/number-bubbles/components/NumberBubbleGrid.tsx
@@ -12,11 +12,10 @@ interface Bubble {
 interface Props {
   bubbles: Bubble[];
   next: number;
-  level: number;
   onTap: (bubble: Bubble) => void;
 }
 
-export default function NumberBubbleGrid({ bubbles, next, level, onTap }: Props) {
+export default function NumberBubbleGrid({ bubbles, next, onTap }: Props) {
   return (
     <div className="relative w-full" style={{ height: '70vh', maxWidth: 400 }}>
       {bubbles.map(b => (

--- a/gamesformykids/app/games/number-bubbles/components/NumberBubbleGrid.tsx
+++ b/gamesformykids/app/games/number-bubbles/components/NumberBubbleGrid.tsx
@@ -13,7 +13,7 @@ interface Props {
   bubbles: Bubble[];
   next: number;
   level: number;
-  onTap: (bubble: Bubble, next: number, level: number) => void;
+  onTap: (bubble: Bubble) => void;
 }
 
 export default function NumberBubbleGrid({ bubbles, next, level, onTap }: Props) {
@@ -22,7 +22,7 @@ export default function NumberBubbleGrid({ bubbles, next, level, onTap }: Props)
       {bubbles.map(b => (
         <button
           key={b.id}
-          onClick={() => onTap(b, next, level)}
+          onClick={() => onTap(b)}
           style={{ position: 'absolute', left: `${b.x}%`, top: `${b.y}%`, transform: 'translate(-50%,-50%)' }}
           className={`w-14 h-14 rounded-full font-black text-xl text-white shadow-lg flex items-center justify-center transition-all duration-200 ${
             b.popped

--- a/gamesformykids/app/games/number-bubbles/numberBubblesStore.ts
+++ b/gamesformykids/app/games/number-bubbles/numberBubblesStore.ts
@@ -1,0 +1,105 @@
+import { makeStore } from '@/lib/stores/createStore';
+import type { PhaseResults as Phase } from '@/lib/types';
+
+// ── Data helpers ───────────────────────────────────────────────────────────
+
+export const BUBBLE_COLORS = [
+  'bg-red-400','bg-blue-400','bg-green-400','bg-yellow-400',
+  'bg-purple-400','bg-pink-400','bg-orange-400','bg-teal-400',
+  'bg-indigo-400','bg-rose-400','bg-lime-400','bg-cyan-400',
+  'bg-fuchsia-400','bg-amber-400','bg-emerald-400',
+];
+
+export interface Bubble { id: number; num: number; x: number; y: number; color: string; popped: boolean; }
+
+let uid = 0;
+
+export function makeBubbles(count: number): Bubble[] {
+  return Array.from({ length: count }, (_, i) => i + 1).map(n => ({
+    id:     uid++,
+    num:    n,
+    x:      5 + Math.random() * 75,
+    y:      5 + Math.random() * 80,
+    color:  BUBBLE_COLORS[n % BUBBLE_COLORS.length],
+    popped: false,
+  }));
+}
+
+// ── Store ──────────────────────────────────────────────────────────────────
+
+interface NumberBubblesState {
+  phase:   Phase;
+  level:   number;
+  bubbles: Bubble[];
+  next:    number;
+  elapsed: number;
+  best:    { level: number; time: number } | null;
+  wrong:   boolean;
+}
+
+interface NumberBubblesActions {
+  startGame:  () => void;
+  startRound: (lvl: number) => void;
+  nextLevel:  () => void;
+  tap:        (bubble: Bubble) => void;
+}
+
+const INITIAL: NumberBubblesState = {
+  phase: 'menu', level: 1, bubbles: [], next: 1,
+  elapsed: 0, best: null, wrong: false,
+};
+
+export const useNumberBubblesStore = makeStore<NumberBubblesState & NumberBubblesActions>(
+  'NumberBubblesStore',
+  (set, get) => {
+    let intervalId: ReturnType<typeof setInterval> | null = null;
+    let startTime  = 0;
+
+    function stopTimer() {
+      if (intervalId) { clearInterval(intervalId); intervalId = null; }
+    }
+
+    function beginRound(lvl: number) {
+      set(
+        { phase: 'playing', level: lvl, bubbles: makeBubbles(5 + lvl * 3), next: 1, elapsed: 0, wrong: false },
+        false, 'bubbles/startRound',
+      );
+      stopTimer();
+      startTime = Date.now();
+      intervalId = setInterval(() => {
+        set({ elapsed: Math.floor((Date.now() - startTime) / 100) / 10 }, false, 'bubbles/tick');
+      }, 100);
+    }
+
+    return {
+      ...INITIAL,
+
+      startGame:  () => beginRound(1),
+      startRound: (lvl: number) => beginRound(lvl),
+      nextLevel:  () => beginRound(get().level + 1),
+
+      tap: (bubble: Bubble) => {
+        const { phase, bubbles, next, level, best } = get();
+        if (phase !== 'playing' || bubble.popped) return;
+
+        if (bubble.num !== next) {
+          set({ wrong: true }, false, 'bubbles/wrong');
+          setTimeout(() => set({ wrong: false }, false, 'bubbles/clearWrong'), 600);
+          return;
+        }
+
+        const updated  = bubbles.map(b => b.id === bubble.id ? { ...b, popped: true } : b);
+        const allPopped = updated.every(b => b.popped);
+
+        if (allPopped) {
+          stopTimer();
+          const t      = Math.floor((Date.now() - startTime) / 100) / 10;
+          const newBest = best && best.time <= t && best.level >= level ? best : { level, time: t };
+          set({ bubbles: updated, next: next + 1, elapsed: t, phase: 'results', best: newBest }, false, 'bubbles/complete');
+        } else {
+          set({ bubbles: updated, next: next + 1 }, false, 'bubbles/pop');
+        }
+      },
+    };
+  },
+);

--- a/gamesformykids/app/games/number-bubbles/useNumberBubblesGame.ts
+++ b/gamesformykids/app/games/number-bubbles/useNumberBubblesGame.ts
@@ -1,99 +1,12 @@
 'use client';
-import { useState, useCallback, useRef, useEffect } from 'react';
+import { useShallow } from 'zustand/react/shallow';
+import { useNumberBubblesStore } from './numberBubblesStore';
 
-export const BUBBLE_COLORS = [
-  'bg-red-400','bg-blue-400','bg-green-400','bg-yellow-400',
-  'bg-purple-400','bg-pink-400','bg-orange-400','bg-teal-400',
-  'bg-indigo-400','bg-rose-400','bg-lime-400','bg-cyan-400',
-  'bg-fuchsia-400','bg-amber-400','bg-emerald-400',
-];
-
-import type { PhaseResults as GamePhase } from '@/lib/types';
-
-export interface Bubble { id: number; num: number; x: number; y: number; color: string; popped: boolean; }
-
-let uid = 0;
-
-export function makeBubbles(count: number): Bubble[] {
-  const nums = Array.from({ length: count }, (_, i) => i + 1);
-  return nums.map(n => ({
-    id: uid++,
-    num: n,
-    x: 5 + Math.random() * 75,
-    y: 5 + Math.random() * 80,
-    color: BUBBLE_COLORS[n % BUBBLE_COLORS.length],
-    popped: false,
-  }));
-}
+export type { Bubble } from './numberBubblesStore';
+export { BUBBLE_COLORS, makeBubbles } from './numberBubblesStore';
 
 export function useNumberBubblesGame() {
-  const [phase,   setPhase]   = useState<GamePhase>('menu');
-  const [level,   setLevel]   = useState(1);
-  const [bubbles, setBubbles] = useState<Bubble[]>([]);
-  const [next,    setNext]    = useState(1);
-  const [elapsed, setElapsed] = useState(0);
-  const [best,    setBest]    = useState<{ level: number; time: number } | null>(null);
-  const [wrong,   setWrong]   = useState(false);
-
-  const phaseRef    = useRef<GamePhase>('menu');
-  const startRef    = useRef(0);
-  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
-
-  const stopTimer = useCallback(() => {
-    if (intervalRef.current) { clearInterval(intervalRef.current); intervalRef.current = null; }
-  }, []);
-
-  const startRound = useCallback((lvl: number) => {
-    const count = 5 + lvl * 3;
-    const bs = makeBubbles(count);
-    phaseRef.current = 'playing';
-    setPhase('playing');
-    setBubbles(bs);
-    setNext(1);
-    setElapsed(0);
-    setWrong(false);
-    startRef.current = Date.now();
-    stopTimer();
-    intervalRef.current = setInterval(() => {
-      setElapsed(Math.floor((Date.now() - startRef.current) / 100) / 10);
-    }, 100);
-  }, [stopTimer]);
-
-  const startGame = useCallback(() => {
-    setLevel(1);
-    startRound(1);
-  }, [startRound]);
-
-  const nextLevel = useCallback((currentLevel: number) => {
-    const nl = currentLevel + 1;
-    setLevel(nl);
-    startRound(nl);
-    return nl;
-  }, [startRound]);
-
-  const tap = useCallback((bubble: Bubble, currentNext: number, currentLevel: number) => {
-    if (phaseRef.current !== 'playing' || bubble.popped) return;
-    if (bubble.num !== currentNext) {
-      setWrong(true);
-      setTimeout(() => setWrong(false), 600);
-      return;
-    }
-    setBubbles(prev => {
-      const updated = prev.map(b => b.id === bubble.id ? { ...b, popped: true } : b);
-      const total = updated.length;
-      const popped = updated.filter(b => b.popped).length;
-      if (popped >= total) {
-        stopTimer();
-        const t = Math.floor((Date.now() - startRef.current) / 100) / 10;
-        setElapsed(t);
-        phaseRef.current = 'results';
-        setPhase('results');
-        setBest(old => old && old.time <= t && old.level >= currentLevel ? old : { level: currentLevel, time: t });
-      }
-      return updated;
-    });
-    setNext(currentNext + 1);
-  }, [stopTimer]);
-  useEffect(() => stopTimer, [stopTimer]);
+  const { phase, level, bubbles, next, elapsed, best, wrong, startGame, startRound, nextLevel, tap } =
+    useNumberBubblesStore(useShallow((s) => s));
   return { phase, level, bubbles, next, elapsed, best, wrong, startGame, startRound, nextLevel, tap };
 }

--- a/gamesformykids/app/games/word-builder/useWordBuilderGame.ts
+++ b/gamesformykids/app/games/word-builder/useWordBuilderGame.ts
@@ -1,81 +1,17 @@
 'use client';
+import { useShallow } from 'zustand/react/shallow';
+import { useWordBuilderStore } from './wordBuilderStore';
 
-import { useState, useCallback } from 'react';
-import { WORD_PUZZLES, WordPuzzle, shuffleLetters } from './data/words';
-
-import type { PhaseResult as WordPhase } from '@/lib/types';
+export type { WordPuzzle, AvailableLetter } from './wordBuilderStore';
 
 export function useWordBuilderGame() {
-  const [phase, setPhase] = useState<WordPhase>('menu');
-  const [index, setIndex] = useState(0);
-  const [score, setScore] = useState(0);
-  const [typed, setTyped] = useState<string[]>([]);       // letters typed so far
-  const [available, setAvailable] = useState<{ letter: string; used: boolean }[]>([]);
-  const [status, setStatus] = useState<'idle' | 'correct' | 'wrong'>('idle');
-
-  // Shuffle the full list once per game
-  const [puzzles] = useState<WordPuzzle[]>(() =>
-    [...WORD_PUZZLES].sort(() => Math.random() - 0.5).slice(0, 10)
-  );
-
-  const current = puzzles[index];
-
-  const loadPuzzle = useCallback((puzzle: WordPuzzle) => {
-    const letters = shuffleLetters(puzzle.word);
-    setAvailable(letters.map(l => ({ letter: l, used: false })));
-    setTyped([]);
-    setStatus('idle');
-  }, []);
-
-  const startGame = useCallback(() => {
-    setIndex(0);
-    setScore(0);
-    setPhase('playing');
-    loadPuzzle(puzzles[0]);
-  }, [puzzles, loadPuzzle]);
-
-  const pressLetter = useCallback((idx: number) => {
-    if (status !== 'idle') return;
-    const letter = available[idx];
-    if (letter.used) return;
-
-    const newTyped = [...typed, letter.letter];
-    const newAvail = available.map((l, i) => i === idx ? { ...l, used: true } : l);
-    setAvailable(newAvail);
-    setTyped(newTyped);
-
-    if (newTyped.length === current.word.length) {
-      const word = newTyped.join('');
-      if (word === current.word) {
-        setStatus('correct');
-        setScore(s => s + 1);
-      } else {
-        setStatus('wrong');
-      }
-    }
-  }, [available, typed, current, status]);
-
-  const clearTyped = useCallback(() => {
-    setAvailable(available.map(l => ({ ...l, used: false })));
-    setTyped([]);
-    setStatus('idle');
-  }, [available]);
-
-  const next = useCallback(() => {
-    if (index < puzzles.length - 1) {
-      const next = index + 1;
-      setIndex(next);
-      loadPuzzle(puzzles[next]);
-    } else {
-      setPhase('result');
-    }
-  }, [index, puzzles, loadPuzzle]);
-
-  const restart = useCallback(() => startGame(), [startGame]);
-
+  const { phase, puzzles, index, score, typed, available, status, startGame, pressLetter, clearTyped, next } =
+    useWordBuilderStore(useShallow((s) => s));
   return {
-    phase, index, score, typed, available, status, current,
+    phase, index, score, typed, available, status,
+    current: puzzles[index],
     total: puzzles.length,
-    startGame, pressLetter, clearTyped, next, restart,
+    startGame, pressLetter, clearTyped, next,
+    restart: startGame,
   };
 }

--- a/gamesformykids/app/games/word-builder/wordBuilderStore.ts
+++ b/gamesformykids/app/games/word-builder/wordBuilderStore.ts
@@ -1,0 +1,99 @@
+import { makeStore } from '@/lib/stores/createStore';
+import type { PhaseResult as Phase } from '@/lib/types';
+import { WORD_PUZZLES, type WordPuzzle, shuffleLetters } from './data/words';
+
+// ── Types ──────────────────────────────────────────────────────────────────
+
+export type { WordPuzzle } from './data/words';
+export interface AvailableLetter { letter: string; used: boolean; }
+
+// ── Store ──────────────────────────────────────────────────────────────────
+
+interface WordBuilderState {
+  phase:     Phase;
+  puzzles:   WordPuzzle[];
+  index:     number;
+  score:     number;
+  typed:     string[];
+  available: AvailableLetter[];
+  status:    'idle' | 'correct' | 'wrong';
+}
+
+interface WordBuilderActions {
+  startGame:   () => void;
+  pressLetter: (idx: number) => void;
+  clearTyped:  () => void;
+  next:        () => void;
+}
+
+const INITIAL: WordBuilderState = {
+  phase: 'menu', puzzles: [], index: 0, score: 0,
+  typed: [], available: [], status: 'idle',
+};
+
+function makePuzzles(): WordPuzzle[] {
+  return [...WORD_PUZZLES].sort(() => Math.random() - 0.5).slice(0, 10);
+}
+
+function loadLetters(word: string): AvailableLetter[] {
+  return shuffleLetters(word).map(l => ({ letter: l, used: false }));
+}
+
+export const useWordBuilderStore = makeStore<WordBuilderState & WordBuilderActions>(
+  'WordBuilderStore',
+  (set, get) => ({
+    ...INITIAL,
+
+    startGame: () => {
+      const puzzles = makePuzzles();
+      set(
+        { ...INITIAL, phase: 'playing', puzzles, available: loadLetters(puzzles[0].word) },
+        false, 'wordBuilder/startGame',
+      );
+    },
+
+    pressLetter: (idx: number) => {
+      const { status, available, typed, puzzles, index, score } = get();
+      if (status !== 'idle') return;
+      const letter = available[idx];
+      if (!letter || letter.used) return;
+
+      const newTyped  = [...typed, letter.letter];
+      const newAvail  = available.map((l, i) => i === idx ? { ...l, used: true } : l);
+      const wordLen   = puzzles[index].word.length;
+
+      if (newTyped.length < wordLen) {
+        set({ typed: newTyped, available: newAvail }, false, 'wordBuilder/press');
+        return;
+      }
+
+      const attempt = newTyped.join('');
+      const correct = attempt === puzzles[index].word;
+      set(
+        { typed: newTyped, available: newAvail, status: correct ? 'correct' : 'wrong', score: correct ? score + 1 : score },
+        false, `wordBuilder/${correct ? 'correct' : 'wrong'}`,
+      );
+    },
+
+    clearTyped: () => {
+      const { available } = get();
+      set(
+        { available: available.map(l => ({ ...l, used: false })), typed: [], status: 'idle' },
+        false, 'wordBuilder/clear',
+      );
+    },
+
+    next: () => {
+      const { index, puzzles } = get();
+      if (index < puzzles.length - 1) {
+        const nextIdx = index + 1;
+        set(
+          { index: nextIdx, available: loadLetters(puzzles[nextIdx].word), typed: [], status: 'idle' },
+          false, 'wordBuilder/next',
+        );
+      } else {
+        set({ phase: 'result' }, false, 'wordBuilder/result');
+      }
+    },
+  }),
+);


### PR DESCRIPTION
## Summary
- **word-builder**: new `wordBuilderStore.ts` — no timers, pure state machine with puzzles + letter picking logic
- **number-bubbles**: new `numberBubblesStore.ts` — moves `uid`, `BUBBLE_COLORS`, `makeBubbles` and all timer logic into the store; `tap(bubble)` now takes 1 arg (no more stale-closure workaround params); `NumberBubbleGrid` updated accordingly
- Both hooks become thin `useShallow` wrappers

## Scope of issue #33
- ✅ word-builder
- ✅ number-bubbles
- tzadikim — does not exist in codebase
- tzedakah — tracked separately in #199 (14 props, complex physics)

## Test plan
- [ ] `tsc --noEmit` passes (verified)
- [ ] word-builder: game starts, letters can be picked/cleared, correct word advances, 10 puzzles → result screen
- [ ] number-bubbles: bubbles spawn correctly, tap in order, wrong tap flashes red, level advances on completion

Closes #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)