### PR TITLE
refactor(number-bubbles): all 4 child components subscribe to store directly

### DIFF
--- a/gamesformykids/app/games/number-bubbles/NumberBubblesGame.tsx
+++ b/gamesformykids/app/games/number-bubbles/NumberBubblesGame.tsx
@@ -1,31 +1,20 @@
 'use client';
-import { useNumberBubblesGame } from './useNumberBubblesGame';
+import { useNumberBubblesStore } from './numberBubblesStore';
 import NumberBubblesMenuScreen from './components/NumberBubblesMenuScreen';
 import NumberBubblesResultScreen from './components/NumberBubblesResultScreen';
 import NumberBubblesHUD from './components/NumberBubblesHUD';
 import NumberBubbleGrid from './components/NumberBubbleGrid';
 
 export default function NumberBubblesGame() {
-  const { phase, level, bubbles, next, elapsed, best, wrong, startGame, nextLevel, tap } = useNumberBubblesGame();
+  const { phase, wrong } = useNumberBubblesStore();
 
-  if (phase === 'menu') return (
-    <NumberBubblesMenuScreen best={best} onStart={startGame} />
-  );
-
-  if (phase === 'results') return (
-    <NumberBubblesResultScreen level={level} elapsed={elapsed} onNextLevel={nextLevel} onRestart={startGame} />
-  );
+  if (phase === 'menu')    return <NumberBubblesMenuScreen />;
+  if (phase === 'results') return <NumberBubblesResultScreen />;
 
   return (
     <div className={`min-h-screen flex flex-col items-center p-3 select-none transition-all ${wrong ? 'bg-red-100' : 'bg-gradient-to-br from-sky-100 to-blue-200'}`} dir="rtl">
-      <NumberBubblesHUD
-        popped={next - 1}
-        total={bubbles.length}
-        level={level}
-        elapsed={elapsed}
-        next={next}
-      />
-      <NumberBubbleGrid bubbles={bubbles} next={next} onTap={tap} />
+      <NumberBubblesHUD />
+      <NumberBubbleGrid />
     </div>
   );
 }

--- a/gamesformykids/app/games/number-bubbles/components/NumberBubbleGrid.tsx
+++ b/gamesformykids/app/games/number-bubbles/components/NumberBubbleGrid.tsx
@@ -1,27 +1,16 @@
 'use client';
 
-interface Bubble {
-  id: number;
-  num: number;
-  x: number;
-  y: number;
-  color: string;
-  popped: boolean;
-}
+import { useNumberBubblesStore } from '../numberBubblesStore';
 
-interface Props {
-  bubbles: Bubble[];
-  next: number;
-  onTap: (bubble: Bubble) => void;
-}
+export default function NumberBubbleGrid() {
+  const { bubbles, next, tap } = useNumberBubblesStore();
 
-export default function NumberBubbleGrid({ bubbles, next, onTap }: Props) {
   return (
     <div className="relative w-full" style={{ height: '70vh', maxWidth: 400 }}>
       {bubbles.map(b => (
         <button
           key={b.id}
-          onClick={() => onTap(b)}
+          onClick={() => tap(b)}
           style={{ position: 'absolute', left: `${b.x}%`, top: `${b.y}%`, transform: 'translate(-50%,-50%)' }}
           className={`w-14 h-14 rounded-full font-black text-xl text-white shadow-lg flex items-center justify-center transition-all duration-200 ${
             b.popped

--- a/gamesformykids/app/games/number-bubbles/components/NumberBubblesHUD.tsx
+++ b/gamesformykids/app/games/number-bubbles/components/NumberBubblesHUD.tsx
@@ -1,14 +1,12 @@
 'use client';
 
-interface Props {
-  popped: number;
-  total: number;
-  level: number;
-  elapsed: number;
-  next: number;
-}
+import { useNumberBubblesStore } from '../numberBubblesStore';
 
-export default function NumberBubblesHUD({ popped, total, level, elapsed, next }: Props) {
+export default function NumberBubblesHUD() {
+  const { next, bubbles, level, elapsed } = useNumberBubblesStore();
+  const popped = next - 1;
+  const total = bubbles.length;
+
   return (
     <>
       <div className="flex gap-5 mb-2 text-center">

--- a/gamesformykids/app/games/number-bubbles/components/NumberBubblesMenuScreen.tsx
+++ b/gamesformykids/app/games/number-bubbles/components/NumberBubblesMenuScreen.tsx
@@ -1,18 +1,11 @@
 'use client';
 
 import GameMenuCard from '@/components/game/shared/GameMenuCard';
+import { useNumberBubblesStore } from '../numberBubblesStore';
 
-interface Best {
-  level: number;
-  time: number;
-}
+export default function NumberBubblesMenuScreen() {
+  const { best, startGame } = useNumberBubblesStore();
 
-interface Props {
-  best: Best | null;
-  onStart: () => void;
-}
-
-export default function NumberBubblesMenuScreen({ best, onStart }: Props) {
   return (
     <GameMenuCard
       emoji="🔢"
@@ -21,7 +14,7 @@ export default function NumberBubblesMenuScreen({ best, onStart }: Props) {
       hint="כל רמה יש יותר מספרים!"
       gradientClass="from-sky-100 to-blue-200"
       buttonClass="from-sky-500 to-blue-600"
-      onStart={onStart}
+      onStart={startGame}
       startLabel="🔢 התחל!"
     >
       {best && (

--- a/gamesformykids/app/games/number-bubbles/components/NumberBubblesResultScreen.tsx
+++ b/gamesformykids/app/games/number-bubbles/components/NumberBubblesResultScreen.tsx
@@ -1,23 +1,19 @@
 'use client';
 import GameResultCard from '@/components/game/shared/GameResultCard';
+import { useNumberBubblesStore } from '../numberBubblesStore';
 
-interface Props {
-  level: number;
-  elapsed: number;
-  onNextLevel: (level: number) => void;
-  onRestart: () => void;
-}
+export default function NumberBubblesResultScreen() {
+  const { level, elapsed, nextLevel, startGame } = useNumberBubblesStore();
 
-export default function NumberBubblesResultScreen({ level, elapsed, onNextLevel, onRestart }: Props) {
   return (
     <GameResultCard
       emoji="🎉"
       title="כל הכבוד!"
       gradientClass="from-sky-100 to-blue-200"
       buttonClass="from-sky-500 to-blue-600"
-      onRestart={() => onNextLevel(level)}
+      onRestart={() => nextLevel()}
       restartLabel={`➡️ רמה ${level + 1}`}
-      secondaryAction={{ label: '🔄 מחדש', onClick: onRestart }}
+      secondaryAction={{ label: '🔄 מחדש', onClick: startGame }}
     >
       <p className="text-gray-500 mb-2">סיימת רמה {level} ב-{elapsed} שניות</p>
       <div className="grid grid-cols-2 gap-4">


### PR DESCRIPTION
## Summary
- `NumberBubblesMenuScreen` -- reads `best`, `startGame` from store; 2-prop interface removed
- `NumberBubblesHUD` -- reads `next`, `bubbles`, `level`, `elapsed` from store; derives `popped` + `total` inline; 5-prop interface removed
- `NumberBubbleGrid` -- reads `bubbles`, `next`, `tap` from store; 3-prop interface removed
- `NumberBubblesResultScreen` -- reads `level`, `elapsed`, `nextLevel`, `startGame` from store; 4-prop interface removed
- `NumberBubblesGame` -- reads only `phase` and `wrong` for the background class

Closes #242
Part of #17