### PR TITLE
refactor(dino-runner): subscribe overlay to store, remove props

### DIFF
--- a/gamesformykids/app/games/dino-runner/DinoRunnerGame.tsx
+++ b/gamesformykids/app/games/dino-runner/DinoRunnerGame.tsx
@@ -41,7 +41,7 @@ export default function DinoRunnerGame() {
             buttonClass="bg-gradient-to-l from-amber-500 to-orange-500 shadow-lg hover:opacity-90"
           />
         )}
-        {phase === 'dead' && <DinoGameOverOverlay score={score} best={best} onRestart={handleTap} />}
+        {phase === 'dead' && <DinoGameOverOverlay onRestart={handleTap} />}
       </>}
       controls={<p className="mt-4 text-amber-600 text-sm font-medium">הקש / לחץ מקש רווח לקפוץ</p>}
     />

--- a/gamesformykids/app/games/dino-runner/components/DinoGameOverOverlay.tsx
+++ b/gamesformykids/app/games/dino-runner/components/DinoGameOverOverlay.tsx
@@ -1,12 +1,14 @@
 'use client';
 
+import { useDinoRunnerStore } from '../dinoRunnerStore';
+import { useShallow } from 'zustand/react/shallow';
+
 interface Props {
-  score: number;
-  best: number;
   onRestart: () => void;
 }
 
-export default function DinoGameOverOverlay({ score, best, onRestart }: Props) {
+export default function DinoGameOverOverlay({ onRestart }: Props) {
+  const { score, best } = useDinoRunnerStore(useShallow(s => ({ score: s.score, best: s.best })));
   return (
     <div className="absolute inset-0 flex items-center justify-center rounded-3xl bg-black/40">
       <div className="bg-white rounded-3xl p-6 text-center shadow-2xl w-64">


### PR DESCRIPTION
## Summary
- `DinoGameOverOverlay` now subscribes to `useDinoRunnerStore` for `score`/`best` directly
- `DinoRunnerGame` no longer passes those values as props to the overlay

## Test plan
- [ ] Launch dino-runner game, play until death — overlay shows correct score and best
- [ ] Start new game from overlay — game resets properly

Closes #274

🤖 Generated with [Claude Code](https://claude.com/claude-code)