### PR TITLE
feat(dino-runner): extract UI state to Zustand store

### DIFF
--- a/gamesformykids/app/games/dino-runner/DinoRunnerGame.tsx
+++ b/gamesformykids/app/games/dino-runner/DinoRunnerGame.tsx
@@ -1,13 +1,18 @@
 'use client';
 
+import { useShallow } from 'zustand/react/shallow';
 import { useDinoRunnerGame, W, H } from './useDinoRunnerGame';
+import { useDinoRunnerStore } from './dinoRunnerStore';
 import { CanvasScoreBar } from '@/components/game/shared/CanvasScoreBar';
 import { CanvasMenuOverlay } from '@/components/game/shared/CanvasMenuOverlay';
 import DinoGameOverOverlay from './components/DinoGameOverOverlay';
 import CanvasGameShell from '@/components/game/canvas/CanvasGameShell';
 
 export default function DinoRunnerGame() {
-  const { canvasRef, ui, handleTap } = useDinoRunnerGame();
+  const { canvasRef, handleTap } = useDinoRunnerGame();
+  const { phase, score, best } = useDinoRunnerStore(
+    useShallow((s) => ({ phase: s.phase, score: s.score, best: s.best })),
+  );
 
   return (
     <CanvasGameShell
@@ -16,27 +21,27 @@ export default function DinoRunnerGame() {
       canvasClassName="rounded-3xl shadow-2xl cursor-pointer border-4 border-amber-300"
       canvasStyle={{ maxWidth: '100%' }}
       canvasProps={{ onClick: handleTap, onTouchStart: handleTap }}
-      hud={ui.phase === 'playing' && (
+      hud={phase === 'playing' && (
         <CanvasScoreBar
           stats={[
-            { value: ui.score, label: "מפגש", valueClass: "text-2xl font-black text-amber-700", labelClass: "text-xs text-amber-500" },
-            { value: ui.best,  label: "שיא",  valueClass: "text-2xl font-black text-gray-600",  labelClass: "text-xs text-gray-400" },
+            { value: score, label: "מפגש", valueClass: "text-2xl font-black text-amber-700", labelClass: "text-xs text-amber-500" },
+            { value: best,  label: "שיא",  valueClass: "text-2xl font-black text-gray-600",  labelClass: "text-xs text-gray-400" },
           ]}
           mb="mb-4"
         />
       )}
       overlays={<>
-        {ui.phase === 'menu' && (
+        {phase === 'menu' && (
           <CanvasMenuOverlay
             emoji="🦖" title="דינוזאור קופץ"
             description="הקש כדי לקפוץ מעל המכשולים!"
-            best={ui.best} onStart={handleTap}
+            best={best} onStart={handleTap}
             backdropClass="rounded-3xl bg-black/35" cardWidth="w-64"
             titleColor="text-amber-700"
             buttonClass="bg-gradient-to-l from-amber-500 to-orange-500 shadow-lg hover:opacity-90"
           />
         )}
-        {ui.phase === 'dead' && <DinoGameOverOverlay score={ui.score} best={ui.best} onRestart={handleTap} />}
+        {phase === 'dead' && <DinoGameOverOverlay score={score} best={best} onRestart={handleTap} />}
       </>}
       controls={<p className="mt-4 text-amber-600 text-sm font-medium">הקש / לחץ מקש רווח לקפוץ</p>}
     />

--- a/gamesformykids/app/games/dino-runner/dinoRunnerStore.ts
+++ b/gamesformykids/app/games/dino-runner/dinoRunnerStore.ts
@@ -1,0 +1,31 @@
+import { makeStore } from '@/lib/stores/createStore';
+import type { PhaseDead } from '@/lib/types';
+
+interface DinoState {
+  phase: PhaseDead;
+  score: number;
+  best: number;
+}
+
+interface DinoActions {
+  startGame: () => void;
+  setScore: (score: number) => void;
+  setGameOver: (score: number) => void;
+  resetToMenu: () => void;
+}
+
+export const useDinoRunnerStore = makeStore<DinoState & DinoActions>(
+  'DinoRunnerStore',
+  (set, get) => ({
+    phase: 'menu',
+    score: 0,
+    best: 0,
+    startGame: () => set({ phase: 'playing', score: 0 }, false, 'dino/startGame'),
+    setScore: (score) => set({ score }, false, 'dino/setScore'),
+    setGameOver: (score) => {
+      const best = Math.max(score, get().best);
+      set({ phase: 'dead', score, best }, false, 'dino/gameOver');
+    },
+    resetToMenu: () => set({ phase: 'menu' }, false, 'dino/resetToMenu'),
+  }),
+);

--- a/gamesformykids/app/games/dino-runner/useDinoRunnerGame.ts
+++ b/gamesformykids/app/games/dino-runner/useDinoRunnerGame.ts
@@ -1,6 +1,7 @@
 ﻿'use client';
 
-import { useEffect, useRef, useCallback, useState } from 'react';
+import { useEffect, useRef, useCallback } from 'react';
+import { useDinoRunnerStore } from './dinoRunnerStore';
 
 export const W = 400;
 export const H = 220;
@@ -27,14 +28,11 @@ export function useDinoRunnerGame() {
     obstacles: [] as Obstacle[],
     clouds: [{ x: 100, y: 40 }, { x: 280, y: 25 }, { x: 360, y: 55 }] as Cloud[],
     score: 0,
-    best: 0,
     frame: 0,
     speed: BASE_SPEED,
     raf: 0,
     nextObstacle: 80,
   });
-  const [ui, setUi] = useState<{ phase: Phase; score: number; best: number }>({ phase: 'menu', score: 0, best: 0 });
-
   const jump = useCallback(() => {
     const s = st.current;
     if (s.phase === 'playing' && s.onGround) {
@@ -50,10 +48,10 @@ export function useDinoRunnerGame() {
       s.frame = 0;
       s.speed = BASE_SPEED;
       s.nextObstacle = 80;
-      setUi({ phase: 'playing', score: 0, best: s.best });
+      useDinoRunnerStore.getState().startGame();
     } else if (s.phase === 'dead') {
       s.phase = 'menu';
-      setUi(u => ({ ...u, phase: 'menu' }));
+      useDinoRunnerStore.getState().resetToMenu();
     }
   }, []);
 
@@ -99,7 +97,7 @@ export function useDinoRunnerGame() {
           if (c.x < -60) c.x = W + 60;
         }
 
-        if (s.frame % 6 === 0) setUi(u => ({ ...u, score: s.score }));
+        if (s.frame % 6 === 0) useDinoRunnerStore.getState().setScore(s.score);
 
         const margin = 8;
         for (const o of s.obstacles) {
@@ -109,8 +107,7 @@ export function useDinoRunnerGame() {
             s.dinoY + DINO_H - margin > GROUND_Y - o.h + margin
           ) {
             s.phase = 'dead';
-            if (s.score > s.best) s.best = s.score;
-            setUi({ phase: 'dead', score: s.score, best: s.best });
+            useDinoRunnerStore.getState().setGameOver(s.score);
           }
         }
       }
@@ -177,5 +174,5 @@ export function useDinoRunnerGame() {
     jump();
   }, [jump]);
 
-  return { canvasRef, ui, jump, handleTap };
+  return { canvasRef, jump, handleTap };
 }


### PR DESCRIPTION
## Summary
- Created `dinoRunnerStore.ts` with `makeStore` holding `phase`, `score`, `best`
- Replaced `useState` in `useDinoRunnerGame` with `useDinoRunnerStore.getState()` calls from within the rAF loop
- `DinoRunnerGame` now subscribes to the store via `useShallow` instead of reading from the hook's `ui` return
- `best` score now persists across component unmounts (store singleton)

## Test plan
- [ ] Play dino-runner: score increments while running
- [ ] Hit an obstacle: game-over overlay appears with correct score/best
- [ ] Tap to restart from game-over: game resets correctly
- [ ] Navigate away and back: best score preserved
- [ ] Check Zustand devtools: `DinoRunnerStore` visible with correct state updates

Closes #224
Part of #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)