### PR TITLE
feat(pong): extract UI state to Zustand store

### DIFF
--- a/gamesformykids/app/games/pong/PongGame.tsx
+++ b/gamesformykids/app/games/pong/PongGame.tsx
@@ -1,6 +1,8 @@
 'use client';
 
-import { usePongGame, W, H, WIN_SCORE } from './usePongGame';
+import { useShallow } from 'zustand/react/shallow';
+import { usePongGame, W, H } from './usePongGame';
+import { usePongStore, WIN_SCORE } from './pongStore';
 import { CanvasScoreBar } from '@/components/game/shared/CanvasScoreBar';
 import { CanvasMenuOverlay } from '@/components/game/shared/CanvasMenuOverlay';
 import PongResultOverlay from './components/PongResultOverlay';
@@ -8,7 +10,11 @@ import PongControls from './components/PongControls';
 import CanvasGameShell from '@/components/game/canvas/CanvasGameShell';
 
 export default function PongGame() {
-  const { canvasRef, ui, startGame, handleMouseMove, handleTouchMove, handleTouchStart, handleCanvasClick, playerWon, nudgeLeft, nudgeRight } = usePongGame();
+  const { canvasRef, startGame, handleMouseMove, handleTouchMove, handleTouchStart, handleCanvasClick, nudgeLeft, nudgeRight } = usePongGame();
+  const { phase, playerScore, aiScore } = usePongStore(
+    useShallow((s) => ({ phase: s.phase, playerScore: s.playerScore, aiScore: s.aiScore })),
+  );
+  const playerWon = playerScore >= WIN_SCORE;
 
   return (
     <CanvasGameShell
@@ -17,18 +23,18 @@ export default function PongGame() {
       canvasClassName="rounded-3xl shadow-2xl border-4 border-slate-700 cursor-none"
       canvasStyle={{ maxHeight: '85vh', width: 'auto' }}
       canvasProps={{ onMouseMove: handleMouseMove, onTouchMove: handleTouchMove, onClick: handleCanvasClick, onTouchStart: handleTouchStart }}
-      hud={ui.phase === 'playing' && (
+      hud={phase === 'playing' && (
         <CanvasScoreBar
           stats={[
-            { value: ui.aiScore,     label: "מחשב 🤖", valueClass: "text-3xl font-black text-red-400",   labelClass: "text-xs text-red-600" },
-            { value: ui.playerScore, label: "אתה 🎮",  valueClass: "text-3xl font-black text-green-400", labelClass: "text-xs text-green-600" },
+            { value: aiScore,     label: "מחשב 🤖", valueClass: "text-3xl font-black text-red-400",   labelClass: "text-xs text-red-600" },
+            { value: playerScore, label: "אתה 🎮",  valueClass: "text-3xl font-black text-green-400", labelClass: "text-xs text-green-600" },
           ]}
           gap="gap-8"
           separator={<div className="text-white/30 text-2xl font-bold self-center">:</div>}
         />
       )}
       overlays={<>
-        {ui.phase === 'menu' && (
+        {phase === 'menu' && (
           <CanvasMenuOverlay
             emoji="🏓" title="פונג"
             description={<>הזז את המחבט הירוק<br />הגע ל-{WIN_SCORE} נקודות לפני המחשב!</>}
@@ -38,11 +44,11 @@ export default function PongGame() {
             buttonClass="bg-gradient-to-l from-slate-600 to-slate-800 shadow-lg hover:opacity-90"
           />
         )}
-        {ui.phase === 'result' && (
-          <PongResultOverlay playerWon={playerWon} playerScore={ui.playerScore} aiScore={ui.aiScore} onRestart={startGame} />
+        {phase === 'result' && (
+          <PongResultOverlay playerWon={playerWon} playerScore={playerScore} aiScore={aiScore} onRestart={startGame} />
         )}
       </>}
-      controls={ui.phase === 'playing' && <PongControls onNudgeLeft={nudgeLeft} onNudgeRight={nudgeRight} />}
+      controls={phase === 'playing' && <PongControls onNudgeLeft={nudgeLeft} onNudgeRight={nudgeRight} />}
     />
   );
 }

--- a/gamesformykids/app/games/pong/pongStore.ts
+++ b/gamesformykids/app/games/pong/pongStore.ts
@@ -1,0 +1,42 @@
+import { makeStore } from '@/lib/stores/createStore';
+import type { PhaseResult } from '@/lib/types';
+
+export const WIN_SCORE = 7;
+
+interface PongState {
+  phase: PhaseResult;
+  playerScore: number;
+  aiScore: number;
+}
+
+interface PongActions {
+  startGame: () => void;
+  playerScores: (score: number) => boolean;
+  aiScores: (score: number) => boolean;
+}
+
+export const usePongStore = makeStore<PongState & PongActions>(
+  'PongStore',
+  (set) => ({
+    phase: 'menu',
+    playerScore: 0,
+    aiScore: 0,
+    startGame: () => set({ phase: 'playing', playerScore: 0, aiScore: 0 }, false, 'pong/startGame'),
+    playerScores: (score) => {
+      if (score >= WIN_SCORE) {
+        set({ playerScore: score, phase: 'result' }, false, 'pong/playerWins');
+        return true;
+      }
+      set({ playerScore: score }, false, 'pong/playerScores');
+      return false;
+    },
+    aiScores: (score) => {
+      if (score >= WIN_SCORE) {
+        set({ aiScore: score, phase: 'result' }, false, 'pong/aiWins');
+        return true;
+      }
+      set({ aiScore: score }, false, 'pong/aiScores');
+      return false;
+    },
+  }),
+);

--- a/gamesformykids/app/games/pong/usePongGame.ts
+++ b/gamesformykids/app/games/pong/usePongGame.ts
@@ -1,13 +1,13 @@
 ﻿'use client';
 
-import { useEffect, useRef, useCallback, useState } from 'react';
+import { useEffect, useRef, useCallback } from 'react';
+import { usePongStore } from './pongStore';
 
 export const W = 360;
 export const H = 560;
 const PAD_W = 70;
 const PAD_H = 12;
 const BALL_R = 8;
-export const WIN_SCORE = 7;
 const AI_SPEED = 3.5;
 
 import type { PhaseResult as Phase } from '@/lib/types';
@@ -21,8 +21,6 @@ export function usePongGame() {
     playerScore: 0, aiScore: 0, raf: 0, frame: 0,
     particles: [] as { x: number; y: number; vx: number; vy: number; life: number }[],
   });
-  const [ui, setUi] = useState<{ phase: Phase; playerScore: number; aiScore: number }>({ phase: 'menu', playerScore: 0, aiScore: 0 });
-
   function serveBall(direction: 1 | -1) {
     const s = st.current;
     const spd = 4 + Math.min(s.playerScore + s.aiScore, 8) * 0.2;
@@ -39,7 +37,7 @@ export function usePongGame() {
     const angle = (Math.random() - 0.5) * 1.2, spd = 4;
     s.ballVX = Math.sin(angle) * spd; s.ballVY = (Math.random() < 0.5 ? 1 : -1) * Math.cos(angle) * spd;
     s.playerScore = 0; s.aiScore = 0; s.frame = 0; s.particles = [];
-    setUi({ phase: 'playing', playerScore: 0, aiScore: 0 });
+    usePongStore.getState().startGame();
   }, []);
 
   const handleCanvasClick = useCallback(() => {
@@ -106,8 +104,8 @@ export function usePongGame() {
           addParticles(s.ballX, aiPad_Y + PAD_H);
         }
 
-        if (s.ballY + BALL_R > H) { s.aiScore++; setUi(u => ({ ...u, aiScore: s.aiScore })); if (s.aiScore >= WIN_SCORE) { s.phase = 'result'; setUi(u => ({ ...u, phase: 'result' })); } else serveBall(-1); }
-        if (s.ballY - BALL_R < 0) { s.playerScore++; setUi(u => ({ ...u, playerScore: s.playerScore })); if (s.playerScore >= WIN_SCORE) { s.phase = 'result'; setUi(u => ({ ...u, phase: 'result' })); } else serveBall(1); }
+        if (s.ballY + BALL_R > H) { s.aiScore++; const aiWon = usePongStore.getState().aiScores(s.aiScore); if (aiWon) { s.phase = 'result'; } else serveBall(-1); }
+        if (s.ballY - BALL_R < 0) { s.playerScore++; const playerWon = usePongStore.getState().playerScores(s.playerScore); if (playerWon) { s.phase = 'result'; } else serveBall(1); }
 
         s.particles = s.particles.filter(p => { p.x += p.vx; p.y += p.vy; p.vy += 0.08; p.life -= 0.05; return p.life > 0; });
       }
@@ -163,10 +161,9 @@ export function usePongGame() {
     return () => { clearInterval(interval); window.removeEventListener('keydown', kd); window.removeEventListener('keyup', ku); };
   }, []);
 
-  const playerWon = ui.playerScore >= WIN_SCORE;
-
-  return { canvasRef, ui, startGame, handleMouseMove, handleTouchMove, handleTouchStart, handleCanvasClick, playerWon,
-    nudgeLeft: () => { const s = st.current; s.playerX = Math.max(0, s.playerX - 45); },
+  return {
+    canvasRef, startGame, handleMouseMove, handleTouchMove, handleTouchStart, handleCanvasClick,
+    nudgeLeft:  () => { const s = st.current; s.playerX = Math.max(0, s.playerX - 45); },
     nudgeRight: () => { const s = st.current; s.playerX = Math.min(W - PAD_W, s.playerX + 45); },
   };
 }


### PR DESCRIPTION
## Summary
- Created `pongStore.ts` with `makeStore` holding `phase`, `playerScore`, `aiScore`
- `WIN_SCORE` moved from the hook to the store and exported from there
- `playerScores()`/`aiScores()` actions handle score increment + win check atomically
- `PongGame` subscribes to the store via `useShallow`; physics refs stay in the hook

## Test plan
- [ ] Play pong: score bars update as points are scored
- [ ] Win/lose: result overlay shows correct scores and winner
- [ ] Restart from result overlay: game resets correctly
- [ ] Mobile touch/nudge controls still work
- [ ] Zustand devtools: `PongStore` visible with correct state transitions

Closes #225
Part of #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)