### PR TITLE
refactor(reflex): all 3 screen components subscribe to store directly

### DIFF
--- a/gamesformykids/app/games/reflex/ReflexGame.tsx
+++ b/gamesformykids/app/games/reflex/ReflexGame.tsx
@@ -1,21 +1,14 @@
 'use client';
 
-import { useReflexGame } from './useReflexGame';
-import { GAME_DURATION } from './data/targets';
+import { useReflexStore } from './reflexStore';
 import ReflexMenuScreen from './components/ReflexMenuScreen';
 import ReflexPlayScreen from './components/ReflexPlayScreen';
 import ReflexResultScreen from './components/ReflexResultScreen';
 
 export default function ReflexGame() {
-  const { phase, targets, score, missed, timeLeft, startGame, hitTarget } = useReflexGame();
+  const phase = useReflexStore((s) => s.phase);
 
-  const timePct = (timeLeft / GAME_DURATION) * 100;
-
-  if (phase === 'menu') return <ReflexMenuScreen gameDuration={GAME_DURATION} onStart={startGame} />;
-
-  if (phase === 'playing') return (
-    <ReflexPlayScreen score={score} timeLeft={timeLeft} timePct={timePct} targets={targets} onHit={hitTarget} />
-  );
-
-  return <ReflexResultScreen score={score} missed={missed} onRestart={startGame} />;
+  if (phase === 'menu')    return <ReflexMenuScreen />;
+  if (phase === 'playing') return <ReflexPlayScreen />;
+  return <ReflexResultScreen />;
 }

--- a/gamesformykids/app/games/reflex/components/ReflexMenuScreen.tsx
+++ b/gamesformykids/app/games/reflex/components/ReflexMenuScreen.tsx
@@ -1,13 +1,12 @@
 'use client';
 
 import GameMenuCard from '@/components/game/shared/GameMenuCard';
+import { useReflexStore } from '../reflexStore';
+import { GAME_DURATION } from '../data/targets';
 
-interface Props {
-  gameDuration: number;
-  onStart: () => void;
-}
+export default function ReflexMenuScreen() {
+  const startGame = useReflexStore((s) => s.startGame);
 
-export default function ReflexMenuScreen({ gameDuration, onStart }: Props) {
   return (
     <GameMenuCard
       emoji="⚡"
@@ -15,11 +14,11 @@ export default function ReflexMenuScreen({ gameDuration, onStart }: Props) {
       description="לחץ על הסמלים לפני שהם נעלמים!"
       gradientClass="from-rose-50 to-red-100"
       buttonClass="from-rose-500 to-red-600"
-      onStart={onStart}
+      onStart={startGame}
       startLabel="🚀 התחל!"
     >
       <div className="bg-red-100 rounded-2xl p-4 text-sm text-red-700 space-y-1 text-right">
-        <p>⏱️ {gameDuration} שניות משחק</p>
+        <p>⏱️ {GAME_DURATION} שניות משחק</p>
         <p>⚡ ככל שאוספים יותר — הסמלים מהירים יותר</p>
         <p>❌ סמל שנעלם = פספוס</p>
       </div>

--- a/gamesformykids/app/games/reflex/components/ReflexPlayScreen.tsx
+++ b/gamesformykids/app/games/reflex/components/ReflexPlayScreen.tsx
@@ -1,16 +1,15 @@
 'use client';
 
-import type { Target } from '../data/targets';
+import { useShallow } from 'zustand/react/shallow';
+import { useReflexStore } from '../reflexStore';
+import { GAME_DURATION } from '../data/targets';
 
-interface Props {
-  score: number;
-  timeLeft: number;
-  timePct: number;
-  targets: Target[];
-  onHit: (id: number) => void;
-}
+export default function ReflexPlayScreen() {
+  const { score, timeLeft, targets, hitTarget } = useReflexStore(
+    useShallow((s) => ({ score: s.score, timeLeft: s.timeLeft, targets: s.targets, hitTarget: s.hitTarget })),
+  );
+  const timePct = (timeLeft / GAME_DURATION) * 100;
 
-export default function ReflexPlayScreen({ score, timeLeft, timePct, targets, onHit }: Props) {
   return (
     <div className="min-h-screen bg-gradient-to-br from-slate-800 to-slate-900 select-none" dir="rtl">
       <div className="absolute top-0 left-0 right-0 p-3 flex items-center gap-3 z-10">
@@ -27,7 +26,7 @@ export default function ReflexPlayScreen({ score, timeLeft, timePct, targets, on
         {targets.map(t => (
           <button
             key={t.id}
-            onClick={() => onHit(t.id)}
+            onClick={() => hitTarget(t.id)}
             style={{ left: `${t.x}%`, top: `${t.y}%` }}
             className="absolute text-5xl transform -translate-x-1/2 -translate-y-1/2 hover:scale-125 active:scale-90 transition-transform animate-pulse drop-shadow-lg"
           >

--- a/gamesformykids/app/games/reflex/components/ReflexResultScreen.tsx
+++ b/gamesformykids/app/games/reflex/components/ReflexResultScreen.tsx
@@ -1,21 +1,18 @@
 'use client';
 import GameResultCard from '@/components/game/shared/GameResultCard';
+import { useReflexStore } from '../reflexStore';
 
-interface Props {
-  score: number;
-  missed: number;
-  onRestart: () => void;
-}
-
-export default function ReflexResultScreen({ score, missed, onRestart }: Props) {
+export default function ReflexResultScreen() {
+  const { score, missed, startGame } = useReflexStore();
   const accuracy = score + missed > 0 ? Math.round((score / (score + missed)) * 100) : 0;
+
   return (
     <GameResultCard
       emoji="⚡"
       title="הסתיים!"
       gradientClass="from-rose-50 to-red-100"
       buttonClass="from-rose-500 to-red-600"
-      onRestart={onRestart}
+      onRestart={startGame}
       animateEmoji
     >
       <div className="grid grid-cols-3 gap-3">


### PR DESCRIPTION
## Summary
- `ReflexMenuScreen` -- reads `startGame` from store; imports `GAME_DURATION` constant directly; Props interface removed
- `ReflexPlayScreen` -- reads `score`, `timeLeft`, `targets`, `hitTarget` from store; derives `timePct` inline; Props interface removed
- `ReflexResultScreen` -- reads `score`, `missed`, `startGame` from store; Props interface removed
- `ReflexGame` -- now only reads `phase` from store; drops `useReflexGame` import

## Test plan
- [ ] Menu shows game duration correctly
- [ ] Targets appear and can be tapped; score increments
- [ ] Missed targets decrement accuracy
- [ ] Timer runs out and shows result screen
- [ ] Restart works

Closes #240
Part of #17