### PR TITLE
refactor: extract *MenuScreen components from 9 root game files (#293)

### DIFF
--- a/gamesformykids/app/games/balloon-pop/BalloonPopGame.tsx
+++ b/gamesformykids/app/games/balloon-pop/BalloonPopGame.tsx
@@ -1,30 +1,17 @@
 'use client';
 import { useEffect } from 'react';
 import { useBalloonPopStore, stopBalloonPopGame } from './balloonPopStore';
-import GameMenuCard from '@/components/game/shared/GameMenuCard';
+import BalloonPopMenuScreen from './components/BalloonPopMenuScreen';
 import BalloonResultScreen from './components/BalloonResultScreen';
 import BalloonHUD from './components/BalloonHUD';
 import BalloonGameArea from './components/BalloonGameArea';
 
 export default function BalloonPopGame() {
-  const phase     = useBalloonPopStore(s => s.phase);
-  const best      = useBalloonPopStore(s => s.best);
-  const startGame = useBalloonPopStore(s => s.startGame);
+  const phase = useBalloonPopStore(s => s.phase);
 
   useEffect(() => stopBalloonPopGame, []);
 
-  if (phase === 'menu') return (
-    <GameMenuCard
-      emoji="🎈"
-      title="פוצץ בלונים!"
-      description="הקש על בלונים לפני שהם עפים · הימנע מפצצות 💣"
-      gradientClass="from-sky-200 to-blue-400"
-      buttonClass="from-pink-500 to-rose-500"
-      onStart={startGame}
-      startLabel="🎈 התחל!"
-      best={best}
-    />
-  );
+  if (phase === 'menu') return <BalloonPopMenuScreen />;
   if (phase === 'result') return <BalloonResultScreen />;
 
   return (

--- a/gamesformykids/app/games/balloon-pop/components/BalloonPopMenuScreen.tsx
+++ b/gamesformykids/app/games/balloon-pop/components/BalloonPopMenuScreen.tsx
@@ -1,0 +1,20 @@
+'use client';
+import GameMenuCard from '@/components/game/shared/GameMenuCard';
+import { useBalloonPopStore } from '../balloonPopStore';
+
+export default function BalloonPopMenuScreen() {
+  const best      = useBalloonPopStore(s => s.best);
+  const startGame = useBalloonPopStore(s => s.startGame);
+  return (
+    <GameMenuCard
+      emoji="🎈"
+      title="פוצץ בלונים!"
+      description="הקש על בלונים לפני שהם עפים · הימנע מפצצות 💣"
+      gradientClass="from-sky-200 to-blue-400"
+      buttonClass="from-pink-500 to-rose-500"
+      onStart={startGame}
+      startLabel="🎈 התחל!"
+      best={best}
+    />
+  );
+}

--- a/gamesformykids/app/games/color-tap/ColorTapGame.tsx
+++ b/gamesformykids/app/games/color-tap/ColorTapGame.tsx
@@ -1,25 +1,13 @@
 'use client';
 import { useColorTapGame } from './useColorTapGame';
-import GameMenuCard from '@/components/game/shared/GameMenuCard';
 import ScoreBestResultCard from '@/components/game/shared/ScoreBestResultCard';
+import ColorTapMenuScreen from './components/ColorTapMenuScreen';
 import ColorTapPlayArea from './components/ColorTapPlayArea';
 
 export default function ColorTapGame() {
   const { phase, score, best, startGame } = useColorTapGame();
 
-  if (phase === 'menu') return (
-    <GameMenuCard
-      emoji="🎨"
-      title="צבע נכון"
-      description="בחר את הצבע הנכון לפני שהזמן נגמר!"
-      hint="3 חיים · 5 שניות לכל שאלה"
-      gradientClass="from-pink-100 to-purple-200"
-      buttonClass="from-pink-500 to-purple-600"
-      onStart={startGame}
-      startLabel="🎨 התחל!"
-      best={best}
-    />
-  );
+  if (phase === 'menu') return <ColorTapMenuScreen />;
   if (phase === 'dead') return (
     <ScoreBestResultCard
       emoji="😢"

--- a/gamesformykids/app/games/color-tap/components/ColorTapMenuScreen.tsx
+++ b/gamesformykids/app/games/color-tap/components/ColorTapMenuScreen.tsx
@@ -1,0 +1,20 @@
+'use client';
+import GameMenuCard from '@/components/game/shared/GameMenuCard';
+import { useColorTapGame } from '../useColorTapGame';
+
+export default function ColorTapMenuScreen() {
+  const { best, startGame } = useColorTapGame();
+  return (
+    <GameMenuCard
+      emoji="🎨"
+      title="צבע נכון"
+      description="בחר את הצבע הנכון לפני שהזמן נגמר!"
+      hint="3 חיים · 5 שניות לכל שאלה"
+      gradientClass="from-pink-100 to-purple-200"
+      buttonClass="from-pink-500 to-purple-600"
+      onStart={startGame}
+      startLabel="🎨 התחל!"
+      best={best}
+    />
+  );
+}

--- a/gamesformykids/app/games/emoji-math/EmojiMathGame.tsx
+++ b/gamesformykids/app/games/emoji-math/EmojiMathGame.tsx
@@ -1,25 +1,13 @@
 'use client';
 import { useEmojiMathGame } from './useEmojiMathGame';
-import GameMenuCard from '@/components/game/shared/GameMenuCard';
 import ScoreBestResultCard from '@/components/game/shared/ScoreBestResultCard';
+import EmojiMathMenuScreen from './components/EmojiMathMenuScreen';
 import EmojiMathPlayArea from './components/EmojiMathPlayArea';
 
 export default function EmojiMathGame() {
   const { phase, score, best, startGame } = useEmojiMathGame();
 
-  if (phase === 'menu') return (
-    <GameMenuCard
-      emoji="🧮"
-      title="מתמטיקה עם אמוג'י"
-      description="ספור את האמוג'י ופתור את התרגיל!"
-      hint="3 חיים · רצף מנצח = +20 נקודות"
-      gradientClass="from-yellow-100 to-orange-200"
-      buttonClass="from-yellow-400 to-orange-500"
-      onStart={startGame}
-      startLabel="🧮 התחל!"
-      best={best}
-    />
-  );
+  if (phase === 'menu') return <EmojiMathMenuScreen />;
   if (phase === 'dead') return (
     <ScoreBestResultCard
       emoji="🤓"

--- a/gamesformykids/app/games/emoji-math/components/EmojiMathMenuScreen.tsx
+++ b/gamesformykids/app/games/emoji-math/components/EmojiMathMenuScreen.tsx
@@ -1,0 +1,20 @@
+'use client';
+import GameMenuCard from '@/components/game/shared/GameMenuCard';
+import { useEmojiMathGame } from '../useEmojiMathGame';
+
+export default function EmojiMathMenuScreen() {
+  const { best, startGame } = useEmojiMathGame();
+  return (
+    <GameMenuCard
+      emoji="🧮"
+      title="מתמטיקה עם אמוג'י"
+      description="ספור את האמוג'י ופתור את התרגיל!"
+      hint="3 חיים · רצף מנצח = +20 נקודות"
+      gradientClass="from-yellow-100 to-orange-200"
+      buttonClass="from-yellow-400 to-orange-500"
+      onStart={startGame}
+      startLabel="🧮 התחל!"
+      best={best}
+    />
+  );
+}

--- a/gamesformykids/app/games/math-race/MathRaceGame.tsx
+++ b/gamesformykids/app/games/math-race/MathRaceGame.tsx
@@ -1,26 +1,13 @@
 'use client';
-import { useMathRaceStore } from './mathRaceStore';
-import { GAME_TIME } from './mathRaceStore';
-import GameMenuCard from '@/components/game/shared/GameMenuCard';
+import { useMathRaceGame } from './useMathRaceGame';
+import MathRaceMenuScreen from './components/MathRaceMenuScreen';
 import MathRaceResultScreen from './components/MathRaceResultScreen';
 import MathRacePlayScreen from './components/MathRacePlayScreen';
 
 export default function MathRaceGame() {
-  const { phase, best, startGame } = useMathRaceStore();
+  const { phase } = useMathRaceGame();
 
-  if (phase === 'menu') return (
-    <GameMenuCard
-      emoji="🏎️"
-      title="מרוץ מתמטיקה"
-      description={`פתור כמה שיותר תרגילים ב-${GAME_TIME} שניות!`}
-      hint="רצף 3+ = 20 נקודות · הקושי עולה עם הניקוד"
-      gradientClass="from-blue-100 to-indigo-200"
-      buttonClass="from-blue-500 to-indigo-600"
-      onStart={startGame}
-      startLabel="🏎️ התחל!"
-      best={best}
-    />
-  );
+  if (phase === 'menu') return <MathRaceMenuScreen />;
   if (phase === 'dead') return <MathRaceResultScreen />;
   return <MathRacePlayScreen />;
 }

--- a/gamesformykids/app/games/math-race/components/MathRaceMenuScreen.tsx
+++ b/gamesformykids/app/games/math-race/components/MathRaceMenuScreen.tsx
@@ -1,0 +1,20 @@
+'use client';
+import GameMenuCard from '@/components/game/shared/GameMenuCard';
+import { useMathRaceGame, GAME_TIME } from '../useMathRaceGame';
+
+export default function MathRaceMenuScreen() {
+  const { best, startGame } = useMathRaceGame();
+  return (
+    <GameMenuCard
+      emoji="🏎️"
+      title="מרוץ מתמטיקה"
+      description={`פתור כמה שיותר תרגילים ב-${GAME_TIME} שניות!`}
+      hint="רצף 3+ = 20 נקודות · הקושי עולה עם הניקוד"
+      gradientClass="from-blue-100 to-indigo-200"
+      buttonClass="from-blue-500 to-indigo-600"
+      onStart={startGame}
+      startLabel="🏎️ התחל!"
+      best={best}
+    />
+  );
+}

--- a/gamesformykids/app/games/simon/SimonGame.tsx
+++ b/gamesformykids/app/games/simon/SimonGame.tsx
@@ -1,27 +1,15 @@
 'use client';
 import { useSimonGame } from './useSimonGame';
-import GameMenuCard from '@/components/game/shared/GameMenuCard';
+import SimonMenuScreen from './components/SimonMenuScreen';
 import SimonBoard from './components/SimonBoard';
 import SimonGameOverScreen from './components/SimonGameOverScreen';
 
 export default function SimonGame() {
-  const { phase, best, startGame, handleTap } = useSimonGame();
+  const { phase, handleTap } = useSimonGame();
 
   return (
     <div className="min-h-screen bg-gray-900 flex flex-col items-center justify-center p-4 select-none" dir="rtl">
-      {phase === 'menu' && (
-        <GameMenuCard
-          emoji="🔴"
-          title="שיימון אומר"
-          description="צפה בסדר הצבעים וחזור עליהם בדיוק!"
-          hint="כל סיבוב — עוד צבע אחד"
-          gradientClass="from-gray-800 to-gray-900"
-          buttonClass="from-gray-600 to-gray-800"
-          onStart={startGame}
-          startLabel="🔴 התחל!"
-          best={best}
-        />
-      )}
+      {phase === 'menu' && <SimonMenuScreen />}
       {(phase === 'showing' || phase === 'input') && <SimonBoard onTap={handleTap} />}
       {phase === 'dead' && <SimonGameOverScreen />}
     </div>

--- a/gamesformykids/app/games/simon/components/SimonMenuScreen.tsx
+++ b/gamesformykids/app/games/simon/components/SimonMenuScreen.tsx
@@ -1,0 +1,20 @@
+'use client';
+import GameMenuCard from '@/components/game/shared/GameMenuCard';
+import { useSimonGame } from '../useSimonGame';
+
+export default function SimonMenuScreen() {
+  const { best, startGame } = useSimonGame();
+  return (
+    <GameMenuCard
+      emoji="🔴"
+      title="שיימון אומר"
+      description="צפה בסדר הצבעים וחזור עליהם בדיוק!"
+      hint="כל סיבוב — עוד צבע אחד"
+      gradientClass="from-gray-800 to-gray-900"
+      buttonClass="from-gray-600 to-gray-800"
+      onStart={startGame}
+      startLabel="🔴 התחל!"
+      best={best}
+    />
+  );
+}

--- a/gamesformykids/app/games/true-false/TrueFalseGame.tsx
+++ b/gamesformykids/app/games/true-false/TrueFalseGame.tsx
@@ -1,25 +1,13 @@
 'use client';
-import { useTrueFalseGame, TIME_PER_Q } from './useTrueFalseGame';
-import GameMenuCard from '@/components/game/shared/GameMenuCard';
+import { useTrueFalseGame } from './useTrueFalseGame';
+import TrueFalseMenuScreen from './components/TrueFalseMenuScreen';
 import TrueFalsePlayScreen from './components/TrueFalsePlayScreen';
 import ScoreBestResultCard from '@/components/game/shared/ScoreBestResultCard';
 
 export default function TrueFalseGame() {
   const { phase, score, best, startGame } = useTrueFalseGame();
 
-  if (phase === 'menu') return (
-    <GameMenuCard
-      emoji="🤔"
-      title="נכון או לא נכון?"
-      description="קרא את המשפט ולחץ ✅ או ❌"
-      hint={`3 חיים · ${TIME_PER_Q} שניות לכל שאלה`}
-      gradientClass="from-teal-100 to-cyan-200"
-      buttonClass="from-teal-500 to-cyan-600"
-      onStart={startGame}
-      startLabel="✅ התחל!"
-      best={best}
-    />
-  );
+  if (phase === 'menu') return <TrueFalseMenuScreen />;
   if (phase === 'dead') return (
     <ScoreBestResultCard
       emoji="🧠"

--- a/gamesformykids/app/games/true-false/components/TrueFalseMenuScreen.tsx
+++ b/gamesformykids/app/games/true-false/components/TrueFalseMenuScreen.tsx
@@ -1,0 +1,20 @@
+'use client';
+import GameMenuCard from '@/components/game/shared/GameMenuCard';
+import { useTrueFalseGame, TIME_PER_Q } from '../useTrueFalseGame';
+
+export default function TrueFalseMenuScreen() {
+  const { best, startGame } = useTrueFalseGame();
+  return (
+    <GameMenuCard
+      emoji="🤔"
+      title="נכון או לא נכון?"
+      description="קרא את המשפט ולחץ ✅ או ❌"
+      hint={`3 חיים · ${TIME_PER_Q} שניות לכל שאלה`}
+      gradientClass="from-teal-100 to-cyan-200"
+      buttonClass="from-teal-500 to-cyan-600"
+      onStart={startGame}
+      startLabel="✅ התחל!"
+      best={best}
+    />
+  );
+}

--- a/gamesformykids/app/games/whack-a-mole/WhackAMoleGame.tsx
+++ b/gamesformykids/app/games/whack-a-mole/WhackAMoleGame.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useWhackAMoleGame } from './useWhackAMoleGame';
-import GameMenuCard from '@/components/game/shared/GameMenuCard';
+import WhackAMoleMenuScreen from './components/WhackAMoleMenuScreen';
 import ScoreBestResultCard from '@/components/game/shared/ScoreBestResultCard';
 import WhackHUD from './components/WhackHUD';
 import WhackGrid from './components/WhackGrid';
@@ -9,19 +9,7 @@ import WhackGrid from './components/WhackGrid';
 export default function WhackAMoleGame() {
   const { phase, score, best, bgColor, startGame } = useWhackAMoleGame();
 
-  if (phase === 'menu') return (
-    <GameMenuCard
-      emoji="🐹"
-      title="חבט על החפרפרת!"
-      description="הקש על החפרפרות לפני שהן נעלמות · הימנע מהפצצות 💣"
-      gradientClass="from-yellow-50 to-amber-100"
-      buttonClass="from-amber-500 to-orange-500"
-      onStart={startGame}
-      startLabel="🔨 התחל!"
-      best={best}
-      animateEmoji
-    />
-  );
+  if (phase === 'menu') return <WhackAMoleMenuScreen />;
 
   if (phase === 'result') return (
     <ScoreBestResultCard

--- a/gamesformykids/app/games/whack-a-mole/components/WhackAMoleMenuScreen.tsx
+++ b/gamesformykids/app/games/whack-a-mole/components/WhackAMoleMenuScreen.tsx
@@ -1,0 +1,20 @@
+'use client';
+import GameMenuCard from '@/components/game/shared/GameMenuCard';
+import { useWhackAMoleGame } from '../useWhackAMoleGame';
+
+export default function WhackAMoleMenuScreen() {
+  const { best, startGame } = useWhackAMoleGame();
+  return (
+    <GameMenuCard
+      emoji="🐹"
+      title="חבט על החפרפרת!"
+      description="הקש על החפרפרות לפני שהן נעלמות · הימנע מהפצצות 💣"
+      gradientClass="from-yellow-50 to-amber-100"
+      buttonClass="from-amber-500 to-orange-500"
+      onStart={startGame}
+      startLabel="🔨 התחל!"
+      best={best}
+      animateEmoji
+    />
+  );
+}

--- a/gamesformykids/app/games/word-builder/WordBuilderGame.tsx
+++ b/gamesformykids/app/games/word-builder/WordBuilderGame.tsx
@@ -1,24 +1,14 @@
 'use client';
 
 import { useWordBuilderGame } from './useWordBuilderGame';
-import GameMenuCard from '@/components/game/shared/GameMenuCard';
+import WordBuilderMenuScreen from './components/WordBuilderMenuScreen';
 import WordBuilderQuestion from './components/WordBuilderQuestion';
 import WordBuilderResultScreen from './components/WordBuilderResultScreen';
 
 export default function WordBuilderGame() {
-  const { phase, startGame } = useWordBuilderGame();
+  const { phase } = useWordBuilderGame();
 
-  if (phase === 'menu') return (
-    <GameMenuCard
-      emoji="🔤"
-      title="בניית מילים"
-      description="סדר את האותיות ובנה את המילה הנכונה!"
-      gradientClass="from-orange-50 to-amber-100"
-      buttonClass="from-orange-500 to-amber-500"
-      onStart={startGame}
-      startLabel="🚀 התחל!"
-    />
-  );
+  if (phase === 'menu') return <WordBuilderMenuScreen />;
 
   if (phase === 'playing') return <WordBuilderQuestion />;
 

--- a/gamesformykids/app/games/word-builder/components/WordBuilderMenuScreen.tsx
+++ b/gamesformykids/app/games/word-builder/components/WordBuilderMenuScreen.tsx
@@ -1,0 +1,18 @@
+'use client';
+import GameMenuCard from '@/components/game/shared/GameMenuCard';
+import { useWordBuilderGame } from '../useWordBuilderGame';
+
+export default function WordBuilderMenuScreen() {
+  const { startGame } = useWordBuilderGame();
+  return (
+    <GameMenuCard
+      emoji="🔤"
+      title="בניית מילים"
+      description="סדר את האותיות ובנה את המילה הנכונה!"
+      gradientClass="from-orange-50 to-amber-100"
+      buttonClass="from-orange-500 to-amber-500"
+      onStart={startGame}
+      startLabel="🚀 התחל!"
+    />
+  );
+}

--- a/gamesformykids/app/games/word-scramble/WordScrambleGame.tsx
+++ b/gamesformykids/app/games/word-scramble/WordScrambleGame.tsx
@@ -1,23 +1,13 @@
 'use client';
 import { useWordScrambleGame } from './useWordScrambleGame';
-import GameMenuCard from '@/components/game/shared/GameMenuCard';
+import WordScrambleMenuScreen from './components/WordScrambleMenuScreen';
 import WordScramblePlayScreen from './components/WordScramblePlayScreen';
 import WordScrambleResultScreen from './components/WordScrambleResultScreen';
 
 export default function WordScrambleGame() {
-  const { phase, startGame } = useWordScrambleGame();
+  const { phase } = useWordScrambleGame();
 
-  if (phase === 'menu') return (
-    <GameMenuCard
-      emoji="🔡"
-      title="מילים מבולבלות"
-      description="לחצו על האותיות בסדר הנכון כדי לכתוב את המילה!"
-      gradientClass="from-green-100 to-emerald-200"
-      buttonClass="from-green-500 to-emerald-600"
-      onStart={startGame}
-      startLabel="🔡 התחל!"
-    />
-  );
+  if (phase === 'menu') return <WordScrambleMenuScreen />;
   if (phase === 'results') return <WordScrambleResultScreen />;
   return <WordScramblePlayScreen />;
 }

--- a/gamesformykids/app/games/word-scramble/components/WordScrambleMenuScreen.tsx
+++ b/gamesformykids/app/games/word-scramble/components/WordScrambleMenuScreen.tsx
@@ -1,0 +1,18 @@
+'use client';
+import GameMenuCard from '@/components/game/shared/GameMenuCard';
+import { useWordScrambleGame } from '../useWordScrambleGame';
+
+export default function WordScrambleMenuScreen() {
+  const { startGame } = useWordScrambleGame();
+  return (
+    <GameMenuCard
+      emoji="🔡"
+      title="מילים מבולבלות"
+      description="לחצו על האותיות בסדר הנכון כדי לכתוב את המילה!"
+      gradientClass="from-green-100 to-emerald-200"
+      buttonClass="from-green-500 to-emerald-600"
+      onStart={startGame}
+      startLabel="🔡 התחל!"
+    />
+  );
+}


### PR DESCRIPTION
## Summary
- Extracted 9 dedicated `*MenuScreen` components (one per game) so that `GameMenuCard` props live close to their game's logic
- Root `*Game.tsx` files are now pure phase-routers: `if (phase === 'menu') return <XMenuScreen />`
- Removed unused imports (`GameMenuCard`, `GAME_TIME`, `TIME_PER_Q`) from root files; removed orphaned store subscriptions (`best`, `startGame`) from roots that no longer need them
- `BalloonPopGame` retains its `useEffect(() => stopBalloonPopGame, [])` cleanup; `SimonGame` retains its wrapper `div`

## Test plan
- [ ] TypeScript passes (`tsc --noEmit`) — pre-existing errors in `lib/supabase/server.ts` and `middleware.ts` are unrelated
- [ ] CI green
- [ ] Each game's menu screen renders correctly in browser
- [ ] Play and result phases unaffected

Closes #293

🤖 Generated with [Claude Code](https://claude.com/claude-code)