### PR TITLE
refactor(frogger): extract UI state to Zustand store, eliminate overlay props (#247)

### DIFF
--- a/gamesformykids/app/games/frogger/FroggerGame.tsx
+++ b/gamesformykids/app/games/frogger/FroggerGame.tsx
@@ -1,14 +1,17 @@
 'use client';
 
 import { useFroggerGame, W, H } from './useFroggerGame';
+import { useFroggerStore } from './froggerStore';
 import { CanvasScoreBar } from '@/components/game/shared/CanvasScoreBar';
 import { CanvasMenuOverlay } from '@/components/game/shared/CanvasMenuOverlay';
 import FroggerGameOverOverlay from './components/FroggerGameOverOverlay';
 import { CanvasDPadControls } from '@/components/game/shared/CanvasDPadControls';
 import CanvasGameShell from '@/components/game/canvas/CanvasGameShell';
+import { useShallow } from 'zustand/react/shallow';
 
 export default function FroggerGame() {
-  const { canvasRef, ui, startGame, moveFrog, handleTouchStart, handleTouchEnd } = useFroggerGame();
+  const { canvasRef, startGame, moveFrog, handleTouchStart, handleTouchEnd } = useFroggerGame();
+  const { phase, score, lives } = useFroggerStore(useShallow(s => ({ phase: s.phase, score: s.score, lives: s.lives })));
 
   return (
     <CanvasGameShell
@@ -17,16 +20,16 @@ export default function FroggerGame() {
       canvasClassName="rounded-2xl shadow-2xl border-2 border-gray-700"
       canvasStyle={{ maxHeight: '70vh', width: 'auto' }}
       canvasProps={{ onTouchStart: handleTouchStart, onTouchEnd: handleTouchEnd }}
-      hud={ui.phase === 'playing' && (
+      hud={phase === 'playing' && (
         <CanvasScoreBar
           stats={[
-            { value: ui.score, label: "ניקוד", valueClass: "text-xl font-black text-green-300", labelClass: "text-xs text-green-600" },
-            { value: <div className="flex gap-1 items-center justify-center">{[0,1,2].map(i => <span key={i} className={`text-xl ${i < ui.lives ? '' : 'opacity-20'}`}>❤️</span>)}</div> },
+            { value: score, label: "ניקוד", valueClass: "text-xl font-black text-green-300", labelClass: "text-xs text-green-600" },
+            { value: <div className="flex gap-1 items-center justify-center">{[0,1,2].map(i => <span key={i} className={`text-xl ${i < lives ? '' : 'opacity-20'}`}>❤️</span>)}</div> },
           ]}
         />
       )}
       overlays={<>
-        {ui.phase === 'menu' && (
+        {phase === 'menu' && (
           <CanvasMenuOverlay
             emoji="🐸" title="צפרדע חוצה"
             description={<>עזור לצפרדע לחצות את הכביש!<br />הימנע מהרכבים — הגע לדגלים 🏁</>}
@@ -36,9 +39,9 @@ export default function FroggerGame() {
             buttonClass="bg-green-500 hover:bg-green-600"
           />
         )}
-        {ui.phase === 'dead' && <FroggerGameOverOverlay score={ui.score} best={ui.best} onRestart={startGame} />}
+        {phase === 'dead' && <FroggerGameOverOverlay onRestart={startGame} />}
       </>}
-      controls={ui.phase === 'playing' && (
+      controls={phase === 'playing' && (
         <CanvasDPadControls
           onUp={() => moveFrog(0, -1)} onDown={() => moveFrog(0, 1)}
           onLeft={() => moveFrog(-1, 0)} onRight={() => moveFrog(1, 0)}

--- a/gamesformykids/app/games/frogger/components/FroggerGameOverOverlay.tsx
+++ b/gamesformykids/app/games/frogger/components/FroggerGameOverOverlay.tsx
@@ -1,12 +1,14 @@
 'use client';
 
+import { useFroggerStore } from '../froggerStore';
+import { useShallow } from 'zustand/react/shallow';
+
 interface Props {
-  score: number;
-  best: number;
   onRestart: () => void;
 }
 
-export default function FroggerGameOverOverlay({ score, best, onRestart }: Props) {
+export default function FroggerGameOverOverlay({ onRestart }: Props) {
+  const { score, best } = useFroggerStore(useShallow(s => ({ score: s.score, best: s.best })));
   return (
     <div className="absolute inset-0 flex items-center justify-center rounded-2xl bg-black/75">
       <div className="bg-white rounded-3xl p-7 text-center shadow-2xl w-72">

--- a/gamesformykids/app/games/frogger/froggerStore.ts
+++ b/gamesformykids/app/games/frogger/froggerStore.ts
@@ -1,0 +1,31 @@
+import { makeStore } from '@/lib/stores/createStore';
+import type { PhaseDead } from '@/lib/types';
+
+interface FroggerState {
+  phase: PhaseDead;
+  score: number;
+  best: number;
+  lives: number;
+}
+
+interface FroggerActions {
+  startPlaying: () => void;
+  setScore: (score: number) => void;
+  endGame: (score: number) => void;
+}
+
+export const useFroggerStore = makeStore<FroggerState & FroggerActions>(
+  'FroggerStore',
+  (set, get) => ({
+    phase: 'menu',
+    score: 0,
+    best: 0,
+    lives: 3,
+    startPlaying: () => set({ phase: 'playing', score: 0, lives: 3 }, false, 'frogger/startPlaying'),
+    setScore: (score) => set({ score }, false, 'frogger/setScore'),
+    endGame: (score) => {
+      const best = Math.max(score, get().best);
+      set({ phase: 'dead', lives: 0, score, best }, false, 'frogger/endGame');
+    },
+  }),
+);

--- a/gamesformykids/app/games/frogger/useFroggerGame.ts
+++ b/gamesformykids/app/games/frogger/useFroggerGame.ts
@@ -1,6 +1,7 @@
 ﻿'use client';
 
-import { useEffect, useRef, useCallback, useState } from 'react';
+import { useEffect, useRef, useCallback } from 'react';
+import { useFroggerStore } from './froggerStore';
 
 const CELL = 40;
 const COLS = 9;
@@ -39,14 +40,12 @@ export function useFroggerGame() {
     frame: 0, raf: 0, dead: false, deadTimer: 0,
     lanes: makeLanes(),
   });
-  const [ui, setUi] = useState({ phase: 'menu' as Phase, lives: 3, score: 0, best: 0 });
-
   const startGame = useCallback(() => {
     const s = st.current;
     s.phase = 'playing'; s.fCol = 4; s.fRow = 8;
     s.lives = 3; s.score = 0; s.level = 1; s.frame = 0; s.dead = false; s.deadTimer = 0;
     s.lanes = makeLanes();
-    setUi({ phase: 'playing', lives: 3, score: 0, best: s.best });
+    useFroggerStore.getState().startPlaying();
   }, []);
 
   const moveFrog = useCallback((dc: number, dr: number) => {
@@ -56,7 +55,7 @@ export function useFroggerGame() {
     const nr = Math.max(0, Math.min(8, s.fRow + dr));
     if (dr < 0) s.score += 2;
     s.fCol = nc; s.fRow = nr;
-    if (nr === 0) { s.score += 30; s.level++; s.fCol = 4; s.fRow = 8; setUi(u => ({ ...u, score: s.score })); }
+    if (nr === 0) { s.score += 30; s.level++; s.fCol = 4; s.fRow = 8; useFroggerStore.getState().setScore(s.score); }
   }, []);
 
   const touchRef = useRef<{ x: number; y: number } | null>(null);
@@ -106,7 +105,7 @@ export function useFroggerGame() {
               const cx = car.x + CAR_W / 2;
               if (Math.abs(fx - cx) < CAR_W / 2 - 4) {
                 s.lives--; s.dead = true; s.deadTimer = 55; s.fCol = 4; s.fRow = 8;
-                if (s.lives <= 0) { s.phase = 'dead'; if (s.score > s.best) s.best = s.score; setUi({ phase: 'dead', lives: 0, score: s.score, best: s.best }); }
+                if (s.lives <= 0) { s.phase = 'dead'; useFroggerStore.getState().endGame(s.score); }
               }
             }
           }
@@ -167,5 +166,5 @@ export function useFroggerGame() {
     return () => window.removeEventListener('keydown', kd);
   }, [moveFrog]);
 
-  return { canvasRef, ui, startGame, moveFrog, handleTouchStart, handleTouchEnd };
+  return { canvasRef, startGame, moveFrog, handleTouchStart, handleTouchEnd };
 }


### PR DESCRIPTION
## Summary
- Add `froggerStore.ts` with `phase`/`score`/`best`/`lives` + `startPlaying`/`setScore`/`endGame` actions
- `useFroggerGame`: replace `useState` with `getState()` calls; remove `ui` from return value
- `FroggerGameOverOverlay`: subscribes to store directly — removes `score`/`best` props
- `FroggerGame`: reads `phase`/`score`/`lives` from store instead of `ui` object

Closes #247

## Test plan
- [ ] Menu → start → game begins with 3 lives
- [ ] Score increments when reaching top row
- [ ] Life lost on car hit (HUD shows remaining lives on death)
- [ ] Game-over overlay shows correct score/best after 0 lives
- [ ] Best score persists across restarts

🤖 Generated with [Claude Code](https://claude.com/claude-code)