### PR TITLE
refactor(zustand): add makeLivesInitial factory, apply to 3 stores

### DIFF
--- a/gamesformykids/app/games/color-tap/colorTapStore.ts
+++ b/gamesformykids/app/games/color-tap/colorTapStore.ts
@@ -1,5 +1,6 @@
 import { makeStore } from '@/lib/stores/createStore';
 import { setupLivesTimer } from '@/lib/stores/livesTimerHelpers';
+import { makeLivesInitial } from '@/lib/stores/utils/sliceUtils';
 import type { LivesGameState } from '@/lib/types';
 
 // ── Color data ──────────────────────────────────────────────────────────────
@@ -40,10 +41,7 @@ interface ColorTapActions {
   handleTap: (color: ColorItem) => void;
 }
 
-const INITIAL: ColorTapState = {
-  phase: 'menu', score: 0, best: 0, lives: 3,
-  timeLeft: TIME_PER_Q, feedback: null, question: makeQuestion(),
-};
+const INITIAL = makeLivesInitial(TIME_PER_Q, { question: makeQuestion() });
 
 export const useColorTapStore = makeStore<ColorTapState & ColorTapActions>(
   'ColorTapStore',

--- a/gamesformykids/app/games/emoji-math/emojiMathStore.ts
+++ b/gamesformykids/app/games/emoji-math/emojiMathStore.ts
@@ -1,5 +1,6 @@
 import { makeStore } from '@/lib/stores/createStore';
 import { setupLivesTimer } from '@/lib/stores/livesTimerHelpers';
+import { makeLivesInitial } from '@/lib/stores/utils/sliceUtils';
 import type { LivesGameState } from '@/lib/types';
 import { randInt as rnd } from '@/lib/utils';
 
@@ -51,10 +52,7 @@ interface EmojiMathActions {
   tap:       (choice: number) => void;
 }
 
-const INITIAL: EmojiMathState = {
-  phase: 'menu', score: 0, best: 0, lives: 3,
-  timeLeft: TIME_PER_Q, feedback: null, q: makeQuestion(1), level: 1, streak: 0,
-};
+const INITIAL = makeLivesInitial(TIME_PER_Q, { q: makeQuestion(1), level: 1, streak: 0 });
 
 export const useEmojiMathStore = makeStore<EmojiMathState & EmojiMathActions>(
   'EmojiMathStore',

--- a/gamesformykids/app/games/true-false/trueFalseStore.ts
+++ b/gamesformykids/app/games/true-false/trueFalseStore.ts
@@ -1,5 +1,6 @@
 import { makeStore } from '@/lib/stores/createStore';
 import { setupLivesTimer } from '@/lib/stores/livesTimerHelpers';
+import { makeLivesInitial } from '@/lib/stores/utils/sliceUtils';
 import type { LivesGameState } from '@/lib/types';
 import { shuffle } from '@/lib/utils';
 
@@ -49,10 +50,7 @@ interface TrueFalseActions {
   answer:    (choice: boolean) => void;
 }
 
-const INITIAL: TrueFalseState = {
-  phase: 'menu', score: 0, best: 0, lives: 3,
-  timeLeft: TIME_PER_Q, feedback: null, deck: shuffle(FACTS), idx: 0,
-};
+const INITIAL = makeLivesInitial(TIME_PER_Q, { deck: shuffle(FACTS), idx: 0 });
 
 export const useTrueFalseStore = makeStore<TrueFalseState & TrueFalseActions>(
   'TrueFalseStore',

--- a/gamesformykids/lib/stores/index.ts
+++ b/gamesformykids/lib/stores/index.ts
@@ -91,3 +91,4 @@ export { useMathChallengeStore } from './mathChallengeStore';
 // Store utilities
 export type { RemoteDataSlice } from './utils/RemoteDataSlice';
 export type { ChallengeStoreState } from './utils/createChallengeStore';
+export { makeLivesInitial, makeSetter, makeToggle, createShallowHook } from './utils/sliceUtils';

--- a/gamesformykids/lib/stores/utils/sliceUtils.ts
+++ b/gamesformykids/lib/stores/utils/sliceUtils.ts
@@ -1,5 +1,33 @@
 import type { StoreMutatorIdentifier, StateCreator, StoreApi, UseBoundStore } from 'zustand';
 import { useShallow } from 'zustand/react/shallow';
+import type { LivesGameState } from '@/lib/types';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// makeLivesInitial
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Builds a typed INITIAL_STATE object for LivesGameState-based stores.
+ * Eliminates the repeated phase/score/best/lives/timeLeft/feedback boilerplate.
+ *
+ * @example
+ * const INITIAL = makeLivesInitial(TIME_PER_Q, { question: makeQuestion() });
+ */
+export function makeLivesInitial<T extends object>(
+  timePerQ: number,
+  extra: T,
+  initialLives = 3,
+): LivesGameState & T {
+  return {
+    phase: 'menu',
+    score: 0,
+    best: 0,
+    lives: initialLives,
+    timeLeft: timePerQ,
+    feedback: null,
+    ...extra,
+  } as LivesGameState & T;
+}
 
 // ─────────────────────────────────────────────────────────────────────────────
 // createShallowHook


### PR DESCRIPTION
## Summary
- Adds `makeLivesInitial<T>(timePerQ, extra, initialLives?)` to `lib/stores/utils/sliceUtils.ts` — builds the shared `LivesGameState` fields so each store only declares its game-specific extras
- Also exports `makeLivesInitial`, `makeSetter`, `makeToggle`, `createShallowHook` from `lib/stores/index.ts`
- Applied to `colorTapStore`, `emojiMathStore`, `trueFalseStore` (the only three stores that extend `LivesGameState`)
- `math-race`, `whack-a-mole`, `reflex` don't extend `LivesGameState` — unchanged

## Before / After
```ts
// Before (repeated in every store):
const INITIAL: ColorTapState = {
  phase: 'menu', score: 0, best: 0, lives: 3,
  timeLeft: TIME_PER_Q, feedback: null, question: makeQuestion(),
};

// After:
const INITIAL = makeLivesInitial(TIME_PER_Q, { question: makeQuestion() });
```

## Test plan
- [ ] Play color-tap — game starts and resets correctly
- [ ] Play emoji-math — level/streak fields initialize correctly
- [ ] Play true-false — deck shuffles on start correctly

Closes #271

🤖 Generated with [Claude Code](https://claude.com/claude-code)