### PR TITLE
refactor(word-scramble): eliminate ResultScreen props drilling

### DIFF
--- a/gamesformykids/app/games/word-scramble/WordScrambleGame.tsx
+++ b/gamesformykids/app/games/word-scramble/WordScrambleGame.tsx
@@ -5,7 +5,7 @@ import WordScramblePlayScreen from './components/WordScramblePlayScreen';
 import WordScrambleResultScreen from './components/WordScrambleResultScreen';
 
 export default function WordScrambleGame() {
-  const { phase, score, lives, startGame } = useWordScrambleGame();
+  const { phase, startGame } = useWordScrambleGame();
 
   if (phase === 'menu') return (
     <GameMenuCard
@@ -18,6 +18,6 @@ export default function WordScrambleGame() {
       startLabel="🔡 התחל!"
     />
   );
-  if (phase === 'results') return <WordScrambleResultScreen score={score} lives={lives} onRestart={startGame} />;
+  if (phase === 'results') return <WordScrambleResultScreen />;
   return <WordScramblePlayScreen />;
 }

--- a/gamesformykids/app/games/word-scramble/components/WordScrambleResultScreen.tsx
+++ b/gamesformykids/app/games/word-scramble/components/WordScrambleResultScreen.tsx
@@ -1,13 +1,9 @@
 'use client';
 import GameResultCard from '@/components/game/shared/GameResultCard';
+import { useWordScrambleStore } from '../wordScrambleStore';
 
-interface Props {
-  score: number;
-  lives: number;
-  onRestart: () => void;
-}
-
-export default function WordScrambleResultScreen({ score, lives, onRestart }: Props) {
+export default function WordScrambleResultScreen() {
+  const { score, lives, startGame: onRestart } = useWordScrambleStore();
   const emoji = score >= 100 ? '🏆' : score >= 60 ? '🎉' : '😊';
   const title = score >= 100 ? 'מדהים!' : score >= 60 ? 'כל הכבוד!' : 'ניסיון טוב!';
   return (


### PR DESCRIPTION
## Summary
- `WordScrambleResultScreen` subscribes to `useWordScrambleStore` directly -- reads `score`, `lives`, calls `startGame`
- Parent `WordScrambleGame` no longer extracts or passes those 3 props
- Props interface removed from `WordScrambleResultScreen`

## Test plan
- [ ] Play through word scramble to result screen -- score and mistakes display correctly
- [ ] Play again button returns to a fresh game

Closes #245
Part of #17