### PR TITLE
refactor: remaining components use game hook instead of subscribing to store directly (#303)

### DIFF
--- a/gamesformykids/app/games/bubbles/components/BubbleGame.tsx
+++ b/gamesformykids/app/games/bubbles/components/BubbleGame.tsx
@@ -1,22 +1,11 @@
 "use client";
 
-import { useShallow } from 'zustand/react/shallow';
 import { useBubbleGame } from '../hooks/useBubbleGame';
-import { useBubblesStore } from '../bubblesStore';
 import BubbleStartScreen from './BubbleStartScreen';
 import Bubble from './Bubble';
 
 export default function BubbleGame() {
-  const { gameContainerRef, stopGame, handleBubblePop, startGame } = useBubbleGame();
-  const { isPlaying, score, level, poppedCount, bubbles } = useBubblesStore(
-    useShallow((s) => ({
-      isPlaying: s.isPlaying,
-      score: s.score,
-      level: s.level,
-      poppedCount: s.poppedCount,
-      bubbles: s.bubbles,
-    })),
-  );
+  const { gameContainerRef, stopGame, handleBubblePop, startGame, isPlaying, score, level, poppedCount, bubbles } = useBubbleGame();
 
   if (!isPlaying) {
     return <BubbleStartScreen startGame={startGame} />;

--- a/gamesformykids/app/games/bubbles/hooks/useBubbleGame.ts
+++ b/gamesformykids/app/games/bubbles/hooks/useBubbleGame.ts
@@ -8,8 +8,8 @@ export function useBubbleGame() {
   const nextBubbleId = useRef(0);
   const gameContainerRef = useRef<HTMLDivElement>(null);
 
-  const { isPlaying, level } = useBubblesStore(
-    useShallow((s) => ({ isPlaying: s.isPlaying, level: s.level })),
+  const { isPlaying, level, score, poppedCount, bubbles } = useBubblesStore(
+    useShallow((s) => ({ isPlaying: s.isPlaying, level: s.level, score: s.score, poppedCount: s.poppedCount, bubbles: s.bubbles })),
   );
 
   const bubbleTypes = useMemo(() => [
@@ -88,5 +88,5 @@ export function useBubbleGame() {
     useBubblesStore.getState().resetGame();
   }, []);
 
-  return { gameContainerRef, startGame, stopGame, resetGame, handleBubblePop };
+  return { gameContainerRef, startGame, stopGame, resetGame, handleBubblePop, isPlaying, score, level, poppedCount, bubbles };
 }

--- a/gamesformykids/app/games/checkers/components/DamkaBoard.tsx
+++ b/gamesformykids/app/games/checkers/components/DamkaBoard.tsx
@@ -1,14 +1,11 @@
 'use client';
 
-import { useShallow } from 'zustand/react/shallow';
-import { useDamkaStore } from '../damkaStore';
+import { useDamkaGame } from '../useDamkaGame';
 
 const isDark = (r: number, c: number) => (r + c) % 2 === 1;
 
 export default function DamkaBoard() {
-  const { board, selected, validMoves, selectCell } = useDamkaStore(
-    useShallow((s) => ({ board: s.board, selected: s.selected, validMoves: s.validMoves, selectCell: s.selectCell })),
-  );
+  const { board, selected, validMoves, selectCell } = useDamkaGame();
 
   const validDests   = new Set(validMoves.map(m => `${m.to.row},${m.to.col}`));
   const captureDests = new Set(validMoves.filter(m => m.captures.length > 0).map(m => `${m.to.row},${m.to.col}`));

--- a/gamesformykids/app/games/checkers/components/DamkaMenuScreen.tsx
+++ b/gamesformykids/app/games/checkers/components/DamkaMenuScreen.tsx
@@ -1,13 +1,10 @@
 'use client';
 
-import { useShallow } from 'zustand/react/shallow';
 import GameMenuCard from '@/components/game/shared/GameMenuCard';
-import { useDamkaStore } from '../damkaStore';
+import { useDamkaGame } from '../useDamkaGame';
 
 export default function DamkaMenuScreen() {
-  const { playerScore, computerScore, startGame } = useDamkaStore(
-    useShallow((s) => ({ playerScore: s.playerScore, computerScore: s.computerScore, startGame: s.startGame })),
-  );
+  const { playerScore, computerScore, startGame } = useDamkaGame();
 
   return (
     <GameMenuCard

--- a/gamesformykids/app/games/checkers/components/DamkaResultScreen.tsx
+++ b/gamesformykids/app/games/checkers/components/DamkaResultScreen.tsx
@@ -1,15 +1,9 @@
 'use client';
 
-import { useShallow } from 'zustand/react/shallow';
-import { useDamkaStore } from '../damkaStore';
+import { useDamkaGame } from '../useDamkaGame';
 
 export default function DamkaResultScreen() {
-  const { phase, playerScore, computerScore, startGame } = useDamkaStore(
-    useShallow((s) => ({
-      phase: s.phase, playerScore: s.playerScore,
-      computerScore: s.computerScore, startGame: s.startGame,
-    })),
-  );
+  const { phase, playerScore, computerScore, startGame } = useDamkaGame();
 
   return (
     <div className="flex flex-col items-center gap-6 text-center">

--- a/gamesformykids/app/games/checkers/components/DamkaScoreBar.tsx
+++ b/gamesformykids/app/games/checkers/components/DamkaScoreBar.tsx
@@ -1,15 +1,9 @@
 'use client';
 
-import { useShallow } from 'zustand/react/shallow';
-import { useDamkaStore } from '../damkaStore';
+import { useDamkaGame } from '../useDamkaGame';
 
 export default function DamkaScoreBar() {
-  const { board, playerScore, computerScore, currentTurn, message } = useDamkaStore(
-    useShallow((s) => ({
-      board: s.board, playerScore: s.playerScore,
-      computerScore: s.computerScore, currentTurn: s.currentTurn, message: s.message,
-    })),
-  );
+  const { board, playerScore, computerScore, currentTurn, message } = useDamkaGame();
 
   const playerPieces = board.flat().filter(c => c.color === 'player').length;
   const compPieces   = board.flat().filter(c => c.color === 'computer').length;

--- a/gamesformykids/app/games/memory/MemoryClient.tsx
+++ b/gamesformykids/app/games/memory/MemoryClient.tsx
@@ -1,19 +1,16 @@
 'use client';
 
-import { useShallow } from 'zustand/react/shallow';
 import MemoryGameHeader from './components/MemoryGameHeader';
 import GameWinMessage from './components/GameWinMessage';
 import GameTimeoutScreen from './components/GameTimeoutScreen';
 import MemoryGameBoard from './components/MemoryGameBoard';
 import MemoryStartScreen from './components/MemoryStartScreen';
 import { useMemoryGameContent } from './useMemoryGameContent';
-import { useMemoryStore } from './stores/useMemoryStore';
+import { useMemoryGame } from './useMemoryGame';
 
 export default function MemoryClient() {
   useMemoryGameContent();
-  const { gameStarted, isGameWon, isCompleted } = useMemoryStore(
-    useShallow((s) => ({ gameStarted: s.gameStarted, isGameWon: s.isGameWon, isCompleted: s.isCompleted })),
-  );
+  const { gameStarted, isGameWon, isCompleted } = useMemoryGame();
 
   if (!gameStarted) return <MemoryStartScreen />;
   if (isGameWon)    return <GameWinMessage />;

--- a/gamesformykids/app/games/memory/useMemoryGame.ts
+++ b/gamesformykids/app/games/memory/useMemoryGame.ts
@@ -1,0 +1,5 @@
+'use client';
+import { createShallowHook } from '@/lib/stores/utils/sliceUtils';
+import { useMemoryStore } from './stores/useMemoryStore';
+
+export const useMemoryGame = createShallowHook(useMemoryStore);

--- a/gamesformykids/app/games/reflex/components/ReflexPlayScreen.tsx
+++ b/gamesformykids/app/games/reflex/components/ReflexPlayScreen.tsx
@@ -1,13 +1,10 @@
 'use client';
 
-import { useShallow } from 'zustand/react/shallow';
-import { useReflexStore } from '../reflexStore';
+import { useReflexGame } from '../useReflexGame';
 import { GAME_DURATION } from '../data/targets';
 
 export default function ReflexPlayScreen() {
-  const { score, timeLeft, targets, hitTarget } = useReflexStore(
-    useShallow((s) => ({ score: s.score, timeLeft: s.timeLeft, targets: s.targets, hitTarget: s.hitTarget })),
-  );
+  const { score, timeLeft, targets, hitTarget } = useReflexGame();
   const timePct = (timeLeft / GAME_DURATION) * 100;
 
   return (

--- a/gamesformykids/app/games/snake/SnakeGame.tsx
+++ b/gamesformykids/app/games/snake/SnakeGame.tsx
@@ -1,9 +1,6 @@
 'use client';
 
-import { useShallow } from 'zustand/react/shallow';
 import { useSnakeGame, W, H } from './useSnakeGame';
-import { useSnakeStore } from './stores/useSnakeStore';
-import { useGameProgressStore, useGameStore } from '@/lib/stores';
 import { CanvasScoreBar } from '@/components/game/shared/CanvasScoreBar';
 import { CanvasMenuOverlay } from '@/components/game/shared/CanvasMenuOverlay';
 import SnakeGameOverOverlay from './components/SnakeGameOverOverlay';
@@ -11,10 +8,7 @@ import { CanvasDPadControls } from '@/components/game/shared/CanvasDPadControls'
 import CanvasGameShell from '@/components/game/canvas/CanvasGameShell';
 
 export default function SnakeGame() {
-  const { canvasRef, startGame, handleTouchStart, handleTouchEnd, controlDir } = useSnakeGame();
-  const phase = useSnakeStore((s) => s.phase);
-  const { score, level } = useGameProgressStore(useShallow((s) => ({ score: s.score, level: s.level })));
-  const best = useGameStore((s) => s.highScores['snake'] ?? 0);
+  const { canvasRef, startGame, handleTouchStart, handleTouchEnd, controlDir, phase, score, level, best } = useSnakeGame();
 
   return (
     <CanvasGameShell

--- a/gamesformykids/app/games/snake/useSnakeGame.ts
+++ b/gamesformykids/app/games/snake/useSnakeGame.ts
@@ -1,6 +1,7 @@
 ﻿'use client';
 
 import { useEffect, useRef, useCallback } from 'react';
+import { useShallow } from 'zustand/react/shallow';
 import { useGameProgressStore, useGameStore } from '@/lib/stores';
 import { useSnakeStore } from './stores/useSnakeStore';
 
@@ -220,5 +221,9 @@ export function useSnakeGame() {
     if (dir !== opposite[s.dir]) s.nextDir = dir;
   }, []);
 
-  return { canvasRef, startGame, handleTouchStart, handleTouchEnd, controlDir };
+  const phase = useSnakeStore((s) => s.phase);
+  const { score, level } = useGameProgressStore(useShallow((s) => ({ score: s.score, level: s.level })));
+  const best = useGameStore((s) => s.highScores['snake'] ?? 0);
+
+  return { canvasRef, startGame, handleTouchStart, handleTouchEnd, controlDir, phase, score, level, best };
 }

--- a/gamesformykids/app/games/tzedakah/CharityCoinGame.tsx
+++ b/gamesformykids/app/games/tzedakah/CharityCoinGame.tsx
@@ -1,7 +1,5 @@
 'use client';
 
-import { useShallow } from 'zustand/react/shallow';
-import { useTzedakahStore } from './tzedakahStore';
 import { useCharityCoinGame } from './useCharityCoinGame';
 import CharityGameHeader from './components/CharityGameHeader';
 import CharityCoin from './components/CharityCoin';
@@ -12,8 +10,7 @@ import TzedakahGameInstructions from './components/TzedakahGameInstructions';
 import styles from './charity.module.css';
 
 const CharityCoinGame = () => {
-  const { gameWidth, gameHeight, handleMouseMove, handleTouchMove } = useCharityCoinGame();
-  const coins = useTzedakahStore(useShallow((s) => s.coins));
+  const { gameWidth, gameHeight, handleMouseMove, handleTouchMove, coins } = useCharityCoinGame();
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-sky-100 via-blue-100 to-indigo-200 p-4">

--- a/gamesformykids/app/games/tzedakah/useCharityCoinGame.ts
+++ b/gamesformykids/app/games/tzedakah/useCharityCoinGame.ts
@@ -9,7 +9,7 @@ export type { Coin } from './tzedakahStore';
 
 export function useCharityCoinGame() {
   const { isMobile, gameWidth, gameHeight, basketX, basketWidth, basketHeight, gameStarted,
-          score, gameTime, collectedCoins, startGame, moveBasket, stepBasket, setIsMobile } =
+          score, gameTime, collectedCoins, coins, startGame, moveBasket, stepBasket, setIsMobile } =
     useTzedakahStore(useShallow((s) => s));
 
   const router = useRouter();
@@ -48,5 +48,5 @@ export function useCharityCoinGame() {
   };
 
   return { isMobile, gameWidth, gameHeight, basketX, basketWidth, basketHeight, gameStarted,
-           score, gameTime, collectedCoins, startGame, handleMouseMove, handleTouchMove, nextGame, router };
+           score, gameTime, collectedCoins, coins, startGame, handleMouseMove, handleTouchMove, nextGame, router };
 }


### PR DESCRIPTION
## Summary
- Eliminates all remaining `useStore(useShallow(...))` calls from component files — zero direct store subscriptions remain in `.tsx` files
- 5 files: drop-in swap to existing `createShallowHook` wrappers (`useReflexGame`, `useDamkaGame`)
- 3 files: extend existing hooks to expose additional fields (`useCharityCoinGame` → `coins`, `useBubbleGame` → `isPlaying/score/level/poppedCount/bubbles`, `useSnakeGame` → `phase/score/level/best`)
- 1 new file: `useMemoryGame` created as `createShallowHook(useMemoryStore)`

## Files changed
**New hook:** `memory/useMemoryGame.ts`

**Hook extensions:** `useCharityCoinGame.ts`, `useBubbleGame.ts`, `useSnakeGame.ts`

**Components migrated (9):** `ReflexPlayScreen`, `DamkaScoreBar`, `DamkaResultScreen`, `DamkaMenuScreen`, `DamkaBoard`, `MemoryClient`, `CharityCoinGame`, `BubbleGame`, `SnakeGame`

## Notes
Pre-existing TypeScript errors in `lib/supabase/server.ts` and `middleware.ts` are unrelated to this PR.

Closes #303

## Test plan
- [ ] TypeScript: `tsc --noEmit` passes (only pre-existing supabase/middleware errors)
- [ ] No `useShallow` imports remain in any `.tsx` component file
- [ ] Snake, Bubbles, Memory, Tzedakah, Reflex, Checkers games work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)