### PR TITLE
refactor: extract useCanvasLoop hook, apply to all 10 canvas games

### DIFF
--- a/gamesformykids/app/games/brick-breaker/useBrickBreakerGame.ts
+++ b/gamesformykids/app/games/brick-breaker/useBrickBreakerGame.ts
@@ -1,7 +1,8 @@
-﻿'use client';
+'use client';
 
 import { useEffect, useRef, useCallback } from 'react';
 import { useBrickBreakerStore } from './brickBreakerStore';
+import { useCanvasLoop } from '@/hooks/shared/common';
 
 export const W = 360;
 export const H = 560;
@@ -32,13 +33,18 @@ function makeBricks(): Brick[] {
   return Array.from({ length: ROWS * COLS }, (_, i) => ({ alive: true, row: Math.floor(i / COLS) }));
 }
 
+function brickRect(i: number) {
+  const col = i % COLS, row = Math.floor(i / COLS);
+  const x = 10 + col * BRICK_W, y = BRICK_TOP + row * (BRICK_H + BRICK_PAD);
+  return { x, y, w: BRICK_W - BRICK_PAD, h: BRICK_H };
+}
+
 export function useBrickBreakerGame() {
-  const canvasRef = useRef<HTMLCanvasElement>(null);
   const st = useRef({
     phase: 'menu' as Phase,
     padX: W / 2 - PAD_W / 2,
     ballX: W / 2, ballY: PAD_Y - BALL_R - 2, ballVX: 3, ballVY: -4, launched: false,
-    bricks: makeBricks(), score: 0, lives: 3, level: 1, raf: 0, frame: 0,
+    bricks: makeBricks(), score: 0, lives: 3, level: 1, frame: 0,
     particles: [] as { x: number; y: number; vx: number; vy: number; life: number; color: string }[],
   });
   const startGame = useCallback((level = 1) => {
@@ -84,98 +90,78 @@ export function useBrickBreakerGame() {
   const nudgeLeft = useCallback(() => { st.current.padX = Math.max(0, st.current.padX - 40); }, []);
   const nudgeRight = useCallback(() => { st.current.padX = Math.min(W - PAD_W, st.current.padX + 40); }, []);
 
-  useEffect(() => {
-    const canvas = canvasRef.current;
-    if (!canvas) return;
-    const ctx = canvas.getContext('2d') as CanvasRenderingContext2D;
-    if (!ctx) return;
+  const canvasRef = useCanvasLoop((ctx) => {
+    const s = st.current;
+    s.frame++;
 
-    function brickRect(i: number) {
-      const col = i % COLS, row = Math.floor(i / COLS);
-      const x = 10 + col * BRICK_W, y = BRICK_TOP + row * (BRICK_H + BRICK_PAD);
-      return { x, y, w: BRICK_W - BRICK_PAD, h: BRICK_H };
-    }
-
-    function loop() {
-      const s = st.current;
-      s.frame++;
-
-      if (s.phase === 'playing') {
-        if (!s.launched) { s.ballX = s.padX + PAD_W / 2; s.ballY = PAD_Y - BALL_R - 2; }
-        else {
-          s.ballX += s.ballVX; s.ballY += s.ballVY;
-          if (s.ballX - BALL_R <= 0) { s.ballX = BALL_R; s.ballVX = Math.abs(s.ballVX); }
-          if (s.ballX + BALL_R >= W) { s.ballX = W - BALL_R; s.ballVX = -Math.abs(s.ballVX); }
-          if (s.ballY - BALL_R <= 0) { s.ballY = BALL_R; s.ballVY = Math.abs(s.ballVY); }
-          if (s.ballY + BALL_R >= PAD_Y && s.ballY + BALL_R <= PAD_Y + PAD_H && s.ballX >= s.padX && s.ballX <= s.padX + PAD_W) {
-            const rel = (s.ballX - s.padX) / PAD_W - 0.5;
-            const spd = Math.sqrt(s.ballVX ** 2 + s.ballVY ** 2);
-            s.ballVX = rel * spd * 2.2; s.ballVY = -Math.abs(s.ballVY);
-          }
-          if (s.ballY + BALL_R > H) {
-            s.lives--;
-            s.launched = false; s.ballX = s.padX + PAD_W / 2; s.ballY = PAD_Y - BALL_R - 2;
-            if (s.lives <= 0) { s.lives = 0; s.phase = 'dead'; useBrickBreakerStore.getState().setGameOver(s.score, s.level); }
-            else { useBrickBreakerStore.getState().setLives(s.lives); }
-          }
-          for (let i = 0; i < s.bricks.length; i++) {
-            if (!s.bricks[i].alive) continue;
-            const { x, y, w, h } = brickRect(i);
-            if (s.ballX + BALL_R > x && s.ballX - BALL_R < x + w && s.ballY + BALL_R > y && s.ballY - BALL_R < y + h) {
-              s.bricks[i].alive = false; s.score += 10;
-              const overlapLeft = s.ballX + BALL_R - x, overlapRight = x + w - (s.ballX - BALL_R);
-              const overlapTop = s.ballY + BALL_R - y, overlapBottom = y + h - (s.ballY - BALL_R);
-              if (Math.min(overlapLeft, overlapRight) < Math.min(overlapTop, overlapBottom)) s.ballVX *= -1; else s.ballVY *= -1;
-              const colors = ROW_COLORS[s.bricks[i].row];
-              for (let p = 0; p < 6; p++) s.particles.push({ x: x + w / 2, y: y + h / 2, vx: (Math.random() - 0.5) * 5, vy: (Math.random() - 0.5) * 5, life: 1, color: colors[Math.floor(Math.random() * colors.length)] });
-              useBrickBreakerStore.getState().setScore(s.score);
-            }
-          }
-          if (s.bricks.every(b => !b.alive)) {
-            const nextLevel = s.level + 1;
-            if (nextLevel > 5) { s.phase = 'won'; useBrickBreakerStore.getState().setWon(s.score, s.lives, s.level); }
-            else { startGame(nextLevel); }
+    if (s.phase === 'playing') {
+      if (!s.launched) { s.ballX = s.padX + PAD_W / 2; s.ballY = PAD_Y - BALL_R - 2; }
+      else {
+        s.ballX += s.ballVX; s.ballY += s.ballVY;
+        if (s.ballX - BALL_R <= 0) { s.ballX = BALL_R; s.ballVX = Math.abs(s.ballVX); }
+        if (s.ballX + BALL_R >= W) { s.ballX = W - BALL_R; s.ballVX = -Math.abs(s.ballVX); }
+        if (s.ballY - BALL_R <= 0) { s.ballY = BALL_R; s.ballVY = Math.abs(s.ballVY); }
+        if (s.ballY + BALL_R >= PAD_Y && s.ballY + BALL_R <= PAD_Y + PAD_H && s.ballX >= s.padX && s.ballX <= s.padX + PAD_W) {
+          const rel = (s.ballX - s.padX) / PAD_W - 0.5;
+          const spd = Math.sqrt(s.ballVX ** 2 + s.ballVY ** 2);
+          s.ballVX = rel * spd * 2.2; s.ballVY = -Math.abs(s.ballVY);
+        }
+        if (s.ballY + BALL_R > H) {
+          s.lives--;
+          s.launched = false; s.ballX = s.padX + PAD_W / 2; s.ballY = PAD_Y - BALL_R - 2;
+          if (s.lives <= 0) { s.lives = 0; s.phase = 'dead'; useBrickBreakerStore.getState().setGameOver(s.score, s.level); }
+          else { useBrickBreakerStore.getState().setLives(s.lives); }
+        }
+        for (let i = 0; i < s.bricks.length; i++) {
+          if (!s.bricks[i].alive) continue;
+          const { x, y, w, h } = brickRect(i);
+          if (s.ballX + BALL_R > x && s.ballX - BALL_R < x + w && s.ballY + BALL_R > y && s.ballY - BALL_R < y + h) {
+            s.bricks[i].alive = false; s.score += 10;
+            const overlapLeft = s.ballX + BALL_R - x, overlapRight = x + w - (s.ballX - BALL_R);
+            const overlapTop = s.ballY + BALL_R - y, overlapBottom = y + h - (s.ballY - BALL_R);
+            if (Math.min(overlapLeft, overlapRight) < Math.min(overlapTop, overlapBottom)) s.ballVX *= -1; else s.ballVY *= -1;
+            const colors = ROW_COLORS[s.bricks[i].row];
+            for (let p = 0; p < 6; p++) s.particles.push({ x: x + w / 2, y: y + h / 2, vx: (Math.random() - 0.5) * 5, vy: (Math.random() - 0.5) * 5, life: 1, color: colors[Math.floor(Math.random() * colors.length)] });
+            useBrickBreakerStore.getState().setScore(s.score);
           }
         }
-        s.particles = s.particles.filter(p => { p.x += p.vx; p.y += p.vy; p.vy += 0.15; p.life -= 0.04; return p.life > 0; });
+        if (s.bricks.every(b => !b.alive)) {
+          const nextLevel = s.level + 1;
+          if (nextLevel > 5) { s.phase = 'won'; useBrickBreakerStore.getState().setWon(s.score, s.lives, s.level); }
+          else { startGame(nextLevel); }
+        }
       }
-
-      const bg = ctx.createLinearGradient(0, 0, 0, H);
-      bg.addColorStop(0, '#0f0c29'); bg.addColorStop(1, '#302b63');
-      ctx.fillStyle = bg; ctx.fillRect(0, 0, W, H);
-
-      for (let i = 0; i < s.bricks.length; i++) {
-        if (!s.bricks[i].alive) continue;
-        const { x, y, w, h } = brickRect(i);
-        const [c1, c2] = ROW_COLORS[s.bricks[i].row];
-        const g = ctx.createLinearGradient(x, y, x, y + h);
-        g.addColorStop(0, c1); g.addColorStop(1, c2);
-        ctx.fillStyle = g; ctx.beginPath(); ctx.roundRect(x, y, w, h, 4); ctx.fill();
-        ctx.fillStyle = 'rgba(255,255,255,0.2)'; ctx.beginPath(); ctx.roundRect(x + 2, y + 2, w - 4, 5, 3); ctx.fill();
-      }
-
-      for (const p of s.particles) { ctx.globalAlpha = p.life; ctx.fillStyle = p.color; ctx.beginPath(); ctx.arc(p.x, p.y, 4, 0, Math.PI * 2); ctx.fill(); }
-      ctx.globalAlpha = 1;
-
-      const ballGlow = ctx.createRadialGradient(s.ballX, s.ballY, 0, s.ballX, s.ballY, BALL_R * 2.5);
-      ballGlow.addColorStop(0, 'rgba(255,255,255,0.4)'); ballGlow.addColorStop(1, 'rgba(255,255,255,0)');
-      ctx.fillStyle = ballGlow; ctx.beginPath(); ctx.arc(s.ballX, s.ballY, BALL_R * 2.5, 0, Math.PI * 2); ctx.fill();
-      ctx.fillStyle = 'white'; ctx.beginPath(); ctx.arc(s.ballX, s.ballY, BALL_R, 0, Math.PI * 2); ctx.fill();
-
-      const padGrad = ctx.createLinearGradient(s.padX, PAD_Y, s.padX + PAD_W, PAD_Y);
-      padGrad.addColorStop(0, '#60A5FA'); padGrad.addColorStop(0.5, '#93C5FD'); padGrad.addColorStop(1, '#60A5FA');
-      ctx.fillStyle = padGrad; ctx.beginPath(); ctx.roundRect(s.padX, PAD_Y, PAD_W, PAD_H, 6); ctx.fill();
-
-      if (s.phase === 'playing' && !s.launched) { ctx.fillStyle = 'rgba(255,255,255,0.7)'; ctx.font = '14px Arial'; ctx.textAlign = 'center'; ctx.fillText('הקש להשיק! 🏏', W / 2, PAD_Y - 20); }
-
-      s.raf = requestAnimationFrame(loop);
+      s.particles = s.particles.filter(p => { p.x += p.vx; p.y += p.vy; p.vy += 0.15; p.life -= 0.04; return p.life > 0; });
     }
 
-    const rafId = requestAnimationFrame(loop);
-    st.current.raf = rafId;
-    const stRef = st.current;
-    return () => cancelAnimationFrame(stRef.raf);
-  }, [startGame]);
+    const bg = ctx.createLinearGradient(0, 0, 0, H);
+    bg.addColorStop(0, '#0f0c29'); bg.addColorStop(1, '#302b63');
+    ctx.fillStyle = bg; ctx.fillRect(0, 0, W, H);
+
+    for (let i = 0; i < s.bricks.length; i++) {
+      if (!s.bricks[i].alive) continue;
+      const { x, y, w, h } = brickRect(i);
+      const [c1, c2] = ROW_COLORS[s.bricks[i].row];
+      const g = ctx.createLinearGradient(x, y, x, y + h);
+      g.addColorStop(0, c1); g.addColorStop(1, c2);
+      ctx.fillStyle = g; ctx.beginPath(); ctx.roundRect(x, y, w, h, 4); ctx.fill();
+      ctx.fillStyle = 'rgba(255,255,255,0.2)'; ctx.beginPath(); ctx.roundRect(x + 2, y + 2, w - 4, 5, 3); ctx.fill();
+    }
+
+    for (const p of s.particles) { ctx.globalAlpha = p.life; ctx.fillStyle = p.color; ctx.beginPath(); ctx.arc(p.x, p.y, 4, 0, Math.PI * 2); ctx.fill(); }
+    ctx.globalAlpha = 1;
+
+    const ballGlow = ctx.createRadialGradient(s.ballX, s.ballY, 0, s.ballX, s.ballY, BALL_R * 2.5);
+    ballGlow.addColorStop(0, 'rgba(255,255,255,0.4)'); ballGlow.addColorStop(1, 'rgba(255,255,255,0)');
+    ctx.fillStyle = ballGlow; ctx.beginPath(); ctx.arc(s.ballX, s.ballY, BALL_R * 2.5, 0, Math.PI * 2); ctx.fill();
+    ctx.fillStyle = 'white'; ctx.beginPath(); ctx.arc(s.ballX, s.ballY, BALL_R, 0, Math.PI * 2); ctx.fill();
+
+    const padGrad = ctx.createLinearGradient(s.padX, PAD_Y, s.padX + PAD_W, PAD_Y);
+    padGrad.addColorStop(0, '#60A5FA'); padGrad.addColorStop(0.5, '#93C5FD'); padGrad.addColorStop(1, '#60A5FA');
+    ctx.fillStyle = padGrad; ctx.beginPath(); ctx.roundRect(s.padX, PAD_Y, PAD_W, PAD_H, 6); ctx.fill();
+
+    if (s.phase === 'playing' && !s.launched) { ctx.fillStyle = 'rgba(255,255,255,0.7)'; ctx.font = '14px Arial'; ctx.textAlign = 'center'; ctx.fillText('הקש להשיק! 🏏', W / 2, PAD_Y - 20); }
+  });
 
   useEffect(() => {
     let left = false, right = false;

--- a/gamesformykids/app/games/catch-fruit/useCatchFruitGame.ts
+++ b/gamesformykids/app/games/catch-fruit/useCatchFruitGame.ts
@@ -1,7 +1,8 @@
-﻿'use client';
+'use client';
 
-import { useEffect, useRef, useCallback } from 'react';
+import { useRef, useCallback } from 'react';
 import { useCatchFruitStore, GAME_DURATION } from './catchFruitStore';
+import { useCanvasLoop } from '@/hooks/shared/common';
 
 export const W = 360;
 export const H = 520;
@@ -17,12 +18,11 @@ const BAD_ITEMS = ['💣', '☠️', '🪨'];
 let idCounter = 0;
 
 export function useCatchFruitGame() {
-  const canvasRef = useRef<HTMLCanvasElement>(null);
   const st = useRef({
     phase: 'menu' as Phase,
     basketX: W / 2 - BASKET_W / 2,
     items: [] as FallingItem[],
-    score: 0, lives: 3, timeLeft: GAME_DURATION, frame: 0, raf: 0, nextItem: 40,
+    score: 0, lives: 3, timeLeft: GAME_DURATION, frame: 0, nextItem: 40,
     bgStars: Array.from({ length: 8 }, () => ({ x: Math.random() * W, y: Math.random() * H * 0.7, r: 2 + Math.random() * 3 })),
   });
   const dragging = useRef(false);
@@ -42,99 +42,83 @@ export function useCatchFruitGame() {
     dragging.current = false;
   }, []);
 
-  useEffect(() => {
-    const canvas = canvasRef.current;
-    if (!canvas) return;
-    const ctx = canvas.getContext('2d') as CanvasRenderingContext2D;
-    if (!ctx) return;
-    let lastTime = performance.now();
+  const canvasRef = useCanvasLoop((ctx, dt) => {
+    const s = st.current;
 
-    function loop(now: number) {
-      const s = st.current;
-      const dt = now - lastTime;
-      lastTime = now;
-
-      if (s.phase === 'playing') {
-        s.frame++;
-        s.timeLeft -= dt / 1000;
-        if (s.timeLeft <= 0) {
-          s.timeLeft = 0;
-          s.phase = 'result';
-          useCatchFruitStore.getState().setGameResult(s.score, s.lives, 0);
+    if (s.phase === 'playing') {
+      s.frame++;
+      s.timeLeft -= dt / 1000;
+      if (s.timeLeft <= 0) {
+        s.timeLeft = 0;
+        s.phase = 'result';
+        useCatchFruitStore.getState().setGameResult(s.score, s.lives, 0);
+      }
+      s.nextItem--;
+      if (s.nextItem <= 0) {
+        const isBad = Math.random() < 0.18;
+        const emojis = isBad ? BAD_ITEMS : GOOD_FRUITS;
+        s.items.push({ id: idCounter++, x: FRUIT_R + Math.random() * (W - FRUIT_R * 2), y: -FRUIT_R, speed: 2.5 + Math.random() * 2 + s.frame / 600, emoji: emojis[Math.floor(Math.random() * emojis.length)], isBad });
+        s.nextItem = 35 + Math.random() * 30;
+      }
+      for (const item of s.items) item.y += item.speed;
+      const bx = s.basketX;
+      s.items = s.items.filter(item => {
+        if (item.y + FRUIT_R >= BASKET_Y && item.y - FRUIT_R <= BASKET_Y + BASKET_H && item.x + FRUIT_R > bx && item.x - FRUIT_R < bx + BASKET_W) {
+          if (item.isBad) {
+            s.lives--;
+            if (s.lives <= 0) { s.lives = 0; s.phase = 'result'; useCatchFruitStore.getState().setGameResult(s.score, 0, Math.ceil(s.timeLeft)); }
+            else { useCatchFruitStore.getState().setLives(s.lives); }
+          } else { s.score += 10; useCatchFruitStore.getState().setScore(s.score); }
+          return false;
         }
-        s.nextItem--;
-        if (s.nextItem <= 0) {
-          const isBad = Math.random() < 0.18;
-          const emojis = isBad ? BAD_ITEMS : GOOD_FRUITS;
-          s.items.push({ id: idCounter++, x: FRUIT_R + Math.random() * (W - FRUIT_R * 2), y: -FRUIT_R, speed: 2.5 + Math.random() * 2 + s.frame / 600, emoji: emojis[Math.floor(Math.random() * emojis.length)], isBad });
-          s.nextItem = 35 + Math.random() * 30;
-        }
-        for (const item of s.items) item.y += item.speed;
-        const bx = s.basketX;
-        s.items = s.items.filter(item => {
-          if (item.y + FRUIT_R >= BASKET_Y && item.y - FRUIT_R <= BASKET_Y + BASKET_H && item.x + FRUIT_R > bx && item.x - FRUIT_R < bx + BASKET_W) {
-            if (item.isBad) {
-              s.lives--;
-              if (s.lives <= 0) { s.lives = 0; s.phase = 'result'; useCatchFruitStore.getState().setGameResult(s.score, 0, Math.ceil(s.timeLeft)); }
-              else { useCatchFruitStore.getState().setLives(s.lives); }
-            } else { s.score += 10; useCatchFruitStore.getState().setScore(s.score); }
-            return false;
-          }
-          if (item.y - FRUIT_R > H) return false;
-          return true;
-        });
-        if (s.frame % 20 === 0 && st.current.phase === 'playing') useCatchFruitStore.getState().setTimeLeft(Math.ceil(s.timeLeft));
-      }
-
-      const grad = ctx.createLinearGradient(0, 0, 0, H);
-      grad.addColorStop(0, '#1a1a2e');
-      grad.addColorStop(1, '#16213e');
-      ctx.fillStyle = grad;
-      ctx.fillRect(0, 0, W, H);
-
-      for (const star of s.bgStars) {
-        ctx.beginPath();
-        ctx.arc(star.x, star.y, star.r, 0, Math.PI * 2);
-        ctx.fillStyle = `rgba(255,255,200,${0.4 + Math.sin(s.frame * 0.05 + star.x) * 0.3})`;
-        ctx.fill();
-      }
-
-      const curr = st.current;
-      ctx.font = `${FRUIT_R * 1.8}px serif`;
-      ctx.textAlign = 'center';
-      ctx.textBaseline = 'middle';
-      for (const item of curr.items) ctx.fillText(item.emoji, item.x, item.y);
-
-      const bxD = curr.basketX;
-      ctx.fillStyle = '#8B4513';
-      ctx.beginPath();
-      ctx.moveTo(bxD, BASKET_Y);
-      ctx.lineTo(bxD + 10, BASKET_Y + BASKET_H);
-      ctx.lineTo(bxD + BASKET_W - 10, BASKET_Y + BASKET_H);
-      ctx.lineTo(bxD + BASKET_W, BASKET_Y);
-      ctx.closePath();
-      ctx.fill();
-      ctx.strokeStyle = '#6B3410';
-      ctx.lineWidth = 2;
-      for (let i = 1; i < 4; i++) {
-        ctx.beginPath();
-        ctx.moveTo(bxD + (BASKET_W / 4) * i, BASKET_Y);
-        ctx.lineTo(bxD + 10 + ((BASKET_W - 20) / 4) * i, BASKET_Y + BASKET_H);
-        ctx.stroke();
-      }
-      ctx.strokeStyle = '#8B4513';
-      ctx.lineWidth = 4;
-      ctx.beginPath();
-      ctx.arc(bxD + BASKET_W / 2, BASKET_Y - 2, BASKET_W / 3, Math.PI, Math.PI * 2);
-      ctx.stroke();
-
-      s.raf = requestAnimationFrame(loop);
+        if (item.y - FRUIT_R > H) return false;
+        return true;
+      });
+      if (s.frame % 20 === 0 && st.current.phase === 'playing') useCatchFruitStore.getState().setTimeLeft(Math.ceil(s.timeLeft));
     }
 
-    st.current.raf = requestAnimationFrame(loop);
-    const stRef = st.current;
-    return () => cancelAnimationFrame(stRef.raf);
-  }, []);
+    const grad = ctx.createLinearGradient(0, 0, 0, H);
+    grad.addColorStop(0, '#1a1a2e');
+    grad.addColorStop(1, '#16213e');
+    ctx.fillStyle = grad;
+    ctx.fillRect(0, 0, W, H);
+
+    for (const star of s.bgStars) {
+      ctx.beginPath();
+      ctx.arc(star.x, star.y, star.r, 0, Math.PI * 2);
+      ctx.fillStyle = `rgba(255,255,200,${0.4 + Math.sin(s.frame * 0.05 + star.x) * 0.3})`;
+      ctx.fill();
+    }
+
+    const curr = st.current;
+    ctx.font = `${FRUIT_R * 1.8}px serif`;
+    ctx.textAlign = 'center';
+    ctx.textBaseline = 'middle';
+    for (const item of curr.items) ctx.fillText(item.emoji, item.x, item.y);
+
+    const bxD = curr.basketX;
+    ctx.fillStyle = '#8B4513';
+    ctx.beginPath();
+    ctx.moveTo(bxD, BASKET_Y);
+    ctx.lineTo(bxD + 10, BASKET_Y + BASKET_H);
+    ctx.lineTo(bxD + BASKET_W - 10, BASKET_Y + BASKET_H);
+    ctx.lineTo(bxD + BASKET_W, BASKET_Y);
+    ctx.closePath();
+    ctx.fill();
+    ctx.strokeStyle = '#6B3410';
+    ctx.lineWidth = 2;
+    for (let i = 1; i < 4; i++) {
+      ctx.beginPath();
+      ctx.moveTo(bxD + (BASKET_W / 4) * i, BASKET_Y);
+      ctx.lineTo(bxD + 10 + ((BASKET_W - 20) / 4) * i, BASKET_Y + BASKET_H);
+      ctx.stroke();
+    }
+    ctx.strokeStyle = '#8B4513';
+    ctx.lineWidth = 4;
+    ctx.beginPath();
+    ctx.arc(bxD + BASKET_W / 2, BASKET_Y - 2, BASKET_W / 3, Math.PI, Math.PI * 2);
+    ctx.stroke();
+  });
 
   const handleMouseMove = useCallback((e: React.MouseEvent<HTMLCanvasElement>) => {
     if (!pointerDown.current) return;
@@ -144,7 +128,7 @@ export function useCatchFruitGame() {
     const scaleX = W / rect.width;
     const mx = (e.clientX - rect.left) * scaleX;
     st.current.basketX = Math.max(0, Math.min(W - BASKET_W, mx - BASKET_W / 2));
-  }, []);
+  }, [canvasRef]);
 
   const handleMouseDown = useCallback((e: React.MouseEvent<HTMLCanvasElement>) => {
     pointerDown.current = true;
@@ -154,7 +138,7 @@ export function useCatchFruitGame() {
     const scaleX = W / rect.width;
     const mx = (e.clientX - rect.left) * scaleX;
     st.current.basketX = Math.max(0, Math.min(W - BASKET_W, mx - BASKET_W / 2));
-  }, []);
+  }, [canvasRef]);
 
   const handleTouchMove = useCallback((e: React.TouchEvent<HTMLCanvasElement>) => {
     e.preventDefault();
@@ -164,7 +148,7 @@ export function useCatchFruitGame() {
     const scaleX = W / rect.width;
     const mx = (e.touches[0].clientX - rect.left) * scaleX;
     st.current.basketX = Math.max(0, Math.min(W - BASKET_W, mx - BASKET_W / 2));
-  }, []);
+  }, [canvasRef]);
 
   const handleTouchStart = useCallback((e: React.TouchEvent<HTMLCanvasElement>) => {
     e.preventDefault();
@@ -175,7 +159,7 @@ export function useCatchFruitGame() {
     const mx = (e.touches[0].clientX - rect.left) * scaleX;
     st.current.basketX = Math.max(0, Math.min(W - BASKET_W, mx - BASKET_W / 2));
     if (st.current.phase !== 'playing') startGame();
-  }, [startGame]);
+  }, [canvasRef, startGame]);
 
   return { canvasRef, startGame, handleMouseMove, handleMouseDown, handleMouseUp, handleTouchMove, handleTouchStart };
 }

--- a/gamesformykids/app/games/dino-runner/useDinoRunnerGame.ts
+++ b/gamesformykids/app/games/dino-runner/useDinoRunnerGame.ts
@@ -1,7 +1,8 @@
-﻿'use client';
+'use client';
 
 import { useEffect, useRef, useCallback } from 'react';
 import { useDinoRunnerStore } from './dinoRunnerStore';
+import { useCanvasLoop } from '@/hooks/shared/common';
 
 export const W = 400;
 export const H = 220;
@@ -19,7 +20,6 @@ interface Obstacle { x: number; w: number; h: number; emoji: string; }
 const OBSTACLE_EMOJIS = ['🌵', '🪨', '🌴', '🌿', '🍄'];
 
 export function useDinoRunnerGame() {
-  const canvasRef = useRef<HTMLCanvasElement>(null);
   const st = useRef({
     phase: 'menu' as Phase,
     dinoY: GROUND_Y - DINO_H,
@@ -30,7 +30,6 @@ export function useDinoRunnerGame() {
     score: 0,
     frame: 0,
     speed: BASE_SPEED,
-    raf: 0,
     nextObstacle: 80,
   });
   const jump = useCallback(() => {
@@ -55,111 +54,98 @@ export function useDinoRunnerGame() {
     }
   }, []);
 
-  useEffect(() => {
-    const canvas = canvasRef.current;
-    if (!canvas) return;
-    const ctx = canvas.getContext('2d') as CanvasRenderingContext2D;
-    if (!ctx) return;
+  const canvasRef = useCanvasLoop((ctx) => {
+    const s = st.current;
 
-    function loop() {
-      const s = st.current;
+    if (s.phase === 'playing') {
+      s.frame++;
+      s.score = Math.floor(s.frame / 6);
+      s.speed = BASE_SPEED + Math.floor(s.score / 200) * 0.5;
 
-      if (s.phase === 'playing') {
-        s.frame++;
-        s.score = Math.floor(s.frame / 6);
-        s.speed = BASE_SPEED + Math.floor(s.score / 200) * 0.5;
-
-        s.dinoVY += GRAVITY;
-        s.dinoY += s.dinoVY;
-        if (s.dinoY >= GROUND_Y - DINO_H) {
-          s.dinoY = GROUND_Y - DINO_H;
-          s.dinoVY = 0;
-          s.onGround = true;
-        }
-
-        s.nextObstacle--;
-        if (s.nextObstacle <= 0) {
-          const w = 28 + Math.random() * 20;
-          const h = 35 + Math.random() * 25;
-          s.obstacles.push({
-            x: W + 20,
-            w,
-            h,
-            emoji: OBSTACLE_EMOJIS[Math.floor(Math.random() * OBSTACLE_EMOJIS.length)],
-          });
-          s.nextObstacle = 60 + Math.random() * 80;
-        }
-        for (const o of s.obstacles) o.x -= s.speed;
-        s.obstacles = s.obstacles.filter(o => o.x > -60);
-
-        for (const c of s.clouds) {
-          c.x -= s.speed * 0.3;
-          if (c.x < -60) c.x = W + 60;
-        }
-
-        if (s.frame % 6 === 0) useDinoRunnerStore.getState().setScore(s.score);
-
-        const margin = 8;
-        for (const o of s.obstacles) {
-          if (
-            DINO_X + DINO_W - margin > o.x + margin &&
-            DINO_X + margin < o.x + o.w - margin &&
-            s.dinoY + DINO_H - margin > GROUND_Y - o.h + margin
-          ) {
-            s.phase = 'dead';
-            useDinoRunnerStore.getState().setGameOver(s.score);
-          }
-        }
+      s.dinoVY += GRAVITY;
+      s.dinoY += s.dinoVY;
+      if (s.dinoY >= GROUND_Y - DINO_H) {
+        s.dinoY = GROUND_Y - DINO_H;
+        s.dinoVY = 0;
+        s.onGround = true;
       }
 
-      ctx.fillStyle = '#fef3c7';
-      ctx.fillRect(0, 0, W, H);
+      s.nextObstacle--;
+      if (s.nextObstacle <= 0) {
+        const w = 28 + Math.random() * 20;
+        const h = 35 + Math.random() * 25;
+        s.obstacles.push({
+          x: W + 20,
+          w,
+          h,
+          emoji: OBSTACLE_EMOJIS[Math.floor(Math.random() * OBSTACLE_EMOJIS.length)],
+        });
+        s.nextObstacle = 60 + Math.random() * 80;
+      }
+      for (const o of s.obstacles) o.x -= s.speed;
+      s.obstacles = s.obstacles.filter(o => o.x > -60);
 
-      ctx.fillStyle = 'rgba(200,230,255,0.6)';
-      for (const c of st.current.clouds) {
-        ctx.beginPath();
-        ctx.ellipse(c.x, c.y, 30, 16, 0, 0, Math.PI * 2);
-        ctx.fill();
-        ctx.beginPath();
-        ctx.ellipse(c.x + 18, c.y - 8, 20, 14, 0, 0, Math.PI * 2);
-        ctx.fill();
-        ctx.beginPath();
-        ctx.ellipse(c.x - 18, c.y - 4, 18, 12, 0, 0, Math.PI * 2);
-        ctx.fill();
+      for (const c of s.clouds) {
+        c.x -= s.speed * 0.3;
+        if (c.x < -60) c.x = W + 60;
       }
 
-      ctx.fillStyle = '#d97706';
-      ctx.fillRect(0, GROUND_Y, W, H - GROUND_Y);
-      ctx.fillStyle = '#b45309';
-      ctx.fillRect(0, GROUND_Y, W, 3);
+      if (s.frame % 6 === 0) useDinoRunnerStore.getState().setScore(s.score);
 
-      if (st.current.phase !== 'menu') {
-        const s2 = st.current;
-        ctx.font = `${DINO_W}px serif`;
-        ctx.textAlign = 'center';
-        ctx.textBaseline = 'bottom';
-        ctx.fillText('🦖', DINO_X + DINO_W / 2, s2.dinoY + DINO_H + 2);
-
-        ctx.textBaseline = 'bottom';
-        for (const o of s2.obstacles) {
-          ctx.font = `${o.h}px serif`;
-          ctx.fillText(o.emoji, o.x + o.w / 2, GROUND_Y + 4);
+      const margin = 8;
+      for (const o of s.obstacles) {
+        if (
+          DINO_X + DINO_W - margin > o.x + margin &&
+          DINO_X + margin < o.x + o.w - margin &&
+          s.dinoY + DINO_H - margin > GROUND_Y - o.h + margin
+        ) {
+          s.phase = 'dead';
+          useDinoRunnerStore.getState().setGameOver(s.score);
         }
       }
-
-      ctx.fillStyle = '#555';
-      ctx.font = 'bold 18px Arial';
-      ctx.textAlign = 'right';
-      ctx.textBaseline = 'top';
-      ctx.fillText(`${st.current.score}`, W - 12, 10);
-
-      st.current.raf = requestAnimationFrame(loop);
     }
 
-    st.current.raf = requestAnimationFrame(loop);
-    const stRef = st.current;
-    return () => cancelAnimationFrame(stRef.raf);
-  }, []);
+    ctx.fillStyle = '#fef3c7';
+    ctx.fillRect(0, 0, W, H);
+
+    ctx.fillStyle = 'rgba(200,230,255,0.6)';
+    for (const c of st.current.clouds) {
+      ctx.beginPath();
+      ctx.ellipse(c.x, c.y, 30, 16, 0, 0, Math.PI * 2);
+      ctx.fill();
+      ctx.beginPath();
+      ctx.ellipse(c.x + 18, c.y - 8, 20, 14, 0, 0, Math.PI * 2);
+      ctx.fill();
+      ctx.beginPath();
+      ctx.ellipse(c.x - 18, c.y - 4, 18, 12, 0, 0, Math.PI * 2);
+      ctx.fill();
+    }
+
+    ctx.fillStyle = '#d97706';
+    ctx.fillRect(0, GROUND_Y, W, H - GROUND_Y);
+    ctx.fillStyle = '#b45309';
+    ctx.fillRect(0, GROUND_Y, W, 3);
+
+    if (st.current.phase !== 'menu') {
+      const s2 = st.current;
+      ctx.font = `${DINO_W}px serif`;
+      ctx.textAlign = 'center';
+      ctx.textBaseline = 'bottom';
+      ctx.fillText('🦖', DINO_X + DINO_W / 2, s2.dinoY + DINO_H + 2);
+
+      ctx.textBaseline = 'bottom';
+      for (const o of s2.obstacles) {
+        ctx.font = `${o.h}px serif`;
+        ctx.fillText(o.emoji, o.x + o.w / 2, GROUND_Y + 4);
+      }
+    }
+
+    ctx.fillStyle = '#555';
+    ctx.font = 'bold 18px Arial';
+    ctx.textAlign = 'right';
+    ctx.textBaseline = 'top';
+    ctx.fillText(`${st.current.score}`, W - 12, 10);
+  });
 
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {

--- a/gamesformykids/app/games/flappy-bird/useFlappyBirdGame.ts
+++ b/gamesformykids/app/games/flappy-bird/useFlappyBirdGame.ts
@@ -1,7 +1,8 @@
-﻿'use client';
+'use client';
 
-import { useEffect, useRef, useCallback } from 'react';
+import { useRef, useCallback } from 'react';
 import { useFlappyBirdStore } from './flappyBirdStore';
+import { useCanvasLoop } from '@/hooks/shared/common';
 
 export const W = 360;
 export const H = 560;
@@ -19,8 +20,21 @@ import type { PhaseDead as Phase } from '@/lib/types';
 
 interface Pipe { x: number; gapY: number; scored: boolean; }
 
+function drawRoundRect(ctx: CanvasRenderingContext2D, x: number, y: number, w: number, h: number, r: number) {
+  ctx.beginPath();
+  ctx.moveTo(x + r, y);
+  ctx.lineTo(x + w - r, y);
+  ctx.quadraticCurveTo(x + w, y, x + w, y + r);
+  ctx.lineTo(x + w, y + h - r);
+  ctx.quadraticCurveTo(x + w, y + h, x + w - r, y + h);
+  ctx.lineTo(x + r, y + h);
+  ctx.quadraticCurveTo(x, y + h, x, y + h - r);
+  ctx.lineTo(x, y + r);
+  ctx.quadraticCurveTo(x, y, x + r, y);
+  ctx.closePath();
+}
+
 export function useFlappyBirdGame() {
-  const canvasRef = useRef<HTMLCanvasElement>(null);
   const s = useRef({
     phase: 'menu' as Phase,
     birdY: H / 2,
@@ -28,7 +42,6 @@ export function useFlappyBirdGame() {
     pipes: [] as Pipe[],
     score: 0,
     frame: 0,
-    raf: 0,
     bgOffset: 0,
   });
   const resetGame = useCallback(() => {
@@ -55,159 +68,128 @@ export function useFlappyBirdGame() {
     }
   }, [resetGame]);
 
-  useEffect(() => {
-    const canvas = canvasRef.current;
-    if (!canvas) return;
-    const ctx = canvas.getContext('2d') as CanvasRenderingContext2D;
-    if (!ctx) return;
+  const canvasRef = useCanvasLoop((ctx) => {
+    const st = s.current;
+    if (st.phase === 'playing') {
+      st.frame++;
+      st.birdVY += GRAVITY;
+      st.birdY += st.birdVY;
 
-    function drawRoundRect(x: number, y: number, w: number, h: number, r: number) {
-      ctx.beginPath();
-      ctx.moveTo(x + r, y);
-      ctx.lineTo(x + w - r, y);
-      ctx.quadraticCurveTo(x + w, y, x + w, y + r);
-      ctx.lineTo(x + w, y + h - r);
-      ctx.quadraticCurveTo(x + w, y + h, x + w - r, y + h);
-      ctx.lineTo(x + r, y + h);
-      ctx.quadraticCurveTo(x, y + h, x, y + h - r);
-      ctx.lineTo(x, y + r);
-      ctx.quadraticCurveTo(x, y, x + r, y);
-      ctx.closePath();
-    }
-
-    function drawFrame() {
-      const st = s.current;
-      const skyGrad = ctx.createLinearGradient(0, 0, 0, H - GROUND_H);
-      skyGrad.addColorStop(0, '#87CEEB');
-      skyGrad.addColorStop(1, '#C9E8F5');
-      ctx.fillStyle = skyGrad;
-      ctx.fillRect(0, 0, W, H);
-
-      st.bgOffset = (st.bgOffset + 0.3) % W;
-      function cloud(x: number, y: number) {
-        ctx.fillStyle = 'rgba(255,255,255,0.85)';
-        ctx.beginPath(); ctx.ellipse(x, y, 38, 22, 0, 0, Math.PI * 2); ctx.fill();
-        ctx.beginPath(); ctx.ellipse(x + 28, y - 8, 26, 18, 0, 0, Math.PI * 2); ctx.fill();
-        ctx.beginPath(); ctx.ellipse(x - 25, y - 5, 20, 14, 0, 0, Math.PI * 2); ctx.fill();
+      if (st.frame % PIPE_INTERVAL === 0) {
+        const gapY = 80 + Math.random() * (H - GROUND_H - 80 - PIPE_GAP - 80);
+        st.pipes.push({ x: W + 10, gapY, scored: false });
       }
-      const offs = st.bgOffset;
-      cloud(((60 + offs) % (W + 100)) - 50, 60);
-      cloud(((200 + offs) % (W + 100)) - 50, 95);
-      cloud(((320 + offs) % (W + 100)) - 50, 45);
 
       for (const p of st.pipes) {
-        ctx.fillStyle = '#4CAF50';
-        ctx.fillRect(p.x, 0, PIPE_W, p.gapY - 20);
-        ctx.fillStyle = '#388E3C';
-        drawRoundRect(p.x - 5, p.gapY - 22, PIPE_W + 10, 22, 6);
-        ctx.fill();
-        ctx.fillStyle = '#4CAF50';
-        const botTop = p.gapY + PIPE_GAP;
-        ctx.fillRect(p.x, botTop + 22, PIPE_W, H - GROUND_H - botTop - 22);
-        ctx.fillStyle = '#388E3C';
-        drawRoundRect(p.x - 5, botTop, PIPE_W + 10, 22, 6);
-        ctx.fill();
-        ctx.fillStyle = 'rgba(255,255,255,0.15)';
-        ctx.fillRect(p.x + 6, 0, 8, p.gapY - 22);
-        ctx.fillRect(p.x + 6, botTop + 22, 8, H - GROUND_H - botTop - 22);
+        p.x -= PIPE_SPEED;
+        if (!p.scored && p.x + PIPE_W < BIRD_X - BIRD_R) {
+          p.scored = true;
+          st.score++;
+          useFlappyBirdStore.getState().setScore(st.score);
+        }
+      }
+      st.pipes = st.pipes.filter(p => p.x > -PIPE_W - 20);
+
+      if (st.birdY + BIRD_R >= H - GROUND_H || st.birdY - BIRD_R <= 0) {
+        st.phase = 'dead';
+        useFlappyBirdStore.getState().endGame(st.score);
       }
 
-      const groundGrad = ctx.createLinearGradient(0, H - GROUND_H, 0, H);
-      groundGrad.addColorStop(0, '#5D8C3A');
-      groundGrad.addColorStop(0.15, '#8B6914');
-      groundGrad.addColorStop(1, '#6B4F10');
-      ctx.fillStyle = groundGrad;
-      ctx.fillRect(0, H - GROUND_H, W, GROUND_H);
-
-      const birdAngle = Math.max(-0.5, Math.min(1.2, st.birdVY * 0.06));
-      ctx.save();
-      ctx.translate(BIRD_X, st.birdY);
-      ctx.rotate(birdAngle);
-      ctx.beginPath();
-      ctx.ellipse(0, 0, BIRD_R + 2, BIRD_R, 0, 0, Math.PI * 2);
-      ctx.fillStyle = st.phase === 'dead' ? '#FF6B6B' : '#FFD700';
-      ctx.fill();
-      ctx.strokeStyle = '#B8860B';
-      ctx.lineWidth = 2.5;
-      ctx.stroke();
-      ctx.beginPath();
-      ctx.ellipse(-4, 4, 12, 7, 0.3, 0, Math.PI * 2);
-      ctx.fillStyle = '#FFA500';
-      ctx.fill();
-      ctx.beginPath();
-      ctx.arc(6, -5, 6, 0, Math.PI * 2);
-      ctx.fillStyle = 'white';
-      ctx.fill();
-      ctx.beginPath();
-      ctx.arc(8, -5, 3, 0, Math.PI * 2);
-      ctx.fillStyle = '#333';
-      ctx.fill();
-      ctx.beginPath();
-      ctx.moveTo(16, -2);
-      ctx.lineTo(26, 1);
-      ctx.lineTo(16, 5);
-      ctx.fillStyle = '#FF6600';
-      ctx.fill();
-      ctx.restore();
-
-      ctx.textAlign = 'center';
-      ctx.font = 'bold 38px Arial';
-      ctx.strokeStyle = 'rgba(0,0,0,0.4)';
-      ctx.lineWidth = 4;
-      ctx.strokeText(String(st.score), W / 2, 52);
-      ctx.fillStyle = 'white';
-      ctx.fillText(String(st.score), W / 2, 52);
-    }
-
-    function loop() {
-      const st = s.current;
-      if (st.phase === 'playing') {
-        st.frame++;
-        st.birdVY += GRAVITY;
-        st.birdY += st.birdVY;
-
-        if (st.frame % PIPE_INTERVAL === 0) {
-          const gapY = 80 + Math.random() * (H - GROUND_H - 80 - PIPE_GAP - 80);
-          st.pipes.push({ x: W + 10, gapY, scored: false });
-        }
-
-        for (const p of st.pipes) {
-          p.x -= PIPE_SPEED;
-          if (!p.scored && p.x + PIPE_W < BIRD_X - BIRD_R) {
-            p.scored = true;
-            st.score++;
-            useFlappyBirdStore.getState().setScore(st.score);
-          }
-        }
-        st.pipes = st.pipes.filter(p => p.x > -PIPE_W - 20);
-
-        if (st.birdY + BIRD_R >= H - GROUND_H || st.birdY - BIRD_R <= 0) {
-          st.phase = 'dead';
-          useFlappyBirdStore.getState().endGame(st.score);
-        }
-
-        for (const p of st.pipes) {
-          const bL = BIRD_X - BIRD_R + 4;
-          const bR = BIRD_X + BIRD_R - 4;
-          const bT = st.birdY - BIRD_R + 4;
-          const bB = st.birdY + BIRD_R - 4;
-          if (bR > p.x && bL < p.x + PIPE_W) {
-            if (bT < p.gapY || bB > p.gapY + PIPE_GAP) {
-              st.phase = 'dead';
-              useFlappyBirdStore.getState().endGame(st.score);
-            }
+      for (const p of st.pipes) {
+        const bL = BIRD_X - BIRD_R + 4;
+        const bR = BIRD_X + BIRD_R - 4;
+        const bT = st.birdY - BIRD_R + 4;
+        const bB = st.birdY + BIRD_R - 4;
+        if (bR > p.x && bL < p.x + PIPE_W) {
+          if (bT < p.gapY || bB > p.gapY + PIPE_GAP) {
+            st.phase = 'dead';
+            useFlappyBirdStore.getState().endGame(st.score);
           }
         }
       }
-
-      drawFrame();
-      st.raf = requestAnimationFrame(loop);
     }
 
-    s.current.raf = requestAnimationFrame(loop);
-    const sRef = s.current;
-    return () => cancelAnimationFrame(sRef.raf);
-  }, []);
+    const skyGrad = ctx.createLinearGradient(0, 0, 0, H - GROUND_H);
+    skyGrad.addColorStop(0, '#87CEEB');
+    skyGrad.addColorStop(1, '#C9E8F5');
+    ctx.fillStyle = skyGrad;
+    ctx.fillRect(0, 0, W, H);
+
+    st.bgOffset = (st.bgOffset + 0.3) % W;
+    function cloud(x: number, y: number) {
+      ctx.fillStyle = 'rgba(255,255,255,0.85)';
+      ctx.beginPath(); ctx.ellipse(x, y, 38, 22, 0, 0, Math.PI * 2); ctx.fill();
+      ctx.beginPath(); ctx.ellipse(x + 28, y - 8, 26, 18, 0, 0, Math.PI * 2); ctx.fill();
+      ctx.beginPath(); ctx.ellipse(x - 25, y - 5, 20, 14, 0, 0, Math.PI * 2); ctx.fill();
+    }
+    const offs = st.bgOffset;
+    cloud(((60 + offs) % (W + 100)) - 50, 60);
+    cloud(((200 + offs) % (W + 100)) - 50, 95);
+    cloud(((320 + offs) % (W + 100)) - 50, 45);
+
+    for (const p of st.pipes) {
+      ctx.fillStyle = '#4CAF50';
+      ctx.fillRect(p.x, 0, PIPE_W, p.gapY - 20);
+      ctx.fillStyle = '#388E3C';
+      drawRoundRect(ctx, p.x - 5, p.gapY - 22, PIPE_W + 10, 22, 6);
+      ctx.fill();
+      ctx.fillStyle = '#4CAF50';
+      const botTop = p.gapY + PIPE_GAP;
+      ctx.fillRect(p.x, botTop + 22, PIPE_W, H - GROUND_H - botTop - 22);
+      ctx.fillStyle = '#388E3C';
+      drawRoundRect(ctx, p.x - 5, botTop, PIPE_W + 10, 22, 6);
+      ctx.fill();
+      ctx.fillStyle = 'rgba(255,255,255,0.15)';
+      ctx.fillRect(p.x + 6, 0, 8, p.gapY - 22);
+      ctx.fillRect(p.x + 6, botTop + 22, 8, H - GROUND_H - botTop - 22);
+    }
+
+    const groundGrad = ctx.createLinearGradient(0, H - GROUND_H, 0, H);
+    groundGrad.addColorStop(0, '#5D8C3A');
+    groundGrad.addColorStop(0.15, '#8B6914');
+    groundGrad.addColorStop(1, '#6B4F10');
+    ctx.fillStyle = groundGrad;
+    ctx.fillRect(0, H - GROUND_H, W, GROUND_H);
+
+    const birdAngle = Math.max(-0.5, Math.min(1.2, st.birdVY * 0.06));
+    ctx.save();
+    ctx.translate(BIRD_X, st.birdY);
+    ctx.rotate(birdAngle);
+    ctx.beginPath();
+    ctx.ellipse(0, 0, BIRD_R + 2, BIRD_R, 0, 0, Math.PI * 2);
+    ctx.fillStyle = st.phase === 'dead' ? '#FF6B6B' : '#FFD700';
+    ctx.fill();
+    ctx.strokeStyle = '#B8860B';
+    ctx.lineWidth = 2.5;
+    ctx.stroke();
+    ctx.beginPath();
+    ctx.ellipse(-4, 4, 12, 7, 0.3, 0, Math.PI * 2);
+    ctx.fillStyle = '#FFA500';
+    ctx.fill();
+    ctx.beginPath();
+    ctx.arc(6, -5, 6, 0, Math.PI * 2);
+    ctx.fillStyle = 'white';
+    ctx.fill();
+    ctx.beginPath();
+    ctx.arc(8, -5, 3, 0, Math.PI * 2);
+    ctx.fillStyle = '#333';
+    ctx.fill();
+    ctx.beginPath();
+    ctx.moveTo(16, -2);
+    ctx.lineTo(26, 1);
+    ctx.lineTo(16, 5);
+    ctx.fillStyle = '#FF6600';
+    ctx.fill();
+    ctx.restore();
+
+    ctx.textAlign = 'center';
+    ctx.font = 'bold 38px Arial';
+    ctx.strokeStyle = 'rgba(0,0,0,0.4)';
+    ctx.lineWidth = 4;
+    ctx.strokeText(String(st.score), W / 2, 52);
+    ctx.fillStyle = 'white';
+    ctx.fillText(String(st.score), W / 2, 52);
+  });
 
   const handleInput = useCallback((e?: React.MouseEvent | React.TouchEvent) => {
     e?.preventDefault();

--- a/gamesformykids/app/games/frogger/useFroggerGame.ts
+++ b/gamesformykids/app/games/frogger/useFroggerGame.ts
@@ -1,7 +1,8 @@
-﻿'use client';
+'use client';
 
 import { useEffect, useRef, useCallback } from 'react';
 import { useFroggerStore } from './froggerStore';
+import { useCanvasLoop } from '@/hooks/shared/common';
 
 const CELL = 40;
 const COLS = 9;
@@ -32,12 +33,11 @@ function makeLanes() {
 }
 
 export function useFroggerGame() {
-  const canvasRef = useRef<HTMLCanvasElement>(null);
   const st = useRef({
     phase: 'menu' as Phase,
     fCol: 4, fRow: 8,
     lives: 3, score: 0, best: 0, level: 1,
-    frame: 0, raf: 0, dead: false, deadTimer: 0,
+    frame: 0, dead: false, deadTimer: 0,
     lanes: makeLanes(),
   });
   const startGame = useCallback(() => {
@@ -75,83 +75,70 @@ export function useFroggerGame() {
     else moveFrog(0, dy > 0 ? 1 : -1);
   }, [moveFrog]);
 
-  useEffect(() => {
-    const canvas = canvasRef.current;
-    if (!canvas) return;
-    const ctx = canvas.getContext('2d') as CanvasRenderingContext2D;
-    if (!ctx) return;
+  const canvasRef = useCanvasLoop((ctx) => {
+    const s = st.current;
+    s.frame++;
 
-    function loop() {
-      const s = st.current;
-      s.frame++;
-
-      if (s.phase === 'playing') {
-        const mul = 1 + (s.level - 1) * 0.18;
-        if (s.dead) {
-          s.deadTimer--;
-          if (s.deadTimer <= 0) s.dead = false;
-        } else {
-          for (const lane of s.lanes) {
-            for (const car of lane.cars) {
-              car.x += lane.speed * mul;
-              if (lane.speed > 0 && car.x > W + 5) car.x -= W + CAR_W * 3.5;
-              if (lane.speed < 0 && car.x + CAR_W < -5) car.x += W + CAR_W * 3.5;
-            }
+    if (s.phase === 'playing') {
+      const mul = 1 + (s.level - 1) * 0.18;
+      if (s.dead) {
+        s.deadTimer--;
+        if (s.deadTimer <= 0) s.dead = false;
+      } else {
+        for (const lane of s.lanes) {
+          for (const car of lane.cars) {
+            car.x += lane.speed * mul;
+            if (lane.speed > 0 && car.x > W + 5) car.x -= W + CAR_W * 3.5;
+            if (lane.speed < 0 && car.x + CAR_W < -5) car.x += W + CAR_W * 3.5;
           }
-          const fx = s.fCol * CELL + CELL / 2, fy = s.fRow * CELL + CELL / 2;
-          for (const lane of s.lanes) {
-            if (Math.abs(fy - (lane.row * CELL + CELL / 2)) > CELL * 0.45) continue;
-            for (const car of lane.cars) {
-              const cx = car.x + CAR_W / 2;
-              if (Math.abs(fx - cx) < CAR_W / 2 - 4) {
-                s.lives--; s.dead = true; s.deadTimer = 55; s.fCol = 4; s.fRow = 8;
-                if (s.lives <= 0) { s.phase = 'dead'; useFroggerStore.getState().endGame(s.score); }
-              }
+        }
+        const fx = s.fCol * CELL + CELL / 2, fy = s.fRow * CELL + CELL / 2;
+        for (const lane of s.lanes) {
+          if (Math.abs(fy - (lane.row * CELL + CELL / 2)) > CELL * 0.45) continue;
+          for (const car of lane.cars) {
+            const cx = car.x + CAR_W / 2;
+            if (Math.abs(fx - cx) < CAR_W / 2 - 4) {
+              s.lives--; s.dead = true; s.deadTimer = 55; s.fCol = 4; s.fRow = 8;
+              if (s.lives <= 0) { s.phase = 'dead'; useFroggerStore.getState().endGame(s.score); }
             }
           }
         }
       }
-
-      for (let row = 0; row < ROWS; row++) {
-        if (row === 0) ctx.fillStyle = '#14532d';
-        else if (row === 4) ctx.fillStyle = '#4b5563';
-        else if (row === 8) ctx.fillStyle = '#166534';
-        else ctx.fillStyle = '#374151';
-        ctx.fillRect(0, row * CELL, W, CELL);
-        if ((row >= 1 && row <= 3) || (row >= 5 && row <= 7)) {
-          ctx.fillStyle = 'rgba(255,220,0,0.2)';
-          for (let c = 0; c < COLS; c++) ctx.fillRect(c * CELL + CELL / 2 - 2, row * CELL + CELL / 2 - 7, 4, 14);
-        }
-      }
-
-      ctx.font = `${CELL * 0.65}px serif`; ctx.textAlign = 'center'; ctx.textBaseline = 'middle';
-      for (let c = 1; c < COLS; c += 2) ctx.fillText('🏁', c * CELL + CELL / 2, CELL / 2);
-
-      const s2 = st.current;
-      for (const lane of s2.lanes) {
-        for (const car of lane.cars) {
-          ctx.fillStyle = car.color; ctx.beginPath(); ctx.roundRect(car.x, lane.row * CELL + 5, CAR_W, CELL - 10, 5); ctx.fill();
-          ctx.font = `${CELL * 0.65}px serif`; ctx.textAlign = 'center'; ctx.textBaseline = 'middle';
-          ctx.fillText(car.emoji, car.x + CAR_W / 2, lane.row * CELL + CELL / 2);
-        }
-      }
-
-      const blink = s2.dead && s2.frame % 6 < 3;
-      if (!blink) {
-        ctx.font = `${CELL * 0.75}px serif`; ctx.textAlign = 'center'; ctx.textBaseline = 'middle';
-        ctx.fillText('🐸', s2.fCol * CELL + CELL / 2, s2.fRow * CELL + CELL / 2);
-      }
-
-      ctx.font = 'bold 15px Arial'; ctx.fillStyle = 'rgba(255,255,255,0.8)'; ctx.textAlign = 'right'; ctx.textBaseline = 'top';
-      ctx.fillText(`${s2.score}`, W - 6, 4);
-
-      s.raf = requestAnimationFrame(loop);
     }
 
-    st.current.raf = requestAnimationFrame(loop);
-    const stRef = st.current;
-    return () => cancelAnimationFrame(stRef.raf);
-  }, []);
+    for (let row = 0; row < ROWS; row++) {
+      if (row === 0) ctx.fillStyle = '#14532d';
+      else if (row === 4) ctx.fillStyle = '#4b5563';
+      else if (row === 8) ctx.fillStyle = '#166534';
+      else ctx.fillStyle = '#374151';
+      ctx.fillRect(0, row * CELL, W, CELL);
+      if ((row >= 1 && row <= 3) || (row >= 5 && row <= 7)) {
+        ctx.fillStyle = 'rgba(255,220,0,0.2)';
+        for (let c = 0; c < COLS; c++) ctx.fillRect(c * CELL + CELL / 2 - 2, row * CELL + CELL / 2 - 7, 4, 14);
+      }
+    }
+
+    ctx.font = `${CELL * 0.65}px serif`; ctx.textAlign = 'center'; ctx.textBaseline = 'middle';
+    for (let c = 1; c < COLS; c += 2) ctx.fillText('🏁', c * CELL + CELL / 2, CELL / 2);
+
+    const s2 = st.current;
+    for (const lane of s2.lanes) {
+      for (const car of lane.cars) {
+        ctx.fillStyle = car.color; ctx.beginPath(); ctx.roundRect(car.x, lane.row * CELL + 5, CAR_W, CELL - 10, 5); ctx.fill();
+        ctx.font = `${CELL * 0.65}px serif`; ctx.textAlign = 'center'; ctx.textBaseline = 'middle';
+        ctx.fillText(car.emoji, car.x + CAR_W / 2, lane.row * CELL + CELL / 2);
+      }
+    }
+
+    const blink = s2.dead && s2.frame % 6 < 3;
+    if (!blink) {
+      ctx.font = `${CELL * 0.75}px serif`; ctx.textAlign = 'center'; ctx.textBaseline = 'middle';
+      ctx.fillText('🐸', s2.fCol * CELL + CELL / 2, s2.fRow * CELL + CELL / 2);
+    }
+
+    ctx.font = 'bold 15px Arial'; ctx.fillStyle = 'rgba(255,255,255,0.8)'; ctx.textAlign = 'right'; ctx.textBaseline = 'top';
+    ctx.fillText(`${s2.score}`, W - 6, 4);
+  });
 
   useEffect(() => {
     const kd = (e: KeyboardEvent) => {

--- a/gamesformykids/app/games/jumper/useJumperGame.ts
+++ b/gamesformykids/app/games/jumper/useJumperGame.ts
@@ -1,7 +1,8 @@
-﻿'use client';
+'use client';
 
 import { useEffect, useRef, useCallback } from 'react';
 import { useJumperStore } from './jumperStore';
+import { useCanvasLoop } from '@/hooks/shared/common';
 
 export const W = 300;
 export const H = 500;
@@ -30,7 +31,6 @@ function generateInitial(): Array<Platform & { id: number }> {
 }
 
 export function useJumperGame() {
-  const canvasRef = useRef<HTMLCanvasElement>(null);
   const st = useRef({
     phase: 'menu' as Phase,
     px: W / 2, py: H - 100,
@@ -39,7 +39,7 @@ export function useJumperGame() {
     maxCamY: 0,
     platforms: generateInitial() as Array<Platform & { id: number }>,
     score: 0, best: 0,
-    frame: 0, raf: 0,
+    frame: 0,
     leftDown: false, rightDown: false,
     nextPlatY: H - 60 - INIT_PLATS * (PLAT_GAP * 0.75),
   });
@@ -64,115 +64,102 @@ export function useJumperGame() {
   const pressRight = useCallback(() => { st.current.rightDown = true; }, []);
   const releaseRight = useCallback(() => { st.current.rightDown = false; }, []);
 
-  useEffect(() => {
-    const canvas = canvasRef.current;
-    if (!canvas) return;
-    const ctx = canvas.getContext('2d') as CanvasRenderingContext2D;
-    if (!ctx) return;
+  const canvasRef = useCanvasLoop((ctx) => {
+    const s = st.current;
+    s.frame++;
 
-    function loop() {
-      const s = st.current;
-      s.frame++;
+    if (s.phase === 'playing') {
+      const HSPEED = 4.5;
+      if (s.leftDown)  s.pvx = Math.max(s.pvx - 0.8, -HSPEED);
+      if (s.rightDown) s.pvx = Math.min(s.pvx + 0.8, HSPEED);
+      if (!s.leftDown && !s.rightDown) s.pvx *= 0.85;
 
-      if (s.phase === 'playing') {
-        const HSPEED = 4.5;
-        if (s.leftDown)  s.pvx = Math.max(s.pvx - 0.8, -HSPEED);
-        if (s.rightDown) s.pvx = Math.min(s.pvx + 0.8, HSPEED);
-        if (!s.leftDown && !s.rightDown) s.pvx *= 0.85;
+      s.pvy += GRAVITY;
+      s.py += s.pvy;
+      s.px += s.pvx;
 
-        s.pvy += GRAVITY;
-        s.py += s.pvy;
-        s.px += s.pvx;
+      if (s.px < -PLAYER_R)    s.px = W + PLAYER_R;
+      if (s.px > W + PLAYER_R) s.px = -PLAYER_R;
 
-        if (s.px < -PLAYER_R)    s.px = W + PLAYER_R;
-        if (s.px > W + PLAYER_R) s.px = -PLAYER_R;
-
-        if (s.pvy > 0) {
-          for (const p of s.platforms) {
-            const screenY = p.y + s.camY;
-            if (
-              s.py + PLAYER_R >= screenY &&
-              s.py + PLAYER_R <= screenY + PLAT_H + Math.abs(s.pvy) + 2 &&
-              s.px + PLAYER_R * 0.7 > p.x &&
-              s.px - PLAYER_R * 0.7 < p.x + p.w
-            ) {
-              s.pvy = JUMP_VY;
-              s.py = screenY - PLAYER_R;
-            }
+      if (s.pvy > 0) {
+        for (const p of s.platforms) {
+          const screenY = p.y + s.camY;
+          if (
+            s.py + PLAYER_R >= screenY &&
+            s.py + PLAYER_R <= screenY + PLAT_H + Math.abs(s.pvy) + 2 &&
+            s.px + PLAYER_R * 0.7 > p.x &&
+            s.px - PLAYER_R * 0.7 < p.x + p.w
+          ) {
+            s.pvy = JUMP_VY;
+            s.py = screenY - PLAYER_R;
           }
         }
-
-        const playerScreenY = s.py;
-        if (playerScreenY < H * 0.45) {
-          const shift = H * 0.45 - playerScreenY;
-          s.camY += shift;
-          s.py += shift;
-        }
-
-        s.score = Math.floor(s.camY / 10);
-        if (s.camY > s.maxCamY) {
-          s.maxCamY = s.camY;
-          if (s.frame % 10 === 0) useJumperStore.getState().setScore(s.score);
-        }
-
-        while (s.nextPlatY > -(s.camY) - H) {
-          s.platforms.push(makePlatform(s.nextPlatY));
-          s.nextPlatY -= PLAT_GAP * (0.6 + Math.random() * 0.5);
-        }
-        s.platforms = s.platforms.filter(p => p.y + s.camY < H + 50);
-
-        if (s.py > H + 60) {
-          s.phase = 'dead';
-          useJumperStore.getState().endGame(s.score);
-        }
       }
 
-      const sky = ctx.createLinearGradient(0, 0, 0, H);
-      sky.addColorStop(0, '#0c1445');
-      sky.addColorStop(1, '#1a237e');
-      ctx.fillStyle = sky;
-      ctx.fillRect(0, 0, W, H);
-
-      ctx.fillStyle = 'rgba(255,255,255,0.6)';
-      for (let i = 0; i < 30; i++) {
-        const sx = ((i * 97 + st.current.camY * 0.05) % W + W) % W;
-        const sy = ((i * 137) % H);
-        ctx.beginPath();
-        ctx.arc(sx, sy, 0.8, 0, Math.PI * 2);
-        ctx.fill();
+      const playerScreenY = s.py;
+      if (playerScreenY < H * 0.45) {
+        const shift = H * 0.45 - playerScreenY;
+        s.camY += shift;
+        s.py += shift;
       }
 
-      const s2 = st.current;
-      for (const p of s2.platforms) {
-        const drawY = p.y + s2.camY;
-        if (drawY > H + 10 || drawY < -PLAT_H - 5) continue;
-        ctx.fillStyle = '#4ade80';
-        ctx.fillRect(p.x, drawY, p.w, PLAT_H);
-        ctx.fillStyle = 'rgba(255,255,255,0.3)';
-        ctx.fillRect(p.x, drawY, p.w, 4);
-        ctx.fillStyle = '#16a34a';
-        ctx.fillRect(p.x, drawY + PLAT_H - 3, p.w, 3);
+      s.score = Math.floor(s.camY / 10);
+      if (s.camY > s.maxCamY) {
+        s.maxCamY = s.camY;
+        if (s.frame % 10 === 0) useJumperStore.getState().setScore(s.score);
       }
 
-      if (s2.phase === 'playing') {
-        ctx.font = `${PLAYER_R * 2.2}px serif`;
-        ctx.textAlign = 'center';
-        ctx.textBaseline = 'middle';
-        ctx.fillText('🦘', s2.px, s2.py);
+      while (s.nextPlatY > -(s.camY) - H) {
+        s.platforms.push(makePlatform(s.nextPlatY));
+        s.nextPlatY -= PLAT_GAP * (0.6 + Math.random() * 0.5);
       }
+      s.platforms = s.platforms.filter(p => p.y + s.camY < H + 50);
 
-      ctx.font = 'bold 22px Arial';
-      ctx.fillStyle = 'rgba(255,255,255,0.85)';
-      ctx.textAlign = 'left';
-      ctx.fillText(`${s2.score}m`, 10, 30);
-
-      s.raf = requestAnimationFrame(loop);
+      if (s.py > H + 60) {
+        s.phase = 'dead';
+        useJumperStore.getState().endGame(s.score);
+      }
     }
 
-    st.current.raf = requestAnimationFrame(loop);
-    const stRef = st.current;
-    return () => cancelAnimationFrame(stRef.raf);
-  }, []);
+    const sky = ctx.createLinearGradient(0, 0, 0, H);
+    sky.addColorStop(0, '#0c1445');
+    sky.addColorStop(1, '#1a237e');
+    ctx.fillStyle = sky;
+    ctx.fillRect(0, 0, W, H);
+
+    ctx.fillStyle = 'rgba(255,255,255,0.6)';
+    for (let i = 0; i < 30; i++) {
+      const sx = ((i * 97 + st.current.camY * 0.05) % W + W) % W;
+      const sy = ((i * 137) % H);
+      ctx.beginPath();
+      ctx.arc(sx, sy, 0.8, 0, Math.PI * 2);
+      ctx.fill();
+    }
+
+    const s2 = st.current;
+    for (const p of s2.platforms) {
+      const drawY = p.y + s2.camY;
+      if (drawY > H + 10 || drawY < -PLAT_H - 5) continue;
+      ctx.fillStyle = '#4ade80';
+      ctx.fillRect(p.x, drawY, p.w, PLAT_H);
+      ctx.fillStyle = 'rgba(255,255,255,0.3)';
+      ctx.fillRect(p.x, drawY, p.w, 4);
+      ctx.fillStyle = '#16a34a';
+      ctx.fillRect(p.x, drawY + PLAT_H - 3, p.w, 3);
+    }
+
+    if (s2.phase === 'playing') {
+      ctx.font = `${PLAYER_R * 2.2}px serif`;
+      ctx.textAlign = 'center';
+      ctx.textBaseline = 'middle';
+      ctx.fillText('🦘', s2.px, s2.py);
+    }
+
+    ctx.font = 'bold 22px Arial';
+    ctx.fillStyle = 'rgba(255,255,255,0.85)';
+    ctx.textAlign = 'left';
+    ctx.fillText(`${s2.score}m`, 10, 30);
+  });
 
   useEffect(() => {
     const kd = (e: KeyboardEvent) => {

--- a/gamesformykids/app/games/meteor-dodge/useMeteorDodgeGame.ts
+++ b/gamesformykids/app/games/meteor-dodge/useMeteorDodgeGame.ts
@@ -1,7 +1,8 @@
-﻿'use client';
+'use client';
 
 import { useEffect, useRef, useCallback } from 'react';
 import { useMeteorDodgeStore } from './meteorDodgeStore';
+import { useCanvasLoop } from '@/hooks/shared/common';
 
 export const W = 360;
 export const H = 560;
@@ -17,12 +18,11 @@ interface StarPick { id: number; x: number; y: number; vy: number; emoji: string
 let uid = 0;
 
 export function useMeteorDodgeGame() {
-  const canvasRef = useRef<HTMLCanvasElement>(null);
   const st = useRef({
     phase: 'menu' as Phase,
     playerX: W / 2,
     meteors: [] as Meteor[], stars: [] as StarPick[],
-    score: 0, best: 0, frame: 0, raf: 0, nextMeteor: 50, nextStar: 120,
+    score: 0, best: 0, frame: 0, nextMeteor: 50, nextStar: 120,
     bgStars: Array.from({ length: 50 }, () => ({ x: Math.random() * W, y: Math.random() * H, r: 0.5 + Math.random() * 1.5, twinkle: Math.random() * Math.PI * 2 })),
     invincible: 0,
   });
@@ -56,99 +56,86 @@ export function useMeteorDodgeGame() {
     handleTouchMove(e);
   }, [startGame, handleTouchMove]);
 
-  useEffect(() => {
-    const canvas = canvasRef.current;
-    if (!canvas) return;
-    const ctx = canvas.getContext('2d') as CanvasRenderingContext2D;
-    if (!ctx) return;
+  const canvasRef = useCanvasLoop((ctx) => {
+    const s = st.current;
 
-    function loop() {
-      const s = st.current;
+    if (s.phase === 'playing') {
+      s.frame++;
+      s.score = Math.floor(s.frame / 4);
+      if (s.invincible > 0) s.invincible--;
 
-      if (s.phase === 'playing') {
-        s.frame++;
-        s.score = Math.floor(s.frame / 4);
-        if (s.invincible > 0) s.invincible--;
+      const difficulty = 1 + Math.floor(s.score / 100) * 0.3;
+      s.nextMeteor--;
+      if (s.nextMeteor <= 0) {
+        const r = 14 + Math.random() * 20;
+        s.meteors.push({ id: uid++, x: r + Math.random() * (W - r * 2), y: -r, r, speed: (1.8 + Math.random() * 2) * difficulty, emoji: METEOR_EMOJIS[Math.floor(Math.random() * METEOR_EMOJIS.length)], spin: (Math.random() - 0.5) * 0.1, angle: 0 });
+        s.nextMeteor = Math.max(15, Math.floor((50 - s.score / 20)));
+      }
+      s.nextStar--;
+      if (s.nextStar <= 0) {
+        s.stars.push({ id: uid++, x: 20 + Math.random() * (W - 40), y: -20, vy: 1.5 + Math.random(), emoji: STAR_EMOJIS[Math.floor(Math.random() * STAR_EMOJIS.length)] });
+        s.nextStar = 100 + Math.random() * 100;
+      }
 
-        const difficulty = 1 + Math.floor(s.score / 100) * 0.3;
-        s.nextMeteor--;
-        if (s.nextMeteor <= 0) {
-          const r = 14 + Math.random() * 20;
-          s.meteors.push({ id: uid++, x: r + Math.random() * (W - r * 2), y: -r, r, speed: (1.8 + Math.random() * 2) * difficulty, emoji: METEOR_EMOJIS[Math.floor(Math.random() * METEOR_EMOJIS.length)], spin: (Math.random() - 0.5) * 0.1, angle: 0 });
-          s.nextMeteor = Math.max(15, Math.floor((50 - s.score / 20)));
+      for (const m of s.meteors) { m.y += m.speed; m.angle += m.spin; }
+      s.meteors = s.meteors.filter(m => m.y - m.r < H + 10);
+      for (const st2 of s.stars) st2.y += st2.vy;
+      s.stars = s.stars.filter(st2 => st2.y < H + 20);
+
+      s.stars = s.stars.filter(st2 => {
+        const dx = st2.x - s.playerX, dy = st2.y - PLAYER_Y;
+        if (Math.sqrt(dx * dx + dy * dy) < PLAYER_R + 16) { s.score += 50; useMeteorDodgeStore.getState().setScore(s.score); return false; }
+        return true;
+      });
+
+      if (s.invincible === 0) {
+        for (const m of s.meteors) {
+          const dx = m.x - s.playerX, dy = m.y - PLAYER_Y;
+          if (Math.sqrt(dx * dx + dy * dy) < PLAYER_R + m.r - 8) { s.phase = 'dead'; useMeteorDodgeStore.getState().endGame(s.score); break; }
         }
-        s.nextStar--;
-        if (s.nextStar <= 0) {
-          s.stars.push({ id: uid++, x: 20 + Math.random() * (W - 40), y: -20, vy: 1.5 + Math.random(), emoji: STAR_EMOJIS[Math.floor(Math.random() * STAR_EMOJIS.length)] });
-          s.nextStar = 100 + Math.random() * 100;
-        }
-
-        for (const m of s.meteors) { m.y += m.speed; m.angle += m.spin; }
-        s.meteors = s.meteors.filter(m => m.y - m.r < H + 10);
-        for (const st2 of s.stars) st2.y += st2.vy;
-        s.stars = s.stars.filter(st2 => st2.y < H + 20);
-
-        s.stars = s.stars.filter(st2 => {
-          const dx = st2.x - s.playerX, dy = st2.y - PLAYER_Y;
-          if (Math.sqrt(dx * dx + dy * dy) < PLAYER_R + 16) { s.score += 50; useMeteorDodgeStore.getState().setScore(s.score); return false; }
-          return true;
-        });
-
-        if (s.invincible === 0) {
-          for (const m of s.meteors) {
-            const dx = m.x - s.playerX, dy = m.y - PLAYER_Y;
-            if (Math.sqrt(dx * dx + dy * dy) < PLAYER_R + m.r - 8) { s.phase = 'dead'; useMeteorDodgeStore.getState().endGame(s.score); break; }
-          }
-        }
-
-        if (s.frame % 8 === 0 && useMeteorDodgeStore.getState().phase === 'playing') useMeteorDodgeStore.getState().setScore(s.score);
       }
 
-      ctx.fillStyle = '#030712'; ctx.fillRect(0, 0, W, H);
-      const curr = st.current;
-      for (const star of curr.bgStars) {
-        const alpha = 0.3 + Math.sin(curr.frame * 0.02 + star.twinkle) * 0.3;
-        ctx.beginPath(); ctx.arc(star.x, star.y, star.r, 0, Math.PI * 2);
-        ctx.fillStyle = `rgba(255,255,230,${alpha})`; ctx.fill();
-      }
-
-      const neb = ctx.createRadialGradient(W * 0.7, H * 0.3, 0, W * 0.7, H * 0.3, 180);
-      neb.addColorStop(0, 'rgba(99,0,150,0.08)'); neb.addColorStop(1, 'rgba(0,0,0,0)');
-      ctx.fillStyle = neb; ctx.fillRect(0, 0, W, H);
-
-      ctx.font = '28px serif'; ctx.textAlign = 'center'; ctx.textBaseline = 'middle';
-      for (const st2 of curr.stars) {
-        const glow = ctx.createRadialGradient(st2.x, st2.y, 0, st2.x, st2.y, 22);
-        glow.addColorStop(0, 'rgba(255,220,0,0.4)'); glow.addColorStop(1, 'rgba(255,220,0,0)');
-        ctx.fillStyle = glow; ctx.beginPath(); ctx.arc(st2.x, st2.y, 22, 0, Math.PI * 2); ctx.fill();
-        ctx.fillText(st2.emoji, st2.x, st2.y);
-      }
-
-      for (const m of curr.meteors) {
-        ctx.save(); ctx.translate(m.x, m.y); ctx.rotate(m.angle);
-        ctx.font = `${m.r * 1.8}px serif`; ctx.textAlign = 'center'; ctx.textBaseline = 'middle';
-        ctx.fillText(m.emoji, 0, 0); ctx.restore();
-      }
-
-      const blink = curr.invincible > 0 && curr.frame % 6 < 3;
-      if (!blink) {
-        const glow = ctx.createRadialGradient(curr.playerX, PLAYER_Y, 0, curr.playerX, PLAYER_Y, PLAYER_R * 2);
-        glow.addColorStop(0, 'rgba(200,150,255,0.5)'); glow.addColorStop(1, 'rgba(150,50,255,0)');
-        ctx.fillStyle = glow; ctx.beginPath(); ctx.arc(curr.playerX, PLAYER_Y, PLAYER_R * 2, 0, Math.PI * 2); ctx.fill();
-        ctx.font = `${PLAYER_R * 2}px serif`; ctx.textAlign = 'center'; ctx.textBaseline = 'middle';
-        ctx.fillText('🚀', curr.playerX, PLAYER_Y);
-      }
-
-      ctx.font = 'bold 20px Arial'; ctx.fillStyle = 'rgba(255,255,255,0.8)'; ctx.textAlign = 'right';
-      ctx.fillText(`${curr.score}`, W - 12, 28);
-
-      s.raf = requestAnimationFrame(loop);
+      if (s.frame % 8 === 0 && useMeteorDodgeStore.getState().phase === 'playing') useMeteorDodgeStore.getState().setScore(s.score);
     }
 
-    st.current.raf = requestAnimationFrame(loop);
-    const stRef = st.current;
-    return () => cancelAnimationFrame(stRef.raf);
-  }, []);
+    ctx.fillStyle = '#030712'; ctx.fillRect(0, 0, W, H);
+    const curr = st.current;
+    for (const star of curr.bgStars) {
+      const alpha = 0.3 + Math.sin(curr.frame * 0.02 + star.twinkle) * 0.3;
+      ctx.beginPath(); ctx.arc(star.x, star.y, star.r, 0, Math.PI * 2);
+      ctx.fillStyle = `rgba(255,255,230,${alpha})`; ctx.fill();
+    }
+
+    const neb = ctx.createRadialGradient(W * 0.7, H * 0.3, 0, W * 0.7, H * 0.3, 180);
+    neb.addColorStop(0, 'rgba(99,0,150,0.08)'); neb.addColorStop(1, 'rgba(0,0,0,0)');
+    ctx.fillStyle = neb; ctx.fillRect(0, 0, W, H);
+
+    ctx.font = '28px serif'; ctx.textAlign = 'center'; ctx.textBaseline = 'middle';
+    for (const st2 of curr.stars) {
+      const glow = ctx.createRadialGradient(st2.x, st2.y, 0, st2.x, st2.y, 22);
+      glow.addColorStop(0, 'rgba(255,220,0,0.4)'); glow.addColorStop(1, 'rgba(255,220,0,0)');
+      ctx.fillStyle = glow; ctx.beginPath(); ctx.arc(st2.x, st2.y, 22, 0, Math.PI * 2); ctx.fill();
+      ctx.fillText(st2.emoji, st2.x, st2.y);
+    }
+
+    for (const m of curr.meteors) {
+      ctx.save(); ctx.translate(m.x, m.y); ctx.rotate(m.angle);
+      ctx.font = `${m.r * 1.8}px serif`; ctx.textAlign = 'center'; ctx.textBaseline = 'middle';
+      ctx.fillText(m.emoji, 0, 0); ctx.restore();
+    }
+
+    const blink = curr.invincible > 0 && curr.frame % 6 < 3;
+    if (!blink) {
+      const glow = ctx.createRadialGradient(curr.playerX, PLAYER_Y, 0, curr.playerX, PLAYER_Y, PLAYER_R * 2);
+      glow.addColorStop(0, 'rgba(200,150,255,0.5)'); glow.addColorStop(1, 'rgba(150,50,255,0)');
+      ctx.fillStyle = glow; ctx.beginPath(); ctx.arc(curr.playerX, PLAYER_Y, PLAYER_R * 2, 0, Math.PI * 2); ctx.fill();
+      ctx.font = `${PLAYER_R * 2}px serif`; ctx.textAlign = 'center'; ctx.textBaseline = 'middle';
+      ctx.fillText('🚀', curr.playerX, PLAYER_Y);
+    }
+
+    ctx.font = 'bold 20px Arial'; ctx.fillStyle = 'rgba(255,255,255,0.8)'; ctx.textAlign = 'right';
+    ctx.fillText(`${curr.score}`, W - 12, 28);
+  });
 
   useEffect(() => {
     let left = false, right = false;

--- a/gamesformykids/app/games/pong/usePongGame.ts
+++ b/gamesformykids/app/games/pong/usePongGame.ts
@@ -1,7 +1,8 @@
-﻿'use client';
+'use client';
 
 import { useEffect, useRef, useCallback } from 'react';
 import { usePongStore } from './pongStore';
+import { useCanvasLoop } from '@/hooks/shared/common';
 
 export const W = 360;
 export const H = 560;
@@ -13,12 +14,11 @@ const AI_SPEED = 3.5;
 import type { PhaseResult as Phase } from '@/lib/types';
 
 export function usePongGame() {
-  const canvasRef = useRef<HTMLCanvasElement>(null);
   const st = useRef({
     phase: 'menu' as Phase,
     playerX: W / 2 - PAD_W / 2, aiX: W / 2 - PAD_W / 2,
     ballX: W / 2, ballY: H / 2, ballVX: 3, ballVY: 4,
-    playerScore: 0, aiScore: 0, raf: 0, frame: 0,
+    playerScore: 0, aiScore: 0, frame: 0,
     particles: [] as { x: number; y: number; vx: number; vy: number; life: number }[],
   });
   function serveBall(direction: 1 | -1) {
@@ -65,80 +65,66 @@ export function usePongGame() {
     handleTouchMove(e);
   }, [startGame, handleTouchMove]);
 
-  useEffect(() => {
-    const canvas = canvasRef.current;
-    if (!canvas) return;
-    const ctx = canvas.getContext('2d') as CanvasRenderingContext2D;
-    if (!ctx) return;
+  const canvasRef = useCanvasLoop((ctx) => {
+    const s = st.current;
+    s.frame++;
 
     function addParticles(x: number, y: number) {
-      const s = st.current;
       for (let i = 0; i < 8; i++) s.particles.push({ x, y, vx: (Math.random() - 0.5) * 6, vy: (Math.random() - 0.5) * 6, life: 1 });
     }
 
-    function loop() {
-      const s = st.current;
-      s.frame++;
+    if (s.phase === 'playing') {
+      s.ballX += s.ballVX; s.ballY += s.ballVY;
+      if (s.ballX - BALL_R <= 0) { s.ballX = BALL_R; s.ballVX = Math.abs(s.ballVX); addParticles(s.ballX, s.ballY); }
+      if (s.ballX + BALL_R >= W) { s.ballX = W - BALL_R; s.ballVX = -Math.abs(s.ballVX); addParticles(s.ballX, s.ballY); }
 
-      if (s.phase === 'playing') {
-        s.ballX += s.ballVX; s.ballY += s.ballVY;
-        if (s.ballX - BALL_R <= 0) { s.ballX = BALL_R; s.ballVX = Math.abs(s.ballVX); addParticles(s.ballX, s.ballY); }
-        if (s.ballX + BALL_R >= W) { s.ballX = W - BALL_R; s.ballVX = -Math.abs(s.ballVX); addParticles(s.ballX, s.ballY); }
+      const aiPad_Y = 30;
+      const aiCenter = s.aiX + PAD_W / 2;
+      if (aiCenter < s.ballX - 2) s.aiX = Math.min(W - PAD_W, s.aiX + AI_SPEED);
+      else if (aiCenter > s.ballX + 2) s.aiX = Math.max(0, s.aiX - AI_SPEED);
 
-        const aiPad_Y = 30;
-        const aiCenter = s.aiX + PAD_W / 2;
-        if (aiCenter < s.ballX - 2) s.aiX = Math.min(W - PAD_W, s.aiX + AI_SPEED);
-        else if (aiCenter > s.ballX + 2) s.aiX = Math.max(0, s.aiX - AI_SPEED);
-
-        const playerPad_Y = H - 45;
-        if (s.ballY + BALL_R >= playerPad_Y && s.ballY - BALL_R <= playerPad_Y + PAD_H && s.ballX >= s.playerX && s.ballX <= s.playerX + PAD_W) {
-          const rel = (s.ballX - s.playerX) / PAD_W - 0.5;
-          const spd = Math.sqrt(s.ballVX ** 2 + s.ballVY ** 2) + 0.1;
-          s.ballVX = rel * spd * 2.5; s.ballVY = -Math.abs(s.ballVY);
-          addParticles(s.ballX, playerPad_Y);
-        }
-        if (s.ballY - BALL_R <= aiPad_Y + PAD_H && s.ballY + BALL_R >= aiPad_Y && s.ballX >= s.aiX && s.ballX <= s.aiX + PAD_W) {
-          const rel = (s.ballX - s.aiX) / PAD_W - 0.5;
-          const spd = Math.sqrt(s.ballVX ** 2 + s.ballVY ** 2) + 0.1;
-          s.ballVX = rel * spd * 2.5; s.ballVY = Math.abs(s.ballVY);
-          addParticles(s.ballX, aiPad_Y + PAD_H);
-        }
-
-        if (s.ballY + BALL_R > H) { s.aiScore++; const aiWon = usePongStore.getState().aiScores(s.aiScore); if (aiWon) { s.phase = 'result'; } else serveBall(-1); }
-        if (s.ballY - BALL_R < 0) { s.playerScore++; const playerWon = usePongStore.getState().playerScores(s.playerScore); if (playerWon) { s.phase = 'result'; } else serveBall(1); }
-
-        s.particles = s.particles.filter(p => { p.x += p.vx; p.y += p.vy; p.vy += 0.08; p.life -= 0.05; return p.life > 0; });
+      const playerPad_Y = H - 45;
+      if (s.ballY + BALL_R >= playerPad_Y && s.ballY - BALL_R <= playerPad_Y + PAD_H && s.ballX >= s.playerX && s.ballX <= s.playerX + PAD_W) {
+        const rel = (s.ballX - s.playerX) / PAD_W - 0.5;
+        const spd = Math.sqrt(s.ballVX ** 2 + s.ballVY ** 2) + 0.1;
+        s.ballVX = rel * spd * 2.5; s.ballVY = -Math.abs(s.ballVY);
+        addParticles(s.ballX, playerPad_Y);
+      }
+      if (s.ballY - BALL_R <= aiPad_Y + PAD_H && s.ballY + BALL_R >= aiPad_Y && s.ballX >= s.aiX && s.ballX <= s.aiX + PAD_W) {
+        const rel = (s.ballX - s.aiX) / PAD_W - 0.5;
+        const spd = Math.sqrt(s.ballVX ** 2 + s.ballVY ** 2) + 0.1;
+        s.ballVX = rel * spd * 2.5; s.ballVY = Math.abs(s.ballVY);
+        addParticles(s.ballX, aiPad_Y + PAD_H);
       }
 
-      ctx.fillStyle = '#0F172A'; ctx.fillRect(0, 0, W, H);
-      ctx.setLineDash([10, 10]); ctx.strokeStyle = 'rgba(255,255,255,0.15)'; ctx.lineWidth = 2;
-      ctx.beginPath(); ctx.moveTo(0, H / 2); ctx.lineTo(W, H / 2); ctx.stroke(); ctx.setLineDash([]);
-      ctx.textAlign = 'center'; ctx.font = 'bold 48px Arial'; ctx.fillStyle = 'rgba(255,255,255,0.15)';
-      ctx.fillText(String(s.aiScore), W / 2, H / 2 - 15); ctx.fillText(String(s.playerScore), W / 2, H / 2 + 55);
+      if (s.ballY + BALL_R > H) { s.aiScore++; const aiWon = usePongStore.getState().aiScores(s.aiScore); if (aiWon) { s.phase = 'result'; } else serveBall(-1); }
+      if (s.ballY - BALL_R < 0) { s.playerScore++; const playerWon = usePongStore.getState().playerScores(s.playerScore); if (playerWon) { s.phase = 'result'; } else serveBall(1); }
 
-      for (const p of s.particles) { ctx.globalAlpha = p.life; ctx.fillStyle = '#FCD34D'; ctx.beginPath(); ctx.arc(p.x, p.y, 3, 0, Math.PI * 2); ctx.fill(); }
-      ctx.globalAlpha = 1;
-
-      const aiPad_Y = 30, playerPad_Y = H - 45;
-      const aiGrad = ctx.createLinearGradient(s.aiX, 0, s.aiX + PAD_W, 0);
-      aiGrad.addColorStop(0, '#F87171'); aiGrad.addColorStop(1, '#EF4444');
-      ctx.fillStyle = aiGrad; ctx.beginPath(); ctx.roundRect(s.aiX, aiPad_Y, PAD_W, PAD_H, 6); ctx.fill();
-      const plGrad = ctx.createLinearGradient(s.playerX, 0, s.playerX + PAD_W, 0);
-      plGrad.addColorStop(0, '#34D399'); plGrad.addColorStop(1, '#10B981');
-      ctx.fillStyle = plGrad; ctx.beginPath(); ctx.roundRect(s.playerX, playerPad_Y, PAD_W, PAD_H, 6); ctx.fill();
-
-      const glow = ctx.createRadialGradient(s.ballX, s.ballY, 0, s.ballX, s.ballY, BALL_R * 3);
-      glow.addColorStop(0, 'rgba(255,255,255,0.5)'); glow.addColorStop(1, 'rgba(255,255,255,0)');
-      ctx.fillStyle = glow; ctx.beginPath(); ctx.arc(s.ballX, s.ballY, BALL_R * 3, 0, Math.PI * 2); ctx.fill();
-      ctx.fillStyle = 'white'; ctx.beginPath(); ctx.arc(s.ballX, s.ballY, BALL_R, 0, Math.PI * 2); ctx.fill();
-
-      s.raf = requestAnimationFrame(loop);
+      s.particles = s.particles.filter(p => { p.x += p.vx; p.y += p.vy; p.vy += 0.08; p.life -= 0.05; return p.life > 0; });
     }
 
-    st.current.raf = requestAnimationFrame(loop);
-    const stRef = st.current;
-    return () => cancelAnimationFrame(stRef.raf);
-  }, []);
+    ctx.fillStyle = '#0F172A'; ctx.fillRect(0, 0, W, H);
+    ctx.setLineDash([10, 10]); ctx.strokeStyle = 'rgba(255,255,255,0.15)'; ctx.lineWidth = 2;
+    ctx.beginPath(); ctx.moveTo(0, H / 2); ctx.lineTo(W, H / 2); ctx.stroke(); ctx.setLineDash([]);
+    ctx.textAlign = 'center'; ctx.font = 'bold 48px Arial'; ctx.fillStyle = 'rgba(255,255,255,0.15)';
+    ctx.fillText(String(s.aiScore), W / 2, H / 2 - 15); ctx.fillText(String(s.playerScore), W / 2, H / 2 + 55);
+
+    for (const p of s.particles) { ctx.globalAlpha = p.life; ctx.fillStyle = '#FCD34D'; ctx.beginPath(); ctx.arc(p.x, p.y, 3, 0, Math.PI * 2); ctx.fill(); }
+    ctx.globalAlpha = 1;
+
+    const aiPad_Y = 30, playerPad_Y = H - 45;
+    const aiGrad = ctx.createLinearGradient(s.aiX, 0, s.aiX + PAD_W, 0);
+    aiGrad.addColorStop(0, '#F87171'); aiGrad.addColorStop(1, '#EF4444');
+    ctx.fillStyle = aiGrad; ctx.beginPath(); ctx.roundRect(s.aiX, aiPad_Y, PAD_W, PAD_H, 6); ctx.fill();
+    const plGrad = ctx.createLinearGradient(s.playerX, 0, s.playerX + PAD_W, 0);
+    plGrad.addColorStop(0, '#34D399'); plGrad.addColorStop(1, '#10B981');
+    ctx.fillStyle = plGrad; ctx.beginPath(); ctx.roundRect(s.playerX, playerPad_Y, PAD_W, PAD_H, 6); ctx.fill();
+
+    const glow = ctx.createRadialGradient(s.ballX, s.ballY, 0, s.ballX, s.ballY, BALL_R * 3);
+    glow.addColorStop(0, 'rgba(255,255,255,0.5)'); glow.addColorStop(1, 'rgba(255,255,255,0)');
+    ctx.fillStyle = glow; ctx.beginPath(); ctx.arc(s.ballX, s.ballY, BALL_R * 3, 0, Math.PI * 2); ctx.fill();
+    ctx.fillStyle = 'white'; ctx.beginPath(); ctx.arc(s.ballX, s.ballY, BALL_R, 0, Math.PI * 2); ctx.fill();
+  });
 
   useEffect(() => {
     let left = false, right = false;

--- a/gamesformykids/app/games/space-defender/useSpaceDefenderGame.ts
+++ b/gamesformykids/app/games/space-defender/useSpaceDefenderGame.ts
@@ -1,7 +1,8 @@
-﻿'use client';
+'use client';
 
 import { useEffect, useRef, useCallback } from 'react';
 import { useSpaceDefenderStore, GAME_DURATION } from './spaceDefenderStore';
+import { useCanvasLoop } from '@/hooks/shared/common';
 
 export const W = 360;
 export const H = 560;
@@ -17,13 +18,12 @@ interface Asteroid { id: number; x: number; y: number; speed: number; r: number;
 let uid = 0;
 
 export function useSpaceDefenderGame() {
-  const canvasRef = useRef<HTMLCanvasElement>(null);
   const st = useRef({
     phase: 'menu' as Phase,
     shipX: W / 2,
     bullets: [] as Bullet[],
     asteroids: [] as Asteroid[],
-    score: 0, lives: 3, timeLeft: GAME_DURATION, frame: 0, raf: 0, nextAsteroid: 60,
+    score: 0, lives: 3, timeLeft: GAME_DURATION, frame: 0, nextAsteroid: 60,
     stars: Array.from({ length: 40 }, () => ({ x: Math.random() * W, y: Math.random() * H, r: 0.5 + Math.random() * 2, twinkle: Math.random() * Math.PI * 2 })),
     lastShot: 0,
   });
@@ -44,13 +44,98 @@ export function useSpaceDefenderGame() {
     useSpaceDefenderStore.getState().startGame();
   }, []);
 
+  const canvasRef = useCanvasLoop((ctx, dt) => {
+    const s = st.current;
+
+    if (s.phase === 'playing') {
+      s.frame++;
+      s.timeLeft -= dt / 1000;
+      if (s.timeLeft <= 0) {
+        s.timeLeft = 0;
+        s.phase = 'result';
+        useSpaceDefenderStore.getState().setGameResult(s.score, s.lives, 0);
+      }
+      s.nextAsteroid--;
+      if (s.nextAsteroid <= 0) {
+        const r = 16 + Math.random() * 20;
+        s.asteroids.push({ id: uid++, x: r + Math.random() * (W - r * 2), y: -r, speed: 1.5 + Math.random() * 2 + s.score / 500, r, emoji: ASTEROID_EMOJIS[Math.floor(Math.random() * ASTEROID_EMOJIS.length)], angle: 0, spin: (Math.random() - 0.5) * 0.06 });
+        s.nextAsteroid = Math.max(20, 55 - Math.floor(s.score / 100) * 3);
+      }
+      s.bullets = s.bullets.filter(b => { b.y -= BULLET_SPEED; return b.y > -10; });
+      for (const a of s.asteroids) { a.y += a.speed; a.angle += a.spin; }
+
+      const toRemoveBullets = new Set<number>();
+      const toRemoveAsteroids = new Set<number>();
+      for (const b of s.bullets) {
+        for (const a of s.asteroids) {
+          const dx = b.x - a.x, dy = b.y - a.y;
+          if (Math.sqrt(dx * dx + dy * dy) < a.r + BULLET_R) { toRemoveBullets.add(b.id); toRemoveAsteroids.add(a.id); s.score += 10; useSpaceDefenderStore.getState().setScore(s.score); }
+        }
+      }
+      s.bullets = s.bullets.filter(b => !toRemoveBullets.has(b.id));
+      s.asteroids = s.asteroids.filter(a => !toRemoveAsteroids.has(a.id));
+
+      const shipY = H - 80;
+      s.asteroids = s.asteroids.filter(a => {
+        if (a.y + a.r > H) { s.lives--; if (s.lives <= 0) { s.lives = 0; s.phase = 'result'; useSpaceDefenderStore.getState().setGameResult(s.score, 0, Math.ceil(s.timeLeft)); } else { useSpaceDefenderStore.getState().setLives(s.lives); } return false; }
+        if (Math.abs(a.x - s.shipX) < SHIP_W / 2 + a.r && Math.abs(a.y - shipY) < SHIP_H / 2 + a.r) { s.lives--; if (s.lives <= 0) { s.lives = 0; s.phase = 'result'; useSpaceDefenderStore.getState().setGameResult(s.score, 0, Math.ceil(s.timeLeft)); } else { useSpaceDefenderStore.getState().setLives(s.lives); } return false; }
+        return true;
+      });
+      if (s.frame % 20 === 0 && st.current.phase === 'playing') useSpaceDefenderStore.getState().setTimeLeft(Math.ceil(s.timeLeft));
+    }
+
+    ctx.fillStyle = '#050514';
+    ctx.fillRect(0, 0, W, H);
+
+    for (const star of s.stars) {
+      const alpha = 0.4 + Math.sin(s.frame * 0.03 + star.twinkle) * 0.3;
+      ctx.beginPath(); ctx.arc(star.x, star.y, star.r, 0, Math.PI * 2);
+      ctx.fillStyle = `rgba(255,255,220,${alpha})`; ctx.fill();
+    }
+
+    const curr = st.current;
+    for (const b of curr.bullets) {
+      const grad = ctx.createLinearGradient(b.x, b.y - 14, b.x, b.y + 4);
+      grad.addColorStop(0, '#FFD700'); grad.addColorStop(1, 'rgba(255,215,0,0)');
+      ctx.fillStyle = grad;
+      ctx.beginPath(); ctx.ellipse(b.x, b.y - 7, BULLET_R, 14, 0, 0, Math.PI * 2); ctx.fill();
+    }
+
+    ctx.font = 'serif'; ctx.textAlign = 'center'; ctx.textBaseline = 'middle';
+    for (const a of curr.asteroids) {
+      ctx.save(); ctx.translate(a.x, a.y); ctx.rotate(a.angle);
+      ctx.font = `${a.r * 1.8}px serif`; ctx.fillText(a.emoji, 0, 0); ctx.restore();
+    }
+
+    const sx = curr.shipX, sy = H - 80;
+    ctx.save(); ctx.translate(sx, sy);
+    if (curr.phase === 'playing') {
+      const thrustGrad = ctx.createRadialGradient(0, SHIP_H / 2 + 6, 0, 0, SHIP_H / 2 + 6, 18);
+      thrustGrad.addColorStop(0, 'rgba(255,140,0,0.9)'); thrustGrad.addColorStop(0.5, 'rgba(255,60,0,0.5)'); thrustGrad.addColorStop(1, 'rgba(255,0,0,0)');
+      ctx.fillStyle = thrustGrad;
+      const flicker = curr.frame % 4 < 2 ? 14 : 10;
+      ctx.beginPath(); ctx.ellipse(0, SHIP_H / 2 + flicker / 2, 8, flicker, 0, 0, Math.PI * 2); ctx.fill();
+    }
+    ctx.fillStyle = '#4FC3F7';
+    ctx.beginPath(); ctx.moveTo(0, -SHIP_H / 2); ctx.lineTo(SHIP_W / 2, SHIP_H / 2); ctx.lineTo(-SHIP_W / 2, SHIP_H / 2); ctx.closePath(); ctx.fill();
+    ctx.fillStyle = '#B3E5FC';
+    ctx.beginPath(); ctx.ellipse(0, -4, 9, 13, 0, 0, Math.PI * 2); ctx.fill();
+    ctx.fillStyle = '#0288D1';
+    ctx.beginPath(); ctx.moveTo(SHIP_W / 2, SHIP_H / 2); ctx.lineTo(SHIP_W / 2 + 14, SHIP_H / 2 + 6); ctx.lineTo(SHIP_W / 3, 4); ctx.fill();
+    ctx.beginPath(); ctx.moveTo(-SHIP_W / 2, SHIP_H / 2); ctx.lineTo(-SHIP_W / 2 - 14, SHIP_H / 2 + 6); ctx.lineTo(-SHIP_W / 3, 4); ctx.fill();
+    ctx.restore();
+
+    ctx.fillStyle = 'rgba(30,100,50,0.3)'; ctx.fillRect(0, H - 18, W, 18);
+    ctx.fillStyle = 'rgba(50,150,80,0.5)'; ctx.fillRect(0, H - 10, W, 10);
+  });
+
   const handleMouseMove = useCallback((e: React.MouseEvent<HTMLCanvasElement>) => {
     const canvas = canvasRef.current;
     if (!canvas) return;
     const rect = canvas.getBoundingClientRect();
     const scaleX = W / rect.width;
     st.current.shipX = Math.max(SHIP_W / 2, Math.min(W - SHIP_W / 2, (e.clientX - rect.left) * scaleX));
-  }, []);
+  }, [canvasRef]);
 
   const handleCanvasClick = useCallback(() => {
     const s = st.current;
@@ -66,113 +151,12 @@ export function useSpaceDefenderGame() {
     const scaleX = W / rect.width;
     st.current.shipX = Math.max(SHIP_W / 2, Math.min(W - SHIP_W / 2, (e.touches[0].clientX - rect.left) * scaleX));
     shoot();
-  }, [shoot]);
+  }, [canvasRef, shoot]);
 
   const handleTouchStart = useCallback((e: React.TouchEvent<HTMLCanvasElement>) => {
     e.preventDefault();
     if (st.current.phase !== 'playing') startGame();
   }, [startGame]);
-
-  useEffect(() => {
-    const canvas = canvasRef.current;
-    if (!canvas) return;
-    const ctx = canvas.getContext('2d') as CanvasRenderingContext2D;
-    if (!ctx) return;
-    let lastTime = performance.now();
-
-    function loop(now: number) {
-      const s = st.current;
-      const dt = now - lastTime;
-      lastTime = now;
-
-      if (s.phase === 'playing') {
-        s.frame++;
-        s.timeLeft -= dt / 1000;
-        if (s.timeLeft <= 0) {
-          s.timeLeft = 0;
-          s.phase = 'result';
-          useSpaceDefenderStore.getState().setGameResult(s.score, s.lives, 0);
-        }
-        s.nextAsteroid--;
-        if (s.nextAsteroid <= 0) {
-          const r = 16 + Math.random() * 20;
-          s.asteroids.push({ id: uid++, x: r + Math.random() * (W - r * 2), y: -r, speed: 1.5 + Math.random() * 2 + s.score / 500, r, emoji: ASTEROID_EMOJIS[Math.floor(Math.random() * ASTEROID_EMOJIS.length)], angle: 0, spin: (Math.random() - 0.5) * 0.06 });
-          s.nextAsteroid = Math.max(20, 55 - Math.floor(s.score / 100) * 3);
-        }
-        s.bullets = s.bullets.filter(b => { b.y -= BULLET_SPEED; return b.y > -10; });
-        for (const a of s.asteroids) { a.y += a.speed; a.angle += a.spin; }
-
-        const toRemoveBullets = new Set<number>();
-        const toRemoveAsteroids = new Set<number>();
-        for (const b of s.bullets) {
-          for (const a of s.asteroids) {
-            const dx = b.x - a.x, dy = b.y - a.y;
-            if (Math.sqrt(dx * dx + dy * dy) < a.r + BULLET_R) { toRemoveBullets.add(b.id); toRemoveAsteroids.add(a.id); s.score += 10; useSpaceDefenderStore.getState().setScore(s.score); }
-          }
-        }
-        s.bullets = s.bullets.filter(b => !toRemoveBullets.has(b.id));
-        s.asteroids = s.asteroids.filter(a => !toRemoveAsteroids.has(a.id));
-
-        const shipY = H - 80;
-        s.asteroids = s.asteroids.filter(a => {
-          if (a.y + a.r > H) { s.lives--; if (s.lives <= 0) { s.lives = 0; s.phase = 'result'; useSpaceDefenderStore.getState().setGameResult(s.score, 0, Math.ceil(s.timeLeft)); } else { useSpaceDefenderStore.getState().setLives(s.lives); } return false; }
-          if (Math.abs(a.x - s.shipX) < SHIP_W / 2 + a.r && Math.abs(a.y - shipY) < SHIP_H / 2 + a.r) { s.lives--; if (s.lives <= 0) { s.lives = 0; s.phase = 'result'; useSpaceDefenderStore.getState().setGameResult(s.score, 0, Math.ceil(s.timeLeft)); } else { useSpaceDefenderStore.getState().setLives(s.lives); } return false; }
-          return true;
-        });
-        if (s.frame % 20 === 0 && st.current.phase === 'playing') useSpaceDefenderStore.getState().setTimeLeft(Math.ceil(s.timeLeft));
-      }
-
-      ctx.fillStyle = '#050514';
-      ctx.fillRect(0, 0, W, H);
-
-      for (const star of s.stars) {
-        const alpha = 0.4 + Math.sin(s.frame * 0.03 + star.twinkle) * 0.3;
-        ctx.beginPath(); ctx.arc(star.x, star.y, star.r, 0, Math.PI * 2);
-        ctx.fillStyle = `rgba(255,255,220,${alpha})`; ctx.fill();
-      }
-
-      const curr = st.current;
-      for (const b of curr.bullets) {
-        const grad = ctx.createLinearGradient(b.x, b.y - 14, b.x, b.y + 4);
-        grad.addColorStop(0, '#FFD700'); grad.addColorStop(1, 'rgba(255,215,0,0)');
-        ctx.fillStyle = grad;
-        ctx.beginPath(); ctx.ellipse(b.x, b.y - 7, BULLET_R, 14, 0, 0, Math.PI * 2); ctx.fill();
-      }
-
-      ctx.font = 'serif'; ctx.textAlign = 'center'; ctx.textBaseline = 'middle';
-      for (const a of curr.asteroids) {
-        ctx.save(); ctx.translate(a.x, a.y); ctx.rotate(a.angle);
-        ctx.font = `${a.r * 1.8}px serif`; ctx.fillText(a.emoji, 0, 0); ctx.restore();
-      }
-
-      const sx = curr.shipX, sy = H - 80;
-      ctx.save(); ctx.translate(sx, sy);
-      if (curr.phase === 'playing') {
-        const thrustGrad = ctx.createRadialGradient(0, SHIP_H / 2 + 6, 0, 0, SHIP_H / 2 + 6, 18);
-        thrustGrad.addColorStop(0, 'rgba(255,140,0,0.9)'); thrustGrad.addColorStop(0.5, 'rgba(255,60,0,0.5)'); thrustGrad.addColorStop(1, 'rgba(255,0,0,0)');
-        ctx.fillStyle = thrustGrad;
-        const flicker = curr.frame % 4 < 2 ? 14 : 10;
-        ctx.beginPath(); ctx.ellipse(0, SHIP_H / 2 + flicker / 2, 8, flicker, 0, 0, Math.PI * 2); ctx.fill();
-      }
-      ctx.fillStyle = '#4FC3F7';
-      ctx.beginPath(); ctx.moveTo(0, -SHIP_H / 2); ctx.lineTo(SHIP_W / 2, SHIP_H / 2); ctx.lineTo(-SHIP_W / 2, SHIP_H / 2); ctx.closePath(); ctx.fill();
-      ctx.fillStyle = '#B3E5FC';
-      ctx.beginPath(); ctx.ellipse(0, -4, 9, 13, 0, 0, Math.PI * 2); ctx.fill();
-      ctx.fillStyle = '#0288D1';
-      ctx.beginPath(); ctx.moveTo(SHIP_W / 2, SHIP_H / 2); ctx.lineTo(SHIP_W / 2 + 14, SHIP_H / 2 + 6); ctx.lineTo(SHIP_W / 3, 4); ctx.fill();
-      ctx.beginPath(); ctx.moveTo(-SHIP_W / 2, SHIP_H / 2); ctx.lineTo(-SHIP_W / 2 - 14, SHIP_H / 2 + 6); ctx.lineTo(-SHIP_W / 3, 4); ctx.fill();
-      ctx.restore();
-
-      ctx.fillStyle = 'rgba(30,100,50,0.3)'; ctx.fillRect(0, H - 18, W, 18);
-      ctx.fillStyle = 'rgba(50,150,80,0.5)'; ctx.fillRect(0, H - 10, W, 10);
-
-      s.raf = requestAnimationFrame(loop);
-    }
-
-    st.current.raf = requestAnimationFrame(loop);
-    const stRef = st.current;
-    return () => cancelAnimationFrame(stRef.raf);
-  }, []);
 
   useEffect(() => {
     let leftDown = false, rightDown = false;

--- a/gamesformykids/app/games/stack/useStackGame.ts
+++ b/gamesformykids/app/games/stack/useStackGame.ts
@@ -1,7 +1,8 @@
-﻿'use client';
+'use client';
 
 import { useEffect, useRef, useCallback } from 'react';
 import { useStackStore } from './stackStore';
+import { useCanvasLoop } from '@/hooks/shared/common';
 
 export const W = 300;
 export const H = 480;
@@ -14,10 +15,7 @@ const TARGET_TOP = 90;
 import type { PhaseDead as Phase } from '@/lib/types';
 interface Block { x: number; y: number; w: number; color: string; }
 
-function makeBricks() { return [] as Block[]; } // placeholder, actual init in startGame
-
 export function useStackGame() {
-  const canvasRef = useRef<HTMLCanvasElement>(null);
   const st = useRef({
     phase: 'menu' as Phase,
     blocks: [] as Block[],
@@ -27,7 +25,7 @@ export function useStackGame() {
     camOffset: 0,
     score: 0, best: 0,
     colorIdx: 0,
-    frame: 0, raf: 0,
+    frame: 0,
   });
   const startGame = useCallback(() => {
     const s = st.current;
@@ -73,70 +71,57 @@ export function useStackGame() {
     else if (st.current.phase === 'menu') startGame();
   }, [drop, startGame]);
 
-  useEffect(() => {
-    const canvas = canvasRef.current;
-    if (!canvas) return;
-    const ctx = canvas.getContext('2d') as CanvasRenderingContext2D;
-    if (!ctx) return;
+  const canvasRef = useCanvasLoop((ctx) => {
+    const s = st.current;
+    s.frame++;
 
-    function loop() {
-      const s = st.current;
-      s.frame++;
-
-      if (s.phase === 'playing') {
-        s.curX += s.curDir * s.curSpeed;
-        const top = s.blocks[s.blocks.length - 1];
-        if (s.curDir > 0 && s.curX > W + 20) s.curDir = -1;
-        if (s.curDir < 0 && s.curX + s.curW < -20) s.curDir = 1;
-        if (s.curX < -W * 0.4) { s.curDir = 1; s.curX = -W * 0.4; }
-        if (s.curX + s.curW > W + W * 0.4) { s.curDir = -1; s.curX = W + W * 0.4 - s.curW; }
-        void top;
-      }
-
-      const grad = ctx.createLinearGradient(0, 0, 0, H);
-      grad.addColorStop(0, '#0f172a');
-      grad.addColorStop(1, '#1e293b');
-      ctx.fillStyle = grad;
-      ctx.fillRect(0, 0, W, H);
-
-      for (const block of s.blocks) {
-        const drawY = block.y + s.camOffset;
-        if (drawY > H + BH || drawY < -BH) continue;
-        ctx.fillStyle = block.color;
-        ctx.fillRect(block.x, drawY, block.w, BH - 2);
-        ctx.fillStyle = 'rgba(255,255,255,0.18)';
-        ctx.fillRect(block.x, drawY, block.w, 5);
-        ctx.fillStyle = 'rgba(0,0,0,0.25)';
-        ctx.fillRect(block.x, drawY + BH - 5, block.w, 3);
-      }
-
-      if (s.phase === 'playing' && s.blocks.length > 0) {
-        const top = s.blocks[s.blocks.length - 1];
-        const sliderScreenY = top.y - BH + s.camOffset;
-        const nextColor = COLORS[(s.colorIdx + 1) % COLORS.length];
-        ctx.fillStyle = 'rgba(255,255,255,0.05)';
-        ctx.fillRect(top.x, sliderScreenY, top.w, BH - 2);
-        ctx.fillStyle = nextColor;
-        ctx.fillRect(s.curX, sliderScreenY, s.curW, BH - 2);
-        ctx.fillStyle = 'rgba(255,255,255,0.25)';
-        ctx.fillRect(s.curX, sliderScreenY, s.curW, 5);
-      }
-
-      ctx.font = 'bold 36px Arial';
-      ctx.fillStyle = 'rgba(255,255,255,0.85)';
-      ctx.textAlign = 'center';
-      ctx.fillText(`${s.score}`, W / 2, 55);
-      ctx.font = '13px Arial';
-      ctx.fillStyle = 'rgba(255,255,255,0.35)';
-      ctx.fillText('TAP to drop!', W / 2, 74);
-
-      s.raf = requestAnimationFrame(loop);
+    if (s.phase === 'playing') {
+      s.curX += s.curDir * s.curSpeed;
+      const top = s.blocks[s.blocks.length - 1];
+      if (s.curDir > 0 && s.curX > W + 20) s.curDir = -1;
+      if (s.curDir < 0 && s.curX + s.curW < -20) s.curDir = 1;
+      if (s.curX < -W * 0.4) { s.curDir = 1; s.curX = -W * 0.4; }
+      if (s.curX + s.curW > W + W * 0.4) { s.curDir = -1; s.curX = W + W * 0.4 - s.curW; }
+      void top;
     }
 
-    st.current.raf = requestAnimationFrame(loop);
-    const stRef = st.current;
-    return () => cancelAnimationFrame(stRef.raf);
-  }, []);
+    const grad = ctx.createLinearGradient(0, 0, 0, H);
+    grad.addColorStop(0, '#0f172a');
+    grad.addColorStop(1, '#1e293b');
+    ctx.fillStyle = grad;
+    ctx.fillRect(0, 0, W, H);
+
+    for (const block of s.blocks) {
+      const drawY = block.y + s.camOffset;
+      if (drawY > H + BH || drawY < -BH) continue;
+      ctx.fillStyle = block.color;
+      ctx.fillRect(block.x, drawY, block.w, BH - 2);
+      ctx.fillStyle = 'rgba(255,255,255,0.18)';
+      ctx.fillRect(block.x, drawY, block.w, 5);
+      ctx.fillStyle = 'rgba(0,0,0,0.25)';
+      ctx.fillRect(block.x, drawY + BH - 5, block.w, 3);
+    }
+
+    if (s.phase === 'playing' && s.blocks.length > 0) {
+      const top = s.blocks[s.blocks.length - 1];
+      const sliderScreenY = top.y - BH + s.camOffset;
+      const nextColor = COLORS[(s.colorIdx + 1) % COLORS.length];
+      ctx.fillStyle = 'rgba(255,255,255,0.05)';
+      ctx.fillRect(top.x, sliderScreenY, top.w, BH - 2);
+      ctx.fillStyle = nextColor;
+      ctx.fillRect(s.curX, sliderScreenY, s.curW, BH - 2);
+      ctx.fillStyle = 'rgba(255,255,255,0.25)';
+      ctx.fillRect(s.curX, sliderScreenY, s.curW, 5);
+    }
+
+    ctx.font = 'bold 36px Arial';
+    ctx.fillStyle = 'rgba(255,255,255,0.85)';
+    ctx.textAlign = 'center';
+    ctx.fillText(`${s.score}`, W / 2, 55);
+    ctx.font = '13px Arial';
+    ctx.fillStyle = 'rgba(255,255,255,0.35)';
+    ctx.fillText('TAP to drop!', W / 2, 74);
+  });
 
   useEffect(() => {
     const kd = (e: KeyboardEvent) => {
@@ -145,9 +130,6 @@ export function useStackGame() {
     window.addEventListener('keydown', kd);
     return () => window.removeEventListener('keydown', kd);
   }, [drop]);
-
-  // suppress unused warning from module-level helper
-  void makeBricks;
 
   return { canvasRef, startGame, drop, handleCanvasClick };
 }

--- a/gamesformykids/hooks/shared/common/index.ts
+++ b/gamesformykids/hooks/shared/common/index.ts
@@ -3,3 +3,5 @@
  * Shared Common Hooks - Index
  * ===============================================
  */
+
+export { useCanvasLoop } from './useCanvasLoop';

--- a/gamesformykids/hooks/shared/common/useCanvasLoop.ts
+++ b/gamesformykids/hooks/shared/common/useCanvasLoop.ts
@@ -1,0 +1,41 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+
+/**
+ * Manages the requestAnimationFrame lifecycle for a canvas game loop.
+ *
+ * Returns a canvasRef to attach to the <canvas> element.
+ * Calls `tick(ctx, dt)` every frame where dt is milliseconds since the
+ * previous frame. The tick callback is stored in a ref so it may close
+ * over game state without causing the effect to re-run.
+ */
+export function useCanvasLoop(
+  tick: (ctx: CanvasRenderingContext2D, dt: number) => void,
+): React.RefObject<HTMLCanvasElement | null> {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const tickRef   = useRef(tick);
+  tickRef.current = tick;
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+
+    let rafId  = 0;
+    let last   = performance.now();
+
+    function loop(now: number) {
+      const dt = now - last;
+      last = now;
+      tickRef.current(ctx!, dt);
+      rafId = requestAnimationFrame(loop);
+    }
+
+    rafId = requestAnimationFrame(loop);
+    return () => cancelAnimationFrame(rafId);
+  }, []);
+
+  return canvasRef;
+}


### PR DESCRIPTION
## Summary
- Adds `hooks/shared/common/useCanvasLoop.ts` — manages `requestAnimationFrame` lifecycle, canvas/ctx acquisition, and stale-closure-safe tick dispatch via `tickRef`
- Applies the hook to all 10 canvas games: catch-fruit, dino-runner, brick-breaker, flappy-bird, pong, space-defender, jumper, frogger, meteor-dodge, stack
- Removes ~100 lines of duplicated RAF boilerplate across the codebase

**Special cases handled:**
- `catch-fruit` / `space-defender`: use the `dt` parameter from the hook instead of a local `lastTime` variable
- `flappy-bird`: `drawRoundRect` moved to module level (gains a `ctx` param); `drawFrame` inlined into tick
- `brick-breaker`: `brickRect` moved to module level (pure function, only uses module constants)
- `pong`: `addParticles` defined as a local function inside the tick callback

Closes #290

## Test plan
- [ ] Build passes (`tsc --noEmit` clean except pre-existing supabase errors)
- [ ] All 10 canvas games render and respond to input
- [ ] RAF loop starts on mount and cancels on unmount (no memory leaks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)