### PR TITLE
refactor(jumper): extract UI state to Zustand store, eliminate overlay props (#248)

### DIFF
--- a/gamesformykids/app/games/jumper/JumperGame.tsx
+++ b/gamesformykids/app/games/jumper/JumperGame.tsx
@@ -1,14 +1,17 @@
 'use client';
 
 import { useJumperGame, W, H } from './useJumperGame';
+import { useJumperStore } from './jumperStore';
 import { CanvasScoreBar } from '@/components/game/shared/CanvasScoreBar';
 import { CanvasMenuOverlay } from '@/components/game/shared/CanvasMenuOverlay';
 import JumperGameOverOverlay from './components/JumperGameOverOverlay';
 import { CanvasLRControls } from '@/components/game/shared/CanvasLRControls';
 import CanvasGameShell from '@/components/game/canvas/CanvasGameShell';
+import { useShallow } from 'zustand/react/shallow';
 
 export default function JumperGame() {
-  const { canvasRef, ui, startGame, handleTouchMove, handleTouchEnd, handleCanvasClick, pressLeft, releaseLeft, pressRight, releaseRight } = useJumperGame();
+  const { canvasRef, startGame, handleTouchMove, handleTouchEnd, handleCanvasClick, pressLeft, releaseLeft, pressRight, releaseRight } = useJumperGame();
+  const { phase, score, best } = useJumperStore(useShallow(s => ({ phase: s.phase, score: s.score, best: s.best })));
 
   return (
     <CanvasGameShell
@@ -17,28 +20,28 @@ export default function JumperGame() {
       canvasClassName="rounded-3xl shadow-2xl border-2 border-indigo-800"
       canvasStyle={{ maxHeight: '78vh', width: 'auto' }}
       canvasProps={{ onTouchMove: handleTouchMove, onTouchEnd: handleTouchEnd, onClick: handleCanvasClick }}
-      hud={ui.phase === 'playing' && (
+      hud={phase === 'playing' && (
         <CanvasScoreBar
           stats={[
-            { value: `${ui.score}m`, label: "גובה", valueClass: "text-2xl font-black text-green-300", labelClass: "text-xs text-green-600" },
-            { value: `${ui.best}m`,  label: "שיא",  valueClass: "text-2xl font-black text-gray-400",  labelClass: "text-xs text-gray-600" },
+            { value: `${score}m`, label: "גובה", valueClass: "text-2xl font-black text-green-300", labelClass: "text-xs text-green-600" },
+            { value: `${best}m`,  label: "שיא",  valueClass: "text-2xl font-black text-gray-400",  labelClass: "text-xs text-gray-600" },
           ]}
         />
       )}
       overlays={<>
-        {ui.phase === 'menu' && (
+        {phase === 'menu' && (
           <CanvasMenuOverlay
             emoji="🦘" title="קפצן"
             description={<>קפץ על הפלטפורמות וטפס גבוה!<br />הזז שמאלה/ימינה· אל תיפול</>}
-            best={ui.best} bestSuffix="m" onStart={startGame}
+            best={best} bestSuffix="m" onStart={startGame}
             backdropClass="rounded-3xl bg-black/70" cardWidth="w-64"
             titleColor="text-gray-700" startLabel="🦘 קפץ!"
             buttonClass="bg-indigo-600 hover:bg-indigo-500"
           />
         )}
-        {ui.phase === 'dead' && <JumperGameOverOverlay score={ui.score} best={ui.best} onRestart={startGame} />}
+        {phase === 'dead' && <JumperGameOverOverlay onRestart={startGame} />}
       </>}
-      controls={ui.phase === 'playing' && (
+      controls={phase === 'playing' && (
         <CanvasLRControls
           onLeft={pressLeft} onRight={pressRight}
           onLeftRelease={releaseLeft} onRightRelease={releaseRight}

--- a/gamesformykids/app/games/jumper/components/JumperGameOverOverlay.tsx
+++ b/gamesformykids/app/games/jumper/components/JumperGameOverOverlay.tsx
@@ -1,12 +1,14 @@
 'use client';
 
+import { useJumperStore } from '../jumperStore';
+import { useShallow } from 'zustand/react/shallow';
+
 interface Props {
-  score: number;
-  best: number;
   onRestart: () => void;
 }
 
-export default function JumperGameOverOverlay({ score, best, onRestart }: Props) {
+export default function JumperGameOverOverlay({ onRestart }: Props) {
+  const { score, best } = useJumperStore(useShallow(s => ({ score: s.score, best: s.best })));
   return (
     <div className="absolute inset-0 flex items-center justify-center rounded-3xl bg-black/70">
       <div className="bg-white rounded-3xl p-7 text-center shadow-2xl w-64">

--- a/gamesformykids/app/games/jumper/jumperStore.ts
+++ b/gamesformykids/app/games/jumper/jumperStore.ts
@@ -1,0 +1,29 @@
+import { makeStore } from '@/lib/stores/createStore';
+import type { PhaseDead } from '@/lib/types';
+
+interface JumperState {
+  phase: PhaseDead;
+  score: number;
+  best: number;
+}
+
+interface JumperActions {
+  startPlaying: () => void;
+  setScore: (score: number) => void;
+  endGame: (score: number) => void;
+}
+
+export const useJumperStore = makeStore<JumperState & JumperActions>(
+  'JumperStore',
+  (set, get) => ({
+    phase: 'menu',
+    score: 0,
+    best: 0,
+    startPlaying: () => set({ phase: 'playing', score: 0 }, false, 'jumper/startPlaying'),
+    setScore: (score) => set({ score }, false, 'jumper/setScore'),
+    endGame: (score) => {
+      const best = Math.max(score, get().best);
+      set({ phase: 'dead', score, best }, false, 'jumper/endGame');
+    },
+  }),
+);

--- a/gamesformykids/app/games/jumper/useJumperGame.ts
+++ b/gamesformykids/app/games/jumper/useJumperGame.ts
@@ -1,6 +1,7 @@
 ﻿'use client';
 
-import { useEffect, useRef, useCallback, useState } from 'react';
+import { useEffect, useRef, useCallback } from 'react';
+import { useJumperStore } from './jumperStore';
 
 export const W = 300;
 export const H = 500;
@@ -42,8 +43,6 @@ export function useJumperGame() {
     leftDown: false, rightDown: false,
     nextPlatY: H - 60 - INIT_PLATS * (PLAT_GAP * 0.75),
   });
-  const [ui, setUi] = useState({ phase: 'menu' as Phase, score: 0, best: 0 });
-
   const startGame = useCallback(() => {
     const s = st.current;
     s.phase = 'playing';
@@ -53,7 +52,7 @@ export function useJumperGame() {
     s.score = 0; s.frame = 0;
     s.platforms = generateInitial();
     s.nextPlatY = H - 60 - INIT_PLATS * (PLAT_GAP * 0.75);
-    setUi({ phase: 'playing', score: 0, best: s.best });
+    useJumperStore.getState().startPlaying();
   }, []);
 
   const handleCanvasClick = useCallback(() => {
@@ -113,7 +112,7 @@ export function useJumperGame() {
         s.score = Math.floor(s.camY / 10);
         if (s.camY > s.maxCamY) {
           s.maxCamY = s.camY;
-          if (s.frame % 10 === 0) setUi(u => ({ ...u, score: s.score }));
+          if (s.frame % 10 === 0) useJumperStore.getState().setScore(s.score);
         }
 
         while (s.nextPlatY > -(s.camY) - H) {
@@ -124,8 +123,7 @@ export function useJumperGame() {
 
         if (s.py > H + 60) {
           s.phase = 'dead';
-          if (s.score > s.best) s.best = s.score;
-          setUi({ phase: 'dead', score: s.score, best: s.best });
+          useJumperStore.getState().endGame(s.score);
         }
       }
 
@@ -205,5 +203,5 @@ export function useJumperGame() {
     st.current.rightDown = false;
   }, []);
 
-  return { canvasRef, ui, startGame, handleTouchMove, handleTouchEnd, handleCanvasClick, pressLeft, releaseLeft, pressRight, releaseRight };
+  return { canvasRef, startGame, handleTouchMove, handleTouchEnd, handleCanvasClick, pressLeft, releaseLeft, pressRight, releaseRight };
 }


### PR DESCRIPTION
## Summary
- Add `jumperStore.ts` with `phase`/`score`/`best` + `startPlaying`/`setScore`/`endGame` actions
- `useJumperGame`: replace `useState` with `getState()` calls every 10 frames and on death; remove `ui` from return value
- `JumperGameOverOverlay`: subscribes to store directly — removes `score`/`best` props
- `JumperGame`: reads `phase`/`score`/`best` from store instead of `ui` object

Closes #248

## Test plan
- [ ] Menu → start → platforms generate and player jumps
- [ ] Height score updates during gameplay
- [ ] Death (fall off bottom) → game-over overlay shows score in meters + best
- [ ] Best persists across restarts

🤖 Generated with [Claude Code](https://claude.com/claude-code)