### PR TITLE
refactor(multiplication): MenuScreen + ResultScreen subscribe to store directly

### DIFF
--- a/gamesformykids/app/games/multiplication/MultiplicationGame.tsx
+++ b/gamesformykids/app/games/multiplication/MultiplicationGame.tsx
@@ -1,19 +1,16 @@
 'use client';
 import { useEffect } from 'react';
-import { useMultiplicationGame } from './useMultiplicationGame';
-import { stopMultiplicationTimer } from './multiplicationGameStore';
-import { LEVELS, QUESTIONS_PER_LEVEL, TIME_PER_QUESTION } from './data/tables';
+import { useMultiplicationGameStore, stopMultiplicationTimer } from './multiplicationGameStore';
 import MultiplicationMenuScreen from './components/MultiplicationMenuScreen';
 import MultiplicationQuestion from './components/MultiplicationQuestion';
 import MultiplicationResultScreen from './components/MultiplicationResultScreen';
 
 export default function MultiplicationGame() {
-  const { phase, level, correct, totalQuestions, score, startGame } = useMultiplicationGame();
+  const phase = useMultiplicationGameStore((s) => s.phase);
 
-  // Stop timer if user navigates away before the game ends
   useEffect(() => stopMultiplicationTimer, []);
 
-  if (phase === 'menu') return <MultiplicationMenuScreen levels={LEVELS} questionsPerLevel={QUESTIONS_PER_LEVEL} timePerQuestion={TIME_PER_QUESTION} onStart={startGame} />;
+  if (phase === 'menu')    return <MultiplicationMenuScreen />;
   if (phase === 'playing') return <MultiplicationQuestion />;
-  return <MultiplicationResultScreen level={level} correct={correct} totalQuestions={totalQuestions} score={score} onRestart={startGame} />;
+  return <MultiplicationResultScreen />;
 }

--- a/gamesformykids/app/games/multiplication/components/MultiplicationMenuScreen.tsx
+++ b/gamesformykids/app/games/multiplication/components/MultiplicationMenuScreen.tsx
@@ -1,15 +1,12 @@
 'use client';
 
 import GameMenuCard from '@/components/game/shared/GameMenuCard';
+import { useMultiplicationGameStore } from '../multiplicationGameStore';
+import { LEVELS, QUESTIONS_PER_LEVEL, TIME_PER_QUESTION } from '../data/tables';
 
-interface Props {
-  levels: number[];
-  questionsPerLevel: number;
-  timePerQuestion: number;
-  onStart: (level: number) => void;
-}
+export default function MultiplicationMenuScreen() {
+  const startGame = useMultiplicationGameStore((s) => s.startGame);
 
-export default function MultiplicationMenuScreen({ levels, questionsPerLevel, timePerQuestion, onStart }: Props) {
   return (
     <GameMenuCard
       emoji="✖️"
@@ -18,15 +15,15 @@ export default function MultiplicationMenuScreen({ levels, questionsPerLevel, ti
       gradientClass="from-violet-50 to-purple-100"
     >
       <div className="grid grid-cols-5 gap-3">
-        {levels.map(lv => (
-          <button key={lv} onClick={() => onStart(lv)}
+        {LEVELS.map(lv => (
+          <button key={lv} onClick={() => startGame(lv)}
             className="aspect-square rounded-2xl text-2xl font-black text-white shadow-lg hover:scale-105 active:scale-95 transition-all bg-gradient-to-br from-purple-500 to-violet-600 hover:from-purple-400 hover:to-violet-500">
             {lv}
           </button>
         ))}
       </div>
       <p className="text-center text-purple-500 text-sm mt-4">
-        {questionsPerLevel} שאלות ל-{timePerQuestion} שניות כל אחת
+        {QUESTIONS_PER_LEVEL} שאלות ל-{TIME_PER_QUESTION} שניות כל אחת
       </p>
     </GameMenuCard>
   );

--- a/gamesformykids/app/games/multiplication/components/MultiplicationResultScreen.tsx
+++ b/gamesformykids/app/games/multiplication/components/MultiplicationResultScreen.tsx
@@ -1,14 +1,9 @@
 'use client';
 import { QuizResultScreen } from '@/components/game/quiz';
+import { useMultiplicationGameStore } from '../multiplicationGameStore';
+import { QUESTIONS_PER_LEVEL } from '../data/tables';
 
-interface Props {
-  level: number;
-  correct: number;
-  totalQuestions: number;
-  score: number;
-  onRestart: (level: number) => void;
-}
-
-export default function MultiplicationResultScreen({ level, correct, totalQuestions, onRestart }: Props) {
-  return <QuizResultScreen correctCount={correct} total={totalQuestions} onRestart={() => onRestart(level)} theme="violet" />;
+export default function MultiplicationResultScreen() {
+  const { level, correct, startGame } = useMultiplicationGameStore();
+  return <QuizResultScreen correctCount={correct} total={QUESTIONS_PER_LEVEL} onRestart={() => startGame(level)} theme="violet" />;
 }


### PR DESCRIPTION
## Summary
- `MultiplicationMenuScreen` -- reads `startGame` from store; imports `LEVELS`, `QUESTIONS_PER_LEVEL`, `TIME_PER_QUESTION` as constants; 4-prop interface removed
- `MultiplicationResultScreen` -- reads `level`, `correct`, `startGame` from store; imports `QUESTIONS_PER_LEVEL` constant; 5-prop interface removed
- `MultiplicationGame` -- reads only `phase` from store

Closes #243
Part of #17