### PR TITLE
refactor: extract shared useNumericQuizRuntime hook

### DIFF
--- a/gamesformykids/app/games/counting/useCountingGame.ts
+++ b/gamesformykids/app/games/counting/useCountingGame.ts
@@ -1,24 +1,18 @@
 'use client';
 
-import { useState } from "react";
 import { CountingChallenge, CountingGameState } from "@/lib/types/games";
 import { BaseGameItem } from "@/lib/types/core/base";
 import { speakHebrew } from "@/lib/utils/speech/enhancedSpeechUtils";
 import { useGameAudio } from "@/hooks/shared/audio/useGameAudio";
-import { 
-  delay, 
-  playSuccessSound as playSound, 
-  getRandomItem,
-  handleWrongGameAnswer,
-  handleCorrectGameAnswer,
-  speakStartMessage
-} from "@/lib/utils/game/gameUtils";
-import { GAME_CONSTANTS, COUNTING_GAME_CONSTANTS } from "@/lib/constants";
-import { useGameProgressStore } from "@/lib/stores/gameProgressStore";
-import { useGameSessionStore } from "@/lib/stores/gameSessionStore";
+import { getRandomItem } from "@/lib/utils/game/gameUtils";
+import { COUNTING_GAME_CONSTANTS } from "@/lib/constants";
 import { useCountingChallengeStore } from "@/lib/stores/countingChallengeStore";
+import { useNumericQuizRuntime } from "@/hooks/games/useNumericQuizRuntime";
 
