### PR TITLE
refactor: ColorTapPlayArea and EmojiMathPlayArea use game hook

### DIFF
--- a/gamesformykids/app/games/color-tap/components/ColorTapPlayArea.tsx
+++ b/gamesformykids/app/games/color-tap/components/ColorTapPlayArea.tsx
@@ -1,10 +1,9 @@
 'use client';
-import { useShallow } from 'zustand/react/shallow';
-import { useColorTapStore, TIME_PER_Q } from '../colorTapStore';
+import { useColorTapGame, TIME_PER_Q } from '../useColorTapGame';
 
 export default function ColorTapPlayArea() {
   const { question, feedback, timeLeft, score, lives, handleTap } =
-    useColorTapStore(useShallow((s) => s));
+    useColorTapGame();
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-pink-100 to-purple-200 flex flex-col items-center justify-center p-4 select-none" dir="rtl">

--- a/gamesformykids/app/games/emoji-math/components/EmojiMathPlayArea.tsx
+++ b/gamesformykids/app/games/emoji-math/components/EmojiMathPlayArea.tsx
@@ -1,6 +1,5 @@
 'use client';
-import { useShallow } from 'zustand/react/shallow';
-import { useEmojiMathStore, TIME_PER_Q } from '../emojiMathStore';
+import { useEmojiMathGame, TIME_PER_Q } from '../useEmojiMathGame';
 
 function renderEmojis(count: number, emoji: string) {
   return Array.from({ length: Math.min(count, 15) }, (_, i) => (
@@ -10,7 +9,7 @@ function renderEmojis(count: number, emoji: string) {
 
 export default function EmojiMathPlayArea() {
   const { q, feedback, level, timeLeft, score, lives, streak, tap } =
-    useEmojiMathStore(useShallow((s) => s));
+    useEmojiMathGame();
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-yellow-100 to-orange-200 flex flex-col items-center justify-center p-4 select-none" dir="rtl">


### PR DESCRIPTION
## Summary
- `ColorTapPlayArea`: replace `useColorTapStore(useShallow(s => s))` with `useColorTapGame()`
- `EmojiMathPlayArea`: replace `useEmojiMathStore(useShallow(s => s))` with `useEmojiMathGame()`

Both game hooks already existed (`createShallowHook` wrappers); the components were bypassing them.

Closes #291

## Test plan
- [ ] Color-tap game plays correctly
- [ ] Emoji-math game plays correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)