### PR TITLE
refactor: add GameMenuGrid shared component

### DIFF
--- a/gamesformykids/app/games/arithmetic/components/ArithmeticMenuScreen.tsx
+++ b/gamesformykids/app/games/arithmetic/components/ArithmeticMenuScreen.tsx
@@ -1,29 +1,31 @@
 'use client';
 
-import GameMenuCard from '@/components/game/shared/GameMenuCard';
+import GameMenuGrid from '@/components/game/shared/GameMenuGrid';
 import { useArithmeticGameStore } from '../arithmeticGameStore';
-import { LEVELS, LEVEL_EMOJIS } from '../data/questions';
+import { LEVELS, LEVEL_EMOJIS, ArithmeticLevel } from '../data/questions';
 
 export default function ArithmeticMenuScreen() {
   const startGame = useArithmeticGameStore(s => s.startGame);
 
   return (
-    <GameMenuCard
+    <GameMenuGrid<ArithmeticLevel>
       emoji="➕"
       title="חשבון מהיר"
       description="בחר רמה ותתחיל!"
       gradientClass="from-blue-50 to-indigo-100"
-    >
-      <div className="grid grid-cols-2 gap-4">
-        {LEVELS.map(lv => (
-          <button key={lv.id} onClick={() => startGame(lv)}
-            className="p-5 rounded-2xl text-white font-bold text-lg shadow-lg hover:scale-105 active:scale-95 transition-all bg-gradient-to-br from-indigo-500 to-blue-600 text-right">
-            <div className="text-2xl mb-1">{LEVEL_EMOJIS[lv.id]}</div>
-            <div>{lv.label}</div>
-            <div className="text-xs opacity-70 mt-1 font-normal">עד {lv.maxNum}{lv.operations.includes('×') ? ' × ' + lv.maxNum : ''}</div>
-          </button>
-        ))}
-      </div>
-    </GameMenuCard>
+      items={LEVELS}
+      getKey={(lv) => lv.id}
+      onSelect={startGame}
+      renderItem={(lv) => (
+        <>
+          <div className="text-2xl mb-1">{LEVEL_EMOJIS[lv.id]}</div>
+          <div>{lv.label}</div>
+          <div className="text-xs opacity-70 mt-1 font-normal">עד {lv.maxNum}{lv.operations.includes('×') ? ' × ' + lv.maxNum : ''}</div>
+        </>
+      )}
+      buttonClass="p-5 rounded-2xl text-white font-bold text-lg shadow-lg hover:scale-105 active:scale-95 transition-all bg-gradient-to-br from-indigo-500 to-blue-600 text-right"
+      columns={2}
+      gap={4}
+    />
   );
 }

--- a/gamesformykids/app/games/multiplication/components/MultiplicationMenuScreen.tsx
+++ b/gamesformykids/app/games/multiplication/components/MultiplicationMenuScreen.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import GameMenuCard from '@/components/game/shared/GameMenuCard';
+import GameMenuGrid from '@/components/game/shared/GameMenuGrid';
 import { useMultiplicationGameStore } from '../multiplicationGameStore';
 import { LEVELS, QUESTIONS_PER_LEVEL, TIME_PER_QUESTION } from '../data/tables';
 
@@ -8,23 +8,23 @@ export default function MultiplicationMenuScreen() {
   const startGame = useMultiplicationGameStore((s) => s.startGame);
 
   return (
-    <GameMenuCard
+    <GameMenuGrid<number>
       emoji="✖️"
       title="לוח הכפל"
       description="בחר לוח כפל ותתחיל!"
       gradientClass="from-violet-50 to-purple-100"
-    >
-      <div className="grid grid-cols-5 gap-3">
-        {LEVELS.map(lv => (
-          <button key={lv} onClick={() => startGame(lv)}
-            className="aspect-square rounded-2xl text-2xl font-black text-white shadow-lg hover:scale-105 active:scale-95 transition-all bg-gradient-to-br from-purple-500 to-violet-600 hover:from-purple-400 hover:to-violet-500">
-            {lv}
-          </button>
-        ))}
-      </div>
-      <p className="text-center text-purple-500 text-sm mt-4">
-        {QUESTIONS_PER_LEVEL} שאלות ל-{TIME_PER_QUESTION} שניות כל אחת
-      </p>
-    </GameMenuCard>
+      items={LEVELS}
+      getKey={(lv) => lv}
+      onSelect={startGame}
+      renderItem={(lv) => lv}
+      buttonClass="aspect-square rounded-2xl text-2xl font-black text-white shadow-lg hover:scale-105 active:scale-95 transition-all bg-gradient-to-br from-purple-500 to-violet-600 hover:from-purple-400 hover:to-violet-500"
+      columns={5}
+      gap={3}
+      footer={
+        <p className="text-center text-purple-500 text-sm mt-4">
+          {QUESTIONS_PER_LEVEL} שאלות ל-{TIME_PER_QUESTION} שניות כל אחת
+        </p>
+      }
+    />
   );
 }