-// אימוג'ים לספירה עם שמות בעברית
+// ---------------------------------------------------------------------------
+// Items
+// ---------------------------------------------------------------------------
+
 const COUNTING_ITEMS = [
   { emoji: "🐶", name: "כלב", plural: "כלבים" },
   { emoji: "🐱", name: "חתול", plural: "חתולים" },
@@ -34,211 +28,87 @@ const COUNTING_ITEMS = [
   { emoji: "🎀", name: "סרט", plural: "סרטים" },
 ];
 
-export function useCountingGame() {
-  const [gameState, setGameState] = useState<CountingGameState>({
-    currentChallenge: null,
-    score: 0,
-    level: 1,
-    isPlaying: false,
-    showCelebration: false,
-    options: [],
-  });
+// ---------------------------------------------------------------------------
+// Pure helpers (defined outside hook — stable references, no closures)
+// ---------------------------------------------------------------------------
 
-  const { audioContext, speechEnabled } = useGameAudio();
+function getMaxCount(level: number): number {
+  return Math.min(
+    COUNTING_GAME_CONSTANTS.BASE_COUNT +
+      Math.floor((level - 1) / COUNTING_GAME_CONSTANTS.LEVEL_THRESHOLD) *
+        COUNTING_GAME_CONSTANTS.INCREMENT,
+    15,
+  );
+}
 
-  // --- Utility Functions ---
-
-  const getMaxCount = (): number => {
-    return Math.min(
-      COUNTING_GAME_CONSTANTS.BASE_COUNT + 
-      Math.floor((gameState.level - 1) / COUNTING_GAME_CONSTANTS.LEVEL_THRESHOLD) * 
-      COUNTING_GAME_CONSTANTS.INCREMENT,
-      15 // מקסימום מוחלט של ספירה
-    );
+function generateCountingChallenge(level: number): CountingChallenge {
+  const maxCount = getMaxCount(level);
+  const count = Math.floor(Math.random() * maxCount) + 1;
+  const item = getRandomItem(COUNTING_ITEMS);
+  return {
+    emojis: item.emoji.repeat(count),
+    correctAnswer: count,
+    itemName: item.name,
+    itemPlural: item.plural,
+    emoji: item.emoji,
   };
+}
 
-  const generateCountingChallenge = (): CountingChallenge => {
-    const maxCount = getMaxCount();
-    const count = Math.floor(Math.random() * maxCount) + 1; // 1 עד maxCount
-    const item = getRandomItem(COUNTING_ITEMS);
-    
-    return {
-      emojis: item.emoji.repeat(count), // נשאיר לתאימות לאחור
-      correctAnswer: count,
-      itemName: item.name,
-      itemPlural: item.plural,
-      emoji: item.emoji
-    };
-  };
+function generateCountingOptions(correctAnswer: number, level: number): number[] {
+  const maxCount = getMaxCount(level);
+  const allNumbers = Array.from({ length: maxCount }, (_, i) => i + 1);
+  const incorrect = allNumbers
+    .filter(n => n !== correctAnswer)
+    .sort(() => Math.random() - 0.5)
+    .slice(0, 3);
+  return [...incorrect, correctAnswer].sort(() => Math.random() - 0.5);
+}
 
-  const generateOptions = (correctAnswer: number): number[] => {
-    const maxCount = getMaxCount();
-    const allNumbers = Array.from({ length: maxCount }, (_, i) => i + 1);
-    
-    // וידוא שהתשובה הנכונה נכללת
-    const incorrectNumbers = allNumbers.filter(num => num !== correctAnswer);
-    
-    // בחירת 3 מספרים שגויים
-    const shuffledIncorrect = incorrectNumbers.sort(() => Math.random() - 0.5);
-    const selectedIncorrect = shuffledIncorrect.slice(0, 3);
-    
-    // שילוב עם התשובה הנכונה וערבוב
-    const options = [...selectedIncorrect, correctAnswer].sort(() => Math.random() - 0.5);
-    
-    return options;
-  };
-
-  // --- Zustand bridge helpers ---
-
-  const toChallengeItem = (challenge: CountingChallenge): BaseGameItem => ({
+function toChallengeItem(challenge: CountingChallenge): BaseGameItem {
+  return {
     name: String(challenge.correctAnswer),
     hebrew: `כמה ${challenge.itemPlural} יש?`,
     english: `How many ${challenge.itemPlural}?`,
     emoji: challenge.emoji,
     color: '#06b6d4',
-  });
-
-  const toOptionItem = (n: number): BaseGameItem => ({
-    name: String(n),
-    hebrew: String(n),
-    english: String(n),
-    emoji: '',
-    color: '#06b6d4',
-  });
-
-  // --- Audio & Speech ---
-
-  const playSuccessSound = () => {
-    playSound(audioContext);
   };
+}
 
-  const speakQuestion = async (challenge: CountingChallenge): Promise<void> => {
+function toOptionItem(n: number): BaseGameItem {
+  return { name: String(n), hebrew: String(n), english: String(n), emoji: '', color: '#06b6d4' };
+}
+
+// ---------------------------------------------------------------------------
+// Hook
+// ---------------------------------------------------------------------------
+
+export function useCountingGame() {
+  const { speechEnabled } = useGameAudio();
+
+  const speakCountingQuestion = async (challenge: CountingChallenge): Promise<void> => {
     if (!speechEnabled) return;
-    
     try {
-      const questionText = `כמה ${challenge.itemPlural} יש?`;
-      await speakHebrew(questionText);
+      await speakHebrew(`כמה ${challenge.itemPlural} יש?`);
     } catch (error) {
       console.error("שגיאה בהשמעת השאלה:", error);
     }
   };
 
-  const startGame = async () => {
-    try {
-      // עדכון ראשוני - מעבר למצב משחק
-      setGameState(prev => ({
-        ...prev,
-        isPlaying: true,
-        currentChallenge: null,
-        score: 0,
-        level: 1,
-        showCelebration: false,
-        options: [],
-      }));
-
-      // Sync to Zustand so UltimateGamePage transitions correctly
-      const progressStore = useGameProgressStore.getState();
-      progressStore.resetProgress();
-      progressStore.setGameActive(true);
-      useGameSessionStore.getState().resetSession();
-
-      await delay(GAME_CONSTANTS.DELAYS.START_GAME_DELAY);
-      await speakStartMessage();
-      
-      const challenge = generateCountingChallenge();
-      const options = generateOptions(challenge.correctAnswer);
-
-      // עדכון שני - הוספת האתגר
-      setGameState((prev) => ({
-        ...prev,
-        currentChallenge: challenge,
-        options,
-      }));
-
-      // Write challenge/options to Zustand so GameMainContent can render them
-      useGameSessionStore.getState().setChallengeAndOptions(
-        toChallengeItem(challenge),
-        options.map(toOptionItem),
-      );
-      useCountingChallengeStore.getState().setChallenge(challenge);
-
-      await delay(GAME_CONSTANTS.DELAYS.NEXT_ITEM_DELAY);
-      await speakQuestion(challenge);
-    } catch (error) {
-      console.error("Error in startGame:", error);
-    }
-  };
-
-  const handleNumberClick = async (selectedNumber: number) => {
-    if (!gameState.currentChallenge) return;
-
-    if (selectedNumber === gameState.currentChallenge.correctAnswer) {
-      playSuccessSound();
-      
-      const challenge = generateCountingChallenge();
-      const options = generateOptions(challenge.correctAnswer);
-      
-      const onComplete = async () => {
-        setGameState((prev) => ({
-          ...prev,
-          currentChallenge: challenge,
-          options,
-        }));
-        useGameSessionStore.getState().setChallengeAndOptions(
-          toChallengeItem(challenge),
-          options.map(toOptionItem),
-        );
-        useCountingChallengeStore.getState().setChallenge(challenge);
-        
-        await delay(300);
-        await speakQuestion(challenge);
-      };
-      
-      await handleCorrectGameAnswer(
-        (v) => {
-          setGameState((prev) => ({ ...prev, showCelebration: v }));
-          useGameSessionStore.getState().setShowCelebration(v);
-        },
-        onComplete
-      );
-    } else {
-      await handleWrongGameAnswer(async () => {
-        if (gameState.currentChallenge) {
-          await speakQuestion(gameState.currentChallenge);
-        }
-      });
-    }
-  };
-
-  const resetGame = () => {
-    setGameState({
-      currentChallenge: null,
-      score: 0,
-      level: 1,
-      isPlaying: false,
-      showCelebration: false,
-      options: [],
+  const { gameState, startGame, handleNumberClick, handleItemClick, speakItemName, resetGame } =
+    useNumericQuizRuntime<CountingChallenge>({
+      generateChallenge: generateCountingChallenge,
+      generateOptions: generateCountingOptions,
+      speakQuestion: speakCountingQuestion,
+      toChallengeItem,
+      toOptionItem,
+      onChallengeChange: (challenge) => useCountingChallengeStore.getState().setChallenge(challenge),
     });
-  };
-
-  // handleItemClick bridges the universal card-click system to handleNumberClick
-  const handleItemClick = async (item: BaseGameItem) => {
-    await handleNumberClick(Number(item.name));
-  };
-
-  const speakItemName = async (itemName: string): Promise<void> => {
-    if (!speechEnabled) return;
-    try {
-      await speakHebrew(itemName);
-    } catch {
-      // ignore speech errors
-    }
-  };
 
   return {
     // For the dedicated app/games/counting/page.tsx
-    gameState,
-    speakQuestion: () => gameState.currentChallenge ? speakQuestion(gameState.currentChallenge) : Promise.resolve(),
+    gameState: gameState as CountingGameState,
+    speakQuestion: () =>
+      gameState.currentChallenge ? speakCountingQuestion(gameState.currentChallenge) : Promise.resolve(),
     startGame,
     handleNumberClick,
     resetGame,

--- a/gamesformykids/app/games/math/hooks/useMathGame.ts
+++ b/gamesformykids/app/games/math/hooks/useMathGame.ts
@@ -1,35 +1,18 @@
 'use client';
 
-import { useState } from "react";
 import { MathChallenge } from "@/lib/types";
 import { BaseGameItem } from "@/lib/types/core/base";
 import { speakHebrew } from "@/lib/utils/speech/enhancedSpeechUtils";
 import { useGameAudio } from "@/hooks/shared/audio/useGameAudio";
-import { 
-  delay, 
-  playSuccessSound as playSound, 
-  getRandomItem,
-  handleWrongGameAnswer,
-  handleCorrectGameAnswer,
-  speakStartMessage
-} from "@/lib/utils/game/gameUtils";
-import { GAME_CONSTANTS, MATH_GAME_CONSTANTS } from "@/lib/constants";
-import { useGameProgressStore } from "@/lib/stores/gameProgressStore";
-import { useGameSessionStore } from "@/lib/stores/gameSessionStore";
+import { delay, getRandomItem } from "@/lib/utils/game/gameUtils";
+import { MATH_GAME_CONSTANTS } from "@/lib/constants";
 import { useMathChallengeStore } from "@/lib/stores/mathChallengeStore";
+import { useNumericQuizRuntime } from "@/hooks/games/useNumericQuizRuntime";
 
-// Math game specific state interface
-interface MathGameState {
-  currentChallenge: MathChallenge | null;
-  score: number;
-  level: number;
-  isPlaying: boolean;
-  showCelebration: boolean;
-  options: number[]; // Math game uses numbers as options, not objects
-  isCorrect?: boolean | null; // הוספה להתמודדות עם תשובות נכונות/שגויות
-}
+// ---------------------------------------------------------------------------
+// Items
+// ---------------------------------------------------------------------------
 
-// אימוג'ים לחיבור וחיסור
 const MATH_ITEMS = [
   { emoji: "🍎", name: "תפוח", plural: "תפוחים" },
   { emoji: "🌟", name: "כוכב", plural: "כוכבים" },
@@ -39,135 +22,85 @@ const MATH_ITEMS = [
   { emoji: "🦋", name: "פרפר", plural: "פרפרים" },
 ];
 
-// --- Helpers for universal Zustand system ---
+// ---------------------------------------------------------------------------
+// Pure helpers (defined outside hook — stable references, no closures)
+// ---------------------------------------------------------------------------
+
+function getMaxNumber(level: number): number {
+  return Math.min(
+    MATH_GAME_CONSTANTS.BASE_MAX_NUMBER +
+      Math.floor((level - 1) / MATH_GAME_CONSTANTS.LEVEL_THRESHOLD) *
+        MATH_GAME_CONSTANTS.NUMBER_INCREMENT,
+    MATH_GAME_CONSTANTS.ABSOLUTE_MAX_NUMBER,
+  );
+}
+
+function generateMathChallenge(level: number): MathChallenge {
+  const maxNumber = getMaxNumber(level);
+  const item = getRandomItem(MATH_ITEMS);
+
+  const operations = level >= 3 ? ['addition', 'subtraction'] : ['addition'];
+  const operation = getRandomItem(operations) as 'addition' | 'subtraction';
+
+  let firstNumber: number;
+  let secondNumber: number;
+  let correctAnswer: number;
+
+  if (operation === 'addition') {
+    firstNumber = Math.floor(Math.random() * (maxNumber - 1)) + 1;
+    secondNumber = Math.floor(Math.random() * (maxNumber - firstNumber)) + 1;
+    correctAnswer = firstNumber + secondNumber;
+  } else {
+    correctAnswer = Math.floor(Math.random() * maxNumber) + 1;
+    secondNumber = Math.floor(Math.random() * correctAnswer) + 1;
+    firstNumber = correctAnswer + secondNumber;
+  }
+
+  return {
+    firstNumber, secondNumber, operation, correctAnswer,
+    itemName: item.name, itemPlural: item.plural, emoji: item.emoji,
+    operand1: firstNumber, operand2: secondNumber,
+    operator: operation === 'addition' ? '+' : '-',
+    answer: correctAnswer,
+    question: `${firstNumber} ${operation === 'addition' ? '+' : '-'} ${secondNumber} = ?`,
+  };
+}
+
+function generateMathOptions(correctAnswer: number, level: number): number[] {
+  const maxNumber = getMaxNumber(level);
+  const allNumbers = Array.from({ length: maxNumber + 5 }, (_, i) => i);
+  const incorrectNumbers = allNumbers.filter(n => n !== correctAnswer);
+
+  const close = incorrectNumbers.filter(n => Math.abs(n - correctAnswer) <= 3 && n >= 0);
+  const pool = close.length >= 3
+    ? close.sort(() => Math.random() - 0.5)
+    : [...close, ...incorrectNumbers.filter(n => n >= 0)].sort(() => Math.random() - 0.5);
+
+  return [...pool.slice(0, 3), correctAnswer].sort(() => Math.random() - 0.5);
+}
 
 function toChallengeItem(challenge: MathChallenge): BaseGameItem {
   const op = challenge.operation === 'addition' ? '+' : '-';
   const equation = `${challenge.firstNumber} ${op} ${challenge.secondNumber} = ?`;
-  return {
-    name: String(challenge.correctAnswer),
-    hebrew: equation,
-    english: equation,
-    emoji: challenge.emoji,
-    color: '#FF7043',
-  };
+  return { name: String(challenge.correctAnswer), hebrew: equation, english: equation, emoji: challenge.emoji, color: '#FF7043' };
 }
 
 function toOptionItem(n: number): BaseGameItem {
-  return {
-    name: String(n),
-    hebrew: String(n),
-    english: String(n),
-    emoji: '🔢',
-    color: '#FF7043',
-  };
+  return { name: String(n), hebrew: String(n), english: String(n), emoji: '🔢', color: '#FF7043' };
 }
 
+// ---------------------------------------------------------------------------
+// Hook
+// ---------------------------------------------------------------------------
+
 export function useMathGame() {
-  const [gameState, setGameState] = useState<MathGameState>({
-    currentChallenge: null,
-    score: 0,
-    level: 1,
-    isPlaying: false,
-    showCelebration: false,
-    options: [],
-  });
+  const { speechEnabled } = useGameAudio();
 
-  const { audioContext, speechEnabled } = useGameAudio();
-
-  // --- Utility Functions ---
-
-  const getMaxNumber = (): number => {
-    return Math.min(
-      MATH_GAME_CONSTANTS.BASE_MAX_NUMBER + 
-      Math.floor((gameState.level - 1) / MATH_GAME_CONSTANTS.LEVEL_THRESHOLD) * 
-      MATH_GAME_CONSTANTS.NUMBER_INCREMENT,
-      MATH_GAME_CONSTANTS.ABSOLUTE_MAX_NUMBER
-    );
-  };
-
-  const generateMathChallenge = (): MathChallenge => {
-    const maxNumber = getMaxNumber();
-    const item = getRandomItem(MATH_ITEMS);
-    
-    // קביעת סוג הפעולה בהתאם לרמה
-    const operations = gameState.level >= 3 ? ['addition', 'subtraction'] : ['addition'];
-    const operation = getRandomItem(operations) as 'addition' | 'subtraction';
-    
-    let firstNumber: number;
-    let secondNumber: number;
-    let correctAnswer: number;
-    
-    if (operation === 'addition') {
-      // חיבור - שני מספרים שהסכום שלהם לא עובר את המקסימום
-      firstNumber = Math.floor(Math.random() * (maxNumber - 1)) + 1;
-      secondNumber = Math.floor(Math.random() * (maxNumber - firstNumber)) + 1;
-      correctAnswer = firstNumber + secondNumber;
-    } else {
-      // חיסור - התוצאה תמיד חיובית
-      correctAnswer = Math.floor(Math.random() * maxNumber) + 1;
-      secondNumber = Math.floor(Math.random() * correctAnswer) + 1;
-      firstNumber = correctAnswer + secondNumber;
-    }
-    
-    return {
-      // Legacy format
-      firstNumber,
-      secondNumber,
-      operation,
-      correctAnswer,
-      itemName: item.name,
-      itemPlural: item.plural,
-      emoji: item.emoji,
-      // New format for compatibility
-      operand1: firstNumber,
-      operand2: secondNumber,
-      operator: operation === 'addition' ? '+' : '-',
-      answer: correctAnswer,
-      question: `${firstNumber} ${operation === 'addition' ? '+' : '-'} ${secondNumber} = ?`
-    };
-  };
-
-  const generateOptions = (correctAnswer: number): number[] => {
-    const maxNumber = getMaxNumber();
-    const allNumbers = Array.from({ length: maxNumber + 5 }, (_, i) => i); // כולל 0 ועד מעבר למקסימום
-    
-    // וידוא שהתשובה הנכונה נכללת
-    const incorrectNumbers = allNumbers.filter(num => num !== correctAnswer);
-    
-    // בחירת 3 מספרים שגויים קרובים לתשובה הנכונה
-    const closeNumbers = incorrectNumbers.filter(num => 
-      Math.abs(num - correctAnswer) <= 3 && num >= 0
-    );
-    
-    // אם אין מספיק מספרים קרובים, הוסף מספרים אקראיים
-    const shuffledIncorrect = closeNumbers.length >= 3 
-      ? closeNumbers.sort(() => Math.random() - 0.5)
-      : [...closeNumbers, ...incorrectNumbers.filter(num => num >= 0)].sort(() => Math.random() - 0.5);
-    
-    const selectedIncorrect = shuffledIncorrect.slice(0, 3);
-    
-    // שילוב עם התשובה הנכונה וערבוב
-    const options = [...selectedIncorrect, correctAnswer].sort(() => Math.random() - 0.5);
-    
-    return options;
-  };
-
-  // --- Audio & Speech ---
-
-  const playSuccessSound = () => {
-    playSound(audioContext);
-  };
-
-  const speakQuestion = async (challenge: MathChallenge): Promise<void> => {
+  const speakMathQuestion = async (challenge: MathChallenge): Promise<void> => {
     if (!speechEnabled) return;
-    
     try {
       const operationText = challenge.operation === 'addition' ? 'ועוד' : 'פחות';
-      const questionText = `${challenge.firstNumber} ${challenge.itemPlural} ${operationText} ${challenge.secondNumber} ${challenge.itemPlural}, `;
-      await speakHebrew(questionText);
-      
-      // הוספת שאלה נוספת
+      await speakHebrew(`${challenge.firstNumber} ${challenge.itemPlural} ${operationText} ${challenge.secondNumber} ${challenge.itemPlural}, `);
       await delay(500);
       await speakHebrew(`כמה ${challenge.itemPlural} יש?`);
     } catch (error) {
@@ -175,122 +108,21 @@ export function useMathGame() {
     }
   };
 
-  const startGame = async () => {
-    try {
-      setGameState({
-        currentChallenge: null,
-        score: 0,
-        level: 1,
-        isPlaying: true,
-        showCelebration: false,
-        options: [],
-        isCorrect: null,
-      });
-
-      // Sync to Zustand so UltimateGamePage transitions correctly
-      const progressStore = useGameProgressStore.getState();
-      progressStore.resetProgress();
-      progressStore.setGameActive(true);
-      useGameSessionStore.getState().resetSession();
-      
-      await delay(GAME_CONSTANTS.DELAYS.START_GAME_DELAY);
-      await speakStartMessage();
-      
-      const challenge = generateMathChallenge();
-      const options = generateOptions(challenge.correctAnswer);
-
-      setGameState((prev: MathGameState) => ({
-        ...prev,
-        currentChallenge: challenge,
-        options,
-      }));
-
-      // Write challenge/options to Zustand so GameMainContent can render them
-      useGameSessionStore.getState().setChallengeAndOptions(
-        toChallengeItem(challenge),
-        options.map(toOptionItem),
-      );
-      // Store raw MathChallenge for visual emoji rendering
-      useMathChallengeStore.getState().setChallenge(challenge);
-
-      await delay(GAME_CONSTANTS.DELAYS.NEXT_ITEM_DELAY);
-      await speakQuestion(challenge);
-    } catch (error) {
-      console.error("Error in startGame:", error);
-    }
-  };
-
-  const handleNumberClick = async (selectedNumber: number) => {
-    if (!gameState.currentChallenge) return;
-
-    if (selectedNumber === gameState.currentChallenge.correctAnswer) {
-      playSuccessSound();
-      
-      const challenge = generateMathChallenge();
-      const options = generateOptions(challenge.correctAnswer);
-      
-      const onComplete = async () => {
-        setGameState((prev: MathGameState) => ({
-          ...prev,
-          currentChallenge: challenge,
-          options,
-        }));
-        useGameSessionStore.getState().setChallengeAndOptions(
-          toChallengeItem(challenge),
-          options.map(toOptionItem),
-        );
-        useMathChallengeStore.getState().setChallenge(challenge);
-        
-        await delay(300);
-        await speakQuestion(challenge);
-      };
-      
-      await handleCorrectGameAnswer(
-        (v) => {
-          setGameState((prev: MathGameState) => ({ ...prev, showCelebration: v }));
-          useGameSessionStore.getState().setShowCelebration(v);
-        },
-        onComplete
-      );
-    } else {
-      await handleWrongGameAnswer(async () => {
-        if (gameState.currentChallenge) {
-          await speakQuestion(gameState.currentChallenge);
-        }
-      });
-    }
-  };
-
-  // handleItemClick bridges the universal card-click system to handleNumberClick
-  const handleItemClick = async (item: BaseGameItem) => {
-    await handleNumberClick(Number(item.name));
-  };
-
-  const speakItemName = async (itemName: string): Promise<void> => {
-    if (!speechEnabled) return;
-    try {
-      await speakHebrew(itemName);
-    } catch {
-      // ignore speech errors
-    }
-  };
-
-  const resetGame = () => {
-    setGameState({
-      currentChallenge: null,
-      score: 0,
-      level: 1,
-      isPlaying: false,
-      showCelebration: false,
-      options: [],
-      isCorrect: null,
+  const { gameState, startGame, handleNumberClick, handleItemClick, speakItemName, resetGame } =
+    useNumericQuizRuntime<MathChallenge>({
+      generateChallenge: generateMathChallenge,
+      generateOptions: generateMathOptions,
+      speakQuestion: speakMathQuestion,
+      toChallengeItem,
+      toOptionItem,
+      onChallengeChange: (challenge) => useMathChallengeStore.getState().setChallenge(challenge),
     });
-  };
 
   return {
     // For the dedicated app/games/math/page.tsx
     gameState,
-    speakQuestion: () => gameState.currentChallenge ? speakQuestion(gameState.currentChallenge) : Promise.resolve(),
+    speakQuestion: () =>
+      gameState.currentChallenge ? speakMathQuestion(gameState.currentChallenge) : Promise.resolve(),
     startGame,
     handleNumberClick,
     resetGame,

--- a/gamesformykids/hooks/games/useNumericQuizRuntime.ts
+++ b/gamesformykids/hooks/games/useNumericQuizRuntime.ts
@@ -1,0 +1,202 @@
+'use client';
+
+import { useState } from "react";
+import { BaseGameItem } from "@/lib/types/core/base";
+import { speakHebrew } from "@/lib/utils/speech/enhancedSpeechUtils";
+import { useGameAudio } from "@/hooks/shared/audio/useGameAudio";
+import {
+  delay,
+  playSuccessSound as playSound,
+  handleWrongGameAnswer,
+  handleCorrectGameAnswer,
+  speakStartMessage,
+} from "@/lib/utils/game/gameUtils";
+import { GAME_CONSTANTS } from "@/lib/constants";
+import { useGameProgressStore } from "@/lib/stores/gameProgressStore";
+import { useGameSessionStore } from "@/lib/stores/gameSessionStore";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface NumericQuizState<TChallenge> {
+  currentChallenge: TChallenge | null;
+  score: number;
+  level: number;
+  isPlaying: boolean;
+  showCelebration: boolean;
+  options: number[];
+}
+
+export interface NumericQuizCallbacks<TChallenge extends { correctAnswer: number }> {
+  /** Generate a new challenge. Receives current level for difficulty scaling. */
+  generateChallenge: (level: number) => TChallenge;
+  /** Generate numeric answer options. Receives the correct answer and current level. */
+  generateOptions: (correctAnswer: number, level: number) => number[];
+  /** Speak the current challenge aloud. Should guard on speechEnabled internally. */
+  speakQuestion: (challenge: TChallenge) => Promise<void>;
+  /** Map a challenge to the universal BaseGameItem format for the session store. */
+  toChallengeItem: (challenge: TChallenge) => BaseGameItem;
+  /** Map a numeric option to the universal BaseGameItem format. */
+  toOptionItem: (n: number) => BaseGameItem;
+  /** Called each time a new challenge is applied (e.g. to update a per-game store). */
+  onChallengeChange?: (challenge: TChallenge) => void;
+}
+
+// ---------------------------------------------------------------------------
+// Hook
+// ---------------------------------------------------------------------------
+
+/**
+ * Shared runtime hook for numeric quiz games (math, counting).
+ *
+ * Owns the common async flow:
+ *   startGame → answer handling → celebration → next challenge → session/progress bridge
+ *
+ * Game-specific logic (challenge generation, speech text, option pool) is
+ * injected via `callbacks` so each game remains independently testable.
+ */
+export function useNumericQuizRuntime<TChallenge extends { correctAnswer: number }>(
+  callbacks: NumericQuizCallbacks<TChallenge>,
+) {
+  const {
+    generateChallenge,
+    generateOptions,
+    speakQuestion,
+    toChallengeItem,
+    toOptionItem,
+    onChallengeChange,
+  } = callbacks;
+
+  const [gameState, setGameState] = useState<NumericQuizState<TChallenge>>({
+    currentChallenge: null,
+    score: 0,
+    level: 1,
+    isPlaying: false,
+    showCelebration: false,
+    options: [],
+  });
+
+  const { audioContext, speechEnabled } = useGameAudio();
+
+  // ---------------------------------------------------------------------------
+  // Internal helpers
+  // ---------------------------------------------------------------------------
+
+  /** Apply a new challenge: update local state + sync Zustand session store. */
+  const _applyChallenge = (challenge: TChallenge, level: number) => {
+    const options = generateOptions(challenge.correctAnswer, level);
+    setGameState(prev => ({ ...prev, currentChallenge: challenge, options }));
+    useGameSessionStore.getState().setChallengeAndOptions(
+      toChallengeItem(challenge),
+      options.map(toOptionItem),
+    );
+    onChallengeChange?.(challenge);
+  };
+
+  // ---------------------------------------------------------------------------
+  // Public API
+  // ---------------------------------------------------------------------------
+
+  const startGame = async () => {
+    try {
+      setGameState({
+        currentChallenge: null,
+        score: 0,
+        level: 1,
+        isPlaying: true,
+        showCelebration: false,
+        options: [],
+      });
+
+      const progressStore = useGameProgressStore.getState();
+      progressStore.resetProgress();
+      progressStore.setGameActive(true);
+      useGameSessionStore.getState().resetSession();
+
+      await delay(GAME_CONSTANTS.DELAYS.START_GAME_DELAY);
+      await speakStartMessage();
+
+      const challenge = generateChallenge(1);
+      _applyChallenge(challenge, 1);
+
+      await delay(GAME_CONSTANTS.DELAYS.NEXT_ITEM_DELAY);
+      await speakQuestion(challenge);
+    } catch (error) {
+      console.error("Error in startGame:", error);
+    }
+  };
+
+  const handleNumberClick = async (selectedNumber: number) => {
+    if (!gameState.currentChallenge) return;
+
+    if (selectedNumber === gameState.currentChallenge.correctAnswer) {
+      playSound(audioContext);
+
+      // Capture level before any awaits to avoid stale closure issues.
+      const level = gameState.level;
+      const nextChallenge = generateChallenge(level);
+      const nextOptions = generateOptions(nextChallenge.correctAnswer, level);
+
+      const onComplete = async () => {
+        setGameState(prev => ({ ...prev, currentChallenge: nextChallenge, options: nextOptions }));
+        useGameSessionStore.getState().setChallengeAndOptions(
+          toChallengeItem(nextChallenge),
+          nextOptions.map(toOptionItem),
+        );
+        onChallengeChange?.(nextChallenge);
+
+        await delay(300);
+        await speakQuestion(nextChallenge);
+      };
+
+      await handleCorrectGameAnswer(
+        (v) => {
+          setGameState(prev => ({ ...prev, showCelebration: v }));
+          useGameSessionStore.getState().setShowCelebration(v);
+        },
+        onComplete,
+      );
+    } else {
+      await handleWrongGameAnswer(async () => {
+        if (gameState.currentChallenge) {
+          await speakQuestion(gameState.currentChallenge);
+        }
+      });
+    }
+  };
+
+  /** Bridge for the universal card-click system (UltimateGamePage). */
+  const handleItemClick = async (item: BaseGameItem) => {
+    await handleNumberClick(Number(item.name));
+  };
+
+  /** Speak an arbitrary item name — used by GameLogicSync. */
+  const speakItemName = async (itemName: string): Promise<void> => {
+    if (!speechEnabled) return;
+    try {
+      await speakHebrew(itemName);
+    } catch {
+      // ignore speech errors
+    }
+  };
+
+  const resetGame = () =>
+    setGameState({
+      currentChallenge: null,
+      score: 0,
+      level: 1,
+      isPlaying: false,
+      showCelebration: false,
+      options: [],
+    });
+
+  return {
+    gameState,
+    startGame,
+    handleNumberClick,
+    handleItemClick,
+    speakItemName,
+    resetGame,
+  };
+}


### PR DESCRIPTION
## Summary

Resolves #264

Extracts duplicated game-loop logic from useMathGame and useCountingGame into a single shared hook: useNumericQuizRuntime<TChallenge>.

## Changes

### New file
- **hooks/games/useNumericQuizRuntime.ts** — generic runtime hook that owns:
  - startGame flow (Zustand bridge, delays, initial challenge)
  - handleNumberClick (correct/wrong answer handling)
  - handleItemClick / speakItemName (universal GamePage bridge)
  - esetGame

### Refactored
- **pp/games/math/hooks/useMathGame.ts** — now a thin adapter; pure helpers (generateMathChallenge, generateMathOptions, 	oChallengeItem, 	oOptionItem) moved outside the hook
- **pp/games/counting/useCountingGame.ts** — same pattern; removed ~200 lines of duplicated logic

## Result
| | Before | After |
|---|---|---|
| Lines changed | — | -441 / +345 |
| Duplication | ✗ | ✓ eliminated |
| TypeScript errors | 0 | 0 |

## Testing
- No TypeScript errors in all 3 files
- Public API of both hooks unchanged — no consumer changes needed