### PR TITLE
refactor: canvas game hooks expose UI state, drop dual store subscriptions (#299)

### DIFF
--- a/gamesformykids/app/games/brick-breaker/BrickBreakerGame.tsx
+++ b/gamesformykids/app/games/brick-breaker/BrickBreakerGame.tsx
@@ -1,8 +1,6 @@
 'use client';
 
-import { useShallow } from 'zustand/react/shallow';
 import { useBrickBreakerGame, W, H } from './useBrickBreakerGame';
-import { useBrickBreakerStore } from './brickBreakerStore';
 import { CanvasScoreBar } from '@/components/game/shared/CanvasScoreBar';
 import { CanvasMenuOverlay } from '@/components/game/shared/CanvasMenuOverlay';
 import BrickGameOverOverlay from './components/BrickGameOverOverlay';
@@ -10,10 +8,7 @@ import { CanvasLRControls } from '@/components/game/shared/CanvasLRControls';
 import CanvasGameShell from '@/components/game/canvas/CanvasGameShell';
 
 export default function BrickBreakerGame() {
-  const { canvasRef, startGame, handleMouseMove, handleTouchMove, handleTouchStart, handleClick, nudgeLeft, nudgeRight } = useBrickBreakerGame();
-  const { phase, score, best, lives, level } = useBrickBreakerStore(
-    useShallow((s) => ({ phase: s.phase, score: s.score, best: s.best, lives: s.lives, level: s.level })),
-  );
+  const { canvasRef, startGame, handleMouseMove, handleTouchMove, handleTouchStart, handleClick, nudgeLeft, nudgeRight, phase, score, best, lives, level } = useBrickBreakerGame();
 
   return (
     <CanvasGameShell

--- a/gamesformykids/app/games/brick-breaker/useBrickBreakerGame.ts
+++ b/gamesformykids/app/games/brick-breaker/useBrickBreakerGame.ts
@@ -1,6 +1,7 @@
 'use client';
 
 import { useEffect, useRef, useCallback } from 'react';
+import { useShallow } from 'zustand/react/shallow';
 import { useBrickBreakerStore } from './brickBreakerStore';
 import { useCanvasLoop } from '@/hooks/shared/common';
 
@@ -185,5 +186,7 @@ export function useBrickBreakerGame() {
     return () => { clearInterval(interval); window.removeEventListener('keydown', kd); window.removeEventListener('keyup', ku); };
   }, [handleClick]);
 
-  return { canvasRef, startGame, handleMouseMove, handleTouchMove, handleTouchStart, handleClick, nudgeLeft, nudgeRight };
+  const { phase, score, best, lives, level } = useBrickBreakerStore(useShallow(s => ({ phase: s.phase, score: s.score, best: s.best, lives: s.lives, level: s.level })));
+
+  return { canvasRef, startGame, handleMouseMove, handleTouchMove, handleTouchStart, handleClick, nudgeLeft, nudgeRight, phase, score, best, lives, level };
 }

--- a/gamesformykids/app/games/catch-fruit/CatchFruitGame.tsx
+++ b/gamesformykids/app/games/catch-fruit/CatchFruitGame.tsx
@@ -1,18 +1,13 @@
 'use client';
 
-import { useShallow } from 'zustand/react/shallow';
 import { useCatchFruitGame, W, H } from './useCatchFruitGame';
-import { useCatchFruitStore } from './catchFruitStore';
 import CatchFruitHUD from './components/CatchFruitHUD';
 import { CanvasMenuOverlay } from '@/components/game/shared/CanvasMenuOverlay';
 import CatchFruitResultOverlay from './components/CatchFruitResultOverlay';
 import CanvasGameShell from '@/components/game/canvas/CanvasGameShell';
 
 export default function CatchFruitGame() {
-  const { canvasRef, startGame, handleMouseMove, handleMouseDown, handleMouseUp, handleTouchMove, handleTouchStart } = useCatchFruitGame();
-  const { phase, best } = useCatchFruitStore(
-    useShallow((s) => ({ phase: s.phase, best: s.best })),
-  );
+  const { canvasRef, startGame, handleMouseMove, handleMouseDown, handleMouseUp, handleTouchMove, handleTouchStart, phase, best } = useCatchFruitGame();
 
   return (
     <CanvasGameShell

--- a/gamesformykids/app/games/catch-fruit/useCatchFruitGame.ts
+++ b/gamesformykids/app/games/catch-fruit/useCatchFruitGame.ts
@@ -1,6 +1,7 @@
 'use client';
 
 import { useRef, useCallback } from 'react';
+import { useShallow } from 'zustand/react/shallow';
 import { useCatchFruitStore, GAME_DURATION } from './catchFruitStore';
 import { useCanvasLoop } from '@/hooks/shared/common';
 
@@ -161,5 +162,7 @@ export function useCatchFruitGame() {
     if (st.current.phase !== 'playing') startGame();
   }, [canvasRef, startGame]);
 
-  return { canvasRef, startGame, handleMouseMove, handleMouseDown, handleMouseUp, handleTouchMove, handleTouchStart };
+  const { phase, best } = useCatchFruitStore(useShallow(s => ({ phase: s.phase, best: s.best })));
+
+  return { canvasRef, startGame, handleMouseMove, handleMouseDown, handleMouseUp, handleTouchMove, handleTouchStart, phase, best };
 }

--- a/gamesformykids/app/games/dino-runner/DinoRunnerGame.tsx
+++ b/gamesformykids/app/games/dino-runner/DinoRunnerGame.tsx
@@ -1,18 +1,13 @@
 'use client';
 
-import { useShallow } from 'zustand/react/shallow';
 import { useDinoRunnerGame, W, H } from './useDinoRunnerGame';
-import { useDinoRunnerStore } from './dinoRunnerStore';
 import { CanvasScoreBar } from '@/components/game/shared/CanvasScoreBar';
 import { CanvasMenuOverlay } from '@/components/game/shared/CanvasMenuOverlay';
 import DinoGameOverOverlay from './components/DinoGameOverOverlay';
 import CanvasGameShell from '@/components/game/canvas/CanvasGameShell';
 
 export default function DinoRunnerGame() {
-  const { canvasRef, handleTap } = useDinoRunnerGame();
-  const { phase, score, best } = useDinoRunnerStore(
-    useShallow((s) => ({ phase: s.phase, score: s.score, best: s.best })),
-  );
+  const { canvasRef, handleTap, phase, score, best } = useDinoRunnerGame();
 
   return (
     <CanvasGameShell

--- a/gamesformykids/app/games/dino-runner/useDinoRunnerGame.ts
+++ b/gamesformykids/app/games/dino-runner/useDinoRunnerGame.ts
@@ -1,6 +1,7 @@
 'use client';
 
 import { useEffect, useRef, useCallback } from 'react';
+import { useShallow } from 'zustand/react/shallow';
 import { useDinoRunnerStore } from './dinoRunnerStore';
 import { useCanvasLoop } from '@/hooks/shared/common';
 
@@ -160,5 +161,7 @@ export function useDinoRunnerGame() {
     jump();
   }, [jump]);
 
-  return { canvasRef, jump, handleTap };
+  const { phase, score, best } = useDinoRunnerStore(useShallow(s => ({ phase: s.phase, score: s.score, best: s.best })));
+
+  return { canvasRef, jump, handleTap, phase, score, best };
 }

--- a/gamesformykids/app/games/flappy-bird/FlappyBirdGame.tsx
+++ b/gamesformykids/app/games/flappy-bird/FlappyBirdGame.tsx
@@ -1,15 +1,12 @@
 'use client';
 
 import { useFlappyBirdGame, W, H } from './useFlappyBirdGame';
-import { useFlappyBirdStore } from './flappyBirdStore';
 import { CanvasMenuOverlay } from '@/components/game/shared/CanvasMenuOverlay';
 import FlappyGameOverOverlay from './components/FlappyGameOverOverlay';
 import CanvasGameShell from '@/components/game/canvas/CanvasGameShell';
-import { useShallow } from 'zustand/react/shallow';
 
 export default function FlappyBirdGame() {
-  const { canvasRef, handleInput } = useFlappyBirdGame();
-  const { phase, best } = useFlappyBirdStore(useShallow(s => ({ phase: s.phase, best: s.best })));
+  const { canvasRef, handleInput, phase, best } = useFlappyBirdGame();
 
   return (
     <CanvasGameShell

--- a/gamesformykids/app/games/flappy-bird/useFlappyBirdGame.ts
+++ b/gamesformykids/app/games/flappy-bird/useFlappyBirdGame.ts
@@ -1,6 +1,7 @@
 'use client';
 
 import { useRef, useCallback } from 'react';
+import { useShallow } from 'zustand/react/shallow';
 import { useFlappyBirdStore } from './flappyBirdStore';
 import { useCanvasLoop } from '@/hooks/shared/common';
 
@@ -196,5 +197,7 @@ export function useFlappyBirdGame() {
     flap();
   }, [flap]);
 
-  return { canvasRef, flap, handleInput };
+  const { phase, best } = useFlappyBirdStore(useShallow(s => ({ phase: s.phase, best: s.best })));
+
+  return { canvasRef, flap, handleInput, phase, best };
 }

--- a/gamesformykids/app/games/frogger/FroggerGame.tsx
+++ b/gamesformykids/app/games/frogger/FroggerGame.tsx
@@ -1,17 +1,14 @@
 'use client';
 
 import { useFroggerGame, W, H } from './useFroggerGame';
-import { useFroggerStore } from './froggerStore';
 import { CanvasScoreBar } from '@/components/game/shared/CanvasScoreBar';
 import { CanvasMenuOverlay } from '@/components/game/shared/CanvasMenuOverlay';
 import FroggerGameOverOverlay from './components/FroggerGameOverOverlay';
 import { CanvasDPadControls } from '@/components/game/shared/CanvasDPadControls';
 import CanvasGameShell from '@/components/game/canvas/CanvasGameShell';
-import { useShallow } from 'zustand/react/shallow';
 
 export default function FroggerGame() {
-  const { canvasRef, startGame, moveFrog, handleTouchStart, handleTouchEnd } = useFroggerGame();
-  const { phase, score, lives } = useFroggerStore(useShallow(s => ({ phase: s.phase, score: s.score, lives: s.lives })));
+  const { canvasRef, startGame, moveFrog, handleTouchStart, handleTouchEnd, phase, score, lives } = useFroggerGame();
 
   return (
     <CanvasGameShell

--- a/gamesformykids/app/games/frogger/useFroggerGame.ts
+++ b/gamesformykids/app/games/frogger/useFroggerGame.ts
@@ -1,6 +1,7 @@
 'use client';
 
 import { useEffect, useRef, useCallback } from 'react';
+import { useShallow } from 'zustand/react/shallow';
 import { useFroggerStore } from './froggerStore';
 import { useCanvasLoop } from '@/hooks/shared/common';
 
@@ -153,5 +154,7 @@ export function useFroggerGame() {
     return () => window.removeEventListener('keydown', kd);
   }, [moveFrog]);
 
-  return { canvasRef, startGame, moveFrog, handleTouchStart, handleTouchEnd };
+  const { phase, score, lives } = useFroggerStore(useShallow(s => ({ phase: s.phase, score: s.score, lives: s.lives })));
+
+  return { canvasRef, startGame, moveFrog, handleTouchStart, handleTouchEnd, phase, score, lives };
 }

--- a/gamesformykids/app/games/jumper/JumperGame.tsx
+++ b/gamesformykids/app/games/jumper/JumperGame.tsx
@@ -1,17 +1,14 @@
 'use client';
 
 import { useJumperGame, W, H } from './useJumperGame';
-import { useJumperStore } from './jumperStore';
 import { CanvasScoreBar } from '@/components/game/shared/CanvasScoreBar';
 import { CanvasMenuOverlay } from '@/components/game/shared/CanvasMenuOverlay';
 import JumperGameOverOverlay from './components/JumperGameOverOverlay';
 import { CanvasLRControls } from '@/components/game/shared/CanvasLRControls';
 import CanvasGameShell from '@/components/game/canvas/CanvasGameShell';
-import { useShallow } from 'zustand/react/shallow';
 
 export default function JumperGame() {
-  const { canvasRef, startGame, handleTouchMove, handleTouchEnd, handleCanvasClick, pressLeft, releaseLeft, pressRight, releaseRight } = useJumperGame();
-  const { phase, score, best } = useJumperStore(useShallow(s => ({ phase: s.phase, score: s.score, best: s.best })));
+  const { canvasRef, startGame, handleTouchMove, handleTouchEnd, handleCanvasClick, pressLeft, releaseLeft, pressRight, releaseRight, phase, score, best } = useJumperGame();
 
   return (
     <CanvasGameShell

--- a/gamesformykids/app/games/jumper/useJumperGame.ts
+++ b/gamesformykids/app/games/jumper/useJumperGame.ts
@@ -1,6 +1,7 @@
 'use client';
 
 import { useEffect, useRef, useCallback } from 'react';
+import { useShallow } from 'zustand/react/shallow';
 import { useJumperStore } from './jumperStore';
 import { useCanvasLoop } from '@/hooks/shared/common';
 
@@ -190,5 +191,7 @@ export function useJumperGame() {
     st.current.rightDown = false;
   }, []);
 
-  return { canvasRef, startGame, handleTouchMove, handleTouchEnd, handleCanvasClick, pressLeft, releaseLeft, pressRight, releaseRight };
+  const { phase, score, best } = useJumperStore(useShallow(s => ({ phase: s.phase, score: s.score, best: s.best })));
+
+  return { canvasRef, startGame, handleTouchMove, handleTouchEnd, handleCanvasClick, pressLeft, releaseLeft, pressRight, releaseRight, phase, score, best };
 }

--- a/gamesformykids/app/games/meteor-dodge/MeteorDodgeGame.tsx
+++ b/gamesformykids/app/games/meteor-dodge/MeteorDodgeGame.tsx
@@ -1,17 +1,14 @@
 'use client';
 
 import { useMeteorDodgeGame, W, H } from './useMeteorDodgeGame';
-import { useMeteorDodgeStore } from './meteorDodgeStore';
 import { CanvasScoreBar } from '@/components/game/shared/CanvasScoreBar';
 import { CanvasMenuOverlay } from '@/components/game/shared/CanvasMenuOverlay';
 import MeteorGameOverOverlay from './components/MeteorGameOverOverlay';
 import { CanvasLRControls } from '@/components/game/shared/CanvasLRControls';
 import CanvasGameShell from '@/components/game/canvas/CanvasGameShell';
-import { useShallow } from 'zustand/react/shallow';
 
 export default function MeteorDodgeGame() {
-  const { canvasRef, startGame, handleMouseMove, handleTouchMove, handleCanvasClick, handleTouchStart, nudgeLeft, nudgeRight } = useMeteorDodgeGame();
-  const { phase, score, best } = useMeteorDodgeStore(useShallow(s => ({ phase: s.phase, score: s.score, best: s.best })));
+  const { canvasRef, startGame, handleMouseMove, handleTouchMove, handleCanvasClick, handleTouchStart, nudgeLeft, nudgeRight, phase, score, best } = useMeteorDodgeGame();
 
   return (
     <CanvasGameShell

--- a/gamesformykids/app/games/meteor-dodge/useMeteorDodgeGame.ts
+++ b/gamesformykids/app/games/meteor-dodge/useMeteorDodgeGame.ts
@@ -1,6 +1,7 @@
 'use client';
 
 import { useEffect, useRef, useCallback } from 'react';
+import { useShallow } from 'zustand/react/shallow';
 import { useMeteorDodgeStore } from './meteorDodgeStore';
 import { useCanvasLoop } from '@/hooks/shared/common';
 
@@ -162,5 +163,7 @@ export function useMeteorDodgeGame() {
     s.playerX = Math.min(W - PLAYER_R, s.playerX + 45);
   }, []);
 
-  return { canvasRef, startGame, handleMouseMove, handleTouchMove, handleCanvasClick, handleTouchStart, nudgeLeft, nudgeRight };
+  const { phase, score, best } = useMeteorDodgeStore(useShallow(s => ({ phase: s.phase, score: s.score, best: s.best })));
+
+  return { canvasRef, startGame, handleMouseMove, handleTouchMove, handleCanvasClick, handleTouchStart, nudgeLeft, nudgeRight, phase, score, best };
 }

--- a/gamesformykids/app/games/pong/PongGame.tsx
+++ b/gamesformykids/app/games/pong/PongGame.tsx
@@ -1,8 +1,7 @@
 'use client';
 
-import { useShallow } from 'zustand/react/shallow';
 import { usePongGame, W, H } from './usePongGame';
-import { usePongStore, WIN_SCORE } from './pongStore';
+import { WIN_SCORE } from './pongStore';
 import { CanvasScoreBar } from '@/components/game/shared/CanvasScoreBar';
 import { CanvasMenuOverlay } from '@/components/game/shared/CanvasMenuOverlay';
 import PongResultOverlay from './components/PongResultOverlay';
@@ -10,10 +9,7 @@ import PongControls from './components/PongControls';
 import CanvasGameShell from '@/components/game/canvas/CanvasGameShell';
 
 export default function PongGame() {
-  const { canvasRef, startGame, handleMouseMove, handleTouchMove, handleTouchStart, handleCanvasClick, nudgeLeft, nudgeRight } = usePongGame();
-  const { phase, playerScore, aiScore } = usePongStore(
-    useShallow((s) => ({ phase: s.phase, playerScore: s.playerScore, aiScore: s.aiScore })),
-  );
+  const { canvasRef, startGame, handleMouseMove, handleTouchMove, handleTouchStart, handleCanvasClick, nudgeLeft, nudgeRight, phase, playerScore, aiScore } = usePongGame();
   return (
     <CanvasGameShell
       canvasRef={canvasRef} width={W} height={H}

--- a/gamesformykids/app/games/pong/usePongGame.ts
+++ b/gamesformykids/app/games/pong/usePongGame.ts
@@ -1,6 +1,7 @@
 'use client';
 
 import { useEffect, useRef, useCallback } from 'react';
+import { useShallow } from 'zustand/react/shallow';
 import { usePongStore } from './pongStore';
 import { useCanvasLoop } from '@/hooks/shared/common';
 
@@ -147,9 +148,12 @@ export function usePongGame() {
     return () => { clearInterval(interval); window.removeEventListener('keydown', kd); window.removeEventListener('keyup', ku); };
   }, []);
 
+  const { phase, playerScore, aiScore } = usePongStore(useShallow(s => ({ phase: s.phase, playerScore: s.playerScore, aiScore: s.aiScore })));
+
   return {
     canvasRef, startGame, handleMouseMove, handleTouchMove, handleTouchStart, handleCanvasClick,
     nudgeLeft:  () => { const s = st.current; s.playerX = Math.max(0, s.playerX - 45); },
     nudgeRight: () => { const s = st.current; s.playerX = Math.min(W - PAD_W, s.playerX + 45); },
+    phase, playerScore, aiScore,
   };
 }

--- a/gamesformykids/app/games/space-defender/SpaceDefenderGame.tsx
+++ b/gamesformykids/app/games/space-defender/SpaceDefenderGame.tsx
@@ -1,8 +1,6 @@
 'use client';
 
-import { useShallow } from 'zustand/react/shallow';
 import { useSpaceDefenderGame, W, H } from './useSpaceDefenderGame';
-import { useSpaceDefenderStore } from './spaceDefenderStore';
 import SpaceDefenderHUD from './components/SpaceDefenderHUD';
 import { CanvasMenuOverlay } from '@/components/game/shared/CanvasMenuOverlay';
 import SpaceDefenderResultOverlay from './components/SpaceDefenderResultOverlay';
@@ -10,10 +8,7 @@ import { CanvasLRControls } from '@/components/game/shared/CanvasLRControls';
 import CanvasGameShell from '@/components/game/canvas/CanvasGameShell';
 
 export default function SpaceDefenderGame() {
-  const { canvasRef, shoot, startGame, handleMouseMove, handleCanvasClick, handleTouchMove, handleTouchStart, nudgeLeft, nudgeRight } = useSpaceDefenderGame();
-  const { phase, best } = useSpaceDefenderStore(
-    useShallow((s) => ({ phase: s.phase, best: s.best })),
-  );
+  const { canvasRef, shoot, startGame, handleMouseMove, handleCanvasClick, handleTouchMove, handleTouchStart, nudgeLeft, nudgeRight, phase, best } = useSpaceDefenderGame();
 
   return (
     <CanvasGameShell

--- a/gamesformykids/app/games/space-defender/useSpaceDefenderGame.ts
+++ b/gamesformykids/app/games/space-defender/useSpaceDefenderGame.ts
@@ -1,6 +1,7 @@
 'use client';
 
 import { useEffect, useRef, useCallback } from 'react';
+import { useShallow } from 'zustand/react/shallow';
 import { useSpaceDefenderStore, GAME_DURATION } from './spaceDefenderStore';
 import { useCanvasLoop } from '@/hooks/shared/common';
 
@@ -180,8 +181,11 @@ export function useSpaceDefenderGame() {
     return () => { window.removeEventListener('keydown', kd); window.removeEventListener('keyup', ku); clearInterval(moveInterval); };
   }, [shoot]);
 
+  const { phase, best } = useSpaceDefenderStore(useShallow(s => ({ phase: s.phase, best: s.best })));
+
   return { canvasRef, shoot, startGame, handleMouseMove, handleCanvasClick, handleTouchMove, handleTouchStart,
     nudgeLeft: () => { const s = st.current; s.shipX = Math.max(SHIP_W / 2, s.shipX - 40); },
     nudgeRight: () => { const s = st.current; s.shipX = Math.min(W - SHIP_W / 2, s.shipX + 40); },
+    phase, best,
   };
 }

--- a/gamesformykids/app/games/stack/StackGame.tsx
+++ b/gamesformykids/app/games/stack/StackGame.tsx
@@ -1,16 +1,13 @@
 'use client';
 
 import { useStackGame, W, H } from './useStackGame';
-import { useStackStore } from './stackStore';
 import { CanvasMenuOverlay } from '@/components/game/shared/CanvasMenuOverlay';
 import StackGameOverOverlay from './components/StackGameOverOverlay';
 import StackDropButton from './components/StackDropButton';
 import CanvasGameShell from '@/components/game/canvas/CanvasGameShell';
-import { useShallow } from 'zustand/react/shallow';
 
 export default function StackGame() {
-  const { canvasRef, startGame, drop, handleCanvasClick } = useStackGame();
-  const { phase, best } = useStackStore(useShallow(s => ({ phase: s.phase, best: s.best })));
+  const { canvasRef, startGame, drop, handleCanvasClick, phase, best } = useStackGame();
 
   return (
     <CanvasGameShell

--- a/gamesformykids/app/games/stack/useStackGame.ts
+++ b/gamesformykids/app/games/stack/useStackGame.ts
@@ -1,6 +1,7 @@
 'use client';
 
 import { useEffect, useRef, useCallback } from 'react';
+import { useShallow } from 'zustand/react/shallow';
 import { useStackStore } from './stackStore';
 import { useCanvasLoop } from '@/hooks/shared/common';
 
@@ -131,5 +132,7 @@ export function useStackGame() {
     return () => window.removeEventListener('keydown', kd);
   }, [drop]);
 
-  return { canvasRef, startGame, drop, handleCanvasClick };
+  const { phase, best } = useStackStore(useShallow(s => ({ phase: s.phase, best: s.best })));
+
+  return { canvasRef, startGame, drop, handleCanvasClick, phase, best };
 }


### PR DESCRIPTION
## Summary
- Each canvas game hook now calls `useStore(useShallow(...))` internally for the `phase`/`score`/`best` (etc.) fields its root file needs, then returns them alongside the canvas ref and handlers
- 10 root files now call **one hook** instead of two — direct store imports and `useShallow` boilerplate removed from all of them
- `PongGame` retains `import { WIN_SCORE } from './pongStore'` since it's used in the menu overlay description

## Files changed
**Hooks** (10): added `useShallow` subscription + expanded return value
`useCatchFruitGame`, `useDinoRunnerGame`, `useBrickBreakerGame`, `useFlappyBirdGame`, `useFroggerGame`, `useJumperGame`, `useMeteorDodgeGame`, `usePongGame`, `useSpaceDefenderGame`, `useStackGame`

**Root files** (10): removed store import + `useShallow` call, destructure new fields from game hook
`CatchFruitGame`, `DinoRunnerGame`, `BrickBreakerGame`, `FlappyBirdGame`, `FroggerGame`, `JumperGame`, `MeteorDodgeGame`, `PongGame`, `SpaceDefenderGame`, `StackGame`

## Test plan
- [ ] TypeScript passes (`tsc --noEmit`) — pre-existing errors in `lib/supabase/server.ts` and `middleware.ts` are unrelated
- [ ] CI green
- [ ] All 10 canvas games render menu, play, and result phases correctly

Closes #299

🤖 Generated with [Claude Code](https://claude.com/claude-code)