### PR TITLE
feat(tzedakah): migrate to Zustand store + eliminate props drilling (#199)

### DIFF
--- a/gamesformykids/app/games/tzedakah/CharityCoinGame.tsx
+++ b/gamesformykids/app/games/tzedakah/CharityCoinGame.tsx
@@ -1,5 +1,8 @@
 'use client';
 
+import { useShallow } from 'zustand/react/shallow';
+import { useTzedakahStore } from './tzedakahStore';
+import { useCharityCoinGame } from './useCharityCoinGame';
 import CharityGameHeader from './components/CharityGameHeader';
 import CharityCoin from './components/CharityCoin';
 import CharityBasket from './components/CharityBasket';
@@ -7,90 +10,33 @@ import GameControls from './components/GameControls';
 import GameAreaBackground from './components/GameAreaBackground';
 import TzedakahGameInstructions from './components/TzedakahGameInstructions';
 import styles from './charity.module.css';
-import { useCharityCoinGame } from './useCharityCoinGame';
 
 const CharityCoinGame = () => {
-  const {
-    coins,
-    score,
-    gameStarted,
-    basketX,
-    gameTime,
-    collectedCoins,
-    isMobile,
-    gameWidth,
-    gameHeight,
-    basketWidth,
-    basketHeight,
-    startGame,
-    handleMouseMove,
-    handleTouchMove,
-  } = useCharityCoinGame();
+  const { gameWidth, gameHeight, handleMouseMove, handleTouchMove } = useCharityCoinGame();
+  const coins = useTzedakahStore(useShallow((s) => s.coins));
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-sky-100 via-blue-100 to-indigo-200 p-4">
       <div className="max-w-6xl mx-auto">
-        
-        {/* כותרת ולוח תוצאות */}
-        <CharityGameHeader 
-          score={score}
-          gameTime={gameTime}
-          collectedCoins={collectedCoins}
-          isMobile={isMobile}
-        />
 
-        {/* כפתורי התחלה וסיום */}
-        <GameControls
-          gameStarted={gameStarted}
-          gameTime={gameTime}
-          score={score}
-          collectedCoins={collectedCoins}
-          isMobile={isMobile}
-          onStartGame={startGame}
-        />
+        <CharityGameHeader />
+        <GameControls />
 
-        {/* איזור המשחק מעוצב */}
         <div className="flex justify-center">
           <div
             className={`relative bg-gradient-to-b from-sky-200 via-sky-300 to-blue-400 border-8 border-white rounded-3xl overflow-hidden shadow-2xl cursor-none touch-none ${styles.charityGameArea || 'charity-game-area'}`}
-            style={{ 
-              width: gameWidth, 
-              height: gameHeight, 
-              touchAction: 'none' 
-            }}
+            style={{ width: gameWidth, height: gameHeight, touchAction: 'none' }}
             onMouseMove={handleMouseMove}
             onTouchMove={handleTouchMove}
             onTouchStart={(e) => e.preventDefault()}
           >
-            
-            {/* רקע מעוצב */}
-            <GameAreaBackground isMobile={isMobile} />
-
-            {/* מטבעות מעוצבים */}
-            {coins.map(coin => (
-              <CharityCoin 
-                key={coin.id}
-                coin={coin}
-                isMobile={isMobile}
-              />
-            ))}
-
-            {/* הסל המעוצב */}
-            <CharityBasket 
-              basketX={basketX}
-              basketWidth={basketWidth}
-              basketHeight={basketHeight}
-              gameStarted={gameStarted}
-              isMobile={isMobile}
-            />
-
-            {/* הוראות מעוצבות */}
-            <TzedakahGameInstructions 
-              gameStarted={gameStarted}
-              isMobile={isMobile}
-            />
+            <GameAreaBackground />
+            {coins.map(coin => <CharityCoin key={coin.id} coin={coin} />)}
+            <CharityBasket />
+            <TzedakahGameInstructions />
           </div>
         </div>
+
       </div>
     </div>
   );

--- a/gamesformykids/app/games/tzedakah/components/CharityBasket.tsx
+++ b/gamesformykids/app/games/tzedakah/components/CharityBasket.tsx
@@ -1,89 +1,59 @@
-interface CharityBasketProps {
-  basketX: number;
-  basketWidth: number;
-  basketHeight: number;
-  gameStarted: boolean;
-  isMobile: boolean;
-}
+'use client';
+import { useShallow } from 'zustand/react/shallow';
+import { useTzedakahStore } from '../tzedakahStore';
 
-export default function CharityBasket({ 
-  basketX, 
-  basketWidth, 
-  basketHeight, 
-  gameStarted, 
-  isMobile 
-}: CharityBasketProps) {
+export default function CharityBasket() {
+  const { basketX, basketWidth, basketHeight, gameStarted, isMobile } =
+    useTzedakahStore(useShallow((s) => s));
+
   return (
     <div
       className="absolute bottom-0 flex items-center justify-center z-10"
-      style={{
-        left: basketX,
-        width: basketWidth,
-        height: basketHeight,
-      }}
+      style={{ left: basketX, width: basketWidth, height: basketHeight }}
     >
       <div className="w-full h-full relative">
-        {/* גוף הסל - מעוצב יותר */}
-        <div 
+        {/* גוף הסל */}
+        <div
           className="w-full h-full bg-gradient-to-b from-amber-500 via-amber-600 to-amber-800 rounded-t-3xl border-4 border-amber-900 shadow-2xl relative overflow-hidden"
           style={{ clipPath: 'polygon(15% 0%, 85% 0%, 80% 100%, 20% 100%)' }}
         >
-          {/* דוגמת קליעה משופרת */}
+          {/* דוגמת קליעה */}
           <div className="absolute inset-2 opacity-50">
             <div className="w-full h-full bg-amber-700 rounded-t-2xl"></div>
-            {/* קווים אופקיים */}
             {[...Array(4)].map((_, i) => (
-              <div 
-                key={i} 
-                className="absolute left-2 right-2 h-px bg-amber-900 opacity-60"
-                style={{ top: `${(i + 1) * 20}%` }}
-              />
+              <div key={i} className="absolute left-2 right-2 h-px bg-amber-900 opacity-60" style={{ top: `${(i + 1) * 20}%` }} />
             ))}
-            {/* קווים אנכיים */}
             {[...Array(3)].map((_, i) => (
-              <div 
-                key={i} 
-                className="absolute top-2 bottom-2 w-px bg-amber-900 opacity-40"
-                style={{ left: `${(i + 1) * 25}%` }}
-              />
+              <div key={i} className="absolute top-2 bottom-2 w-px bg-amber-900 opacity-40" style={{ left: `${(i + 1) * 25}%` }} />
             ))}
           </div>
-
-          {/* ברק זהב בקצוות */}
           <div className="absolute top-0 left-0 right-0 h-1 bg-gradient-to-r from-transparent via-yellow-300 to-transparent opacity-80"></div>
         </div>
-        
-        {/* תווית הסל - גדולה יותר ובולטת יותר */}
+
+        {/* תווית הסל */}
         <div className={`absolute -top-6 left-1/2 transform -translate-x-1/2 bg-white bg-opacity-95 rounded-xl shadow-xl border-2 border-amber-400 ${
           isMobile ? 'px-2 py-1' : 'px-3 py-2'
         }`}>
-          <div className={`text-amber-800 font-bold text-center ${
-            isMobile ? 'text-xs' : 'text-sm'
-          } flex items-center gap-1`}>
+          <div className={`text-amber-800 font-bold text-center ${isMobile ? 'text-xs' : 'text-sm'} flex items-center gap-1`}>
             <span className="text-red-500">💝</span>
             <span>קופת צדקה</span>
             <span className="text-red-500">💝</span>
           </div>
         </div>
-        
-        {/* אפקט ברק כאשר תופסים מטבע */}
+
         {gameStarted && (
           <div className="absolute -top-4 left-1/2 transform -translate-x-1/2 text-yellow-400 animate-bounce">
             <span className={isMobile ? 'text-xl' : 'text-2xl'}>✨</span>
           </div>
         )}
 
-        {/* אפקט זוהר סביב הסל */}
         <div className="absolute inset-0 rounded-t-3xl shadow-inner pointer-events-none">
           <div className="absolute inset-0 bg-gradient-to-t from-amber-400/20 to-transparent rounded-t-3xl"></div>
         </div>
 
-        {/* חץ מנחה */}
         {gameStarted && (
           <div className="absolute -top-10 left-1/2 transform -translate-x-1/2 animate-bounce">
-            <div className={`text-green-500 ${isMobile ? 'text-lg' : 'text-xl'}`}>
-              ⬇️
-            </div>
+            <div className={`text-green-500 ${isMobile ? 'text-lg' : 'text-xl'}`}>⬇️</div>
           </div>
         )}
       </div>

--- a/gamesformykids/app/games/tzedakah/components/CharityCoin.tsx
+++ b/gamesformykids/app/games/tzedakah/components/CharityCoin.tsx
@@ -1,33 +1,23 @@
-import type { Coin } from '../useCharityCoinGame';
+'use client';
+import { useTzedakahStore } from '../tzedakahStore';
+import type { Coin } from '../tzedakahStore';
 
-interface CharityCoinProps {
-  coin: Coin;
-  isMobile: boolean;
-}
+interface CharityCoinProps { coin: Coin; }
 
-export default function CharityCoin({ coin, isMobile }: CharityCoinProps) {
+export default function CharityCoin({ coin }: CharityCoinProps) {
+  const isMobile = useTzedakahStore((s) => s.isMobile);
+
   return (
     <div
       className={`absolute flex items-center justify-center ${isMobile ? 'w-8 h-8' : 'w-12 h-12'} animate-pulse`}
-      style={{
-        left: coin.x,
-        top: coin.y,
-        transform: `rotate(${coin.rotation}deg)`,
-        transition: 'transform 0.1s ease-out'
-      }}
+      style={{ left: coin.x, top: coin.y, transform: `rotate(${coin.rotation}deg)`, transition: 'transform 0.1s ease-out' }}
     >
       <div className={`w-full h-full bg-gradient-to-br from-yellow-300 via-yellow-500 to-yellow-700 rounded-full ${
         isMobile ? 'border-2' : 'border-3'
       } border-yellow-800 shadow-lg flex items-center justify-center relative hover:scale-110 transition-transform`}>
         <div className="absolute inset-1 bg-gradient-to-br from-yellow-200 to-yellow-400 rounded-full opacity-80"></div>
-        <span className={`text-yellow-900 font-bold ${
-          isMobile ? 'text-sm' : 'text-lg'
-        } relative z-10 drop-shadow-sm`}>₪</span>
-        <div className={`absolute top-1 ${
-          isMobile ? 'left-1 w-1 h-1' : 'left-2 w-2 h-2'
-        } bg-yellow-100 rounded-full opacity-90`}></div>
-        
-        {/* אפקט ברק */}
+        <span className={`text-yellow-900 font-bold ${isMobile ? 'text-sm' : 'text-lg'} relative z-10 drop-shadow-sm`}>₪</span>
+        <div className={`absolute top-1 ${isMobile ? 'left-1 w-1 h-1' : 'left-2 w-2 h-2'} bg-yellow-100 rounded-full opacity-90`}></div>
         <div className="absolute inset-0 bg-gradient-to-r from-transparent via-white to-transparent opacity-20 animate-pulse rounded-full"></div>
       </div>
     </div>

--- a/gamesformykids/app/games/tzedakah/components/CharityGameHeader.tsx
+++ b/gamesformykids/app/games/tzedakah/components/CharityGameHeader.tsx
@@ -1,17 +1,11 @@
+'use client';
+import { useShallow } from 'zustand/react/shallow';
+import { useTzedakahStore } from '../tzedakahStore';
 
-interface CharityGameHeaderProps {
-  score: number;
-  gameTime: number;
-  collectedCoins: number;
-  isMobile: boolean;
-}
+export default function CharityGameHeader() {
+  const { score, gameTime, collectedCoins, isMobile } =
+    useTzedakahStore(useShallow((s) => s));
 
-export default function CharityGameHeader({ 
-  score, 
-  gameTime, 
-  collectedCoins, 
-  isMobile 
-}: CharityGameHeaderProps) {
   return (
     <>
       {/* כותרת מעוצבת */}
@@ -54,30 +48,18 @@ export default function CharityGameHeader({
         }`}>
           <div className={`flex items-center justify-center ${isMobile ? 'gap-4' : 'gap-8'}`}>
             <div className="text-center">
-              <div className={`font-bold text-blue-600 mb-1 ${isMobile ? 'text-2xl' : 'text-3xl'}`}>
-                {score}
-              </div>
-              <div className={`font-semibold text-gray-600 ${isMobile ? 'text-xs' : 'text-sm'}`}>
-                💰 ניקוד
-              </div>
+              <div className={`font-bold text-blue-600 mb-1 ${isMobile ? 'text-2xl' : 'text-3xl'}`}>{score}</div>
+              <div className={`font-semibold text-gray-600 ${isMobile ? 'text-xs' : 'text-sm'}`}>💰 ניקוד</div>
             </div>
             <div className={`bg-gray-300 ${isMobile ? 'w-px h-8' : 'w-px h-12'}`}></div>
             <div className="text-center">
-              <div className={`font-bold text-red-500 mb-1 ${isMobile ? 'text-2xl' : 'text-3xl'}`}>
-                {gameTime}
-              </div>
-              <div className={`font-semibold text-gray-600 ${isMobile ? 'text-xs' : 'text-sm'}`}>
-                ⏰ זמן
-              </div>
+              <div className={`font-bold text-red-500 mb-1 ${isMobile ? 'text-2xl' : 'text-3xl'}`}>{gameTime}</div>
+              <div className={`font-semibold text-gray-600 ${isMobile ? 'text-xs' : 'text-sm'}`}>⏰ זמן</div>
             </div>
             <div className={`bg-gray-300 ${isMobile ? 'w-px h-8' : 'w-px h-12'}`}></div>
             <div className="text-center">
-              <div className={`font-bold text-green-600 mb-1 ${isMobile ? 'text-2xl' : 'text-3xl'}`}>
-                {collectedCoins}
-              </div>
-              <div className={`font-semibold text-gray-600 ${isMobile ? 'text-xs' : 'text-sm'}`}>
-                🪙 מטבעות
-              </div>
+              <div className={`font-bold text-green-600 mb-1 ${isMobile ? 'text-2xl' : 'text-3xl'}`}>{collectedCoins}</div>
+              <div className={`font-semibold text-gray-600 ${isMobile ? 'text-xs' : 'text-sm'}`}>🪙 מטבעות</div>
             </div>
           </div>
         </div>

--- a/gamesformykids/app/games/tzedakah/components/GameAreaBackground.tsx
+++ b/gamesformykids/app/games/tzedakah/components/GameAreaBackground.tsx
@@ -1,57 +1,46 @@
+'use client';
+import { useTzedakahStore } from '../tzedakahStore';
 
+export default function GameAreaBackground() {
+  const isMobile = useTzedakahStore((s) => s.isMobile);
 
-interface GameAreaBackgroundProps {
-  isMobile: boolean;
-}
-
-export default function GameAreaBackground({ isMobile }: GameAreaBackgroundProps) {
   return (
     <div className="absolute inset-0">
-      {/* עננים מעוצבים */}
+      {/* עננים */}
       <div className={`absolute ${isMobile ? 'top-4 left-6 w-12 h-8' : 'top-8 left-12 w-20 h-12'} bg-white rounded-full opacity-80 shadow-lg animate-pulse`}></div>
       <div className={`absolute ${isMobile ? 'top-8 right-8 w-14 h-9' : 'top-16 right-16 w-24 h-14'} bg-white rounded-full opacity-70 shadow-md animate-pulse`} style={{ animationDelay: '1s' }}></div>
       <div className={`absolute ${isMobile ? 'top-2 right-16 w-10 h-6' : 'top-4 right-32 w-16 h-10'} bg-white rounded-full opacity-60 shadow-sm animate-pulse`} style={{ animationDelay: '2s' }}></div>
       <div className={`absolute ${isMobile ? 'top-10 left-1/2 w-11 h-7' : 'top-20 left-1/2 w-18 h-11'} bg-white rounded-full opacity-75 shadow-md animate-pulse`} style={{ animationDelay: '0.5s' }}></div>
-      
-      {/* שמש מעוצבת */}
+
+      {/* שמש */}
       <div className={`absolute ${isMobile ? 'top-3 right-3 w-12 h-12' : 'top-6 right-6 w-16 h-16'} bg-gradient-to-br from-yellow-400 to-orange-500 rounded-full shadow-lg animate-spin`} style={{ animationDuration: '20s' }}>
         <div className={`absolute ${isMobile ? 'inset-1' : 'inset-2'} bg-gradient-to-br from-yellow-300 to-yellow-500 rounded-full`}>
           <div className="absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 text-orange-600">
             <span className={isMobile ? 'text-sm' : 'text-lg'}>☀️</span>
           </div>
         </div>
-        
-        {/* קרני שמש */}
         {[...Array(8)].map((_, i) => (
           <div
             key={i}
             className="absolute bg-yellow-300 opacity-60"
             style={{
-              width: '2px',
-              height: isMobile ? '8px' : '12px',
-              top: isMobile ? '-6px' : '-8px',
-              left: '50%',
+              width: '2px', height: isMobile ? '8px' : '12px',
+              top: isMobile ? '-6px' : '-8px', left: '50%',
               transformOrigin: `1px ${isMobile ? '18px' : '24px'}`,
-              transform: `translateX(-50%) rotate(${i * 45}deg)`
+              transform: `translateX(-50%) rotate(${i * 45}deg)`,
             }}
           />
         ))}
       </div>
 
-      {/* גרדיאנט רקע נוסף */}
       <div className="absolute inset-0 bg-gradient-to-b from-transparent via-sky-200/20 to-blue-300/30 pointer-events-none"></div>
-      
-      {/* כוכבים קטנים */}
+
+      {/* כוכבים */}
       {[...Array(6)].map((_, i) => (
         <div
           key={i}
           className="absolute text-yellow-300 opacity-70 animate-twinkle"
-          style={{
-            left: `${15 + i * 15}%`,
-            top: `${10 + (i % 2) * 20}%`,
-            animationDelay: `${i * 0.5}s`,
-            fontSize: isMobile ? '8px' : '12px'
-          }}
+          style={{ left: `${15 + i * 15}%`, top: `${10 + (i % 2) * 20}%`, animationDelay: `${i * 0.5}s`, fontSize: isMobile ? '8px' : '12px' }}
         >
           ✨
         </div>

--- a/gamesformykids/app/games/tzedakah/components/GameControls.tsx
+++ b/gamesformykids/app/games/tzedakah/components/GameControls.tsx
@@ -1,27 +1,16 @@
+'use client';
+import { useShallow } from 'zustand/react/shallow';
+import { useTzedakahStore } from '../tzedakahStore';
 
+export default function GameControls() {
+  const { gameStarted, gameTime, score, collectedCoins, isMobile, startGame } =
+    useTzedakahStore(useShallow((s) => s));
 
-interface GameControlsProps {
-  gameStarted: boolean;
-  gameTime: number;
-  score: number;
-  collectedCoins: number;
-  isMobile: boolean;
-  onStartGame: () => void;
-}
-
-export default function GameControls({
-  gameStarted,
-  gameTime,
-  score,
-  collectedCoins,
-  isMobile,
-  onStartGame,
-}: GameControlsProps) {
   return (
     <div className="flex justify-center mb-6">
       {!gameStarted && gameTime > 0 && (
         <button
-          onClick={onStartGame}
+          onClick={startGame}
           className={`bg-gradient-to-r from-green-500 to-emerald-600 hover:from-green-600 hover:to-emerald-700 text-white font-bold rounded-2xl shadow-2xl transform hover:scale-105 transition-all duration-300 border-2 border-green-300 ${
             isMobile ? 'py-3 px-6 text-lg' : 'py-4 px-8 text-2xl'
           }`}
@@ -44,10 +33,9 @@ export default function GameControls({
           <p className={`text-gray-600 mb-4 ${isMobile ? 'text-sm' : 'text-lg'}`}>
             תפסת <span className="font-bold text-green-600">{collectedCoins}</span> מטבעות! 🪙
           </p>
-          
           <div className="flex flex-col gap-3">
             <button
-              onClick={onStartGame}
+              onClick={startGame}
               className={`bg-gradient-to-r from-blue-500 to-purple-600 hover:from-blue-600 hover:to-purple-700 text-white font-bold rounded-xl transition-all duration-300 transform hover:scale-105 shadow-lg ${
                 isMobile ? 'py-2 px-4 text-sm' : 'py-3 px-6'
               }`}

--- a/gamesformykids/app/games/tzedakah/components/TzedakahGameInstructions.tsx
+++ b/gamesformykids/app/games/tzedakah/components/TzedakahGameInstructions.tsx
@@ -1,11 +1,10 @@
+'use client';
+import { useTzedakahStore } from '../tzedakahStore';
 
+export default function TzedakahGameInstructions() {
+  const gameStarted = useTzedakahStore((s) => s.gameStarted);
+  const isMobile    = useTzedakahStore((s) => s.isMobile);
 
-interface GameInstructionsProps {
-  gameStarted: boolean;
-  isMobile: boolean;
-}
-
-export default function GameInstructions({ gameStarted, isMobile }: GameInstructionsProps) {
   if (!gameStarted) return null;
 
   return (
@@ -14,9 +13,7 @@ export default function GameInstructions({ gameStarted, isMobile }: GameInstruct
     }`}>
       <div className="flex items-center gap-2 mb-2">
         <span className={isMobile ? 'text-lg' : 'text-2xl'}>🎯</span>
-        <div className={`font-bold text-purple-800 ${isMobile ? 'text-sm' : 'text-base'}`}>
-          הוראות:
-        </div>
+        <div className={`font-bold text-purple-800 ${isMobile ? 'text-sm' : 'text-base'}`}>הוראות:</div>
       </div>
       <div className={`text-gray-700 ${isMobile ? 'text-xs' : 'text-sm'}`}>
         {isMobile ? 'גע והזז את האצבע לתפיסת מטבעות!' : 'הזז את העכבר כדי לתפוס מטבעות!'}
@@ -25,8 +22,6 @@ export default function GameInstructions({ gameStarted, isMobile }: GameInstruct
         <span>🪙</span>
         <span>כל מטבע = 10 נקודות</span>
       </div>
-      
-      {/* אינדיקטור כיוון */}
       <div className="flex items-center justify-center mt-2">
         <div className="animate-bounce">
           <span className={isMobile ? 'text-sm' : 'text-base'}>👆</span>

--- a/gamesformykids/app/games/tzedakah/tzedakahStore.ts
+++ b/gamesformykids/app/games/tzedakah/tzedakahStore.ts
@@ -1,0 +1,128 @@
+import { makeStore } from '@/lib/stores/createStore';
+
+// ── Types ──────────────────────────────────────────────────────────────────
+
+export interface Coin {
+  id:       number;
+  x:        number;
+  y:        number;
+  speed:    number;
+  rotation: number;
+}
+
+function getDims(isMobile: boolean) {
+  return {
+    gameWidth:    isMobile ? 350 : 800,
+    gameHeight:   isMobile ? 450 : 600,
+    basketWidth:  isMobile ? 80  : 120,
+    basketHeight: isMobile ? 50  : 70,
+  };
+}
+
+// ── Store ──────────────────────────────────────────────────────────────────
+
+interface TzedakahState {
+  coins:          Coin[];
+  score:          number;
+  gameStarted:    boolean;
+  basketX:        number;
+  gameTime:       number;
+  collectedCoins: number;
+  isMobile:       boolean;
+  gameWidth:      number;
+  gameHeight:     number;
+  basketWidth:    number;
+  basketHeight:   number;
+}
+
+interface TzedakahActions {
+  startGame:   () => void;
+  moveBasket:  (rawX: number) => void;
+  stepBasket:  (dir: -1 | 1) => void;
+  setIsMobile: (v: boolean) => void;
+}
+
+const INITIAL: TzedakahState = {
+  coins: [], score: 0, gameStarted: false, basketX: 400, gameTime: 60,
+  collectedCoins: 0, isMobile: false, ...getDims(false),
+};
+
+export const useTzedakahStore = makeStore<TzedakahState & TzedakahActions>(
+  'TzedakahStore',
+  (set, get) => {
+    let coinId  = 0;
+    let moveId:  ReturnType<typeof setInterval> | null = null;
+    let spawnId: ReturnType<typeof setInterval> | null = null;
+    let timerId: ReturnType<typeof setInterval> | null = null;
+
+    function stopAll() {
+      if (moveId)  { clearInterval(moveId);  moveId  = null; }
+      if (spawnId) { clearInterval(spawnId); spawnId = null; }
+      if (timerId) { clearInterval(timerId); timerId = null; }
+    }
+
+    function tickCoins() {
+      const { isMobile, coins, basketX, gameHeight, basketWidth, basketHeight, score, collectedCoins } = get();
+      const coinSize = isMobile ? 32 : 48;
+      let s = score, c = collectedCoins;
+      const updated = coins
+        .map(coin => ({ ...coin, y: coin.y + coin.speed, rotation: coin.rotation + 5 }))
+        .filter(coin => {
+          if (
+            coin.y + coinSize >= gameHeight - basketHeight &&
+            coin.y + coinSize <= gameHeight    &&
+            coin.x + coinSize >= basketX       &&
+            coin.x            <= basketX + basketWidth
+          ) { s += 10; c += 1; return false; }
+          return coin.y < gameHeight + coinSize;
+        });
+      set({ coins: updated, score: s, collectedCoins: c }, false, 'tzedakah/tick');
+    }
+
+    function spawnCoin() {
+      const { isMobile, gameWidth, coins } = get();
+      const coinSize = isMobile ? 32 : 48;
+      set({
+        coins: [...coins, {
+          id: coinId++, x: Math.random() * (gameWidth - coinSize),
+          y: -coinSize, speed: 2 + Math.random() * 3, rotation: 0,
+        }],
+      }, false, 'tzedakah/spawn');
+    }
+
+    return {
+      ...INITIAL,
+
+      setIsMobile: (v: boolean) => set({ isMobile: v, ...getDims(v) }, false, 'tzedakah/resize'),
+
+      moveBasket: (rawX: number) => {
+        const { gameStarted, gameWidth, basketWidth } = get();
+        if (!gameStarted) return;
+        set({ basketX: Math.max(0, Math.min(gameWidth - basketWidth, rawX)) }, false, 'tzedakah/moveBasket');
+      },
+
+      stepBasket: (dir: -1 | 1) => {
+        const { gameStarted, basketX, gameWidth, basketWidth } = get();
+        if (!gameStarted) return;
+        set({ basketX: Math.max(0, Math.min(gameWidth - basketWidth, basketX + dir * 20)) }, false, 'tzedakah/stepBasket');
+      },
+
+      startGame: () => {
+        stopAll();
+        coinId = 0;
+        const { isMobile } = get();
+        set({
+          coins: [], score: 0, gameStarted: true, gameTime: 60, collectedCoins: 0,
+          basketX: isMobile ? 135 : 340, ...getDims(isMobile),
+        }, false, 'tzedakah/start');
+        moveId  = setInterval(tickCoins, 16);
+        spawnId = setInterval(spawnCoin, 800);
+        timerId = setInterval(() => {
+          const t = get().gameTime;
+          if (t <= 1) { stopAll(); set({ gameTime: 0, gameStarted: false }, false, 'tzedakah/end'); }
+          else        { set({ gameTime: t - 1 }, false, 'tzedakah/timerTick'); }
+        }, 1000);
+      },
+    };
+  },
+);

--- a/gamesformykids/app/games/tzedakah/useCharityCoinGame.ts
+++ b/gamesformykids/app/games/tzedakah/useCharityCoinGame.ts
@@ -1,182 +1,50 @@
 'use client';
-
-import { useState, useEffect, useCallback } from 'react';
+import { useEffect } from 'react';
+import { useShallow } from 'zustand/react/shallow';
+import { useTzedakahStore } from './tzedakahStore';
 import { GamesRegistry } from '@/lib/registry/gamesRegistry';
 import { useRouter } from 'next/navigation';
 
-export interface Coin {
-  id: number;
-  x: number;
-  y: number;
-  speed: number;
-  rotation: number;
-}
+export type { Coin } from './tzedakahStore';
 
 export function useCharityCoinGame() {
-  const [coins, setCoins] = useState<Coin[]>([]);
-  const [score, setScore] = useState(0);
-  const [gameStarted, setGameStarted] = useState(false);
-  const [basketX, setBasketX] = useState(400);
-  const [gameTime, setGameTime] = useState(60);
-  const [coinId, setCoinId] = useState(0);
-  const [collectedCoins, setCollectedCoins] = useState(0);
-  const [isMobile, setIsMobile] = useState(false);
+  const { isMobile, gameWidth, gameHeight, basketWidth, gameStarted, moveBasket, stepBasket, setIsMobile } =
+    useTzedakahStore(useShallow((s) => s));
 
   const router = useRouter();
 
-  // זיהוי גדלי מסך
   useEffect(() => {
-    const checkMobile = () => setIsMobile(window.innerWidth <= 768);
-    checkMobile();
-    window.addEventListener('resize', checkMobile);
-    return () => window.removeEventListener('resize', checkMobile);
-  }, []);
+    const check = () => setIsMobile(window.innerWidth <= 768);
+    check();
+    window.addEventListener('resize', check);
+    return () => window.removeEventListener('resize', check);
+  }, [setIsMobile]);
 
-  const gameWidth = isMobile ? 350 : 800;
-  const gameHeight = isMobile ? 450 : 600;
-  const basketWidth = isMobile ? 80 : 120;
-  const basketHeight = isMobile ? 50 : 70;
-
-  // מציאת המשחק הבא
-  const availableGames = GamesRegistry.getAllGameRegistrations()
-    .filter(game => game.available)
-    .sort((a, b) => a.order - b.order);
-  const currentIndex = availableGames.findIndex(game => game.id === 'tzedakah');
-  const nextGame =
-    currentIndex < availableGames.length - 1
-      ? availableGames[currentIndex + 1]
-      : availableGames[0];
-
-  // יצירת מטבע חדש
-  const createCoin = useCallback(() => {
-    if (!gameStarted || gameTime <= 0) return;
-    const coinSize = isMobile ? 32 : 48;
-    const newCoin: Coin = {
-      id: coinId,
-      x: Math.random() * (gameWidth - coinSize),
-      y: -coinSize,
-      speed: 2 + Math.random() * 3,
-      rotation: 0,
-    };
-    setCoins(prev => [...prev, newCoin]);
-    setCoinId(prev => prev + 1);
-  }, [gameStarted, gameTime, coinId, gameWidth, isMobile]);
-
-  // עדכון מיקום מטבעות
-  useEffect(() => {
-    if (!gameStarted) return;
-    const interval = setInterval(() => {
-      const coinSize = isMobile ? 32 : 48;
-      setCoins(prev =>
-        prev
-          .map(coin => ({
-            ...coin,
-            y: coin.y + coin.speed,
-            rotation: coin.rotation + 5,
-          }))
-          .filter(coin => coin.y < gameHeight + coinSize)
-      );
-    }, 16);
-    return () => clearInterval(interval);
-  }, [gameStarted, gameHeight, isMobile]);
-
-  // יצירת מטבעות חדשים
-  useEffect(() => {
-    if (!gameStarted) return;
-    const interval = setInterval(createCoin, 800);
-    return () => clearInterval(interval);
-  }, [createCoin, gameStarted]);
-
-  // ספירה לאחור
-  useEffect(() => {
-    if (!gameStarted || gameTime <= 0) return;
-    const timer = setTimeout(() => setGameTime(prev => prev - 1), 1000);
-    return () => clearTimeout(timer);
-  }, [gameStarted, gameTime]);
-
-  // סיום משחק
-  useEffect(() => {
-    if (gameTime <= 0 && gameStarted) setGameStarted(false);
-  }, [gameTime, gameStarted]);
-
-  // מקשי חצים
   useEffect(() => {
     if (!gameStarted || isMobile) return;
-    const handleKeyPress = (e: KeyboardEvent) => {
-      if (e.key === 'ArrowLeft') {
-        e.preventDefault();
-        setBasketX(prev => Math.max(0, prev - 20));
-      } else if (e.key === 'ArrowRight') {
-        e.preventDefault();
-        setBasketX(prev => Math.min(gameWidth - basketWidth, prev + 20));
-      }
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'ArrowLeft')  { e.preventDefault(); stepBasket(-1); }
+      if (e.key === 'ArrowRight') { e.preventDefault(); stepBasket(1); }
     };
-    window.addEventListener('keydown', handleKeyPress);
-    return () => window.removeEventListener('keydown', handleKeyPress);
-  }, [gameStarted, isMobile, gameWidth, basketWidth]);
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [gameStarted, isMobile, stepBasket]);
 
-  // בדיקת התנגשות
-  useEffect(() => {
-    const coinSize = isMobile ? 32 : 48;
-    coins.forEach(coin => {
-      if (
-        coin.y + coinSize >= gameHeight - basketHeight &&
-        coin.y + coinSize <= gameHeight &&
-        coin.x + coinSize >= basketX &&
-        coin.x <= basketX + basketWidth
-      ) {
-        setScore(prev => prev + 10);
-        setCollectedCoins(prev => prev + 1);
-        setCoins(prev => prev.filter(c => c.id !== coin.id));
-      }
-    });
-  }, [coins, basketX, basketWidth, basketHeight, gameHeight, isMobile]);
+  const availableGames = GamesRegistry.getAllGameRegistrations()
+    .filter(g => g.available).sort((a, b) => a.order - b.order);
+  const idx      = availableGames.findIndex(g => g.id === 'tzedakah');
+  const nextGame = idx < availableGames.length - 1 ? availableGames[idx + 1] : availableGames[0];
 
-  // התחלת משחק חדש
-  const startGame = () => {
-    setGameStarted(true);
-    setScore(0);
-    setGameTime(60);
-    setCoins([]);
-    setCoinId(0);
-    setBasketX(isMobile ? 135 : 340);
-    setCollectedCoins(0);
-  };
-
-  // תנועת עכבר
   const handleMouseMove = (e: React.MouseEvent) => {
-    if (!gameStarted) return;
     const rect = e.currentTarget.getBoundingClientRect();
-    const mouseX = e.clientX - rect.left;
-    setBasketX(Math.max(0, Math.min(gameWidth - basketWidth, mouseX - basketWidth / 2)));
+    moveBasket(e.clientX - rect.left - basketWidth / 2);
   };
 
-  // תנועת מגע
   const handleTouchMove = (e: React.TouchEvent) => {
-    if (!gameStarted) return;
     e.preventDefault();
     const rect = e.currentTarget.getBoundingClientRect();
-    const touch = e.touches[0];
-    const touchX = touch.clientX - rect.left;
-    setBasketX(Math.max(0, Math.min(gameWidth - basketWidth, touchX - basketWidth / 2)));
+    moveBasket(e.touches[0].clientX - rect.left - basketWidth / 2);
   };
 
-  return {
-    coins,
-    score,
-    gameStarted,
-    basketX,
-    gameTime,
-    collectedCoins,
-    isMobile,
-    gameWidth,
-    gameHeight,
-    basketWidth,
-    basketHeight,
-    nextGame,
-    startGame,
-    handleMouseMove,
-    handleTouchMove,
-    router,
-  };
+  return { isMobile, gameWidth, gameHeight, handleMouseMove, handleTouchMove, nextGame, router };
 }


### PR DESCRIPTION
## Summary
- Creates `tzedakahStore.ts` — all game state and timers live in the Zustand store closure:
  - 16ms coin-tick interval (movement + collision detection integrated into one pass)
  - 800ms coin-spawn interval
  - 1s countdown timer
- Eliminates all 14 props across 5 components — each subscribes to `useTzedakahStore` directly
- `useCharityCoinGame.ts` keeps only what needs React lifecycle: window resize listener, keyboard listener, mouse/touch event handlers, `nextGame`/`router`
- `CharityCoinGame.tsx` reduced to layout container + event wiring — zero state props passed to children
- `CharityCoin` keeps its `coin` prop (per-item in a list); drops `isMobile` (reads from store)

## Test plan
- [ ] Game starts when pressing the button
- [ ] Coins fall and rotate
- [ ] Basket follows mouse / touch
- [ ] Arrow keys move basket (desktop)
- [ ] Catching a coin increments score by 10
- [ ] Timer counts down from 60 and game ends at 0
- [ ] "שחק שוב" resets and starts a new round
- [ ] Mobile layout works (smaller dimensions)

Closes #199

🤖 Generated with [Claude Code](https://claude.com/claude-code)