### PR TITLE
refactor: eliminate useShallow boilerplate with createShallowHook (closes #270)

### DIFF
--- a/gamesformykids/app/games/checkers/useDamkaGame.ts
+++ b/gamesformykids/app/games/checkers/useDamkaGame.ts
@@ -1,11 +1,7 @@
 'use client';
-import { useShallow } from 'zustand/react/shallow';
+import { createShallowHook } from '@/lib/stores/utils/sliceUtils';
 import { useDamkaStore } from './damkaStore';
 
 export type { Side, GamePhase, Cell, Board, Pos, DamkaMove } from './damkaStore';
 
-export function useDamkaGame() {
-  const { phase, board, selected, validMoves, currentTurn, playerScore, computerScore, message, startGame, selectCell } =
-    useDamkaStore(useShallow((s) => s));
-  return { phase, board, selected, validMoves, currentTurn, playerScore, computerScore, message, startGame, selectCell };
-}
+export const useDamkaGame = createShallowHook(useDamkaStore);

--- a/gamesformykids/app/games/color-tap/useColorTapGame.ts
+++ b/gamesformykids/app/games/color-tap/useColorTapGame.ts
@@ -1,12 +1,8 @@
 'use client';
-import { useShallow } from 'zustand/react/shallow';
+import { createShallowHook } from '@/lib/stores/utils/sliceUtils';
 import { useColorTapStore } from './colorTapStore';
 
 export type { ColorItem, Question } from './colorTapStore';
-export { COLORS, TIME_PER_Q }       from './colorTapStore';
+export { COLORS, TIME_PER_Q } from './colorTapStore';
 
-export function useColorTapGame() {
-  const { phase, score, best, lives, timeLeft, feedback, question, startGame, handleTap } =
-    useColorTapStore(useShallow((s) => s));
-  return { phase, score, best, lives, question, timeLeft, feedback, startGame, handleTap };
-}
+export const useColorTapGame = createShallowHook(useColorTapStore);

--- a/gamesformykids/app/games/emoji-math/useEmojiMathGame.ts
+++ b/gamesformykids/app/games/emoji-math/useEmojiMathGame.ts
@@ -1,12 +1,8 @@
 'use client';
-import { useShallow } from 'zustand/react/shallow';
+import { createShallowHook } from '@/lib/stores/utils/sliceUtils';
 import { useEmojiMathStore } from './emojiMathStore';
 
 export type { Op, Question } from './emojiMathStore';
 export { makeQuestion, TIME_PER_Q } from './emojiMathStore';
 
-export function useEmojiMathGame() {
-  const { phase, q, score, best, lives, level, timeLeft, feedback, streak, startGame, tap } =
-    useEmojiMathStore(useShallow((s) => s));
-  return { phase, q, score, best, lives, level, timeLeft, feedback, streak, startGame, tap };
-}
+export const useEmojiMathGame = createShallowHook(useEmojiMathStore);

--- a/gamesformykids/app/games/math-race/useMathRaceGame.ts
+++ b/gamesformykids/app/games/math-race/useMathRaceGame.ts
@@ -1,13 +1,14 @@
 'use client';
-import { useShallow } from 'zustand/react/shallow';
+import { createShallowHook } from '@/lib/stores/utils/sliceUtils';
 import { useMathRaceStore } from './mathRaceStore';
 
 export type { Question } from './mathRaceStore';
 export { makeQ, GAME_TIME } from './mathRaceStore';
 
+const _useStore = createShallowHook(useMathRaceStore);
+
 export function useMathRaceGame() {
-  const { phase, q, score, best, timeLeft, feedback, streak, total, correct, startGame, tap } =
-    useMathRaceStore(useShallow((s) => s));
-  const accuracy = total > 0 ? Math.round((correct / total) * 100) : 0;
-  return { phase, q, score, best, timeLeft, feedback, streak, total, correct, accuracy, startGame, tap };
+  const state = _useStore();
+  const accuracy = state.total > 0 ? Math.round((state.correct / state.total) * 100) : 0;
+  return { ...state, accuracy };
 }

--- a/gamesformykids/app/games/number-bubbles/useNumberBubblesGame.ts
+++ b/gamesformykids/app/games/number-bubbles/useNumberBubblesGame.ts
@@ -1,12 +1,8 @@
 'use client';
-import { useShallow } from 'zustand/react/shallow';
+import { createShallowHook } from '@/lib/stores/utils/sliceUtils';
 import { useNumberBubblesStore } from './numberBubblesStore';
 
 export type { Bubble } from './numberBubblesStore';
 export { BUBBLE_COLORS, makeBubbles } from './numberBubblesStore';
 
-export function useNumberBubblesGame() {
-  const { phase, level, bubbles, next, elapsed, best, wrong, startGame, startRound, nextLevel, tap } =
-    useNumberBubblesStore(useShallow((s) => s));
-  return { phase, level, bubbles, next, elapsed, best, wrong, startGame, startRound, nextLevel, tap };
-}
+export const useNumberBubblesGame = createShallowHook(useNumberBubblesStore);

--- a/gamesformykids/app/games/reflex/useReflexGame.ts
+++ b/gamesformykids/app/games/reflex/useReflexGame.ts
@@ -1,11 +1,7 @@
 'use client';
-import { useShallow } from 'zustand/react/shallow';
+import { createShallowHook } from '@/lib/stores/utils/sliceUtils';
 import { useReflexStore } from './reflexStore';
 
 export type { Target } from './reflexStore';
 
-export function useReflexGame() {
-  const { phase, targets, score, missed, timeLeft, startGame, hitTarget } =
-    useReflexStore(useShallow((s) => s));
-  return { phase, targets, score, missed, timeLeft, startGame, hitTarget };
-}
+export const useReflexGame = createShallowHook(useReflexStore);

--- a/gamesformykids/app/games/true-false/useTrueFalseGame.ts
+++ b/gamesformykids/app/games/true-false/useTrueFalseGame.ts
@@ -1,12 +1,13 @@
 'use client';
-import { useShallow } from 'zustand/react/shallow';
+import { createShallowHook } from '@/lib/stores/utils/sliceUtils';
 import { useTrueFalseStore } from './trueFalseStore';
 
 export type { Fact } from './trueFalseStore';
 export { FACTS, TIME_PER_Q } from './trueFalseStore';
 
+const _useStore = createShallowHook(useTrueFalseStore);
+
 export function useTrueFalseGame() {
-  const { phase, score, best, lives, timeLeft, feedback, deck, idx, startGame, answer } =
-    useTrueFalseStore(useShallow((s) => s));
-  return { phase, q: deck[idx], score, best, lives, timeLeft, feedback, startGame, answer };
+  const state = _useStore();
+  return { ...state, q: state.deck[state.idx] };
 }

--- a/gamesformykids/app/games/whack-a-mole/useWhackAMoleGame.ts
+++ b/gamesformykids/app/games/whack-a-mole/useWhackAMoleGame.ts
@@ -1,14 +1,15 @@
 'use client';
-import { useShallow } from 'zustand/react/shallow';
+import { createShallowHook } from '@/lib/stores/utils/sliceUtils';
 import { useWhackAMoleStore, GAME_DURATION } from './whackAMoleStore';
 
 export type { HoleState } from './whackAMoleStore';
 export { GAME_DURATION } from './whackAMoleStore';
 
+const _useStore = createShallowHook(useWhackAMoleStore);
+
 export function useWhackAMoleGame() {
-  const { phase, holes, holeValues, score, timeLeft, best, combo, startGame, whack } =
-    useWhackAMoleStore(useShallow((s) => s));
-  const pct     = (timeLeft / GAME_DURATION) * 100;
-  const bgColor = timeLeft <= 10 ? 'from-red-100 to-rose-200' : 'from-yellow-50 to-amber-100';
-  return { phase, holes, holeValues, score, timeLeft, best, combo, bgColor, pct, startGame, whack };
+  const state = _useStore();
+  const pct     = (state.timeLeft / GAME_DURATION) * 100;
+  const bgColor = state.timeLeft <= 10 ? 'from-red-100 to-rose-200' : 'from-yellow-50 to-amber-100';
+  return { ...state, bgColor, pct };
 }

--- a/gamesformykids/app/games/word-builder/useWordBuilderGame.ts
+++ b/gamesformykids/app/games/word-builder/useWordBuilderGame.ts
@@ -1,17 +1,17 @@
 'use client';
-import { useShallow } from 'zustand/react/shallow';
+import { createShallowHook } from '@/lib/stores/utils/sliceUtils';
 import { useWordBuilderStore } from './wordBuilderStore';
 
 export type { WordPuzzle, AvailableLetter } from './wordBuilderStore';
 
+const _useStore = createShallowHook(useWordBuilderStore);
+
 export function useWordBuilderGame() {
-  const { phase, puzzles, index, score, typed, available, status, startGame, pressLetter, clearTyped, next } =
-    useWordBuilderStore(useShallow((s) => s));
+  const state = _useStore();
   return {
-    phase, index, score, typed, available, status,
-    current: puzzles[index],
-    total: puzzles.length,
-    startGame, pressLetter, clearTyped, next,
-    restart: startGame,
+    ...state,
+    current: state.puzzles[state.index],
+    total: state.puzzles.length,
+    restart: state.startGame,
   };
 }

--- a/gamesformykids/app/games/word-scramble/useWordScrambleGame.ts
+++ b/gamesformykids/app/games/word-scramble/useWordScrambleGame.ts
@@ -1,12 +1,8 @@
 'use client';
-import { useShallow } from 'zustand/react/shallow';
+import { createShallowHook } from '@/lib/stores/utils/sliceUtils';
 import { useWordScrambleStore } from './wordScrambleStore';
 
 export type { WordEntry, LetterSlot, PickedLetter } from './wordScrambleStore';
 export { WORD_LIST } from './wordScrambleStore';
 
-export function useWordScrambleGame() {
-  const { phase, words, wIdx, letters, picked, score, lives, shake, correct, startGame, pickLetter, unpick } =
-    useWordScrambleStore(useShallow((s) => s));
-  return { phase, words, wIdx, letters, picked, score, lives, shake, correct, startGame, pickLetter, unpick };
-}
+export const useWordScrambleGame = createShallowHook(useWordScrambleStore);

--- a/gamesformykids/lib/stores/utils/sliceUtils.ts
+++ b/gamesformykids/lib/stores/utils/sliceUtils.ts
@@ -1,4 +1,21 @@
-import type { StoreMutatorIdentifier, StateCreator } from 'zustand';
+import type { StoreMutatorIdentifier, StateCreator, StoreApi, UseBoundStore } from 'zustand';
+import { useShallow } from 'zustand/react/shallow';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// createShallowHook
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Returns a React hook that selects the entire store state shallowly.
+ * Eliminates the repeated `useXStore(useShallow((s) => s))` boilerplate.
+ *
+ * @example
+ * export const useColorTapGame = createShallowHook(useColorTapStore);
+ */
+export function createShallowHook<S>(store: UseBoundStore<StoreApi<S>>): () => S {
+  return () => store(useShallow((s) => s));
+}
+
 
 /**
  * Type alias for the `set` function injected into a Zustand StateCreator.


### PR DESCRIPTION
## Summary

Adds `createShallowHook<S>` factory to `lib/stores/utils/sliceUtils.ts` and applies it across 10 game hook files.

## Changes

### New utility (sliceUtils.ts)
```ts
function createShallowHook<S>(store: UseBoundStore<StoreApi<S>>): () => S
```n
### Full replacement (6 files)
Pure field-pickers replaced with a single `const` export:
- `useColorTapGame`  
- `useEmojiMathGame`  
- `useWordScrambleGame`  
- `useNumberBubblesGame`  
- `useDamkaGame`  
- `useReflexGame`  

### Simplified with internal `_useStore` (4 files)
Functions that add derived values still exist but delegate to factory:
- `useTrueFalseGame` — `q: deck[idx]`  
- `useWordBuilderGame` — `current`, `total`, `restart`  
- `useWhackAMoleGame` — `pct`, `bgColor`  
- `useMathRaceGame` — `accuracy`  

### Unchanged (complex hook logic)
- `useSimonGame` — `useCallback` + imperative sequence  
- `useCharityCoinGame` — `useEffect` + `useRouter`  

## Closes

Closes #270