### PR TITLE
refactor: canvas game sub-components use game hook instead of direct store (#301)

### DIFF
--- a/gamesformykids/app/games/brick-breaker/components/BrickGameOverOverlay.tsx
+++ b/gamesformykids/app/games/brick-breaker/components/BrickGameOverOverlay.tsx
@@ -1,14 +1,13 @@
 'use client';
 
-import { useBrickBreakerStore } from '../brickBreakerStore';
-import { useShallow } from 'zustand/react/shallow';
+import { useBrickBreakerGame } from '../useBrickBreakerGame';
 
 interface Props {
   onRestart: () => void;
 }
 
 export default function BrickGameOverOverlay({ onRestart }: Props) {
-  const { phase, score, best } = useBrickBreakerStore(useShallow(s => ({ phase: s.phase, score: s.score, best: s.best })));
+  const { phase, score, best } = useBrickBreakerGame();
   return (
     <div className="absolute inset-0 flex items-center justify-center rounded-3xl bg-black/60">
       <div className="bg-white rounded-3xl p-7 text-center shadow-2xl w-72">

--- a/gamesformykids/app/games/catch-fruit/components/CatchFruitHUD.tsx
+++ b/gamesformykids/app/games/catch-fruit/components/CatchFruitHUD.tsx
@@ -1,10 +1,9 @@
 'use client';
 
-import { useCatchFruitStore } from '../catchFruitStore';
-import { useShallow } from 'zustand/react/shallow';
+import { useCatchFruitGame } from '../useCatchFruitGame';
 
 export default function CatchFruitHUD() {
-  const { score, lives, timeLeft } = useCatchFruitStore(useShallow(s => ({ score: s.score, lives: s.lives, timeLeft: s.timeLeft })));
+  const { score, lives, timeLeft } = useCatchFruitGame();
   return (
     <div className="flex gap-5 mb-3 text-white text-center">
       <div>

--- a/gamesformykids/app/games/catch-fruit/components/CatchFruitResultOverlay.tsx
+++ b/gamesformykids/app/games/catch-fruit/components/CatchFruitResultOverlay.tsx
@@ -1,14 +1,13 @@
 'use client';
 
-import { useCatchFruitStore } from '../catchFruitStore';
-import { useShallow } from 'zustand/react/shallow';
+import { useCatchFruitGame } from '../useCatchFruitGame';
 
 interface Props {
   onRestart: () => void;
 }
 
 export default function CatchFruitResultOverlay({ onRestart }: Props) {
-  const { score, best, lives } = useCatchFruitStore(useShallow(s => ({ score: s.score, best: s.best, lives: s.lives })));
+  const { score, best, lives } = useCatchFruitGame();
   return (
     <div className="absolute inset-0 flex items-center justify-center rounded-3xl bg-black/50">
       <div className="bg-white rounded-3xl p-7 text-center shadow-2xl w-72">

--- a/gamesformykids/app/games/catch-fruit/useCatchFruitGame.ts
+++ b/gamesformykids/app/games/catch-fruit/useCatchFruitGame.ts
@@ -162,7 +162,7 @@ export function useCatchFruitGame() {
     if (st.current.phase !== 'playing') startGame();
   }, [canvasRef, startGame]);
 
-  const { phase, best } = useCatchFruitStore(useShallow(s => ({ phase: s.phase, best: s.best })));
+  const { phase, best, score, lives, timeLeft } = useCatchFruitStore(useShallow(s => ({ phase: s.phase, best: s.best, score: s.score, lives: s.lives, timeLeft: s.timeLeft })));
 
-  return { canvasRef, startGame, handleMouseMove, handleMouseDown, handleMouseUp, handleTouchMove, handleTouchStart, phase, best };
+  return { canvasRef, startGame, handleMouseMove, handleMouseDown, handleMouseUp, handleTouchMove, handleTouchStart, phase, best, score, lives, timeLeft };
 }

--- a/gamesformykids/app/games/dino-runner/components/DinoGameOverOverlay.tsx
+++ b/gamesformykids/app/games/dino-runner/components/DinoGameOverOverlay.tsx
@@ -1,14 +1,13 @@
 'use client';
 
-import { useDinoRunnerStore } from '../dinoRunnerStore';
-import { useShallow } from 'zustand/react/shallow';
+import { useDinoRunnerGame } from '../useDinoRunnerGame';
 
 interface Props {
   onRestart: () => void;
 }
 
 export default function DinoGameOverOverlay({ onRestart }: Props) {
-  const { score, best } = useDinoRunnerStore(useShallow(s => ({ score: s.score, best: s.best })));
+  const { score, best } = useDinoRunnerGame();
   return (
     <div className="absolute inset-0 flex items-center justify-center rounded-3xl bg-black/40">
       <div className="bg-white rounded-3xl p-6 text-center shadow-2xl w-64">

--- a/gamesformykids/app/games/flappy-bird/components/FlappyGameOverOverlay.tsx
+++ b/gamesformykids/app/games/flappy-bird/components/FlappyGameOverOverlay.tsx
@@ -1,14 +1,13 @@
 'use client';
 
-import { useFlappyBirdStore } from '../flappyBirdStore';
-import { useShallow } from 'zustand/react/shallow';
+import { useFlappyBirdGame } from '../useFlappyBirdGame';
 
 interface Props {
   onRestart: () => void;
 }
 
 export default function FlappyGameOverOverlay({ onRestart }: Props) {
-  const { score, best } = useFlappyBirdStore(useShallow(s => ({ score: s.score, best: s.best })));
+  const { score, best } = useFlappyBirdGame();
   return (
     <div className="absolute inset-0 flex flex-col items-center justify-center rounded-3xl bg-black/40">
       <div className="bg-white rounded-3xl p-7 text-center shadow-2xl w-72">

--- a/gamesformykids/app/games/flappy-bird/useFlappyBirdGame.ts
+++ b/gamesformykids/app/games/flappy-bird/useFlappyBirdGame.ts
@@ -197,7 +197,7 @@ export function useFlappyBirdGame() {
     flap();
   }, [flap]);
 
-  const { phase, best } = useFlappyBirdStore(useShallow(s => ({ phase: s.phase, best: s.best })));
+  const { phase, best, score } = useFlappyBirdStore(useShallow(s => ({ phase: s.phase, best: s.best, score: s.score })));
 
-  return { canvasRef, flap, handleInput, phase, best };
+  return { canvasRef, flap, handleInput, phase, best, score };
 }

--- a/gamesformykids/app/games/frogger/components/FroggerGameOverOverlay.tsx
+++ b/gamesformykids/app/games/frogger/components/FroggerGameOverOverlay.tsx
@@ -1,14 +1,13 @@
 'use client';
 
-import { useFroggerStore } from '../froggerStore';
-import { useShallow } from 'zustand/react/shallow';
+import { useFroggerGame } from '../useFroggerGame';
 
 interface Props {
   onRestart: () => void;
 }
 
 export default function FroggerGameOverOverlay({ onRestart }: Props) {
-  const { score, best } = useFroggerStore(useShallow(s => ({ score: s.score, best: s.best })));
+  const { score, best } = useFroggerGame();
   return (
     <div className="absolute inset-0 flex items-center justify-center rounded-2xl bg-black/75">
       <div className="bg-white rounded-3xl p-7 text-center shadow-2xl w-72">

--- a/gamesformykids/app/games/frogger/useFroggerGame.ts
+++ b/gamesformykids/app/games/frogger/useFroggerGame.ts
@@ -154,7 +154,7 @@ export function useFroggerGame() {
     return () => window.removeEventListener('keydown', kd);
   }, [moveFrog]);
 
-  const { phase, score, lives } = useFroggerStore(useShallow(s => ({ phase: s.phase, score: s.score, lives: s.lives })));
+  const { phase, score, lives, best } = useFroggerStore(useShallow(s => ({ phase: s.phase, score: s.score, lives: s.lives, best: s.best })));
 
-  return { canvasRef, startGame, moveFrog, handleTouchStart, handleTouchEnd, phase, score, lives };
+  return { canvasRef, startGame, moveFrog, handleTouchStart, handleTouchEnd, phase, score, lives, best };
 }

--- a/gamesformykids/app/games/jumper/components/JumperGameOverOverlay.tsx
+++ b/gamesformykids/app/games/jumper/components/JumperGameOverOverlay.tsx
@@ -1,14 +1,13 @@
 'use client';
 
-import { useJumperStore } from '../jumperStore';
-import { useShallow } from 'zustand/react/shallow';
+import { useJumperGame } from '../useJumperGame';
 
 interface Props {
   onRestart: () => void;
 }
 
 export default function JumperGameOverOverlay({ onRestart }: Props) {
-  const { score, best } = useJumperStore(useShallow(s => ({ score: s.score, best: s.best })));
+  const { score, best } = useJumperGame();
   return (
     <div className="absolute inset-0 flex items-center justify-center rounded-3xl bg-black/70">
       <div className="bg-white rounded-3xl p-7 text-center shadow-2xl w-64">

--- a/gamesformykids/app/games/meteor-dodge/components/MeteorGameOverOverlay.tsx
+++ b/gamesformykids/app/games/meteor-dodge/components/MeteorGameOverOverlay.tsx
@@ -1,14 +1,13 @@
 'use client';
 
-import { useMeteorDodgeStore } from '../meteorDodgeStore';
-import { useShallow } from 'zustand/react/shallow';
+import { useMeteorDodgeGame } from '../useMeteorDodgeGame';
 
 interface Props {
   onRestart: () => void;
 }
 
 export default function MeteorGameOverOverlay({ onRestart }: Props) {
-  const { score, best } = useMeteorDodgeStore(useShallow(s => ({ score: s.score, best: s.best })));
+  const { score, best } = useMeteorDodgeGame();
   return (
     <div className="absolute inset-0 flex items-center justify-center rounded-3xl bg-black/70">
       <div className="bg-white rounded-3xl p-7 text-center shadow-2xl w-72">

--- a/gamesformykids/app/games/pong/components/PongResultOverlay.tsx
+++ b/gamesformykids/app/games/pong/components/PongResultOverlay.tsx
@@ -1,14 +1,14 @@
 'use client';
 
-import { usePongStore, WIN_SCORE } from '../pongStore';
-import { useShallow } from 'zustand/react/shallow';
+import { usePongGame } from '../usePongGame';
+import { WIN_SCORE } from '../pongStore';
 
 interface Props {
   onRestart: () => void;
 }
 
 export default function PongResultOverlay({ onRestart }: Props) {
-  const { playerScore, aiScore } = usePongStore(useShallow(s => ({ playerScore: s.playerScore, aiScore: s.aiScore })));
+  const { playerScore, aiScore } = usePongGame();
   const playerWon = playerScore >= WIN_SCORE;
   return (
     <div className="absolute inset-0 flex items-center justify-center rounded-3xl bg-black/70">

--- a/gamesformykids/app/games/space-defender/components/SpaceDefenderHUD.tsx
+++ b/gamesformykids/app/games/space-defender/components/SpaceDefenderHUD.tsx
@@ -1,10 +1,9 @@
 'use client';
 
-import { useSpaceDefenderStore } from '../spaceDefenderStore';
-import { useShallow } from 'zustand/react/shallow';
+import { useSpaceDefenderGame } from '../useSpaceDefenderGame';
 
 export default function SpaceDefenderHUD() {
-  const { score, lives, timeLeft } = useSpaceDefenderStore(useShallow(s => ({ score: s.score, lives: s.lives, timeLeft: s.timeLeft })));
+  const { score, lives, timeLeft } = useSpaceDefenderGame();
   return (
     <div className="flex gap-5 mb-2 text-white text-center">
       <div>

--- a/gamesformykids/app/games/space-defender/components/SpaceDefenderResultOverlay.tsx
+++ b/gamesformykids/app/games/space-defender/components/SpaceDefenderResultOverlay.tsx
@@ -1,14 +1,13 @@
 'use client';
 
-import { useSpaceDefenderStore } from '../spaceDefenderStore';
-import { useShallow } from 'zustand/react/shallow';
+import { useSpaceDefenderGame } from '../useSpaceDefenderGame';
 
 interface Props {
   onRestart: () => void;
 }
 
 export default function SpaceDefenderResultOverlay({ onRestart }: Props) {
-  const { lives, score, best } = useSpaceDefenderStore(useShallow(s => ({ lives: s.lives, score: s.score, best: s.best })));
+  const { lives, score, best } = useSpaceDefenderGame();
   const outOfLives = lives === 0;
   return (
     <div className="absolute inset-0 flex items-center justify-center rounded-3xl bg-black/60">

--- a/gamesformykids/app/games/space-defender/useSpaceDefenderGame.ts
+++ b/gamesformykids/app/games/space-defender/useSpaceDefenderGame.ts
@@ -181,11 +181,11 @@ export function useSpaceDefenderGame() {
     return () => { window.removeEventListener('keydown', kd); window.removeEventListener('keyup', ku); clearInterval(moveInterval); };
   }, [shoot]);
 
-  const { phase, best } = useSpaceDefenderStore(useShallow(s => ({ phase: s.phase, best: s.best })));
+  const { phase, best, score, lives, timeLeft } = useSpaceDefenderStore(useShallow(s => ({ phase: s.phase, best: s.best, score: s.score, lives: s.lives, timeLeft: s.timeLeft })));
 
   return { canvasRef, shoot, startGame, handleMouseMove, handleCanvasClick, handleTouchMove, handleTouchStart,
     nudgeLeft: () => { const s = st.current; s.shipX = Math.max(SHIP_W / 2, s.shipX - 40); },
     nudgeRight: () => { const s = st.current; s.shipX = Math.min(W - SHIP_W / 2, s.shipX + 40); },
-    phase, best,
+    phase, best, score, lives, timeLeft,
   };
 }

--- a/gamesformykids/app/games/stack/components/StackGameOverOverlay.tsx
+++ b/gamesformykids/app/games/stack/components/StackGameOverOverlay.tsx
@@ -1,14 +1,13 @@
 'use client';
 
-import { useStackStore } from '../stackStore';
-import { useShallow } from 'zustand/react/shallow';
+import { useStackGame } from '../useStackGame';
 
 interface Props {
   onRestart: () => void;
 }
 
 export default function StackGameOverOverlay({ onRestart }: Props) {
-  const { score, best } = useStackStore(useShallow(s => ({ score: s.score, best: s.best })));
+  const { score, best } = useStackGame();
   return (
     <div className="absolute inset-0 flex items-center justify-center rounded-3xl bg-black/70">
       <div className="bg-white rounded-3xl p-7 text-center shadow-2xl w-60">

--- a/gamesformykids/app/games/stack/useStackGame.ts
+++ b/gamesformykids/app/games/stack/useStackGame.ts
@@ -132,7 +132,7 @@ export function useStackGame() {
     return () => window.removeEventListener('keydown', kd);
   }, [drop]);
 
-  const { phase, best } = useStackStore(useShallow(s => ({ phase: s.phase, best: s.best })));
+  const { phase, best, score } = useStackStore(useShallow(s => ({ phase: s.phase, best: s.best, score: s.score })));
 
-  return { canvasRef, startGame, drop, handleCanvasClick, phase, best };
+  return { canvasRef, startGame, drop, handleCanvasClick, phase, best, score };
 }


### PR DESCRIPTION
## Summary
- Extends 5 canvas game hooks (`useCatchFruitGame`, `useFlappyBirdGame`, `useFroggerGame`, `useSpaceDefenderGame`, `useStackGame`) with additional UI state fields needed by sub-components
- Migrates 12 overlay/HUD sub-components away from `useStore(useShallow(...))` to their game hooks, eliminating direct store knowledge in leaf components
- No behaviour changes — purely structural: same reactive fields, sourced from the hook instead of the store directly

## Files changed
**Hook extensions (5):** `useCatchFruitGame`, `useFlappyBirdGame`, `useFroggerGame`, `useSpaceDefenderGame`, `useStackGame`

**Sub-components migrated (12):** `BrickGameOverOverlay`, `CatchFruitHUD`, `CatchFruitResultOverlay`, `DinoGameOverOverlay`, `FlappyGameOverOverlay`, `FroggerGameOverOverlay`, `JumperGameOverOverlay`, `MeteorGameOverOverlay`, `PongResultOverlay`, `SpaceDefenderHUD`, `SpaceDefenderResultOverlay`, `StackGameOverOverlay`

## Notes
Pre-existing TypeScript errors in `lib/supabase/server.ts` and `middleware.ts` (implicit `any` in cookie handlers) are unrelated to this PR and exist on `main`.

Closes #301

## Test plan
- [ ] TypeScript: `tsc --noEmit` passes (only pre-existing supabase/middleware errors)
- [ ] All game overlays and HUDs display correct score/best/lives/timeLeft values
- [ ] No regressions in game phase transitions

🤖 Generated with [Claude Code](https://claude.com/claude-code)