### PR TITLE
refactor(catch-fruit): subscribe HUD/overlay to store, remove props

### DIFF
--- a/gamesformykids/app/games/catch-fruit/CatchFruitGame.tsx
+++ b/gamesformykids/app/games/catch-fruit/CatchFruitGame.tsx
@@ -10,8 +10,8 @@ import CanvasGameShell from '@/components/game/canvas/CanvasGameShell';
 
 export default function CatchFruitGame() {
   const { canvasRef, startGame, handleMouseMove, handleMouseDown, handleMouseUp, handleTouchMove, handleTouchStart } = useCatchFruitGame();
-  const { phase, score, best, lives, timeLeft } = useCatchFruitStore(
-    useShallow((s) => ({ phase: s.phase, score: s.score, best: s.best, lives: s.lives, timeLeft: s.timeLeft })),
+  const { phase, best } = useCatchFruitStore(
+    useShallow((s) => ({ phase: s.phase, best: s.best })),
   );
 
   return (
@@ -21,7 +21,7 @@ export default function CatchFruitGame() {
       canvasClassName="rounded-3xl shadow-2xl cursor-grab active:cursor-grabbing border-4 border-purple-700"
       canvasStyle={{ maxHeight: '80vh', width: 'auto' }}
       canvasProps={{ onMouseDown: handleMouseDown, onMouseMove: handleMouseMove, onMouseUp: handleMouseUp, onTouchStart: handleTouchStart, onTouchMove: handleTouchMove }}
-      hud={phase === 'playing' && <CatchFruitHUD score={score} lives={lives} timeLeft={timeLeft} />}
+      hud={phase === 'playing' && <CatchFruitHUD />}
       overlays={<>
         {phase === 'menu' && (
           <CanvasMenuOverlay
@@ -33,7 +33,7 @@ export default function CatchFruitGame() {
             buttonClass="bg-gradient-to-l from-purple-500 to-indigo-600 shadow-lg hover:opacity-90"
           />
         )}
-        {phase === 'result' && <CatchFruitResultOverlay score={score} best={best} lives={lives} onRestart={startGame} />}
+        {phase === 'result' && <CatchFruitResultOverlay onRestart={startGame} />}
       </>}
     />
   );

--- a/gamesformykids/app/games/catch-fruit/components/CatchFruitHUD.tsx
+++ b/gamesformykids/app/games/catch-fruit/components/CatchFruitHUD.tsx
@@ -1,12 +1,10 @@
 'use client';
 
-interface Props {
-  score: number;
-  lives: number;
-  timeLeft: number;
-}
+import { useCatchFruitStore } from '../catchFruitStore';
+import { useShallow } from 'zustand/react/shallow';
 
-export default function CatchFruitHUD({ score, lives, timeLeft }: Props) {
+export default function CatchFruitHUD() {
+  const { score, lives, timeLeft } = useCatchFruitStore(useShallow(s => ({ score: s.score, lives: s.lives, timeLeft: s.timeLeft })));
   return (
     <div className="flex gap-5 mb-3 text-white text-center">
       <div>

--- a/gamesformykids/app/games/catch-fruit/components/CatchFruitResultOverlay.tsx
+++ b/gamesformykids/app/games/catch-fruit/components/CatchFruitResultOverlay.tsx
@@ -1,13 +1,14 @@
 'use client';
 
+import { useCatchFruitStore } from '../catchFruitStore';
+import { useShallow } from 'zustand/react/shallow';
+
 interface Props {
-  score: number;
-  best: number;
-  lives: number;
   onRestart: () => void;
 }
 
-export default function CatchFruitResultOverlay({ score, best, lives, onRestart }: Props) {
+export default function CatchFruitResultOverlay({ onRestart }: Props) {
+  const { score, best, lives } = useCatchFruitStore(useShallow(s => ({ score: s.score, best: s.best, lives: s.lives })));
   return (
     <div className="absolute inset-0 flex items-center justify-center rounded-3xl bg-black/50">
       <div className="bg-white rounded-3xl p-7 text-center shadow-2xl w-72">


### PR DESCRIPTION
## Summary
- `CatchFruitHUD` subscribes to `useCatchFruitStore` for `score`/`lives`/`timeLeft` directly
- `CatchFruitResultOverlay` subscribes to `useCatchFruitStore` for `score`/`best`/`lives` directly
- `CatchFruitGame` store subscription narrows to `{ phase, best }` and removes all score/lives/timeLeft props from HUD and overlay

## Test plan
- [ ] Play catch-fruit — HUD shows updating score, lives, timer correctly
- [ ] Let timer expire — result overlay shows correct score and best
- [ ] Lose all lives — result overlay shows correct livs-out message

Closes #276

🤖 Generated with [Claude Code](https://claude.com/claude-code)