### PR TITLE
refactor(simon): SimonGameOverScreen subscribes to store directly

### DIFF
--- a/gamesformykids/app/games/simon/SimonGame.tsx
+++ b/gamesformykids/app/games/simon/SimonGame.tsx
@@ -5,7 +5,7 @@ import SimonBoard from './components/SimonBoard';
 import SimonGameOverScreen from './components/SimonGameOverScreen';
 
 export default function SimonGame() {
-  const { phase, best, roundScore, startGame, handleTap } = useSimonGame();
+  const { phase, best, startGame, handleTap } = useSimonGame();
 
   return (
     <div className="min-h-screen bg-gray-900 flex flex-col items-center justify-center p-4 select-none" dir="rtl">
@@ -23,7 +23,7 @@ export default function SimonGame() {
         />
       )}
       {(phase === 'showing' || phase === 'input') && <SimonBoard onTap={handleTap} />}
-      {phase === 'dead' && <SimonGameOverScreen roundScore={roundScore} best={best} onRestart={startGame} />}
+      {phase === 'dead' && <SimonGameOverScreen />}
     </div>
   );
 }

--- a/gamesformykids/app/games/simon/components/SimonGameOverScreen.tsx
+++ b/gamesformykids/app/games/simon/components/SimonGameOverScreen.tsx
@@ -1,21 +1,18 @@
 'use client';
 
 import GameResultCard from '@/components/game/shared/GameResultCard';
+import { useSimonStore } from '../simonStore';
 
