### PR TITLE
refactor(pong): subscribe overlay to store, remove props

### DIFF
--- a/gamesformykids/app/games/pong/PongGame.tsx
+++ b/gamesformykids/app/games/pong/PongGame.tsx
@@ -14,8 +14,6 @@ export default function PongGame() {
   const { phase, playerScore, aiScore } = usePongStore(
     useShallow((s) => ({ phase: s.phase, playerScore: s.playerScore, aiScore: s.aiScore })),
   );
-  const playerWon = playerScore >= WIN_SCORE;
-
   return (
     <CanvasGameShell
       canvasRef={canvasRef} width={W} height={H}
@@ -45,7 +43,7 @@ export default function PongGame() {
           />
         )}
         {phase === 'result' && (
-          <PongResultOverlay playerWon={playerWon} playerScore={playerScore} aiScore={aiScore} onRestart={startGame} />
+          <PongResultOverlay onRestart={startGame} />
         )}
       </>}
       controls={phase === 'playing' && <PongControls onNudgeLeft={nudgeLeft} onNudgeRight={nudgeRight} />}

--- a/gamesformykids/app/games/pong/components/PongResultOverlay.tsx
+++ b/gamesformykids/app/games/pong/components/PongResultOverlay.tsx
@@ -1,13 +1,15 @@
 'use client';
 
+import { usePongStore, WIN_SCORE } from '../pongStore';
+import { useShallow } from 'zustand/react/shallow';
+
 interface Props {
-  playerWon: boolean;
-  playerScore: number;
-  aiScore: number;
   onRestart: () => void;
 }
 
-export default function PongResultOverlay({ playerWon, playerScore, aiScore, onRestart }: Props) {
+export default function PongResultOverlay({ onRestart }: Props) {
+  const { playerScore, aiScore } = usePongStore(useShallow(s => ({ playerScore: s.playerScore, aiScore: s.aiScore })));
+  const playerWon = playerScore >= WIN_SCORE;
   return (
     <div className="absolute inset-0 flex items-center justify-center rounded-3xl bg-black/70">
       <div className="bg-white rounded-3xl p-7 text-center shadow-2xl w-72">


### PR DESCRIPTION
## Summary
- `PongResultOverlay` now subscribes to `usePongStore` for `playerScore`/`aiScore` and derives `playerWon` locally
- `PongGame` removes the now-unused `playerWon` variable and no longer passes score props to the overlay

## Test plan
- [ ] Play pong to completion (player wins) — overlay shows correct win state and scores
- [ ] Play pong to completion (AI wins) — overlay shows correct lose state and scores

Closes #277

🤖 Generated with [Claude Code](https://claude.com/claude-code)