### PR TITLE
refactor: extract setupGameTimer helper for countdown games (#190)

### DIFF
--- a/gamesformykids/app/games/reflex/reflexStore.ts
+++ b/gamesformykids/app/games/reflex/reflexStore.ts
@@ -1,4 +1,5 @@
 import { makeStore } from '@/lib/stores/createStore';
+import { setupGameTimer } from '@/lib/stores/gameTimerHelpers';
 import type { PhaseResult as Phase } from '@/lib/types';
 import { TARGET_EMOJIS, GAME_DURATION, type Target, getLifetime, getSpawnInterval } from './data/targets';
 
@@ -26,13 +27,21 @@ const INITIAL: ReflexState = {
 export const useReflexStore = makeStore<ReflexState & ReflexActions>(
   'ReflexStore',
   (set, get) => {
-    let nextId:  number = 0;
-    let spawnId: ReturnType<typeof setTimeout>  | null = null;
-    let tickId:  ReturnType<typeof setInterval> | null = null;
+    let nextId  = 0;
+    let spawnId: ReturnType<typeof setTimeout> | null = null;
+
+    const timer = setupGameTimer({
+      name: 'reflex',
+      set, get,
+      onEnd: () => {
+        if (spawnId) { clearTimeout(spawnId); spawnId = null; }
+        set({ timeLeft: 0, phase: 'result' }, false, 'reflex/gameOver');
+      },
+    });
 
     function clearTimers() {
-      if (spawnId) { clearTimeout(spawnId);  spawnId = null; }
-      if (tickId)  { clearInterval(tickId);  tickId  = null; }
+      timer.stop();
+      if (spawnId) { clearTimeout(spawnId); spawnId = null; }
     }
 
     function spawnTarget() {
@@ -58,18 +67,6 @@ export const useReflexStore = makeStore<ReflexState & ReflexActions>(
       spawnId = setTimeout(spawnTarget, getSpawnInterval(get().score));
     }
 
-    function startTick() {
-      tickId = setInterval(() => {
-        const { timeLeft } = get();
-        if (timeLeft <= 1) {
-          clearTimers();
-          set({ timeLeft: 0, phase: 'result' }, false, 'reflex/gameOver');
-        } else {
-          set({ timeLeft: timeLeft - 1 }, false, 'reflex/tick');
-        }
-      }, 1000);
-    }
-
     return {
       ...INITIAL,
 
@@ -78,7 +75,7 @@ export const useReflexStore = makeStore<ReflexState & ReflexActions>(
         nextId = 0;
         set({ ...INITIAL, phase: 'playing' }, false, 'reflex/startGame');
         spawnId = setTimeout(spawnTarget, 600);
-        startTick();
+        timer.start();
       },
 
       hitTarget: (id: number) => {

--- a/gamesformykids/app/games/whack-a-mole/whackAMoleStore.ts
+++ b/gamesformykids/app/games/whack-a-mole/whackAMoleStore.ts
@@ -1,4 +1,5 @@
 import { makeStore } from '@/lib/stores/createStore';
+import { setupGameTimer } from '@/lib/stores/gameTimerHelpers';
 import type { PhaseResult as Phase } from '@/lib/types';
 
 // ── Constants ──────────────────────────────────────────────────────────────
@@ -39,12 +40,22 @@ function freshState(best = 0): WhackAMoleState {
 export const useWhackAMoleStore = makeStore<WhackAMoleState & WhackAMoleActions>(
   'WhackAMoleStore',
   (set, get) => {
-    let timerRef:     ReturnType<typeof setInterval> | null = null;
     let moleSpawnRef: ReturnType<typeof setTimeout>  | null = null;
     const moleTimers: (ReturnType<typeof setTimeout> | null)[] = Array(GRID).fill(null);
 
+    const timer = setupGameTimer({
+      name: 'whack',
+      set, get,
+      onEnd: () => {
+        if (moleSpawnRef) { clearTimeout(moleSpawnRef); moleSpawnRef = null; }
+        moleTimers.forEach((t, i) => { if (t) { clearTimeout(t); moleTimers[i] = null; } });
+        const { score, best } = get();
+        set({ timeLeft: 0, phase: 'result', best: Math.max(best, score) }, false, 'whack/gameOver');
+      },
+    });
+
     function clearAllTimers() {
-      if (timerRef)     { clearInterval(timerRef);    timerRef     = null; }
+      timer.stop();
       if (moleSpawnRef) { clearTimeout(moleSpawnRef); moleSpawnRef = null; }
       moleTimers.forEach((t, i) => { if (t) { clearTimeout(t); moleTimers[i] = null; } });
     }
@@ -90,17 +101,7 @@ export const useWhackAMoleStore = makeStore<WhackAMoleState & WhackAMoleActions>
       startGame: () => {
         clearAllTimers();
         set({ ...freshState(get().best), phase: 'playing' }, false, 'whack/startGame');
-
-        timerRef = setInterval(() => {
-          const { timeLeft, score, best } = get();
-          if (timeLeft <= 1) {
-            clearAllTimers();
-            set({ timeLeft: 0, phase: 'result', best: Math.max(best, score) }, false, 'whack/gameOver');
-          } else {
-            set({ timeLeft: timeLeft - 1 }, false, 'whack/tick');
-          }
-        }, 1000);
-
+        timer.start();
         moleSpawnRef = setTimeout(spawnMole, 400);
       },
 

--- a/gamesformykids/lib/stores/gameTimerHelpers.ts
+++ b/gamesformykids/lib/stores/gameTimerHelpers.ts
@@ -1,0 +1,44 @@
+/**
+ * Shared countdown timer for fixed-duration games (whack-a-mole, reflex, …).
+ *
+ * Manages its own interval ID.  Call `start()` when the game begins and
+ * `stop()` when cleaning up (startGame reset, page unmount, etc.).
+ * When time reaches 0 the interval self-stops and fires `onEnd` — put
+ * game-over state updates and any remaining timer cleanup there.
+ */
+
+type TimerSet = (partial: Record<string, unknown>, replace?: false, label?: string) => void;
+type TimerGet = () => { timeLeft: number };
+
+export interface GameTimerConfig {
+  name:  string;   // used as devtools action prefix
+  set:   TimerSet;
+  get:   TimerGet;
+  onEnd: () => void;
+}
+
+export function setupGameTimer({ name, set, get, onEnd }: GameTimerConfig): {
+  start: () => void;
+  stop:  () => void;
+} {
+  let id: ReturnType<typeof setInterval> | null = null;
+
+  function stop() {
+    if (id) { clearInterval(id); id = null; }
+  }
+
+  function start() {
+    stop();
+    id = setInterval(() => {
+      const t = get().timeLeft;
+      if (t <= 1) {
+        stop();
+        onEnd();
+      } else {
+        set({ timeLeft: t - 1 }, false, `${name}/tick`);
+      }
+    }, 1000);
+  }
+
+  return { start, stop };
+}


### PR DESCRIPTION
## Summary
- Adds `lib/stores/gameTimerHelpers.ts` with `setupGameTimer()` — mirrors the existing `setupLivesTimer` pattern
- `whackAMoleStore.ts`: drops manual `timerRef` + inline `setInterval` (7 lines → `timer.start()` / `timer.stop()`)
- `reflexStore.ts`: drops `tickId` + `startTick()` function (9 lines → `timer.start()` / `timer.stop()`)
- Future countdown games call `setupGameTimer` instead of duplicating the pattern

## API
```ts
const timer = setupGameTimer({ name, set, get, onEnd });
timer.start();  // begins 1s countdown using get().timeLeft
timer.stop();   // clears the interval (call in startGame reset and cleanup)
// onEnd() fires when timeLeft reaches 0 — put game-over state + cleanup there
```

Closes #190

🤖 Generated with [Claude Code](https://claude.com/claude-code)