### PR TITLE
refactor(meteor-dodge): extract UI state to Zustand store, eliminate overlay props (#249)

### DIFF
--- a/gamesformykids/app/games/meteor-dodge/MeteorDodgeGame.tsx
+++ b/gamesformykids/app/games/meteor-dodge/MeteorDodgeGame.tsx
@@ -1,14 +1,17 @@
 'use client';
 
 import { useMeteorDodgeGame, W, H } from './useMeteorDodgeGame';
+import { useMeteorDodgeStore } from './meteorDodgeStore';
 import { CanvasScoreBar } from '@/components/game/shared/CanvasScoreBar';
 import { CanvasMenuOverlay } from '@/components/game/shared/CanvasMenuOverlay';
 import MeteorGameOverOverlay from './components/MeteorGameOverOverlay';
 import { CanvasLRControls } from '@/components/game/shared/CanvasLRControls';
 import CanvasGameShell from '@/components/game/canvas/CanvasGameShell';
+import { useShallow } from 'zustand/react/shallow';
 
 export default function MeteorDodgeGame() {
-  const { canvasRef, ui, startGame, handleMouseMove, handleTouchMove, handleCanvasClick, handleTouchStart, nudgeLeft, nudgeRight } = useMeteorDodgeGame();
+  const { canvasRef, startGame, handleMouseMove, handleTouchMove, handleCanvasClick, handleTouchStart, nudgeLeft, nudgeRight } = useMeteorDodgeGame();
+  const { phase, score, best } = useMeteorDodgeStore(useShallow(s => ({ phase: s.phase, score: s.score, best: s.best })));
 
   return (
     <CanvasGameShell
@@ -17,29 +20,29 @@ export default function MeteorDodgeGame() {
       canvasClassName="rounded-3xl shadow-2xl border-4 border-slate-700 cursor-none"
       canvasStyle={{ maxHeight: '85vh', width: 'auto' }}
       canvasProps={{ onMouseMove: handleMouseMove, onTouchMove: handleTouchMove, onClick: handleCanvasClick, onTouchStart: handleTouchStart }}
-      hud={ui.phase === 'playing' && (
+      hud={phase === 'playing' && (
         <CanvasScoreBar
           stats={[
-            { value: ui.score, label: "ניקוד", valueClass: "text-2xl font-black text-yellow-300", labelClass: "text-xs text-yellow-500" },
-            { value: ui.best,  label: "שיא",   valueClass: "text-2xl font-black text-gray-400",   labelClass: "text-xs text-gray-500" },
+            { value: score, label: "ניקוד", valueClass: "text-2xl font-black text-yellow-300", labelClass: "text-xs text-yellow-500" },
+            { value: best,  label: "שיא",   valueClass: "text-2xl font-black text-gray-400",   labelClass: "text-xs text-gray-500" },
           ]}
           className="text-white"
         />
       )}
       overlays={<>
-        {ui.phase === 'menu' && (
+        {phase === 'menu' && (
           <CanvasMenuOverlay
             emoji="☄️" title="התחמק ממטאורים"
             description={<>הזז את הספינה 🚀 והימנע ממטאורים<br />אסוף כוכבים ⭐ לנקודות בונוס!</>}
-            best={ui.best} onStart={startGame}
+            best={best} onStart={startGame}
             backdropClass="rounded-3xl bg-black/70"
             titleColor="text-slate-700"
             buttonClass="bg-gradient-to-l from-violet-600 to-purple-700 shadow-lg hover:opacity-90"
           />
         )}
-        {ui.phase === 'dead' && <MeteorGameOverOverlay score={ui.score} best={ui.best} onRestart={startGame} />}
+        {phase === 'dead' && <MeteorGameOverOverlay onRestart={startGame} />}
       </>}
-      controls={ui.phase === 'playing' && <CanvasLRControls onLeft={nudgeLeft} onRight={nudgeRight} buttonClass="bg-violet-700/80 text-white rounded-xl px-8 py-3 text-xl font-bold active:bg-violet-500 touch-none" />}
+      controls={phase === 'playing' && <CanvasLRControls onLeft={nudgeLeft} onRight={nudgeRight} buttonClass="bg-violet-700/80 text-white rounded-xl px-8 py-3 text-xl font-bold active:bg-violet-500 touch-none" />}
     />
   );
 }

--- a/gamesformykids/app/games/meteor-dodge/components/MeteorGameOverOverlay.tsx
+++ b/gamesformykids/app/games/meteor-dodge/components/MeteorGameOverOverlay.tsx
@@ -1,12 +1,14 @@
 'use client';
 
+import { useMeteorDodgeStore } from '../meteorDodgeStore';
+import { useShallow } from 'zustand/react/shallow';
+
 interface Props {
-  score: number;
-  best: number;
   onRestart: () => void;
 }
 
-export default function MeteorGameOverOverlay({ score, best, onRestart }: Props) {
+export default function MeteorGameOverOverlay({ onRestart }: Props) {
+  const { score, best } = useMeteorDodgeStore(useShallow(s => ({ score: s.score, best: s.best })));
   return (
     <div className="absolute inset-0 flex items-center justify-center rounded-3xl bg-black/70">
       <div className="bg-white rounded-3xl p-7 text-center shadow-2xl w-72">

--- a/gamesformykids/app/games/meteor-dodge/meteorDodgeStore.ts
+++ b/gamesformykids/app/games/meteor-dodge/meteorDodgeStore.ts
@@ -1,0 +1,29 @@
+import { makeStore } from '@/lib/stores/createStore';
+import type { PhaseDead } from '@/lib/types';
+
+interface MeteorState {
+  phase: PhaseDead;
+  score: number;
+  best: number;
+}
+
+interface MeteorActions {
+  startPlaying: () => void;
+  setScore: (score: number) => void;
+  endGame: (score: number) => void;
+}
+
+export const useMeteorDodgeStore = makeStore<MeteorState & MeteorActions>(
+  'MeteorDodgeStore',
+  (set, get) => ({
+    phase: 'menu',
+    score: 0,
+    best: 0,
+    startPlaying: () => set({ phase: 'playing', score: 0 }, false, 'meteor/startPlaying'),
+    setScore: (score) => set({ score }, false, 'meteor/setScore'),
+    endGame: (score) => {
+      const best = Math.max(score, get().best);
+      set({ phase: 'dead', score, best }, false, 'meteor/endGame');
+    },
+  }),
+);

--- a/gamesformykids/app/games/meteor-dodge/useMeteorDodgeGame.ts
+++ b/gamesformykids/app/games/meteor-dodge/useMeteorDodgeGame.ts
@@ -1,6 +1,7 @@
 ﻿'use client';
 
-import { useEffect, useRef, useCallback, useState } from 'react';
+import { useEffect, useRef, useCallback } from 'react';
+import { useMeteorDodgeStore } from './meteorDodgeStore';
 
 export const W = 360;
 export const H = 560;
@@ -25,13 +26,11 @@ export function useMeteorDodgeGame() {
     bgStars: Array.from({ length: 50 }, () => ({ x: Math.random() * W, y: Math.random() * H, r: 0.5 + Math.random() * 1.5, twinkle: Math.random() * Math.PI * 2 })),
     invincible: 0,
   });
-  const [ui, setUi] = useState<{ phase: Phase; score: number; best: number }>({ phase: 'menu', score: 0, best: 0 });
-
   const startGame = useCallback(() => {
     const s = st.current;
     s.phase = 'playing'; s.playerX = W / 2; s.meteors = []; s.stars = [];
     s.score = 0; s.frame = 0; s.nextMeteor = 50; s.nextStar = 120; s.invincible = 0;
-    setUi({ phase: 'playing', score: 0, best: s.best });
+    useMeteorDodgeStore.getState().startPlaying();
   }, []);
 
   const handleMouseMove = useCallback((e: React.MouseEvent<HTMLCanvasElement>) => {
@@ -91,18 +90,18 @@ export function useMeteorDodgeGame() {
 
         s.stars = s.stars.filter(st2 => {
           const dx = st2.x - s.playerX, dy = st2.y - PLAYER_Y;
-          if (Math.sqrt(dx * dx + dy * dy) < PLAYER_R + 16) { s.score += 50; setUi(u => ({ ...u, score: s.score })); return false; }
+          if (Math.sqrt(dx * dx + dy * dy) < PLAYER_R + 16) { s.score += 50; useMeteorDodgeStore.getState().setScore(s.score); return false; }
           return true;
         });
 
         if (s.invincible === 0) {
           for (const m of s.meteors) {
             const dx = m.x - s.playerX, dy = m.y - PLAYER_Y;
-            if (Math.sqrt(dx * dx + dy * dy) < PLAYER_R + m.r - 8) { s.phase = 'dead'; if (s.score > s.best) s.best = s.score; setUi({ phase: 'dead', score: s.score, best: s.best }); break; }
+            if (Math.sqrt(dx * dx + dy * dy) < PLAYER_R + m.r - 8) { s.phase = 'dead'; useMeteorDodgeStore.getState().endGame(s.score); break; }
           }
         }
 
-        if (s.frame % 8 === 0) setUi(u => u.phase === 'playing' ? { ...u, score: s.score } : u);
+        if (s.frame % 8 === 0 && useMeteorDodgeStore.getState().phase === 'playing') useMeteorDodgeStore.getState().setScore(s.score);
       }
 
       ctx.fillStyle = '#030712'; ctx.fillRect(0, 0, W, H);
@@ -176,5 +175,5 @@ export function useMeteorDodgeGame() {
     s.playerX = Math.min(W - PLAYER_R, s.playerX + 45);
   }, []);
 
-  return { canvasRef, ui, startGame, handleMouseMove, handleTouchMove, handleCanvasClick, handleTouchStart, nudgeLeft, nudgeRight };
+  return { canvasRef, startGame, handleMouseMove, handleTouchMove, handleCanvasClick, handleTouchStart, nudgeLeft, nudgeRight };
 }


### PR DESCRIPTION
## Summary
- Add `meteorDodgeStore.ts` with `phase`/`score`/`best` + `startPlaying`/`setScore`/`endGame` actions
- `useMeteorDodgeGame`: replace `useState` with `getState()` calls (star pickup, periodic score, meteor hit); remove `ui` from return value
- `MeteorGameOverOverlay`: subscribes to store directly — removes `score`/`best` props
- `MeteorDodgeGame`: reads `phase`/`score`/`best` from store instead of `ui` object

Closes #249

## Test plan
- [ ] Menu → start → rocket appears, meteors fall
- [ ] Score increments every 8 frames and on star pickup (+50)
- [ ] Meteor hit → game-over overlay shows correct score/best
- [ ] Best persists across restarts

🤖 Generated with [Claude Code](https://claude.com/claude-code)