### PR TITLE
feat(snake): migrate phase from useState to SnakeStore

### DIFF
--- a/gamesformykids/app/games/snake/stores/useSnakeStore.ts
+++ b/gamesformykids/app/games/snake/stores/useSnakeStore.ts
@@ -1,0 +1,17 @@
+'use client';
+
+import { makeStore } from '@/lib/stores/createStore';
+import type { PhaseDead as Phase } from '@/lib/types';
+
+interface SnakeState {
+  phase: Phase;
+}
+
+interface SnakeActions {
+  setPhase: (phase: Phase) => void;
+}
+
+export const useSnakeStore = makeStore<SnakeState & SnakeActions>('SnakeStore', (set) => ({
+  phase: 'menu',
+  setPhase: (phase) => set({ phase }, false, 'snake/setPhase'),
+}));

--- a/gamesformykids/app/games/snake/useSnakeGame.ts
+++ b/gamesformykids/app/games/snake/useSnakeGame.ts
@@ -1,7 +1,8 @@
 ﻿'use client';
 
-import { useEffect, useRef, useCallback, useState } from 'react';
+import { useEffect, useRef, useCallback } from 'react';
 import { useGameProgressStore, useGameStore } from '@/lib/stores';
+import { useSnakeStore } from './stores/useSnakeStore';
 
 const COLS = 20;
 const ROWS = 20;
@@ -34,8 +35,7 @@ export function useSnakeGame() {
     animFrame: 0,
   });
 
-  // פאזה בלבד נשמרת ב-local state — ניקוד/רמה/שיא בין דרך Zustand stores
-  const [phase, setPhase] = useState<Phase>('menu');
+  const phase = useSnakeStore((s) => s.phase);
   const score = useGameProgressStore((s) => s.score);
   const level = useGameProgressStore((s) => s.level);
   const best  = useGameStore((s) => s.highScores['snake'] ?? 0);
@@ -62,7 +62,7 @@ export function useSnakeGame() {
     // endGame() automatically persists score as highScore['snake']
     useGameStore.getState().endGame();
     useGameProgressStore.getState().setGameActive(false);
-    setPhase('dead');
+    useSnakeStore.getState().setPhase('dead');
   }
 
   function step() {
@@ -114,7 +114,7 @@ export function useSnakeGame() {
     useGameProgressStore.getState().resetProgress();
     useGameProgressStore.getState().setGameActive(true);
     useGameStore.getState().startGame('snake');
-    setPhase('playing');
+    useSnakeStore.getState().setPhase('playing');
     scheduleStep();
     // intentionally omit all deps — all references are stable (st.current ref, Zustand
     // getState() calls, and scheduleStep uses st.current internally); empty deps ensures


### PR DESCRIPTION
## Summary
- Created `stores/useSnakeStore.ts` with a minimal `phase` + `setPhase` action using `makeStore`
- Removed `useState<Phase>` from `useSnakeGame.ts` -- `phase` now reads from the store via selector
- `setPhase(...)` calls replaced with `useSnakeStore.getState().setPhase(...)` (same pattern as the existing store calls)
- `SnakeGame.tsx` unchanged -- still reads `ui.phase` from the hook

All game state (score, level, best, phase) is now visible in Zustand devtools under `SnakeStore` + `GameProgressStore` + `GameStore`.

## Test plan
- [ ] Start screen shows on load (phase: menu)
- [ ] Click start -> game runs (phase: playing), score bar visible
- [ ] Hit wall or self -> game over overlay shows (phase: dead)
- [ ] Restart from game over -> back to playing
- [ ] Zustand devtools: `SnakeStore` visible with `phase` field

Closes #230
Part of #34

Generated with Claude Code