### PR TITLE
refactor(math-race): MathRaceResultScreen subscribes to store directly

### DIFF
--- a/gamesformykids/app/games/math-race/MathRaceGame.tsx
+++ b/gamesformykids/app/games/math-race/MathRaceGame.tsx
@@ -1,11 +1,12 @@
 'use client';
-import { useMathRaceGame, GAME_TIME } from './useMathRaceGame';
+import { useMathRaceStore } from './mathRaceStore';
+import { GAME_TIME } from './mathRaceStore';
 import GameMenuCard from '@/components/game/shared/GameMenuCard';
 import MathRaceResultScreen from './components/MathRaceResultScreen';
 import MathRacePlayScreen from './components/MathRacePlayScreen';
 
 export default function MathRaceGame() {
-  const { phase, score, best, correct, total, accuracy, startGame } = useMathRaceGame();
+  const { phase, best, startGame } = useMathRaceStore();
 
   if (phase === 'menu') return (
     <GameMenuCard
@@ -20,10 +21,6 @@ export default function MathRaceGame() {
       best={best}
     />
   );
-  if (phase === 'dead') return (
-    <MathRaceResultScreen
-      score={score} best={best} correct={correct} total={total} accuracy={accuracy} onRestart={startGame}
-    />
-  );
+  if (phase === 'dead') return <MathRaceResultScreen />;
   return <MathRacePlayScreen />;
 }

--- a/gamesformykids/app/games/math-race/components/MathRaceResultScreen.tsx
+++ b/gamesformykids/app/games/math-race/components/MathRaceResultScreen.tsx
@@ -1,23 +1,18 @@
 'use client';
 import GameResultCard from '@/components/game/shared/GameResultCard';
+import { useMathRaceStore } from '../mathRaceStore';
 
-interface Props {
-  score: number;
-  best: number;
-  correct: number;
-  total: number;
-  accuracy: number;
-  onRestart: () => void;
-}
+export default function MathRaceResultScreen() {
+  const { score, best, correct, total, startGame } = useMathRaceStore();
+  const accuracy = total > 0 ? Math.round((correct / total) * 100) : 0;
 
-export default function MathRaceResultScreen({ score, best, correct, total, accuracy, onRestart }: Props) {
   return (
     <GameResultCard
       emoji="🏁"
       title="הסיום!"
       gradientClass="from-blue-100 to-indigo-200"
       buttonClass="from-blue-500 to-indigo-600"
-      onRestart={onRestart}
+      onRestart={startGame}
       restartLabel="🔄 שוב!"
     >
       <div className="grid grid-cols-2 gap-3">


### PR DESCRIPTION
## Summary
- `MathRaceResultScreen` reads `score`, `best`, `correct`, `total`, `startGame` from store; derives `accuracy` inline; 6-prop interface removed
- `MathRaceGame` reads only `phase`, `best`, `startGame` — drops all drilled result state

Closes #239
Part of #17