### PR TITLE
refactor(space-defender): subscribe HUD/overlay to store, remove props

### DIFF
--- a/gamesformykids/app/games/space-defender/SpaceDefenderGame.tsx
+++ b/gamesformykids/app/games/space-defender/SpaceDefenderGame.tsx
@@ -11,8 +11,8 @@ import CanvasGameShell from '@/components/game/canvas/CanvasGameShell';
 
 export default function SpaceDefenderGame() {
   const { canvasRef, shoot, startGame, handleMouseMove, handleCanvasClick, handleTouchMove, handleTouchStart, nudgeLeft, nudgeRight } = useSpaceDefenderGame();
-  const { phase, score, best, lives, timeLeft } = useSpaceDefenderStore(
-    useShallow((s) => ({ phase: s.phase, score: s.score, best: s.best, lives: s.lives, timeLeft: s.timeLeft })),
+  const { phase, best } = useSpaceDefenderStore(
+    useShallow((s) => ({ phase: s.phase, best: s.best })),
   );
 
   return (
@@ -22,7 +22,7 @@ export default function SpaceDefenderGame() {
       canvasClassName="rounded-3xl shadow-2xl border-4 border-indigo-700 cursor-crosshair"
       canvasStyle={{ maxHeight: '85vh', width: 'auto' }}
       canvasProps={{ onMouseMove: handleMouseMove, onClick: handleCanvasClick, onTouchMove: handleTouchMove, onTouchStart: handleTouchStart }}
-      hud={phase === 'playing' && <SpaceDefenderHUD score={score} lives={lives} timeLeft={timeLeft} />}
+      hud={phase === 'playing' && <SpaceDefenderHUD />}
       overlays={<>
         {phase === 'menu' && (
           <CanvasMenuOverlay
@@ -35,7 +35,7 @@ export default function SpaceDefenderGame() {
           />
         )}
         {phase === 'result' && (
-          <SpaceDefenderResultOverlay lives={lives} score={score} best={best} onRestart={startGame} />
+          <SpaceDefenderResultOverlay onRestart={startGame} />
         )}
       </>}
       controls={phase === 'playing' && (

--- a/gamesformykids/app/games/space-defender/components/SpaceDefenderHUD.tsx
+++ b/gamesformykids/app/games/space-defender/components/SpaceDefenderHUD.tsx
@@ -1,12 +1,10 @@
 'use client';
 
-interface Props {
-  score: number;
-  lives: number;
-  timeLeft: number;
-}
+import { useSpaceDefenderStore } from '../spaceDefenderStore';
+import { useShallow } from 'zustand/react/shallow';
 
-export default function SpaceDefenderHUD({ score, lives, timeLeft }: Props) {
+export default function SpaceDefenderHUD() {
+  const { score, lives, timeLeft } = useSpaceDefenderStore(useShallow(s => ({ score: s.score, lives: s.lives, timeLeft: s.timeLeft })));
   return (
     <div className="flex gap-5 mb-2 text-white text-center">
       <div>

--- a/gamesformykids/app/games/space-defender/components/SpaceDefenderResultOverlay.tsx
+++ b/gamesformykids/app/games/space-defender/components/SpaceDefenderResultOverlay.tsx
@@ -1,13 +1,14 @@
 'use client';
 
+import { useSpaceDefenderStore } from '../spaceDefenderStore';
+import { useShallow } from 'zustand/react/shallow';
+
 interface Props {
-  lives: number;
-  score: number;
-  best: number;
   onRestart: () => void;
 }
 
-export default function SpaceDefenderResultOverlay({ lives, score, best, onRestart }: Props) {
+export default function SpaceDefenderResultOverlay({ onRestart }: Props) {
+  const { lives, score, best } = useSpaceDefenderStore(useShallow(s => ({ lives: s.lives, score: s.score, best: s.best })));
   const outOfLives = lives === 0;
   return (
     <div className="absolute inset-0 flex items-center justify-center rounded-3xl bg-black/60">


### PR DESCRIPTION
## Summary
- `SpaceDefenderHUD` subscribes to `useSpaceDefenderStore` for `score`/`lives`/`timeLeft` directly
- `SpaceDefenderResultOverlay` subscribes to `useSpaceDefenderStore` for `lives`/`score`/`best` directly
- `SpaceDefenderGame` store subscription narrows to `{ phase, best }` and removes all score/lives/timeLeft props from HUD and overlay

## Test plan
- [ ] Play space-defender — HUD shows updating score, lives, timer correctly
- [ ] Let timer expire — result overlay shows correct score and best
- [ ] Lose all lives — result overlay shows correct lives-out message

Closes #278

🤖 Generated with [Claude Code](https://claude.com/claude-code)