### PR TITLE
chore(ts): enable exactOptionalPropertyTypes in tsconfig (follow-up to #286)

### DIFF
--- a/gamesformykids/app/games/hebrew-letters/components/canvas/WritingCanvasContext.tsx
+++ b/gamesformykids/app/games/hebrew-letters/components/canvas/WritingCanvasContext.tsx
@@ -4,7 +4,7 @@ import React, { createContext, useContext } from 'react';
 import { useWritingCanvas } from './useWritingCanvas';
 
 type WritingCanvasContextValue = ReturnType<typeof useWritingCanvas> & {
-  guideLetter?: string;
+  guideLetter?: string | undefined;
 };
 
 const WritingCanvasContext = createContext<WritingCanvasContextValue | null>(null);
@@ -17,7 +17,7 @@ export function useWritingCanvasContext(): WritingCanvasContextValue {
 
 interface WritingCanvasProviderProps {
   value: ReturnType<typeof useWritingCanvas>;
-  guideLetter?: string;
+  guideLetter?: string | undefined;
   children: React.ReactNode;
 }
 

--- a/gamesformykids/app/games/hebrew-letters/components/practice/LetterWritingStep.tsx
+++ b/gamesformykids/app/games/hebrew-letters/components/practice/LetterWritingStep.tsx
@@ -33,10 +33,7 @@ export default function LetterWritingStep() {
         </p>
       </div>
 
-      <WritingCanvas
-        height={300}
-        guideLetter={undefined}
-      />
+      <WritingCanvas height={300} />
     </motion.div>
   );
 }

--- a/gamesformykids/components/game/quiz/QuizAnswerGrid.tsx
+++ b/gamesformykids/components/game/quiz/QuizAnswerGrid.tsx
@@ -9,8 +9,8 @@ interface Props {
   correctValue: string;
   onSelect: (choice: string) => void;
   theme: QuizTheme;
-  renderChoice?: (choice: string) => ReactNode;
-  cols?: 1 | 2;
+  renderChoice?: ((choice: string) => ReactNode) | undefined;
+  cols?: 1 | 2 | undefined;
 }
 
 export function QuizAnswerGrid({

--- a/gamesformykids/components/game/quiz/QuizFeedback.tsx
+++ b/gamesformykids/components/game/quiz/QuizFeedback.tsx
@@ -5,10 +5,10 @@ import { QUIZ_THEMES, type QuizTheme } from './quizTheme';
 
 interface Props {
   correctLabel: string;
-  funFact?: string;
+  funFact?: string | undefined;
   theme: QuizTheme;
-  correctMsg?: string;
-  wrongMsg?: string;
+  correctMsg?: string | undefined;
+  wrongMsg?: string | undefined;
 }
 
 export function QuizFeedback({

--- a/gamesformykids/components/game/quiz/QuizMenuScreen.tsx
+++ b/gamesformykids/components/game/quiz/QuizMenuScreen.tsx
@@ -10,7 +10,7 @@ interface Props {
   theme: QuizTheme;
   /** Optional preview/example content shown above the button */
   preview?: ReactNode;
-  buttonLabel?: string;
+  buttonLabel?: string | undefined;
   onStart: () => void;
 }
 

--- a/gamesformykids/components/game/quiz/QuizQuestionShell.tsx
+++ b/gamesformykids/components/game/quiz/QuizQuestionShell.tsx
@@ -11,12 +11,12 @@ interface Props {
   choices: string[];
   correctLabel: string;
   onSelect: (choice: string) => void;
-  correctMsg?: string;
-  wrongMsg?: string;
-  funFact?: string;
+  correctMsg?: string | undefined;
+  wrongMsg?: string | undefined;
+  funFact?: string | undefined;
   cardVariant?: 'themed' | 'white';
-  cols?: 1 | 2;
-  renderChoice?: (choice: string) => ReactNode;
+  cols?: 1 | 2 | undefined;
+  renderChoice?: ((choice: string) => ReactNode) | undefined;
   children: ReactNode;
 }
 

--- a/gamesformykids/components/game/shared/GameMenuCard.tsx
+++ b/gamesformykids/components/game/shared/GameMenuCard.tsx
@@ -11,9 +11,9 @@ interface Props {
   buttonClass?: string;
   onStart?: () => void;
   startLabel?: string;
-  animateEmoji?: boolean;
+  animateEmoji?: boolean | undefined;
   /** Optional extra info line below description (e.g. rules, time per question) */
-  hint?: string;
+  hint?: string | undefined;
   /** Optional best score to display */
   best?: number;
   /** Optional extra content rendered below the description (e.g. level/category grid) */

--- a/gamesformykids/components/game/universal/auto-game/AutoGameBody.tsx
+++ b/gamesformykids/components/game/universal/auto-game/AutoGameBody.tsx
@@ -7,7 +7,7 @@ import { GameHints } from "../../../shared";
 import { TipsBox } from "../../../shared";
 
 interface AutoGameBodyProps {
-  renderCard?: (item: BaseGameItem, onClick: (item: BaseGameItem) => void) => React.ReactNode;
+  renderCard?: ((item: BaseGameItem, onClick: (item: BaseGameItem) => void) => React.ReactNode) | undefined;
 }
 
 /**

--- a/gamesformykids/components/game/universal/ultimate-game/GameLogicSync.tsx
+++ b/gamesformykids/components/game/universal/ultimate-game/GameLogicSync.tsx
@@ -17,10 +17,10 @@ function GameLogicSyncInner() {
   // This component doesn't subscribe to the store, so no infinite loop.
   useEffect(() => {
     useGameActionsStore.getState().setGameActions({
-      startGame: gameHookResult.startGame,
-      resetGame: gameHookResult.resetGame,
-      handleItemClick: gameHookResult.handleItemClick,
-      speakItemName: gameHookResult.speakItemName,
+      startGame: gameHookResult.startGame ?? (() => {}),
+      resetGame: gameHookResult.resetGame ?? (() => {}),
+      handleItemClick: gameHookResult.handleItemClick ?? (() => {}),
+      speakItemName: gameHookResult.speakItemName ?? (() => {}),
       hints: gameHookResult.hints?.map((h) => {
         const hint = h as string | { text?: string };
         return typeof hint === 'string' ? hint : hint.text ?? '';

--- a/gamesformykids/components/shared/buttons/SimpleGameStartButton.tsx
+++ b/gamesformykids/components/shared/buttons/SimpleGameStartButton.tsx
@@ -4,7 +4,7 @@ type SimpleGameStartButtonProps = {
   fromColor?: string;
   toColor?: string;
   text?: string;
-  customOnStart?: () => void;
+  customOnStart?: (() => void) | undefined;
 };
 
 /**

--- a/gamesformykids/lib/types/events/game-events.ts
+++ b/gamesformykids/lib/types/events/game-events.ts
@@ -50,7 +50,7 @@ interface EventMetadata {
  * נתונים נוספים לאירוע - עקרון Single Responsibility
  */
 interface EventPayload {
-  readonly data?: Readonly<Record<string, unknown>>;
+  readonly data?: Readonly<Record<string, unknown>> | undefined;
 }
 
 /**

--- a/gamesformykids/lib/types/hooks/game-state.ts
+++ b/gamesformykids/lib/types/hooks/game-state.ts
@@ -69,9 +69,9 @@ export interface GameProgress {
  * תכונות מתקדמות של משחק - עקרון Single Responsibility
  */
 interface GameEnhancements {
-  readonly hints?: readonly string[];
-  readonly hasMoreHints?: boolean;
-  readonly showNextHint?: () => void;
+  readonly hints?: readonly string[] | undefined;
+  readonly hasMoreHints?: boolean | undefined;
+  readonly showNextHint?: (() => void) | undefined;
 }
 
 /**
@@ -128,7 +128,7 @@ export interface GameLogicState extends
   GameConfiguration {
   readonly gameState: GameState | null;
   readonly isGameActive: boolean;
-  readonly progressStats?: Record<string, unknown>;
+  readonly progressStats?: Record<string, unknown> | undefined;
 }
 
 /**

--- a/gamesformykids/lib/types/ui/core.ts
+++ b/gamesformykids/lib/types/ui/core.ts
@@ -41,5 +41,5 @@ export interface GoogleAnalyticsProps {
 export interface LoadingScreenProps {
   readonly message?: string;
   readonly showSpinner?: boolean;
-  readonly onLoadingComplete?: () => void;
+  readonly onLoadingComplete?: (() => void) | undefined;
 }

--- a/gamesformykids/lib/utils/game/gameNavigation.ts
+++ b/gamesformykids/lib/utils/game/gameNavigation.ts
@@ -21,15 +21,7 @@ export function getGameNavigation(currentGameId: string): {
   const next = currentIndex < allGames.length - 1 ? allGames[currentIndex + 1] : undefined;
 
   return {
-    previous: previous ? {
-      href: previous.href,
-      title: previous.title,
-      icon: previous.icon
-    } : undefined,
-    next: next ? {
-      href: next.href,
-      title: next.title,
-      icon: next.icon
-    } : undefined
+    ...(previous ? { previous: { href: previous.href, title: previous.title, icon: previous.icon } } : {}),
+    ...(next    ? { next:     { href: next.href,     title: next.title,     icon: next.icon     } } : {}),
   };
 }

--- a/gamesformykids/tsconfig.json
+++ b/gamesformykids/tsconfig.json
@@ -5,6 +5,7 @@
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
+    "exactOptionalPropertyTypes": true,
     "noEmit": true,
     "esModuleInterop": true,
     "module": "esnext",


### PR DESCRIPTION
## Summary

Follow-up to #286 — the `tsconfig.json` change and the first 15 type-fix files were edited in the prior session but never staged, so they were absent from the merged PR. This PR lands them.

- Enables `"exactOptionalPropertyTypes": true` in `tsconfig.json`
- Adds `| undefined` to optional prop types in quiz components, shared components, and type definitions
- Fixes `GameLogicSync.tsx` action fallbacks and `gameNavigation.ts` conditional spread

## Files

- `tsconfig.json` — the flag itself
- `components/game/quiz/*` — QuizFeedback, QuizMenuScreen, QuizAnswerGrid, QuizQuestionShell
- `components/game/shared/GameMenuCard.tsx`
- `components/game/universal/auto-game/AutoGameBody.tsx`
- `components/game/universal/ultimate-game/GameLogicSync.tsx`
- `components/shared/buttons/SimpleGameStartButton.tsx`
- `lib/types/hooks/game-state.ts`
- `lib/types/events/game-events.ts`
- `lib/types/ui/core.ts`
- `lib/utils/game/gameNavigation.ts`
- `app/games/hebrew-letters/components/canvas/WritingCanvasContext.tsx`
- `app/games/hebrew-letters/components/practice/LetterWritingStep.tsx`

## Test plan
- [x] `npx tsc --noEmit` — only pre-existing supabase/middleware errors remain
- [ ] CI Typecheck green
- [ ] CI Build green

🤖 Generated with [Claude Code](https://claude.com/claude-code)