### PR TITLE
refactor(whack-a-mole): WhackHUD + WhackGrid subscribe to store directly

### DIFF
--- a/gamesformykids/app/games/whack-a-mole/WhackAMoleGame.tsx
+++ b/gamesformykids/app/games/whack-a-mole/WhackAMoleGame.tsx
@@ -7,7 +7,7 @@ import WhackHUD from './components/WhackHUD';
 import WhackGrid from './components/WhackGrid';
 
 export default function WhackAMoleGame() {
-  const { phase, holes, holeValues, score, timeLeft, best, combo, bgColor, pct, startGame, whack } = useWhackAMoleGame();
+  const { phase, score, best, bgColor, startGame } = useWhackAMoleGame();
 
   if (phase === 'menu') return (
     <GameMenuCard
@@ -40,8 +40,8 @@ export default function WhackAMoleGame() {
 
   return (
     <div className={`min-h-screen bg-gradient-to-br ${bgColor} flex flex-col items-center justify-center p-4 select-none`} dir="rtl">
-      <WhackHUD score={score} timeLeft={timeLeft} pct={pct} combo={combo} />
-      <WhackGrid holes={holes} holeValues={holeValues} onWhack={whack} />
+      <WhackHUD />
+      <WhackGrid />
     </div>
   );
 }

--- a/gamesformykids/app/games/whack-a-mole/components/WhackGrid.tsx
+++ b/gamesformykids/app/games/whack-a-mole/components/WhackGrid.tsx
@@ -1,14 +1,10 @@
 'use client';
 
-type HoleState = 'empty' | 'mole' | 'bad' | 'hit' | 'miss';
+import { useWhackAMoleStore } from '../whackAMoleStore';
 
-interface Props {
-  holes: HoleState[];
-  holeValues: string[];
-  onWhack: (index: number) => void;
-}
+export default function WhackGrid() {
+  const { holes, holeValues, whack: onWhack } = useWhackAMoleStore();
 
-export default function WhackGrid({ holes, holeValues, onWhack }: Props) {
   return (
     <>
       <div className="grid grid-cols-3 gap-4 max-w-sm w-full">

--- a/gamesformykids/app/games/whack-a-mole/components/WhackHUD.tsx
+++ b/gamesformykids/app/games/whack-a-mole/components/WhackHUD.tsx
@@ -1,13 +1,11 @@
 'use client';
 
-interface Props {
-  score: number;
-  timeLeft: number;
-  pct: number;
-  combo: number;
-}
+import { useWhackAMoleStore, GAME_DURATION } from '../whackAMoleStore';
 
-export default function WhackHUD({ score, timeLeft, pct, combo }: Props) {
+export default function WhackHUD() {
+  const { score, timeLeft, combo } = useWhackAMoleStore();
+  const pct = (timeLeft / GAME_DURATION) * 100;
+
   return (
     <div className="flex items-center gap-4 mb-4 w-full max-w-sm">
       <div className="text-center">


### PR DESCRIPTION
## Summary
- `WhackHUD` subscribes to `useWhackAMoleStore` directly -- reads `score`, `timeLeft`, `combo`; derives `pct` via exported `GAME_DURATION`; Props interface removed
- `WhackGrid` subscribes to `useWhackAMoleStore` directly -- reads `holes`, `holeValues`, calls `whack`; Props interface removed
- `WhackAMoleGame` drops 7 props from destructuring; still reads `score` for the result card and `bgColor` for the wrapper

## Test plan
- [ ] Moles appear and can be tapped (score goes up, combo increments)
- [ ] Bombs reduce score on tap
- [ ] Timer bar depletes; result card shows final score and best
- [ ] Restart works

Closes #238
Part of #17