### PR TITLE
refactor(flappy-bird): extract UI state to Zustand store, eliminate overlay props (#246)

### DIFF
--- a/gamesformykids/app/games/flappy-bird/FlappyBirdGame.tsx
+++ b/gamesformykids/app/games/flappy-bird/FlappyBirdGame.tsx
@@ -1,12 +1,15 @@
 'use client';
 
 import { useFlappyBirdGame, W, H } from './useFlappyBirdGame';
+import { useFlappyBirdStore } from './flappyBirdStore';
 import { CanvasMenuOverlay } from '@/components/game/shared/CanvasMenuOverlay';
 import FlappyGameOverOverlay from './components/FlappyGameOverOverlay';
 import CanvasGameShell from '@/components/game/canvas/CanvasGameShell';
+import { useShallow } from 'zustand/react/shallow';
 
 export default function FlappyBirdGame() {
-  const { canvasRef, ui, handleInput } = useFlappyBirdGame();
+  const { canvasRef, handleInput } = useFlappyBirdGame();
+  const { phase, best } = useFlappyBirdStore(useShallow(s => ({ phase: s.phase, best: s.best })));
 
   return (
     <CanvasGameShell
@@ -16,17 +19,17 @@ export default function FlappyBirdGame() {
       canvasStyle={{ maxHeight: '90vh', width: 'auto' }}
       canvasProps={{ onClick: handleInput, onTouchStart: handleInput }}
       overlays={<>
-        {ui.phase === 'menu' && (
+        {phase === 'menu' && (
           <CanvasMenuOverlay
             emoji="🐦" title="ציפור מעופפת"
             description={<>הקש כדי לעוף!<br />עזור לציפור לעבור בין הצינורות</>}
-            best={ui.best} onStart={handleInput}
+            best={best} onStart={handleInput}
             backdropClass="rounded-3xl bg-black/35"
             emojiSize="text-6xl" titleSize="text-3xl" titleColor="text-sky-600"
             buttonClass="bg-gradient-to-l from-sky-500 to-blue-600 shadow-lg hover:opacity-90"
           />
         )}
-        {ui.phase === 'dead' && <FlappyGameOverOverlay score={ui.score} best={ui.best} onRestart={handleInput} />}
+        {phase === 'dead' && <FlappyGameOverOverlay onRestart={handleInput} />}
       </>}
     />
   );

--- a/gamesformykids/app/games/flappy-bird/components/FlappyGameOverOverlay.tsx
+++ b/gamesformykids/app/games/flappy-bird/components/FlappyGameOverOverlay.tsx
@@ -1,12 +1,14 @@
 'use client';
 
+import { useFlappyBirdStore } from '../flappyBirdStore';
+import { useShallow } from 'zustand/react/shallow';
+
 interface Props {
-  score: number;
-  best: number;
   onRestart: () => void;
 }
 
-export default function FlappyGameOverOverlay({ score, best, onRestart }: Props) {
+export default function FlappyGameOverOverlay({ onRestart }: Props) {
+  const { score, best } = useFlappyBirdStore(useShallow(s => ({ score: s.score, best: s.best })));
   return (
     <div className="absolute inset-0 flex flex-col items-center justify-center rounded-3xl bg-black/40">
       <div className="bg-white rounded-3xl p-7 text-center shadow-2xl w-72">

--- a/gamesformykids/app/games/flappy-bird/flappyBirdStore.ts
+++ b/gamesformykids/app/games/flappy-bird/flappyBirdStore.ts
@@ -1,0 +1,29 @@
+import { makeStore } from '@/lib/stores/createStore';
+import type { PhaseDead } from '@/lib/types';
+
+interface FlappyState {
+  phase: PhaseDead;
+  score: number;
+  best: number;
+}
+
+interface FlappyActions {
+  setPhase: (phase: PhaseDead) => void;
+  setScore: (score: number) => void;
+  endGame: (score: number) => void;
+}
+
+export const useFlappyBirdStore = makeStore<FlappyState & FlappyActions>(
+  'FlappyBirdStore',
+  (set, get) => ({
+    phase: 'menu',
+    score: 0,
+    best: 0,
+    setPhase: (phase) => set({ phase }, false, 'flappy/setPhase'),
+    setScore: (score) => set({ score }, false, 'flappy/setScore'),
+    endGame: (score) => {
+      const best = Math.max(score, get().best);
+      set({ phase: 'dead', score, best }, false, 'flappy/endGame');
+    },
+  }),
+);

--- a/gamesformykids/app/games/flappy-bird/useFlappyBirdGame.ts
+++ b/gamesformykids/app/games/flappy-bird/useFlappyBirdGame.ts
@@ -1,6 +1,7 @@
 ﻿'use client';
 
-import { useEffect, useRef, useCallback, useState } from 'react';
+import { useEffect, useRef, useCallback } from 'react';
+import { useFlappyBirdStore } from './flappyBirdStore';
 
 export const W = 360;
 export const H = 560;
@@ -30,9 +31,6 @@ export function useFlappyBirdGame() {
     raf: 0,
     bgOffset: 0,
   });
-  const [ui, setUi] = useState<{ phase: Phase; score: number; best: number }>({ phase: 'menu', score: 0, best: 0 });
-  const bestRef = useRef(0);
-
   const resetGame = useCallback(() => {
     const st = s.current;
     st.phase = 'playing';
@@ -41,7 +39,8 @@ export function useFlappyBirdGame() {
     st.pipes = [];
     st.score = 0;
     st.frame = 0;
-    setUi({ phase: 'playing', score: 0, best: bestRef.current });
+    useFlappyBirdStore.getState().setPhase('playing');
+    useFlappyBirdStore.getState().setScore(0);
   }, []);
 
   const flap = useCallback(() => {
@@ -52,7 +51,7 @@ export function useFlappyBirdGame() {
       resetGame();
     } else if (st.phase === 'dead') {
       st.phase = 'menu';
-      setUi(u => ({ ...u, phase: 'menu' }));
+      useFlappyBirdStore.getState().setPhase('menu');
     }
   }, [resetGame]);
 
@@ -177,15 +176,14 @@ export function useFlappyBirdGame() {
           if (!p.scored && p.x + PIPE_W < BIRD_X - BIRD_R) {
             p.scored = true;
             st.score++;
-            setUi(u => ({ ...u, score: st.score }));
+            useFlappyBirdStore.getState().setScore(st.score);
           }
         }
         st.pipes = st.pipes.filter(p => p.x > -PIPE_W - 20);
 
         if (st.birdY + BIRD_R >= H - GROUND_H || st.birdY - BIRD_R <= 0) {
           st.phase = 'dead';
-          if (st.score > bestRef.current) bestRef.current = st.score;
-          setUi({ phase: 'dead', score: st.score, best: bestRef.current });
+          useFlappyBirdStore.getState().endGame(st.score);
         }
 
         for (const p of st.pipes) {
@@ -196,8 +194,7 @@ export function useFlappyBirdGame() {
           if (bR > p.x && bL < p.x + PIPE_W) {
             if (bT < p.gapY || bB > p.gapY + PIPE_GAP) {
               st.phase = 'dead';
-              if (st.score > bestRef.current) bestRef.current = st.score;
-              setUi({ phase: 'dead', score: st.score, best: bestRef.current });
+              useFlappyBirdStore.getState().endGame(st.score);
             }
           }
         }
@@ -217,5 +214,5 @@ export function useFlappyBirdGame() {
     flap();
   }, [flap]);
 
-  return { canvasRef, ui, flap, handleInput };
+  return { canvasRef, flap, handleInput };
 }


### PR DESCRIPTION
## Summary
- Add `flappyBirdStore.ts` with `phase`/`score`/`best` + `setPhase`/`setScore`/`endGame` actions
- `useFlappyBirdGame`: replace `useState` + `bestRef` with `getState()` calls inside RAF loop and `flap` callback
- `FlappyGameOverOverlay`: subscribes to store directly — removes `score`/`best` props
- `FlappyBirdGame`: reads `phase`/`best` from store instead of `ui` object

Closes #246

## Test plan
- [ ] Menu → tap → game starts
- [ ] Score increments as pipes are passed
- [ ] Death (ground, ceiling, pipe) → game-over overlay shows correct score/best
- [ ] Restart button returns to menu, then tap restarts game
- [ ] Best score persists across restarts

🤖 Generated with [Claude Code](https://claude.com/claude-code)