### PR TITLE
feat(brick-breaker): extract UI state to Zustand store

### DIFF
--- a/gamesformykids/app/games/brick-breaker/BrickBreakerGame.tsx
+++ b/gamesformykids/app/games/brick-breaker/BrickBreakerGame.tsx
@@ -1,6 +1,8 @@
 'use client';
 
+import { useShallow } from 'zustand/react/shallow';
 import { useBrickBreakerGame, W, H } from './useBrickBreakerGame';
+import { useBrickBreakerStore } from './brickBreakerStore';
 import { CanvasScoreBar } from '@/components/game/shared/CanvasScoreBar';
 import { CanvasMenuOverlay } from '@/components/game/shared/CanvasMenuOverlay';
 import BrickGameOverOverlay from './components/BrickGameOverOverlay';
@@ -8,7 +10,10 @@ import { CanvasLRControls } from '@/components/game/shared/CanvasLRControls';
 import CanvasGameShell from '@/components/game/canvas/CanvasGameShell';
 
 export default function BrickBreakerGame() {
-  const { canvasRef, ui, startGame, handleMouseMove, handleTouchMove, handleTouchStart, handleClick, nudgeLeft, nudgeRight } = useBrickBreakerGame();
+  const { canvasRef, startGame, handleMouseMove, handleTouchMove, handleTouchStart, handleClick, nudgeLeft, nudgeRight } = useBrickBreakerGame();
+  const { phase, score, best, lives, level } = useBrickBreakerStore(
+    useShallow((s) => ({ phase: s.phase, score: s.score, best: s.best, lives: s.lives, level: s.level })),
+  );
 
   return (
     <CanvasGameShell
@@ -17,32 +22,32 @@ export default function BrickBreakerGame() {
       canvasClassName="rounded-3xl shadow-2xl border-4 border-purple-700 cursor-none"
       canvasStyle={{ maxHeight: '85vh', width: 'auto' }}
       canvasProps={{ onMouseMove: handleMouseMove, onClick: handleClick, onTouchMove: handleTouchMove, onTouchStart: handleTouchStart }}
-      hud={ui.phase === 'playing' && (
+      hud={phase === 'playing' && (
         <CanvasScoreBar
           stats={[
-            { value: ui.score,                              label: "ניקוד", valueClass: "text-2xl font-black text-yellow-300", labelClass: "text-xs text-yellow-500" },
-            { value: Array(ui.lives).fill('❤️').join(''), label: "חיים",  valueClass: "text-lg",                             labelClass: "text-xs text-red-400" },
-            { value: `Lv.${ui.level}`,                      label: "רמה",   valueClass: "text-2xl font-black text-blue-300",   labelClass: "text-xs text-blue-500" },
+            { value: score,                              label: "ניקוד", valueClass: "text-2xl font-black text-yellow-300", labelClass: "text-xs text-yellow-500" },
+            { value: Array(lives).fill('❤️').join(''), label: "חיים",  valueClass: "text-lg",                             labelClass: "text-xs text-red-400" },
+            { value: `Lv.${level}`,                      label: "רמה",   valueClass: "text-2xl font-black text-blue-300",   labelClass: "text-xs text-blue-500" },
           ]}
           gap="gap-5" className="text-white"
         />
       )}
       overlays={<>
-        {ui.phase === 'menu' && (
+        {phase === 'menu' && (
           <CanvasMenuOverlay
             emoji="🧱" title="שובר לבנים"
             description={<>הזז את המחבט ושבור את כל הלבנים!<br />5 רמות של כיף</>}
-            best={ui.best} onStart={() => startGame(1)}
+            best={best} onStart={() => startGame(1)}
             backdropClass="rounded-3xl bg-black/60"
             titleColor="text-purple-700"
             buttonClass="bg-gradient-to-l from-purple-500 to-indigo-600 shadow-lg hover:opacity-90"
           />
         )}
-        {(ui.phase === 'dead' || ui.phase === 'won') && (
-          <BrickGameOverOverlay phase={ui.phase as 'dead' | 'won'} score={ui.score} best={ui.best} onRestart={() => startGame(1)} />
+        {(phase === 'dead' || phase === 'won') && (
+          <BrickGameOverOverlay phase={phase as 'dead' | 'won'} score={score} best={best} onRestart={() => startGame(1)} />
         )}
       </>}
-      controls={ui.phase === 'playing' && (
+      controls={phase === 'playing' && (
         <CanvasLRControls
           onLeft={nudgeLeft} onRight={nudgeRight}
           center={{ label: "🏸 השק", onAction: handleClick, className: "bg-white/20 text-white rounded-xl px-6 py-3 text-sm font-bold active:bg-white/40 touch-none" }}

--- a/gamesformykids/app/games/brick-breaker/brickBreakerStore.ts
+++ b/gamesformykids/app/games/brick-breaker/brickBreakerStore.ts
@@ -1,0 +1,41 @@
+import { makeStore } from '@/lib/stores/createStore';
+import type { PhaseWonDead } from '@/lib/types';
+
+interface BrickBreakerState {
+  phase: PhaseWonDead;
+  score: number;
+  best: number;
+  lives: number;
+  level: number;
+}
+
+interface BrickBreakerActions {
+  startLevel: (opts: { score: number; lives: number; level: number }) => void;
+  setScore: (score: number) => void;
+  setLives: (lives: number) => void;
+  setGameOver: (score: number, level: number) => void;
+  setWon: (score: number, lives: number, level: number) => void;
+}
+
+export const useBrickBreakerStore = makeStore<BrickBreakerState & BrickBreakerActions>(
+  'BrickBreakerStore',
+  (set, get) => ({
+    phase: 'menu',
+    score: 0,
+    best: 0,
+    lives: 3,
+    level: 1,
+    startLevel: ({ score, lives, level }) =>
+      set({ phase: 'playing', score, lives, level }, false, 'brickBreaker/startLevel'),
+    setScore: (score) => set({ score }, false, 'brickBreaker/setScore'),
+    setLives: (lives) => set({ lives }, false, 'brickBreaker/setLives'),
+    setGameOver: (score, level) => {
+      const best = Math.max(score, get().best);
+      set({ phase: 'dead', score, best, lives: 0, level }, false, 'brickBreaker/gameOver');
+    },
+    setWon: (score, lives, level) => {
+      const best = Math.max(score, get().best);
+      set({ phase: 'won', score, best, lives, level }, false, 'brickBreaker/won');
+    },
+  }),
+);

--- a/gamesformykids/app/games/brick-breaker/useBrickBreakerGame.ts
+++ b/gamesformykids/app/games/brick-breaker/useBrickBreakerGame.ts
@@ -1,6 +1,7 @@
 ﻿'use client';
 
-import { useEffect, useRef, useCallback, useState } from 'react';
+import { useEffect, useRef, useCallback } from 'react';
+import { useBrickBreakerStore } from './brickBreakerStore';
 
 export const W = 360;
 export const H = 560;
@@ -37,13 +38,9 @@ export function useBrickBreakerGame() {
     phase: 'menu' as Phase,
     padX: W / 2 - PAD_W / 2,
     ballX: W / 2, ballY: PAD_Y - BALL_R - 2, ballVX: 3, ballVY: -4, launched: false,
-    bricks: makeBricks(), score: 0, best: 0, lives: 3, level: 1, raf: 0, frame: 0,
+    bricks: makeBricks(), score: 0, lives: 3, level: 1, raf: 0, frame: 0,
     particles: [] as { x: number; y: number; vx: number; vy: number; life: number; color: string }[],
   });
-  const [ui, setUi] = useState<{ phase: Phase; score: number; best: number; lives: number; level: number }>(
-    { phase: 'menu', score: 0, best: 0, lives: 3, level: 1 }
-  );
-
   const startGame = useCallback((level = 1) => {
     const s = st.current;
     s.phase = 'playing';
@@ -54,7 +51,7 @@ export function useBrickBreakerGame() {
     s.score = level === 1 ? 0 : s.score;
     s.lives = level === 1 ? 3 : s.lives;
     s.level = level; s.particles = [];
-    setUi({ phase: 'playing', score: s.score, best: s.best, lives: s.lives, level });
+    useBrickBreakerStore.getState().startLevel({ score: s.score, lives: s.lives, level });
   }, []);
 
   const handleClick = useCallback(() => {
@@ -118,8 +115,8 @@ export function useBrickBreakerGame() {
           if (s.ballY + BALL_R > H) {
             s.lives--;
             s.launched = false; s.ballX = s.padX + PAD_W / 2; s.ballY = PAD_Y - BALL_R - 2;
-            if (s.lives <= 0) { s.lives = 0; s.phase = 'dead'; if (s.score > s.best) s.best = s.score; setUi({ phase: 'dead', score: s.score, best: s.best, lives: 0, level: s.level }); }
-            else { setUi(u => ({ ...u, lives: s.lives })); }
+            if (s.lives <= 0) { s.lives = 0; s.phase = 'dead'; useBrickBreakerStore.getState().setGameOver(s.score, s.level); }
+            else { useBrickBreakerStore.getState().setLives(s.lives); }
           }
           for (let i = 0; i < s.bricks.length; i++) {
             if (!s.bricks[i].alive) continue;
@@ -131,12 +128,12 @@ export function useBrickBreakerGame() {
               if (Math.min(overlapLeft, overlapRight) < Math.min(overlapTop, overlapBottom)) s.ballVX *= -1; else s.ballVY *= -1;
               const colors = ROW_COLORS[s.bricks[i].row];
               for (let p = 0; p < 6; p++) s.particles.push({ x: x + w / 2, y: y + h / 2, vx: (Math.random() - 0.5) * 5, vy: (Math.random() - 0.5) * 5, life: 1, color: colors[Math.floor(Math.random() * colors.length)] });
-              setUi(u => ({ ...u, score: s.score }));
+              useBrickBreakerStore.getState().setScore(s.score);
             }
           }
           if (s.bricks.every(b => !b.alive)) {
             const nextLevel = s.level + 1;
-            if (nextLevel > 5) { s.phase = 'won'; if (s.score > s.best) s.best = s.score; setUi({ phase: 'won', score: s.score, best: s.best, lives: s.lives, level: s.level }); }
+            if (nextLevel > 5) { s.phase = 'won'; useBrickBreakerStore.getState().setWon(s.score, s.lives, s.level); }
             else { startGame(nextLevel); }
           }
         }
@@ -202,5 +199,5 @@ export function useBrickBreakerGame() {
     return () => { clearInterval(interval); window.removeEventListener('keydown', kd); window.removeEventListener('keyup', ku); };
   }, [handleClick]);
 
-  return { canvasRef, ui, startGame, handleMouseMove, handleTouchMove, handleTouchStart, handleClick, nudgeLeft, nudgeRight };
+  return { canvasRef, startGame, handleMouseMove, handleTouchMove, handleTouchStart, handleClick, nudgeLeft, nudgeRight };
 }


### PR DESCRIPTION
## Summary
- Created `brickBreakerStore.ts` with `makeStore` holding `phase`, `score`, `best`, `lives`, `level`
- `setGameOver`/`setWon` actions compute best score atomically
- `BrickBreakerGame` subscribes to store via `useShallow`; physics refs stay in the hook

## Test plan
- [ ] Play: score increments on brick hits, HUD updates
- [ ] Lose all lives: game-over overlay shows correct score/best
- [ ] Complete level 5: win overlay shows
- [ ] Next level continues score/lives from previous level
- [ ] Zustand devtools: `BrickBreakerStore` visible

Closes #226
Part of #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)