### PR TITLE
refactor: tzedakah sub-components and SimonBoard use game hook

### DIFF
--- a/gamesformykids/app/games/simon/components/SimonBoard.tsx
+++ b/gamesformykids/app/games/simon/components/SimonBoard.tsx
@@ -1,16 +1,13 @@
 'use client';
-import { useShallow } from 'zustand/react/shallow';
-import { useSimonStore } from '../simonStore';
-import { BUTTONS, type ButtonId } from '../useSimonGame';
+import { useSimonGame, BUTTONS, type ButtonId } from '../useSimonGame';
 
 interface Props {
   onTap: (id: ButtonId) => void;
 }
 
 export default function SimonBoard({ onTap }: Props) {
-  const { phase, activeColor, playerIdx, best, sequence } =
-    useSimonStore(useShallow((s) => s));
-  const sequenceLength = sequence.length;
+  const { phase, activeColor, playerIdx, best, sequenceLength } =
+    useSimonGame();
 
   return (
     <div className="flex flex-col items-center gap-6">

--- a/gamesformykids/app/games/tzedakah/components/CharityBasket.tsx
+++ b/gamesformykids/app/games/tzedakah/components/CharityBasket.tsx
@@ -1,10 +1,9 @@
 'use client';
-import { useShallow } from 'zustand/react/shallow';
-import { useTzedakahStore } from '../tzedakahStore';
+import { useCharityCoinGame } from '../useCharityCoinGame';
 
 export default function CharityBasket() {
   const { basketX, basketWidth, basketHeight, gameStarted, isMobile } =
-    useTzedakahStore(useShallow((s) => s));
+    useCharityCoinGame();
 
   return (
     <div

--- a/gamesformykids/app/games/tzedakah/components/CharityGameHeader.tsx
+++ b/gamesformykids/app/games/tzedakah/components/CharityGameHeader.tsx
@@ -1,10 +1,9 @@
 'use client';
-import { useShallow } from 'zustand/react/shallow';
-import { useTzedakahStore } from '../tzedakahStore';
+import { useCharityCoinGame } from '../useCharityCoinGame';
 
 export default function CharityGameHeader() {
   const { score, gameTime, collectedCoins, isMobile } =
-    useTzedakahStore(useShallow((s) => s));
+    useCharityCoinGame();
 
   return (
     <>

--- a/gamesformykids/app/games/tzedakah/components/GameControls.tsx
+++ b/gamesformykids/app/games/tzedakah/components/GameControls.tsx
@@ -1,10 +1,9 @@
 'use client';
-import { useShallow } from 'zustand/react/shallow';
-import { useTzedakahStore } from '../tzedakahStore';
+import { useCharityCoinGame } from '../useCharityCoinGame';
 
 export default function GameControls() {
   const { gameStarted, gameTime, score, collectedCoins, isMobile, startGame } =
-    useTzedakahStore(useShallow((s) => s));
+    useCharityCoinGame();
 
   return (
     <div className="flex justify-center mb-6">

--- a/gamesformykids/app/games/tzedakah/useCharityCoinGame.ts
+++ b/gamesformykids/app/games/tzedakah/useCharityCoinGame.ts
@@ -8,7 +8,8 @@ import { useRouter } from 'next/navigation';
 export type { Coin } from './tzedakahStore';
 
 export function useCharityCoinGame() {
-  const { isMobile, gameWidth, gameHeight, basketWidth, gameStarted, moveBasket, stepBasket, setIsMobile } =
+  const { isMobile, gameWidth, gameHeight, basketX, basketWidth, basketHeight, gameStarted,
+          score, gameTime, collectedCoins, startGame, moveBasket, stepBasket, setIsMobile } =
     useTzedakahStore(useShallow((s) => s));
 
   const router = useRouter();
@@ -46,5 +47,6 @@ export function useCharityCoinGame() {
     moveBasket(e.touches[0].clientX - rect.left - basketWidth / 2);
   };
 
-  return { isMobile, gameWidth, gameHeight, handleMouseMove, handleTouchMove, nextGame, router };
+  return { isMobile, gameWidth, gameHeight, basketX, basketWidth, basketHeight, gameStarted,
+           score, gameTime, collectedCoins, startGame, handleMouseMove, handleTouchMove, nextGame, router };
 }


### PR DESCRIPTION
## Summary
- `CharityBasket`, `CharityGameHeader`, `GameControls`: replace `useTzedakahStore(useShallow(s => s))` with `useCharityCoinGame()`
- `SimonBoard`: replace `useSimonStore(useShallow(s => s))` + manual `sequence.length` with `useSimonGame()` (exposes `sequenceLength` directly)
- Extended `useCharityCoinGame` to return `basketX`, `basketHeight`, `gameStarted`, `score`, `gameTime`, `collectedCoins`, `startGame` — fields the sub-components need

Closes #292

## Test plan
- [ ] Tzedakah game renders and plays correctly (basket moves, coins fall, timer counts down, score updates)
- [ ] Simon game renders correctly (board shows, sequence plays, player input works)

🤖 Generated with [Claude Code](https://claude.com/claude-code)