### PR TITLE
refactor(snake): remove ui shim, subscribe components to stores directly

### DIFF
--- a/gamesformykids/app/games/snake/SnakeGame.tsx
+++ b/gamesformykids/app/games/snake/SnakeGame.tsx
@@ -1,6 +1,9 @@
 'use client';
 
+import { useShallow } from 'zustand/react/shallow';
 import { useSnakeGame, W, H } from './useSnakeGame';
+import { useSnakeStore } from './stores/useSnakeStore';
+import { useGameProgressStore, useGameStore } from '@/lib/stores';
 import { CanvasScoreBar } from '@/components/game/shared/CanvasScoreBar';
 import { CanvasMenuOverlay } from '@/components/game/shared/CanvasMenuOverlay';
 import SnakeGameOverOverlay from './components/SnakeGameOverOverlay';
@@ -8,7 +11,10 @@ import { CanvasDPadControls } from '@/components/game/shared/CanvasDPadControls'
 import CanvasGameShell from '@/components/game/canvas/CanvasGameShell';
 
 export default function SnakeGame() {
-  const { canvasRef, ui, startGame, handleTouchStart, handleTouchEnd, controlDir } = useSnakeGame();
+  const { canvasRef, startGame, handleTouchStart, handleTouchEnd, controlDir } = useSnakeGame();
+  const phase = useSnakeStore((s) => s.phase);
+  const { score, level } = useGameProgressStore(useShallow((s) => ({ score: s.score, level: s.level })));
+  const best = useGameStore((s) => s.highScores['snake'] ?? 0);
 
   return (
     <CanvasGameShell
@@ -17,28 +23,28 @@ export default function SnakeGame() {
       canvasClassName="rounded-2xl shadow-2xl border-4 border-green-700"
       canvasStyle={{ maxHeight: '60vh', width: 'auto' }}
       canvasProps={{ onTouchStart: handleTouchStart, onTouchEnd: handleTouchEnd }}
-      hud={ui.phase === 'playing' && (
+      hud={phase === 'playing' && (
         <CanvasScoreBar
           stats={[
-            { value: ui.score, label: "ניקוד", valueClass: "text-2xl font-black text-green-300", labelClass: "text-xs text-green-500" },
-            { value: ui.level, label: "רמה",   valueClass: "text-2xl font-black text-yellow-300", labelClass: "text-xs text-yellow-500" },
-            { value: ui.best,  label: "שיא",   valueClass: "text-2xl font-black text-gray-300",   labelClass: "text-xs text-gray-500" },
+            { value: score, label: "ניקוד", valueClass: "text-2xl font-black text-green-300", labelClass: "text-xs text-green-500" },
+            { value: level, label: "רמה",   valueClass: "text-2xl font-black text-yellow-300", labelClass: "text-xs text-yellow-500" },
+            { value: best,  label: "שיא",   valueClass: "text-2xl font-black text-gray-300",   labelClass: "text-xs text-gray-500" },
           ]}
           mb="mb-3" className="text-white"
         />
       )}
       overlays={<>
-        {ui.phase === 'menu' && (
+        {phase === 'menu' && (
           <CanvasMenuOverlay
             emoji="🐍" title="נחש"
             description={<>אסוף פירות וגדל!<br />הימנע מהקירות ומעצמך</>}
-            best={ui.best} onStart={startGame}
+            best={best} onStart={startGame}
             backdropClass="rounded-2xl bg-black/50" cardWidth="w-64"
             emojiSize="text-6xl" titleSize="text-3xl" titleColor="text-green-700"
             buttonClass="bg-gradient-to-l from-green-500 to-emerald-600 shadow-lg hover:opacity-90"
           />
         )}
-        {ui.phase === 'dead' && <SnakeGameOverOverlay score={ui.score} best={ui.best} onRestart={startGame} />}
+        {phase === 'dead' && <SnakeGameOverOverlay onRestart={startGame} />}
       </>}
       controls={
         <CanvasDPadControls

--- a/gamesformykids/app/games/snake/components/SnakeGameOverOverlay.tsx
+++ b/gamesformykids/app/games/snake/components/SnakeGameOverOverlay.tsx
@@ -1,12 +1,14 @@
 'use client';
 
+import { useGameProgressStore, useGameStore } from '@/lib/stores';
+
 interface Props {
-  score: number;
-  best: number;
   onRestart: () => void;
 }
 
-export default function SnakeGameOverOverlay({ score, best, onRestart }: Props) {
+export default function SnakeGameOverOverlay({ onRestart }: Props) {
+  const score = useGameProgressStore(s => s.score);
+  const best = useGameStore(s => s.highScores['snake'] ?? 0);
   return (
     <div className="absolute inset-0 flex items-center justify-center rounded-2xl bg-black/50">
       <div className="bg-white rounded-3xl p-7 text-center shadow-2xl w-64">

--- a/gamesformykids/app/games/snake/useSnakeGame.ts
+++ b/gamesformykids/app/games/snake/useSnakeGame.ts
@@ -35,14 +35,6 @@ export function useSnakeGame() {
     animFrame: 0,
   });
 
-  const phase = useSnakeStore((s) => s.phase);
-  const score = useGameProgressStore((s) => s.score);
-  const level = useGameProgressStore((s) => s.level);
-  const best  = useGameStore((s) => s.highScores['snake'] ?? 0);
-
-  // אובייקט ui באפייניין אחורה-תאימות לקוד שקורא את ה-hook
-  const ui = { phase, score, level, best };
-
   function placeFood(snake: Pt[]): Pt {
     let pt: Pt;
     do { pt = { x: rnd(COLS), y: rnd(ROWS) }; }
@@ -228,5 +220,5 @@ export function useSnakeGame() {
     if (dir !== opposite[s.dir]) s.nextDir = dir;
   }, []);
 
-  return { canvasRef, ui, startGame, handleTouchStart, handleTouchEnd, controlDir };
+  return { canvasRef, startGame, handleTouchStart, handleTouchEnd, controlDir };
 }


### PR DESCRIPTION
## Summary
- `useSnakeGame` drops the `ui` backward-compat shim and all reactive store subscriptions — it now only manages game loop logic
- `SnakeGame` subscribes to `useSnakeStore` (phase), `useGameProgressStore` (score, level), and `useGameStore` (best) directly
- `SnakeGameOverOverlay` reads `score`/`best` from stores, no longer needs props

## Test plan
- [ ] Play snake — HUD shows updating score, level, and best correctly
- [ ] Die — game-over overlay shows correct score and best
- [ ] Restart — game resets properly

Closes #273

🤖 Generated with [Claude Code](https://claude.com/claude-code)