### PR TITLE
fix(memory): show win/timeout result screens exclusively, add play-again/menu buttons

### DIFF
--- a/gamesformykids/app/games/memory/MemoryClient.tsx
+++ b/gamesformykids/app/games/memory/MemoryClient.tsx
@@ -1,23 +1,28 @@
 'use client';
 
+import { useShallow } from 'zustand/react/shallow';
 import MemoryGameHeader from './components/MemoryGameHeader';
 import GameWinMessage from './components/GameWinMessage';
+import GameTimeoutScreen from './components/GameTimeoutScreen';
 import MemoryGameBoard from './components/MemoryGameBoard';
 import MemoryStartScreen from './components/MemoryStartScreen';
 import { useMemoryGameContent } from './useMemoryGameContent';
+import { useMemoryStore } from './stores/useMemoryStore';
 
 export default function MemoryClient() {
-  const { gameStarted, isGameWon } = useMemoryGameContent();
+  useMemoryGameContent();
+  const { gameStarted, isGameWon, isCompleted } = useMemoryStore(
+    useShallow((s) => ({ gameStarted: s.gameStarted, isGameWon: s.isGameWon, isCompleted: s.isCompleted })),
+  );
 
-  if (!gameStarted) {
-    return <MemoryStartScreen />;
-  }
+  if (!gameStarted) return <MemoryStartScreen />;
+  if (isGameWon)    return <GameWinMessage />;
+  if (isCompleted)  return <GameTimeoutScreen />;
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-pink-100 via-purple-100 to-indigo-200 p-4">
       <div className="max-w-4xl mx-auto">
         <MemoryGameHeader />
-        {isGameWon && <GameWinMessage />}
         <MemoryGameBoard />
       </div>
     </div>

--- a/gamesformykids/app/games/memory/components/GameTimeoutScreen.tsx
+++ b/gamesformykids/app/games/memory/components/GameTimeoutScreen.tsx
@@ -1,0 +1,38 @@
+'use client';
+
+import { useMemoryStore } from "../stores/useMemoryStore";
+
+export default function GameTimeoutScreen() {
+  const { gameStats, difficulty, getDifficultyConfig, initializeGame, resetToMenu } = useMemoryStore();
+  const difficultyConfig = getDifficultyConfig();
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-pink-100 via-purple-100 to-indigo-200 p-4 flex items-center justify-center">
+      <div className="max-w-md w-full mx-auto text-center p-8 bg-white/80 rounded-3xl shadow-xl">
+        <div className="text-6xl mb-4">⏰</div>
+        <h2 className="text-4xl font-bold text-purple-800 mb-2">נגמר הזמן!</h2>
+        <p className="text-xl text-purple-600 mb-6">
+          ברמת <span className="font-bold">{difficultyConfig.name}</span>
+        </p>
+        <div className="bg-purple-100 rounded-xl p-4 mb-8">
+          <div className="text-3xl font-bold text-purple-700">{gameStats.score} נקודות</div>
+          <div className="text-gray-600 mt-1">זוגות שנמצאו: {gameStats.matches}</div>
+        </div>
+        <div className="flex gap-4 justify-center flex-wrap">
+          <button
+            onClick={() => initializeGame(difficulty)}
+            className="bg-gradient-to-r from-purple-500 to-pink-500 hover:from-purple-600 hover:to-pink-600 text-white font-bold py-3 px-8 rounded-full text-xl transition-all duration-300 transform hover:scale-105 shadow-lg"
+          >
+            🎮 נסה שוב
+          </button>
+          <button
+            onClick={resetToMenu}
+            className="bg-white/80 hover:bg-white text-gray-700 font-bold py-3 px-8 rounded-full text-xl transition-all duration-300 transform hover:scale-105 shadow-lg border border-gray-200"
+          >
+            🏠 תפריט
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/gamesformykids/app/games/memory/components/GameWinMessage.tsx
+++ b/gamesformykids/app/games/memory/components/GameWinMessage.tsx
@@ -1,32 +1,53 @@
+'use client';
+
 import { useMemoryStore } from "../stores/useMemoryStore";
 import WinStatsGrid from "./WinStatsGrid";
 import WinAchievements from "./WinAchievements";
 
 export default function GameWinMessage() {
-  const { gameStats, getDifficultyConfig, getPerformanceLevel } = useMemoryStore();
+  const { gameStats, difficulty, getDifficultyConfig, getPerformanceLevel, initializeGame, resetToMenu } = useMemoryStore();
   const difficultyConfig = getDifficultyConfig();
   const performance = getPerformanceLevel();
 
   return (
-    <div className="text-center mb-8 p-8 bg-gradient-to-r from-yellow-200 via-orange-200 to-pink-200 rounded-3xl shadow-xl animate-bounce-gentle">
-      <div className="mb-6">
-        <h2 className="text-5xl font-bold text-orange-800 mb-2">🎉 {performance.level} 🎉</h2>
-        <p className="text-2xl text-orange-700 mb-2">
-          סיימת ברמת <span className="font-bold">{difficultyConfig.name}</span>!
-        </p>
-        <p className="text-lg text-orange-600 mb-2">{performance.timeComment}</p>
-        <div className={`text-4xl ${performance.color} font-bold`}>
-          {performance.emoji} {gameStats.score} נקודות
+    <div className="min-h-screen bg-gradient-to-br from-pink-100 via-purple-100 to-indigo-200 p-4 flex items-center justify-center">
+      <div className="max-w-2xl w-full mx-auto">
+        <div className="text-center p-8 bg-gradient-to-r from-yellow-200 via-orange-200 to-pink-200 rounded-3xl shadow-xl animate-bounce-gentle">
+          <div className="mb-6">
+            <h2 className="text-5xl font-bold text-orange-800 mb-2">🎉 {performance.level} 🎉</h2>
+            <p className="text-2xl text-orange-700 mb-2">
+              סיימת ברמת <span className="font-bold">{difficultyConfig.name}</span>!
+            </p>
+            <p className="text-lg text-orange-600 mb-2">{performance.timeComment}</p>
+            <div className={`text-4xl ${performance.color} font-bold`}>
+              {performance.emoji} {gameStats.score} נקודות
+            </div>
+          </div>
+
+          <WinStatsGrid />
+          <WinAchievements />
+
+          <div className="bg-white/80 rounded-xl p-6 shadow-lg mb-6">
+            <div className="text-3xl mb-2">🌟</div>
+            <h3 className="text-xl font-bold text-gray-800 mb-2">כל הכבוד!</h3>
+            <p className="text-gray-600">זיכרון מעולה! אתה מוכן לאתגר הבא?</p>
+          </div>
+
+          <div className="flex gap-4 justify-center flex-wrap">
+            <button
+              onClick={() => initializeGame(difficulty)}
+              className="bg-gradient-to-r from-purple-500 to-pink-500 hover:from-purple-600 hover:to-pink-600 text-white font-bold py-3 px-8 rounded-full text-xl transition-all duration-300 transform hover:scale-105 shadow-lg"
+            >
+              🎮 שחק שוב
+            </button>
+            <button
+              onClick={resetToMenu}
+              className="bg-white/80 hover:bg-white text-gray-700 font-bold py-3 px-8 rounded-full text-xl transition-all duration-300 transform hover:scale-105 shadow-lg"
+            >
+              🏠 תפריט
+            </button>
+          </div>
         </div>
-      </div>
-
-      <WinStatsGrid />
-      <WinAchievements />
-
-      <div className="bg-white/80 rounded-xl p-6 shadow-lg">
-        <div className="text-3xl mb-2">🌟</div>
-        <h3 className="text-xl font-bold text-gray-800 mb-2">כל הכבוד!</h3>
-        <p className="text-gray-600">זיכרון מעולה! אתה מוכן לאתגר הבא?</p>
       </div>
     </div>
   );


### PR DESCRIPTION
Closes #212

## Problem

When finishing the memory game the layout was broken in two ways:

1. **Win state** — `MemoryClient` rendered `<GameWinMessage />` stacked on top of `<MemoryGameBoard />`, so the full board of matched cards was visible below the celebration. No action buttons existed.
2. **Timeout state** — when time ran out (`isCompleted=true, isGameWon=false`), the normal play layout showed with no game-over indication at all.

## Changes

| File | What changed |
|------|-------------|
| `MemoryClient.tsx` | Phase routing: `!gameStarted → menu \| isGameWon → win \| isCompleted → timeout \| else → play`. Calls `useMemoryGameContent()` for side-effects only; reads phase state directly from store. |
| `GameWinMessage.tsx` | Added `'use client'`, wrapped in full-page layout (no board beneath), added **שחק שוב** and **תפריט** action buttons. |
| `GameTimeoutScreen.tsx` | New component — shows "נגמר הזמן!" with score, pairs found, and the same two action buttons. |

## Test plan

- [ ] Play a game to completion (match all pairs) — see win screen only, no board
- [ ] Click "שחק שוב" — new game starts at same difficulty
- [ ] Click "תפריט" — returns to start screen
- [ ] Let the timer expire — see timeout screen with score
- [ ] Click "נסה שוב" on timeout screen — new game starts

🤖 Generated with [Claude Code](https://claude.com/claude-code)