### PR TITLE
refactor(word-builder): WordBuilderQuestion + ResultScreen subscribe to store directly

### DIFF
--- a/gamesformykids/app/games/word-builder/WordBuilderGame.tsx
+++ b/gamesformykids/app/games/word-builder/WordBuilderGame.tsx
@@ -1,4 +1,4 @@
-﻿'use client';
+'use client';
 
 import { useWordBuilderGame } from './useWordBuilderGame';
 import GameMenuCard from '@/components/game/shared/GameMenuCard';
@@ -6,10 +6,7 @@ import WordBuilderQuestion from './components/WordBuilderQuestion';
 import WordBuilderResultScreen from './components/WordBuilderResultScreen';
 
 export default function WordBuilderGame() {
-  const {
-    phase, index, score, typed, available, status, current, total,
-    startGame, pressLetter, clearTyped, next, restart,
-  } = useWordBuilderGame();
+  const { phase, startGame } = useWordBuilderGame();
 
   if (phase === 'menu') return (
     <GameMenuCard
@@ -23,26 +20,7 @@ export default function WordBuilderGame() {
     />
   );
 
-  if (phase === 'playing' && current) return (
-    <WordBuilderQuestion
-      index={index}
-      total={total}
-      score={score}
-      current={current}
-      typed={typed}
-      available={available}
-      status={status}
-      onPressLetter={pressLetter}
-      onClear={clearTyped}
-      onNext={next}
-    />
-  );
+  if (phase === 'playing') return <WordBuilderQuestion />;
 
-  return (
-    <WordBuilderResultScreen
-      score={score}
-      total={total}
-      onRestart={restart}
-    />
-  );
+  return <WordBuilderResultScreen />;
 }

--- a/gamesformykids/app/games/word-builder/components/WordBuilderQuestion.tsx
+++ b/gamesformykids/app/games/word-builder/components/WordBuilderQuestion.tsx
@@ -1,33 +1,15 @@
 'use client';
 
-interface AvailableLetter {
-  letter: string;
-  used: boolean;
-}
+import { useWordBuilderStore } from '../wordBuilderStore';
 
-interface WordBuilderItem {
-  emoji: string;
-  hint: string;
-  category: string;
-  word: string;
-}
+export default function WordBuilderQuestion() {
+  const { puzzles, index, score, typed, available, status, pressLetter, clearTyped, next } =
+    useWordBuilderStore();
+  const current = puzzles[index];
+  const total = puzzles.length;
 
-interface Props {
-  index: number;
-  total: number;
-  score: number;
-  current: WordBuilderItem;
-  typed: string[];
-  available: AvailableLetter[];
-  status: 'idle' | 'correct' | 'wrong';
-  onPressLetter: (i: number) => void;
-  onClear: () => void;
-  onNext: () => void;
-}
+  if (!current) return null;
 
-export default function WordBuilderQuestion({
-  index, total, score, current, typed, available, status, onPressLetter, onClear, onNext,
-}: Props) {
   return (
     <div className="min-h-screen bg-gradient-to-br from-orange-50 to-amber-100 p-4" dir="rtl">
       <div className="max-w-xl mx-auto">
@@ -71,7 +53,7 @@ export default function WordBuilderQuestion({
             {available.map((item, i) => (
               <button
                 key={i}
-                onClick={() => onPressLetter(i)}
+                onClick={() => pressLetter(i)}
                 disabled={item.used}
                 className={`w-12 h-12 rounded-xl text-2xl font-black transition-all active:scale-90
                   ${item.used ? 'bg-gray-200 text-gray-400 cursor-not-allowed' :
@@ -84,17 +66,17 @@ export default function WordBuilderQuestion({
         )}
         <div className="flex gap-3">
           {status === 'idle' && typed.length > 0 && (
-            <button onClick={onClear} className="flex-1 py-3 rounded-2xl border-2 border-orange-300 text-orange-600 font-semibold hover:bg-orange-50 transition-all">
+            <button onClick={clearTyped} className="flex-1 py-3 rounded-2xl border-2 border-orange-300 text-orange-600 font-semibold hover:bg-orange-50 transition-all">
               🔄 נקה
             </button>
           )}
           {(status === 'correct' || status === 'wrong') && (
-            <button onClick={onNext} className="flex-1 py-4 rounded-2xl text-white font-bold text-xl bg-gradient-to-l from-orange-500 to-amber-500 shadow-lg hover:opacity-90 active:scale-95 transition-all">
+            <button onClick={next} className="flex-1 py-4 rounded-2xl text-white font-bold text-xl bg-gradient-to-l from-orange-500 to-amber-500 shadow-lg hover:opacity-90 active:scale-95 transition-all">
               {index < total - 1 ? 'מילה הבאה ←' : 'תוצאות! 🎉'}
             </button>
           )}
           {status === 'wrong' && (
-            <button onClick={onClear} className="flex-1 py-4 rounded-2xl border-2 border-gray-200 text-gray-600 font-semibold hover:bg-gray-50 transition-all">
+            <button onClick={clearTyped} className="flex-1 py-4 rounded-2xl border-2 border-gray-200 text-gray-600 font-semibold hover:bg-gray-50 transition-all">
               🔄 נסה שוב
             </button>
           )}

--- a/gamesformykids/app/games/word-builder/components/WordBuilderResultScreen.tsx
+++ b/gamesformykids/app/games/word-builder/components/WordBuilderResultScreen.tsx
@@ -1,13 +1,8 @@
 'use client';
 import { QuizResultScreen } from '@/components/game/quiz';
+import { useWordBuilderStore } from '../wordBuilderStore';
 
-interface Props {
-  score: number;
-  total: number;
-  onRestart: () => void;
-}
-
-export default function WordBuilderResultScreen({ score, total, onRestart }: Props) {
-  return <QuizResultScreen correctCount={score} total={total} onRestart={onRestart} theme="amber" />;
-
+export default function WordBuilderResultScreen() {
+  const { score, puzzles, startGame } = useWordBuilderStore();
+  return <QuizResultScreen correctCount={score} total={puzzles.length} onRestart={startGame} theme="amber" />;
 }


### PR DESCRIPTION
## Summary
- `WordBuilderQuestion` -- reads all state (`index`, `score`, `typed`, `available`, `status`, `pressLetter`, `clearTyped`, `next`) from store; derives `current` and `total` inline; 10-prop interface removed
- `WordBuilderResultScreen` -- reads `score`, `puzzles.length`, `startGame` from store; 3-prop interface removed
- `WordBuilderGame` -- now only needs `phase` and `startGame`; drops all drilled state

## Test plan
- [ ] Start game, emoji + hint displays, letter grid works
- [ ] Correct word shows green feedback and advances
- [ ] Wrong word shows red feedback and allows retry
- [ ] After 10 words, result screen shows correct count
- [ ] Restart works

Closes #241
Part of #17