### PR TITLE
chore(ts): enable exactOptionalPropertyTypes and fix all errors (#76)

### DIFF
--- a/gamesformykids/app/games/puzzles/store/slices/dropSlice.ts
+++ b/gamesformykids/app/games/puzzles/store/slices/dropSlice.ts
@@ -23,11 +23,11 @@ export const createDropSlice: StateCreator<PuzzleStore, [], [], DropSlice> = (se
     const existingPiece = newPlacedPieces[gridIndex];
     if (existingPiece) {
       set({
-        pieces: get().pieces.map(p =>
-          p.id === existingPiece.id
-            ? { ...p, isPlaced: false, isCorrect: false, currentPosition: undefined }
-            : p,
-        ),
+        pieces: get().pieces.map(p => {
+          if (p.id !== existingPiece.id) return p;
+          const { currentPosition: _cp, ...rest } = p;
+          return { ...rest, isPlaced: false, isCorrect: false };
+        }),
       });
     }
 

--- a/gamesformykids/app/games/puzzles/utils/puzzleTypes.ts
+++ b/gamesformykids/app/games/puzzles/utils/puzzleTypes.ts
@@ -8,7 +8,7 @@ export interface PuzzlePiece {
   isPlaced: boolean;
   isCorrect: boolean;
   expectedPosition: { row: number; col: number };
-  currentPosition?: { row: number; col: number };
+  currentPosition?: { row: number; col: number } | undefined;
 }
 
 export interface SimplePuzzlePiece extends PuzzlePiece {

--- a/gamesformykids/components/shared/GameCardMap.tsx
+++ b/gamesformykids/components/shared/GameCardMap.tsx
@@ -16,10 +16,10 @@ import { createPhotoCard } from './cards/PhotoGameCard';
 
 // Generic card component that works for all game types
 const DefaultGameCard = ({ item, onClick, isSelected }: GameItemCardProps) => (
-  <UnifiedCard 
+  <UnifiedCard
     item={item}
-    onClick={onClick ? () => onClick(item) : undefined}
-    isSelected={isSelected}
+    onClick={() => onClick(item)}
+    {...(isSelected !== undefined ? { isSelected } : {})}
     variant="advanced"
   />
 );

--- a/gamesformykids/lib/types/components/cards.ts
+++ b/gamesformykids/lib/types/components/cards.ts
@@ -104,7 +104,7 @@ interface CardCustomContent {
  */
 interface BaseCardProps extends CardAppearance, CardBehavior, CardCustomContent {
   className?: string;
-  isSelected?: boolean;
+  isSelected?: boolean | undefined;
 }
 
 /**
@@ -132,12 +132,12 @@ export interface ColoredShapeCardProps extends BaseCardProps {
  */
 export interface UnifiedCardProps extends BaseCardProps {
   // Data
-  item?: BaseGameItem;
-  onClick?: (item?: BaseGameItem) => void;
+  item?: BaseGameItem | undefined;
+  onClick?: ((item?: BaseGameItem) => void) | undefined;
   showContent?: CardContent;
-  
+
   // Simple mode - for direct text input
-  hebrewText?: string;
+  hebrewText?: string | undefined;
   secondaryText?: string;
   name?: string;
   

--- a/gamesformykids/lib/types/components/screens.ts
+++ b/gamesformykids/lib/types/components/screens.ts
@@ -7,11 +7,11 @@
 export interface GenericStartScreenProps<T> {
   // Header props
   title: string;
-  subtitle?: string;
-  subTitle?: string; // alias for subtitle
-  textColorHeader?: string;
-  textColorSubHeader?: string;
-  
+  subtitle?: string | undefined;
+  subTitle?: string | undefined;
+  textColorHeader?: string | undefined;
+  textColorSubHeader?: string | undefined;
+
   // Game props
   items: T[];
   gameSteps?: Array<{
@@ -20,36 +20,36 @@ export interface GenericStartScreenProps<T> {
     icon: string;
     title: string;
     description: string;
-  }>;
-  gameStepsBgClass?: string;
-  onStart?: () => void;
-  customOnStart?: () => void;
-  onItemClick?: (item: T) => void;
-  onSpeak?: (name: string) => void;
-  showPreview?: boolean;
-  difficulty?: 'easy' | 'medium' | 'hard';
-  
+  }> | undefined;
+  gameStepsBgClass?: string | undefined;
+  onStart?: (() => void) | undefined;
+  customOnStart?: (() => void) | undefined;
+  onItemClick?: ((item: T) => void) | undefined;
+  onSpeak?: ((name: string) => void) | undefined;
+  showPreview?: boolean | undefined;
+  difficulty?: 'easy' | 'medium' | 'hard' | undefined;
+
   // Button colors
-  buttonFromColor?: string;
-  buttonToColor?: string;
-  
+  buttonFromColor?: string | undefined;
+  buttonToColor?: string | undefined;
+
   // Background
-  backgroundStyle?: string;
-  
+  backgroundStyle?: string | undefined;
+
   // Items display
-  itemsTitle?: string;
-  itemsDescription?: string;
-  itemsDescriptionColor?: string;
-  itemsGridClass?: string;
-  
+  itemsTitle?: string | undefined;
+  itemsDescription?: string | undefined;
+  itemsDescriptionColor?: string | undefined;
+  itemsGridClass?: string | undefined;
+
   // Item rendering function
-  renderItem?: (item: T, index: number) => React.ReactNode;
-  customItemsRenderer?: () => React.ReactNode;
+  renderItem?: ((item: T, index: number) => React.ReactNode) | undefined;
+  customItemsRenderer?: (() => React.ReactNode) | undefined;
   customContent?: React.ReactNode;
-  
+
   // Layout options
-  showAudioCheck?: boolean;
-  className?: string;
+  showAudioCheck?: boolean | undefined;
+  className?: string | undefined;
 }
 
 export interface GameErrorScreenProps {


### PR DESCRIPTION
## Summary

- Enables `"exactOptionalPropertyTypes": true` in `tsconfig.json` (closes #76)
- Fixes all 21 resulting type errors across 19 files with no regressions
- Zero new errors beyond the pre-existing `supabase/server.ts` / `middleware.ts` implicit-any issues

## Changes

**tsconfig.json**
- Add `exactOptionalPropertyTypes: true`

**Type definitions** — add `| undefined` to optional fields that receive explicit `undefined` from callers:
- `lib/types/hooks/game-state.ts` — `GameEnhancements`, `GameLogicState`
- `lib/types/events/game-events.ts` — `EventPayload.data`
- `lib/types/ui/core.ts` — `LoadingScreenProps.onLoadingComplete`
- `lib/types/components/cards.ts` — `BaseCardProps.isSelected`, `UnifiedCardProps.item/hebrewText/onClick`
- `lib/types/components/screens.ts` — all optional fields in `GenericStartScreenProps`

**Component fixes** — fix call-sites passing explicit `undefined`:
- `components/game/quiz/*` — add `| undefined` to optional prop types
- `components/game/shared/GameMenuCard.tsx` — same
- `components/game/universal/auto-game/AutoGameBody.tsx` — same
- `components/game/universal/ultimate-game/GameLogicSync.tsx` — `?? (() => {})` fallbacks
- `components/shared/buttons/SimpleGameStartButton.tsx` — same
- `components/shared/GameCardMap.tsx` — simplify onClick, conditional-spread isSelected

**Game-specific fixes:**
- `app/games/hebrew-letters/components/canvas/WritingCanvasContext.tsx` — add `| undefined`
- `app/games/hebrew-letters/components/practice/LetterWritingStep.tsx` — remove explicit `guideLetter={undefined}`
- `app/games/puzzles/utils/puzzleTypes.ts` — `PuzzlePiece.currentPosition | undefined`
- `app/games/puzzles/store/slices/dropSlice.ts` — destructure `currentPosition` out instead of setting to `undefined`
- `lib/utils/game/gameNavigation.ts` — conditional spread instead of `key: T | undefined`

## Test plan
- [x] `npx tsc --noEmit` — only pre-existing supabase/middleware errors remain
- [ ] CI Typecheck green
- [ ] CI Build green

🤖 Generated with [Claude Code](https://claude.com/claude-code)