### PR TITLE
refactor(play-screens): use game hook instead of direct store subscription (#289)

### DIFF
--- a/gamesformykids/app/games/math-race/components/MathRacePlayScreen.tsx
+++ b/gamesformykids/app/games/math-race/components/MathRacePlayScreen.tsx
@@ -1,13 +1,10 @@
 'use client';
-import { useShallow } from 'zustand/react/shallow';
-import { useMathRaceStore, GAME_TIME } from '../mathRaceStore';
+import { useMathRaceGame, GAME_TIME } from '../useMathRaceGame';
 import MathRaceProgressBar from './MathRaceProgressBar';
 import MathRaceQuestion from './MathRaceQuestion';
 
 export default function MathRacePlayScreen() {
-  const { q, score, timeLeft, feedback, streak, correct, total, tap } =
-    useMathRaceStore(useShallow((s) => s));
-  const accuracy = total > 0 ? Math.round((correct / total) * 100) : 0;
+  const { q, score, timeLeft, feedback, streak, correct, total, tap, accuracy } = useMathRaceGame();
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-blue-100 to-indigo-200 flex flex-col items-center justify-center p-4 select-none" dir="rtl">

--- a/gamesformykids/app/games/true-false/components/TrueFalsePlayScreen.tsx
+++ b/gamesformykids/app/games/true-false/components/TrueFalsePlayScreen.tsx
@@ -1,11 +1,8 @@
 'use client';
-import { useShallow } from 'zustand/react/shallow';
-import { useTrueFalseStore, TIME_PER_Q } from '../trueFalseStore';
+import { useTrueFalseGame, TIME_PER_Q } from '../useTrueFalseGame';
 
 export default function TrueFalsePlayScreen() {
-  const { score, lives, timeLeft, feedback, deck, idx, answer } =
-    useTrueFalseStore(useShallow((s) => s));
-  const q = deck[idx];
+  const { score, lives, timeLeft, feedback, q, answer } = useTrueFalseGame();
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-teal-100 to-cyan-200 flex flex-col items-center justify-center p-4 select-none" dir="rtl">

--- a/gamesformykids/app/games/word-scramble/components/WordScramblePlayScreen.tsx
+++ b/gamesformykids/app/games/word-scramble/components/WordScramblePlayScreen.tsx
@@ -1,10 +1,9 @@
 'use client';
-import { useShallow } from 'zustand/react/shallow';
-import { useWordScrambleStore } from '../wordScrambleStore';
+import { useWordScrambleGame } from '../useWordScrambleGame';
 
 export default function WordScramblePlayScreen() {
   const { words, wIdx, letters, picked, score, lives, shake, correct, pickLetter, unpick } =
-    useWordScrambleStore(useShallow((s) => s));
+    useWordScrambleGame();
   const entry  = words[wIdx];
   const target = entry.word;
 


### PR DESCRIPTION
## Summary

Three play-screen components were subscribing directly to their Zustand store and re-computing derived values already available in the game hook.

| Component | Removed duplication |
|-----------|-------------------|
| `WordScramblePlayScreen` | `useWordScrambleStore(useShallow(s=>s))` → `useWordScrambleGame()` |
| `MathRacePlayScreen` | manual `accuracy = total > 0 ? Math.round(...)` → `useMathRaceGame().accuracy` |
| `TrueFalsePlayScreen` | manual `q = deck[idx]` → `useTrueFalseGame().q` |

Each file loses its direct store import and `useShallow` import.

Closes #289

## Test plan
- [x] `npx tsc --noEmit` — no new errors
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)