### PR TITLE
refactor(brick-breaker): subscribe overlay to store, remove props

### DIFF
--- a/gamesformykids/app/games/brick-breaker/BrickBreakerGame.tsx
+++ b/gamesformykids/app/games/brick-breaker/BrickBreakerGame.tsx
@@ -44,7 +44,7 @@ export default function BrickBreakerGame() {
           />
         )}
         {(phase === 'dead' || phase === 'won') && (
-          <BrickGameOverOverlay phase={phase as 'dead' | 'won'} score={score} best={best} onRestart={() => startGame(1)} />
+          <BrickGameOverOverlay onRestart={() => startGame(1)} />
         )}
       </>}
       controls={phase === 'playing' && (

--- a/gamesformykids/app/games/brick-breaker/components/BrickGameOverOverlay.tsx
+++ b/gamesformykids/app/games/brick-breaker/components/BrickGameOverOverlay.tsx
@@ -1,13 +1,14 @@
 'use client';
 
+import { useBrickBreakerStore } from '../brickBreakerStore';
+import { useShallow } from 'zustand/react/shallow';
+
 interface Props {
-  phase: 'dead' | 'won';
-  score: number;
-  best: number;
   onRestart: () => void;
 }
 
-export default function BrickGameOverOverlay({ phase, score, best, onRestart }: Props) {
+export default function BrickGameOverOverlay({ onRestart }: Props) {
+  const { phase, score, best } = useBrickBreakerStore(useShallow(s => ({ phase: s.phase, score: s.score, best: s.best })));
   return (
     <div className="absolute inset-0 flex items-center justify-center rounded-3xl bg-black/60">
       <div className="bg-white rounded-3xl p-7 text-center shadow-2xl w-72">


### PR DESCRIPTION
## Summary
- `BrickGameOverOverlay` now subscribes to `useBrickBreakerStore` for `phase`/`score`/`best` directly
- `BrickBreakerGame` no longer passes those values as props to the overlay

## Test plan
- [ ] Play brick-breaker until game over — overlay shows correct score/best and win/lose message
- [ ] Play through to win condition — overlay shows win state correctly

Closes #275

🤖 Generated with [Claude Code](https://claude.com/claude-code)