### PR TITLE
refactor(stack): extract UI state to Zustand store, eliminate overlay props (#250)

### DIFF
--- a/gamesformykids/app/games/stack/StackGame.tsx
+++ b/gamesformykids/app/games/stack/StackGame.tsx
@@ -1,13 +1,16 @@
 'use client';
 
 import { useStackGame, W, H } from './useStackGame';
+import { useStackStore } from './stackStore';
 import { CanvasMenuOverlay } from '@/components/game/shared/CanvasMenuOverlay';
 import StackGameOverOverlay from './components/StackGameOverOverlay';
 import StackDropButton from './components/StackDropButton';
 import CanvasGameShell from '@/components/game/canvas/CanvasGameShell';
+import { useShallow } from 'zustand/react/shallow';
 
 export default function StackGame() {
-  const { canvasRef, ui, startGame, drop, handleCanvasClick } = useStackGame();
+  const { canvasRef, startGame, drop, handleCanvasClick } = useStackGame();
+  const { phase, best } = useStackStore(useShallow(s => ({ phase: s.phase, best: s.best })));
 
   return (
     <CanvasGameShell
@@ -17,19 +20,19 @@ export default function StackGame() {
       canvasStyle={{ maxHeight: '80vh', width: 'auto' }}
       canvasProps={{ onClick: handleCanvasClick }}
       overlays={<>
-        {ui.phase === 'menu' && (
+        {phase === 'menu' && (
           <CanvasMenuOverlay
             emoji="🏗️" title="ערם לבנים"
             description={<>לחץ / הקש בזמן הנכון<br />ועצב מגדל גבוה!</>}
-            best={ui.best} onStart={startGame}
+            best={best} onStart={startGame}
             backdropClass="rounded-3xl bg-black/70" cardWidth="w-60"
             titleColor="text-gray-700" startLabel="🏗️ התחל!"
             buttonClass="bg-blue-600 hover:bg-blue-500"
           />
         )}
-        {ui.phase === 'dead' && <StackGameOverOverlay score={ui.score} best={ui.best} onRestart={startGame} />}
+        {phase === 'dead' && <StackGameOverOverlay onRestart={startGame} />}
       </>}
-      controls={ui.phase === 'playing' && <StackDropButton onDrop={drop} />}
+      controls={phase === 'playing' && <StackDropButton onDrop={drop} />}
     />
   );
 }

--- a/gamesformykids/app/games/stack/components/StackGameOverOverlay.tsx
+++ b/gamesformykids/app/games/stack/components/StackGameOverOverlay.tsx
@@ -1,12 +1,14 @@
 'use client';
 
+import { useStackStore } from '../stackStore';
+import { useShallow } from 'zustand/react/shallow';
+
 interface Props {
-  score: number;
-  best: number;
   onRestart: () => void;
 }
 
-export default function StackGameOverOverlay({ score, best, onRestart }: Props) {
+export default function StackGameOverOverlay({ onRestart }: Props) {
+  const { score, best } = useStackStore(useShallow(s => ({ score: s.score, best: s.best })));
   return (
     <div className="absolute inset-0 flex items-center justify-center rounded-3xl bg-black/70">
       <div className="bg-white rounded-3xl p-7 text-center shadow-2xl w-60">

--- a/gamesformykids/app/games/stack/stackStore.ts
+++ b/gamesformykids/app/games/stack/stackStore.ts
@@ -1,0 +1,29 @@
+import { makeStore } from '@/lib/stores/createStore';
+import type { PhaseDead } from '@/lib/types';
+
+interface StackState {
+  phase: PhaseDead;
+  score: number;
+  best: number;
+}
+
+interface StackActions {
+  startPlaying: () => void;
+  setScore: (score: number) => void;
+  endGame: (score: number) => void;
+}
+
+export const useStackStore = makeStore<StackState & StackActions>(
+  'StackStore',
+  (set, get) => ({
+    phase: 'menu',
+    score: 0,
+    best: 0,
+    startPlaying: () => set({ phase: 'playing', score: 0 }, false, 'stack/startPlaying'),
+    setScore: (score) => set({ score }, false, 'stack/setScore'),
+    endGame: (score) => {
+      const best = Math.max(score, get().best);
+      set({ phase: 'dead', score, best }, false, 'stack/endGame');
+    },
+  }),
+);

--- a/gamesformykids/app/games/stack/useStackGame.ts
+++ b/gamesformykids/app/games/stack/useStackGame.ts
@@ -1,6 +1,7 @@
 ﻿'use client';
 
-import { useEffect, useRef, useCallback, useState } from 'react';
+import { useEffect, useRef, useCallback } from 'react';
+import { useStackStore } from './stackStore';
 
 export const W = 300;
 export const H = 480;
@@ -28,8 +29,6 @@ export function useStackGame() {
     colorIdx: 0,
     frame: 0, raf: 0,
   });
-  const [ui, setUi] = useState({ phase: 'menu' as Phase, score: 0, best: 0 });
-
   const startGame = useCallback(() => {
     const s = st.current;
     s.phase = 'playing';
@@ -37,7 +36,7 @@ export function useStackGame() {
     s.curW = INIT_W; s.curX = (W - INIT_W) / 2;
     s.curDir = 1; s.curSpeed = 2.5; s.colorIdx = 0;
     s.blocks = [{ x: (W - INIT_W) / 2, y: FLOOR_Y, w: INIT_W, color: '#6b7280' }];
-    setUi({ phase: 'playing', score: 0, best: s.best });
+    useStackStore.getState().startPlaying();
   }, []);
 
   const drop = useCallback(() => {
@@ -52,8 +51,7 @@ export function useStackGame() {
 
     if (overlap <= 2) {
       s.phase = 'dead';
-      if (s.score > s.best) s.best = s.score;
-      setUi({ phase: 'dead', score: s.score, best: s.best });
+      useStackStore.getState().endGame(s.score);
       return;
     }
 
@@ -67,7 +65,7 @@ export function useStackGame() {
 
     const topWorldY = sliderWorldY;
     s.camOffset = Math.max(0, TARGET_TOP - topWorldY);
-    setUi(u => ({ ...u, score: s.score }));
+    useStackStore.getState().setScore(s.score);
   }, []);
 
   const handleCanvasClick = useCallback(() => {
@@ -151,5 +149,5 @@ export function useStackGame() {
   // suppress unused warning from module-level helper
   void makeBricks;
 
-  return { canvasRef, ui, startGame, drop, handleCanvasClick };
+  return { canvasRef, startGame, drop, handleCanvasClick };
 }


### PR DESCRIPTION
## Summary
- Add `stackStore.ts` with `phase`/`score`/`best` + `startPlaying`/`setScore`/`endGame` actions
- `useStackGame`: replace `useState` with `getState()` calls in `drop` (score update + game-over) and `startGame`; remove `ui` from return value
- `StackGameOverOverlay`: subscribes to store directly — removes `score`/`best` props
- `StackGame`: reads `phase`/`best` from store instead of `ui` object

Closes #250

## Test plan
- [ ] Menu → start → slider block begins moving
- [ ] Tap/click to drop — block stacks and score increments
- [ ] Missed drop (overlap ≤ 2) → game-over overlay shows score/best in bricks
- [ ] Best persists across restarts

🤖 Generated with [Claude Code](https://claude.com/claude-code)