### PR TITLE
refactor(damka): eliminate props drilling — components subscribe to store directly (#208)

### DIFF
--- a/gamesformykids/app/games/checkers/DamkaGame.tsx
+++ b/gamesformykids/app/games/checkers/DamkaGame.tsx
@@ -1,50 +1,22 @@
 'use client';
 
-import { useDamkaGame } from './useDamkaGame';
+import { useDamkaStore } from './damkaStore';
 import { DamkaMenuScreen, DamkaResultScreen, DamkaBoard, DamkaScoreBar } from './components';
 
 export default function DamkaGame() {
-  const { phase, board, selected, validMoves, currentTurn, playerScore, computerScore, message, startGame, selectCell } = useDamkaGame();
-
-  const playerPieces = board.flat().filter(c => c.color === 'player').length;
-  const compPieces   = board.flat().filter(c => c.color === 'computer').length;
+  const phase = useDamkaStore((s) => s.phase);
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-amber-900 via-amber-950 to-stone-950 flex flex-col items-center justify-center p-4 select-none" dir="rtl">
 
-      {phase === 'menu' && (
-        <DamkaMenuScreen
-          playerScore={playerScore}
-          computerScore={computerScore}
-          onStart={startGame}
-        />
-      )}
+      {phase === 'menu' && <DamkaMenuScreen />}
 
-      {(phase === 'won' || phase === 'lost') && (
-        <DamkaResultScreen
-          phase={phase}
-          playerScore={playerScore}
-          computerScore={computerScore}
-          onRestart={startGame}
-        />
-      )}
+      {(phase === 'won' || phase === 'lost') && <DamkaResultScreen />}
 
       {phase === 'playing' && (
         <div className="flex flex-col items-center gap-3 w-full max-w-sm">
-          <DamkaScoreBar
-            playerPieces={playerPieces}
-            compPieces={compPieces}
-            playerScore={playerScore}
-            computerScore={computerScore}
-            currentTurn={currentTurn}
-            message={message}
-          />
-          <DamkaBoard
-            board={board}
-            selected={selected}
-            validMoves={validMoves}
-            onCellClick={selectCell}
-          />
+          <DamkaScoreBar />
+          <DamkaBoard />
         </div>
       )}
     </div>

--- a/gamesformykids/app/games/checkers/components/DamkaBoard.tsx
+++ b/gamesformykids/app/games/checkers/components/DamkaBoard.tsx
@@ -1,17 +1,15 @@
 'use client';
 
-import type { Board, Pos, DamkaMove } from '../useDamkaGame';
+import { useShallow } from 'zustand/react/shallow';
+import { useDamkaStore } from '../damkaStore';
 
 const isDark = (r: number, c: number) => (r + c) % 2 === 1;
 
-interface DamkaBoardProps {
-  board: Board;
-  selected: Pos | null;
-  validMoves: DamkaMove[];
-  onCellClick: (pos: Pos) => void;
-}
+export default function DamkaBoard() {
+  const { board, selected, validMoves, selectCell } = useDamkaStore(
+    useShallow((s) => ({ board: s.board, selected: s.selected, validMoves: s.validMoves, selectCell: s.selectCell })),
+  );
 
-export default function DamkaBoard({ board, selected, validMoves, onCellClick }: DamkaBoardProps) {
   const validDests   = new Set(validMoves.map(m => `${m.to.row},${m.to.col}`));
   const captureDests = new Set(validMoves.filter(m => m.captures.length > 0).map(m => `${m.to.row},${m.to.col}`));
 
@@ -27,14 +25,14 @@ export default function DamkaBoard({ board, selected, validMoves, onCellClick }:
             const isCapture = captureDests.has(key);
 
             let bg = isLight ? 'bg-amber-100' : 'bg-amber-800';
-            if (isSel)       bg = 'bg-yellow-400';
+            if (isSel)          bg = 'bg-yellow-400';
             else if (isCapture) bg = 'bg-red-500/70';
             else if (isValid)   bg = 'bg-green-500/70';
 
             return (
               <div
                 key={c}
-                onClick={() => onCellClick({ row: r, col: c })}
+                onClick={() => selectCell({ row: r, col: c })}
                 className={`w-10 h-10 sm:w-11 sm:h-11 flex items-center justify-center cursor-pointer ${bg} transition-colors`}
               >
                 {cell.color && (

--- a/gamesformykids/app/games/checkers/components/DamkaMenuScreen.tsx
+++ b/gamesformykids/app/games/checkers/components/DamkaMenuScreen.tsx
@@ -1,14 +1,14 @@
 'use client';
 
+import { useShallow } from 'zustand/react/shallow';
 import GameMenuCard from '@/components/game/shared/GameMenuCard';
+import { useDamkaStore } from '../damkaStore';
 
-interface DamkaMenuScreenProps {
-  playerScore: number;
-  computerScore: number;
-  onStart: () => void;
-}
+export default function DamkaMenuScreen() {
+  const { playerScore, computerScore, startGame } = useDamkaStore(
+    useShallow((s) => ({ playerScore: s.playerScore, computerScore: s.computerScore, startGame: s.startGame })),
+  );
 
-export default function DamkaMenuScreen({ playerScore, computerScore, onStart }: DamkaMenuScreenProps) {
   return (
     <GameMenuCard
       emoji="♟️"
@@ -16,7 +16,7 @@ export default function DamkaMenuScreen({ playerScore, computerScore, onStart }:
       description="משחק הדמקה הקלאסי נגד המחשב!"
       gradientClass="from-amber-900 to-stone-950"
       buttonClass="from-amber-400 to-amber-500"
-      onStart={onStart}
+      onStart={startGame}
       startLabel="🎮 התחל משחק"
     >
       {(playerScore > 0 || computerScore > 0) && (

--- a/gamesformykids/app/games/checkers/components/DamkaResultScreen.tsx
+++ b/gamesformykids/app/games/checkers/components/DamkaResultScreen.tsx
@@ -1,15 +1,16 @@
 'use client';
 
-import type { GamePhase } from '../useDamkaGame';
+import { useShallow } from 'zustand/react/shallow';
+import { useDamkaStore } from '../damkaStore';
 
-interface DamkaResultScreenProps {
-  phase: Extract<GamePhase, 'won' | 'lost'>;
-  playerScore: number;
-  computerScore: number;
-  onRestart: () => void;
-}
+export default function DamkaResultScreen() {
+  const { phase, playerScore, computerScore, startGame } = useDamkaStore(
+    useShallow((s) => ({
+      phase: s.phase, playerScore: s.playerScore,
+      computerScore: s.computerScore, startGame: s.startGame,
+    })),
+  );
 
-export default function DamkaResultScreen({ phase, playerScore, computerScore, onRestart }: DamkaResultScreenProps) {
   return (
     <div className="flex flex-col items-center gap-6 text-center">
       <div className="text-8xl">{phase === 'won' ? '🎉' : '😢'}</div>
@@ -21,7 +22,7 @@ export default function DamkaResultScreen({ phase, playerScore, computerScore, o
         <span>⚪ מחשב: {computerScore}</span>
       </div>
       <button
-        onClick={onRestart}
+        onClick={startGame}
         className="bg-amber-400 hover:bg-amber-300 text-gray-900 font-extrabold text-xl px-10 py-4 rounded-2xl shadow-xl transition-transform hover:scale-105 active:scale-95"
       >
         🔄 שחק שוב

--- a/gamesformykids/app/games/checkers/components/DamkaScoreBar.tsx
+++ b/gamesformykids/app/games/checkers/components/DamkaScoreBar.tsx
@@ -1,22 +1,21 @@
 'use client';
 
-import type { Side } from '../useDamkaGame';
+import { useShallow } from 'zustand/react/shallow';
+import { useDamkaStore } from '../damkaStore';
 
-interface DamkaScoreBarProps {
-  playerPieces: number;
-  compPieces: number;
-  playerScore: number;
-  computerScore: number;
-  currentTurn: Side;
-  message: string;
-}
+export default function DamkaScoreBar() {
+  const { board, playerScore, computerScore, currentTurn, message } = useDamkaStore(
+    useShallow((s) => ({
+      board: s.board, playerScore: s.playerScore,
+      computerScore: s.computerScore, currentTurn: s.currentTurn, message: s.message,
+    })),
+  );
 
-export default function DamkaScoreBar({
-  playerPieces, compPieces, playerScore, computerScore, currentTurn, message
-}: DamkaScoreBarProps) {
+  const playerPieces = board.flat().filter(c => c.color === 'player').length;
+  const compPieces   = board.flat().filter(c => c.color === 'computer').length;
+
   return (
     <>
-      {/* Turn indicator + piece counts */}
       <div className="flex justify-between w-full text-white text-sm font-semibold px-1">
         <span>🔴 {playerPieces} אסימונים</span>
         <span className={`px-3 py-1 rounded-full text-xs font-bold ${
@@ -27,12 +26,10 @@ export default function DamkaScoreBar({
         <span>⚪ {compPieces} אסימונים</span>
       </div>
 
-      {/* Message */}
       <p className="text-amber-200 text-sm font-medium bg-black/30 rounded-xl py-2 px-4 text-center max-w-xs">
         {message}
       </p>
 
-      {/* Win counts */}
       <div className="flex gap-4 text-white text-sm">
         <span>🔴 ניצחונות: {playerScore}</span>
         <span>⚪ ניצחונות: {computerScore}</span>


### PR DESCRIPTION
Closes #208

## Summary

All four Damka sub-components now read their own state from `useDamkaStore` directly via `useShallow`. `DamkaGame` becomes a pure phase router with zero props passed to children.

| Component | Props before → after |
|-----------|----------------------|
| `DamkaMenuScreen` | `playerScore`, `computerScore`, `onStart` → **0** |
| `DamkaResultScreen` | `phase`, `playerScore`, `computerScore`, `onRestart` → **0** |
| `DamkaScoreBar` | `playerPieces`, `compPieces`, `playerScore`, `computerScore`, `currentTurn`, `message` → **0** |
| `DamkaBoard` | `board`, `selected`, `validMoves`, `onCellClick` → **0** |

`DamkaScoreBar` derives `playerPieces`/`compPieces` locally from `board` (moved from `DamkaGame`).  
`DamkaGame` now only reads `phase` to decide which screen to render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)