--- a/gamesformykids/components/game/shared/GameMenuGrid.tsx
+++ b/gamesformykids/components/game/shared/GameMenuGrid.tsx
@@ -1,0 +1,87 @@
+'use client';
+
+import { ReactNode } from 'react';
+import GameMenuCard from '@/components/game/shared/GameMenuCard';
+
+// Tailwind safe-list (full strings so JIT doesn't purge):
+// grid-cols-2 grid-cols-3 grid-cols-4 grid-cols-5
+// gap-2 gap-3 gap-4 gap-6
+const COLS_MAP = {
+  2: 'grid-cols-2',
+  3: 'grid-cols-3',
+  4: 'grid-cols-4',
+  5: 'grid-cols-5',
+} as const;
+
+const GAP_MAP = {
+  2: 'gap-2',
+  3: 'gap-3',
+  4: 'gap-4',
+  6: 'gap-6',
+} as const;
+
+interface Props<T> {
+  // GameMenuCard passthrough
+  emoji: string;
+  title: string;
+  description: string;
+  gradientClass: string;
+  animateEmoji?: boolean;
+  hint?: string;
+  // Grid
+  items: T[];
+  getKey: (item: T) => string | number;
+  onSelect: (item: T) => void;
+  renderItem: (item: T) => ReactNode;
+  buttonClass: string;
+  columns?: keyof typeof COLS_MAP;
+  gap?: keyof typeof GAP_MAP;
+  // Optional footer rendered below the grid
+  footer?: ReactNode;
+}
+
+/**
+ * Configuration-driven menu renderer.
+ * Wraps GameMenuCard and renders a responsive grid of selectable buttons.
+ * Use for game lobby screens that offer a choice of levels/categories.
+ */
+export default function GameMenuGrid<T>({
+  emoji,
+  title,
+  description,
+  gradientClass,
+  animateEmoji,
+  hint,
+  items,
+  getKey,
+  onSelect,
+  renderItem,
+  buttonClass,
+  columns = 2,
+  gap = 3,
+  footer,
+}: Props<T>) {
+  return (
+    <GameMenuCard
+      emoji={emoji}
+      title={title}
+      description={description}
+      gradientClass={gradientClass}
+      animateEmoji={animateEmoji}
+      hint={hint}
+    >
+      <div className={`grid ${COLS_MAP[columns]} ${GAP_MAP[gap]}`}>
+        {items.map((item) => (
+          <button
+            key={getKey(item)}
+            onClick={() => onSelect(item)}
+            className={buttonClass}
+          >
+            {renderItem(item)}
+          </button>
+        ))}
+      </div>
+      {footer}
+    </GameMenuCard>
+  );
+}


### PR DESCRIPTION
## Summary

Resolves #265

Adds a configuration-driven GameMenuGrid component and refactors the two menu screens that had inline grid scaffolding.

## Changes

### New file
- **components/game/shared/GameMenuGrid.tsx** — generic wrapper around \GameMenuCard\ that renders a responsive button grid:
  - Props: \items[]\, \getKey\, \onSelect\, \enderItem\, \uttonClass\, \columns\ (2/3/4/5), \gap\ (2/3/4/6), \ooter\
  - Tailwind classes fully spelled out (no dynamic string concat — JIT-safe)

### Refactored
- **\MultiplicationMenuScreen.tsx\** — replaced \GameMenuCard\ + inline grid with \GameMenuGrid<number>\
- **\ArithmeticMenuScreen.tsx\** — replaced \GameMenuCard\ + inline grid with \GameMenuGrid<ArithmeticLevel>\

### Unchanged (already thin)
- \ReflexMenuScreen\, \NumberBubblesMenuScreen\, \DamkaMenuScreen\ — use \GameMenuCard\ with \onStart\, no grid pattern

## Result
| | Before | After |
|---|---|---|
| Grid boilerplate per screen | ~8 lines | 0 lines |
| TypeScript errors | 0 | 0 |