### PR TITLE
refactor(damka): eliminate props drilling — components subscribe to store directly (#208)

### DIFF
--- a/gamesformykids/app/games/checkers/DamkaGame.tsx
+++ b/gamesformykids/app/games/checkers/DamkaGame.tsx
@@ -4,47 +4,19 @@ import { useDamkaGame } from './useDamkaGame';
 import { DamkaMenuScreen, DamkaResultScreen, DamkaBoard, DamkaScoreBar } from './components';
 
 export default function DamkaGame() {
-  const { phase, board, selected, validMoves, currentTurn, playerScore, computerScore, message, startGame, selectCell } = useDamkaGame();
-
-  const playerPieces = board.flat().filter(c => c.color === 'player').length;
-  const compPieces   = board.flat().filter(c => c.color === 'computer').length;
+  const { phase } = useDamkaGame();
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-amber-900 via-amber-950 to-stone-950 flex flex-col items-center justify-center p-4 select-none" dir="rtl">
 
-      {phase === 'menu' && (
-        <DamkaMenuScreen
-          playerScore={playerScore}
-          computerScore={computerScore}
-          onStart={startGame}
-        />
-      )}
+      {phase === 'menu' && <DamkaMenuScreen />}
 
-      {(phase === 'won' || phase === 'lost') && (
-        <DamkaResultScreen
-          phase={phase}
-          playerScore={playerScore}
-          computerScore={computerScore}
-          onRestart={startGame}
-        />
-      )}
+      {(phase === 'won' || phase === 'lost') && <DamkaResultScreen />}
 
       {phase === 'playing' && (
         <div className="flex flex-col items-center gap-3 w-full max-w-sm">
-          <DamkaScoreBar
-            playerPieces={playerPieces}
-            compPieces={compPieces}
-            playerScore={playerScore}
-            computerScore={computerScore}
-            currentTurn={currentTurn}
-            message={message}
-          />
-          <DamkaBoard
-            board={board}
-            selected={selected}
-            validMoves={validMoves}
-            onCellClick={selectCell}
-          />
+          <DamkaScoreBar />
+          <DamkaBoard />
         </div>
       )}
     </div>

--- a/gamesformykids/app/games/checkers/components/DamkaBoard.tsx
+++ b/gamesformykids/app/games/checkers/components/DamkaBoard.tsx
@@ -1,17 +1,13 @@
 'use client';
-
-import type { Board, Pos, DamkaMove } from '../useDamkaGame';
+import { useShallow } from 'zustand/react/shallow';
+import { useDamkaStore } from '../damkaStore';
 
 const isDark = (r: number, c: number) => (r + c) % 2 === 1;
 
-interface DamkaBoardProps {
-  board: Board;
-  selected: Pos | null;
-  validMoves: DamkaMove[];
-  onCellClick: (pos: Pos) => void;
-}
+export default function DamkaBoard() {
+  const { board, selected, validMoves, selectCell } =
+    useDamkaStore(useShallow((s) => s));
 
-export default function DamkaBoard({ board, selected, validMoves, onCellClick }: DamkaBoardProps) {
   const validDests   = new Set(validMoves.map(m => `${m.to.row},${m.to.col}`));
   const captureDests = new Set(validMoves.filter(m => m.captures.length > 0).map(m => `${m.to.row},${m.to.col}`));
 
@@ -20,21 +16,21 @@ export default function DamkaBoard({ board, selected, validMoves, onCellClick }:
       {board.map((row, r) => (
         <div key={r} className="flex">
           {row.map((cell, c) => {
-            const key     = `${r},${c}`;
-            const isLight = !isDark(r, c);
-            const isSel   = selected?.row === r && selected?.col === c;
-            const isValid = validDests.has(key);
+            const key       = `${r},${c}`;
+            const isLight   = !isDark(r, c);
+            const isSel     = selected?.row === r && selected?.col === c;
+            const isValid   = validDests.has(key);
             const isCapture = captureDests.has(key);
 
             let bg = isLight ? 'bg-amber-100' : 'bg-amber-800';
-            if (isSel)       bg = 'bg-yellow-400';
+            if (isSel)          bg = 'bg-yellow-400';
             else if (isCapture) bg = 'bg-red-500/70';
             else if (isValid)   bg = 'bg-green-500/70';
 
             return (
               <div
                 key={c}
-                onClick={() => onCellClick({ row: r, col: c })}
+                onClick={() => selectCell({ row: r, col: c })}
                 className={`w-10 h-10 sm:w-11 sm:h-11 flex items-center justify-center cursor-pointer ${bg} transition-colors`}
               >
                 {cell.color && (

--- a/gamesformykids/app/games/checkers/components/DamkaMenuScreen.tsx
+++ b/gamesformykids/app/games/checkers/components/DamkaMenuScreen.tsx
@@ -1,14 +1,12 @@
 'use client';
-
+import { useShallow } from 'zustand/react/shallow';
+import { useDamkaStore } from '../damkaStore';
 import GameMenuCard from '@/components/game/shared/GameMenuCard';
 
-interface DamkaMenuScreenProps {
-  playerScore: number;
-  computerScore: number;
-  onStart: () => void;
-}
+export default function DamkaMenuScreen() {
+  const { playerScore, computerScore, startGame } =
+    useDamkaStore(useShallow((s) => s));
 
-export default function DamkaMenuScreen({ playerScore, computerScore, onStart }: DamkaMenuScreenProps) {
   return (
     <GameMenuCard
       emoji="♟️"
@@ -16,7 +14,7 @@ export default function DamkaMenuScreen({ playerScore, computerScore, onStart }:
       description="משחק הדמקה הקלאסי נגד המחשב!"
       gradientClass="from-amber-900 to-stone-950"
       buttonClass="from-amber-400 to-amber-500"
-      onStart={onStart}
+      onStart={startGame}
       startLabel="🎮 התחל משחק"
     >
       {(playerScore > 0 || computerScore > 0) && (

--- a/gamesformykids/app/games/checkers/components/DamkaResultScreen.tsx
+++ b/gamesformykids/app/games/checkers/components/DamkaResultScreen.tsx
@@ -1,15 +1,11 @@
 'use client';
+import { useShallow } from 'zustand/react/shallow';
+import { useDamkaStore } from '../damkaStore';
 
-import type { GamePhase } from '../useDamkaGame';
+export default function DamkaResultScreen() {
+  const { phase, playerScore, computerScore, startGame } =
+    useDamkaStore(useShallow((s) => s));
 
-interface DamkaResultScreenProps {
-  phase: Extract<GamePhase, 'won' | 'lost'>;
-  playerScore: number;
-  computerScore: number;
-  onRestart: () => void;
-}
-
-export default function DamkaResultScreen({ phase, playerScore, computerScore, onRestart }: DamkaResultScreenProps) {
   return (
     <div className="flex flex-col items-center gap-6 text-center">
       <div className="text-8xl">{phase === 'won' ? '🎉' : '😢'}</div>
@@ -21,7 +17,7 @@ export default function DamkaResultScreen({ phase, playerScore, computerScore, o
         <span>⚪ מחשב: {computerScore}</span>
       </div>
       <button
-        onClick={onRestart}
+        onClick={startGame}
         className="bg-amber-400 hover:bg-amber-300 text-gray-900 font-extrabold text-xl px-10 py-4 rounded-2xl shadow-xl transition-transform hover:scale-105 active:scale-95"
       >
         🔄 שחק שוב

--- a/gamesformykids/app/games/checkers/components/DamkaScoreBar.tsx
+++ b/gamesformykids/app/games/checkers/components/DamkaScoreBar.tsx
@@ -1,19 +1,14 @@
 'use client';
+import { useShallow } from 'zustand/react/shallow';
+import { useDamkaStore } from '../damkaStore';
 
-import type { Side } from '../useDamkaGame';
+export default function DamkaScoreBar() {
+  const { board, currentTurn, playerScore, computerScore, message } =
+    useDamkaStore(useShallow((s) => s));
 
-interface DamkaScoreBarProps {
-  playerPieces: number;
-  compPieces: number;
-  playerScore: number;
-  computerScore: number;
-  currentTurn: Side;
-  message: string;
-}
+  const playerPieces = board.flat().filter(c => c.color === 'player').length;
+  const compPieces   = board.flat().filter(c => c.color === 'computer').length;
 
-export default function DamkaScoreBar({
-  playerPieces, compPieces, playerScore, computerScore, currentTurn, message
-}: DamkaScoreBarProps) {
   return (
     <>
       {/* Turn indicator + piece counts */}


### PR DESCRIPTION
## Summary
- `DamkaGame.tsx` is now a pure phase router — zero state props passed to children
- Each component reads what it needs from `useDamkaStore` directly via `useShallow`
- `DamkaScoreBar` derives `playerPieces`/`compPieces` from `board` instead of receiving them as props
- `DamkaBoard` calls `selectCell` from the store directly
- `DamkaMenuScreen` and `DamkaResultScreen` read scores and `startGame` from the store

Depends on #207 (Zustand migration). Closes #208.

## Test plan
- [ ] Menu screen shows previous scores after a game
- [ ] Game starts when pressing the button
- [ ] Board renders, pieces can be selected and moved
- [ ] Computer responds after player move
- [ ] Win/loss screen shows scores and restart works

🤖 Generated with [Claude Code](https://claude.com/claude-code)