-interface Props {
-  roundScore: number;
-  best: number;
-  onRestart: () => void;
-}
+export default function SimonGameOverScreen() {
+  const { roundScore, best, startGame } = useSimonStore();
 
-export default function SimonGameOverScreen({ roundScore, best, onRestart }: Props) {
   return (
     <GameResultCard
       emoji="😵"
       title="טעית!"
       gradientClass="from-gray-800 to-gray-900"
       buttonClass="from-gray-600 to-gray-800"
-      onRestart={onRestart}
+      onRestart={startGame}
       restartLabel="🔄 שוב!"
     >
       <p className="text-gray-400 text-sm mb-4">הגעת לרצף של {roundScore} צבעים</p>

--- a/gamesformykids/app/games/simon/simonStore.ts
+++ b/gamesformykids/app/games/simon/simonStore.ts
@@ -1,23 +1,32 @@
 import { makeStore } from '@/lib/stores/createStore';
 import type { PhaseSimon as Phase } from '@/lib/types';
-import type { ButtonId } from './useSimonGame';
+
+export const BUTTONS = [
+  { id: 'red',    bg: 'bg-red-500',    active: 'bg-red-200',    label: '' },
+  { id: 'blue',   bg: 'bg-blue-500',   active: 'bg-blue-200',   label: '' },
+  { id: 'green',  bg: 'bg-green-500',  active: 'bg-green-200',  label: '' },
+  { id: 'yellow', bg: 'bg-yellow-400', active: 'bg-yellow-100', label: '' },
+] as const;
+
+export type ButtonId = typeof BUTTONS[number]['id'];
 
 interface SimonState {
-  phase: Phase;
+  phase:       Phase;
   activeColor: ButtonId | null;
-  playerIdx: number;
-  best: number;
-  roundScore: number;
-  sequence: ButtonId[];
+  playerIdx:   number;
+  best:        number;
+  roundScore:  number;
+  sequence:    ButtonId[];
 }
 
 interface SimonActions {
-  setPhase: (phase: Phase) => void;
+  setPhase:      (phase: Phase) => void;
   setActiveColor: (color: ButtonId | null) => void;
-  setPlayerIdx: (idx: number) => void;
-  updateBest: (score: number) => void;
+  setPlayerIdx:  (idx: number) => void;
+  updateBest:    (score: number) => void;
   setRoundScore: (score: number) => void;
-  setSequence: (seq: ButtonId[]) => void;
+  setSequence:   (seq: ButtonId[]) => void;
+  startGame:     () => void;
 }
 
 const INITIAL: SimonState = {
@@ -29,12 +38,45 @@ const INITIAL: SimonState = {
   sequence: [],
 };
 
+function flash(id: ButtonId, ms: number): Promise<void> {
+  return new Promise(resolve => {
+    useSimonStore.getState().setActiveColor(id);
+    setTimeout(() => {
+      useSimonStore.getState().setActiveColor(null);
+      setTimeout(resolve, 120);
+    }, ms);
+  });
+}
+
+export async function showSequence(seq: ButtonId[]) {
+  const store = useSimonStore.getState();
+  store.setPhase('showing');
+  store.setPlayerIdx(0);
+  await new Promise(r => setTimeout(r, 500));
+  const speed = Math.max(280, 650 - seq.length * 25);
+  for (const id of seq) {
+    if (useSimonStore.getState().phase !== 'showing') return;
+    await flash(id, speed);
+  }
+  if (useSimonStore.getState().phase !== 'showing') return;
+  useSimonStore.getState().setPhase('input');
+  useSimonStore.getState().setPlayerIdx(0);
+}
+
 export const useSimonStore = makeStore<SimonState & SimonActions>('SimonStore', (set) => ({
   ...INITIAL,
-  setPhase: (phase) => set({ phase }, false, 'simon/setPhase'),
+  setPhase:       (phase) => set({ phase }, false, 'simon/setPhase'),
   setActiveColor: (color) => set({ activeColor: color }, false, 'simon/setActiveColor'),
-  setPlayerIdx: (idx) => set({ playerIdx: idx }, false, 'simon/setPlayerIdx'),
-  updateBest: (score) => set((s) => ({ best: Math.max(s.best, score) }), false, 'simon/updateBest'),
-  setRoundScore: (score) => set({ roundScore: score }, false, 'simon/setRoundScore'),
-  setSequence: (seq) => set({ sequence: seq }, false, 'simon/setSequence'),
+  setPlayerIdx:   (idx)   => set({ playerIdx: idx }, false, 'simon/setPlayerIdx'),
+  updateBest:     (score) => set((s) => ({ best: Math.max(s.best, score) }), false, 'simon/updateBest'),
+  setRoundScore:  (score) => set({ roundScore: score }, false, 'simon/setRoundScore'),
+  setSequence:    (seq)   => set({ sequence: seq }, false, 'simon/setSequence'),
+
+  startGame: () => {
+    const first = BUTTONS[Math.floor(Math.random() * BUTTONS.length)].id;
+    const seq: ButtonId[] = [first];
+    useSimonStore.getState().setSequence(seq);
+    useSimonStore.getState().setRoundScore(0);
+    showSequence(seq);
+  },
 }));

--- a/gamesformykids/app/games/simon/useSimonGame.ts
+++ b/gamesformykids/app/games/simon/useSimonGame.ts
@@ -2,56 +2,21 @@
 
 import { useCallback } from 'react';
 import { useShallow } from 'zustand/react/shallow';
-import { useSimonStore } from './simonStore';
+import { useSimonStore, showSequence, BUTTONS } from './simonStore';
+export type { ButtonId } from './simonStore';
+export { BUTTONS };
 
-export const BUTTONS = [
-  { id: 'red',    bg: 'bg-red-500',    active: 'bg-red-200',    label: '' },
-  { id: 'blue',   bg: 'bg-blue-500',   active: 'bg-blue-200',   label: '' },
-  { id: 'green',  bg: 'bg-green-500',  active: 'bg-green-200',  label: '' },
-  { id: 'yellow', bg: 'bg-yellow-400', active: 'bg-yellow-100', label: '' },
-] as const;
-
-export type ButtonId = typeof BUTTONS[number]['id'];
 import type { PhaseSimon as Phase } from '@/lib/types';
 
 export function useSimonGame() {
-  const { phase, activeColor, playerIdx, best, roundScore, sequence } =
+  const { phase, activeColor, playerIdx, best, roundScore, sequence, startGame } =
     useSimonStore(useShallow((s) => s));
 
-  const flash = useCallback((id: ButtonId, ms: number) =>
-    new Promise<void>(resolve => {
-      useSimonStore.getState().setActiveColor(id);
-      setTimeout(() => { useSimonStore.getState().setActiveColor(null); setTimeout(resolve, 120); }, ms);
-    }), []);
-
-  const showSequence = useCallback(async (seq: ButtonId[]) => {
-    const store = useSimonStore.getState();
-    store.setPhase('showing');
-    store.setPlayerIdx(0);
-    await new Promise(r => setTimeout(r, 500));
-    const speed = Math.max(280, 650 - seq.length * 25);
-    for (const id of seq) {
-      if (useSimonStore.getState().phase !== 'showing') return;
-      await flash(id, speed);
-    }
-    if (useSimonStore.getState().phase !== 'showing') return;
-    useSimonStore.getState().setPhase('input');
-    useSimonStore.getState().setPlayerIdx(0);
-  }, [flash]);
-
-  const startGame = useCallback(() => {
-    const first = BUTTONS[Math.floor(Math.random() * BUTTONS.length)].id;
-    const seq: ButtonId[] = [first];
-    useSimonStore.getState().setSequence(seq);
-    useSimonStore.getState().setRoundScore(0);
-    showSequence(seq);
-  }, [showSequence]);
-
-  const handleTap = useCallback((id: ButtonId) => {
+  const handleTap = useCallback((id: string) => {
     const { phase: currentPhase, playerIdx: idx, sequence: seq } = useSimonStore.getState();
     if (currentPhase !== 'input') return;
 
-    useSimonStore.getState().setActiveColor(id);
+    useSimonStore.getState().setActiveColor(id as typeof BUTTONS[number]['id']);
     setTimeout(() => useSimonStore.getState().setActiveColor(null), 180);
 
     if (id !== seq[idx]) {
@@ -67,14 +32,13 @@ export function useSimonGame() {
     if (next >= seq.length) {
       useSimonStore.getState().setRoundScore(seq.length);
       const nextBtn = BUTTONS[Math.floor(Math.random() * BUTTONS.length)].id;
-      const newSeq: ButtonId[] = [...seq, nextBtn];
+      const newSeq = [...seq, nextBtn];
       useSimonStore.getState().setSequence(newSeq);
       setTimeout(() => showSequence(newSeq), 900);
     }
-  }, [showSequence]);
+  }, []);
 
   return { phase, activeColor, playerIdx, best, roundScore, sequenceLength: sequence.length, startGame, handleTap };
 }
 
-// keep Phase exported for consumers
 export type { Phase };


### PR DESCRIPTION
## Summary
- Moved `BUTTONS`, `ButtonId`, `flash`, `showSequence`, and `startGame` into `simonStore.ts` -- they only use `useSimonStore.getState()`, no React state
- `SimonGameOverScreen` subscribes to `useSimonStore` directly -- reads `roundScore`, `best`, calls `startGame`; Props interface removed
- `useSimonGame` re-exports `BUTTONS`/`ButtonId` for backward compat with `SimonBoard`; `handleTap` calls `showSequence` imported from the store module
- `SimonGame` drops `roundScore` from destructuring and renders `<SimonGameOverScreen />` with no props

## Test plan
- [ ] Menu shows, best score visible
- [ ] Start game -- sequence plays, buttons light up
- [ ] Correct taps advance round, wrong tap shows game-over screen
- [ ] Game-over shows round score and best; restart works
- [ ] Zustand devtools: `SimonStore` shows all state including `startGame` action

Closes #244
Part of #17