### PR TITLE
refactor: tetris, chess, balloon-pop components use game hook instead of store directly (#317)

### DIFF
--- a/gamesformykids/app/games/balloon-pop/BalloonPopGame.tsx
+++ b/gamesformykids/app/games/balloon-pop/BalloonPopGame.tsx
@@ -1,13 +1,14 @@
 'use client';
 import { useEffect } from 'react';
-import { useBalloonPopStore, stopBalloonPopGame } from './balloonPopStore';
+import { useBalloonPopGame } from './useBalloonPopGame';
+import { stopBalloonPopGame } from './balloonPopStore';
 import BalloonPopMenuScreen from './components/BalloonPopMenuScreen';
 import BalloonResultScreen from './components/BalloonResultScreen';
 import BalloonHUD from './components/BalloonHUD';
 import BalloonGameArea from './components/BalloonGameArea';
 
 export default function BalloonPopGame() {
-  const phase = useBalloonPopStore(s => s.phase);
+  const { phase } = useBalloonPopGame();
 
   useEffect(() => stopBalloonPopGame, []);
 

--- a/gamesformykids/app/games/balloon-pop/components/BalloonGameArea.tsx
+++ b/gamesformykids/app/games/balloon-pop/components/BalloonGameArea.tsx
@@ -1,11 +1,9 @@
 'use client';
 import { useRef, useEffect } from 'react';
-import { useBalloonPopStore } from '../balloonPopStore';
+import { useBalloonPopGame } from '../useBalloonPopGame';
 
 export default function BalloonGameArea() {
-  const balloons      = useBalloonPopStore(s => s.balloons);
-  const pop           = useBalloonPopStore(s => s.pop);
-  const setDimensions = useBalloonPopStore(s => s.setDimensions);
+  const { balloons, pop, setDimensions } = useBalloonPopGame();
 
   const containerRef = useRef<HTMLDivElement>(null);
 

--- a/gamesformykids/app/games/balloon-pop/components/BalloonHUD.tsx
+++ b/gamesformykids/app/games/balloon-pop/components/BalloonHUD.tsx
@@ -1,10 +1,9 @@
 'use client';
-import { useBalloonPopStore, GAME_DURATION } from '../balloonPopStore';
+import { useBalloonPopGame } from '../useBalloonPopGame';
+import { GAME_DURATION } from '../balloonPopStore';
 
 export default function BalloonHUD() {
-  const score    = useBalloonPopStore(s => s.score);
-  const lives    = useBalloonPopStore(s => s.lives);
-  const timeLeft = useBalloonPopStore(s => s.timeLeft);
+  const { score, lives, timeLeft } = useBalloonPopGame();
   const pct      = (timeLeft / GAME_DURATION) * 100;
 
   return (

--- a/gamesformykids/app/games/balloon-pop/components/BalloonPopMenuScreen.tsx
+++ b/gamesformykids/app/games/balloon-pop/components/BalloonPopMenuScreen.tsx
@@ -1,10 +1,9 @@
 'use client';
 import GameMenuCard from '@/components/game/shared/GameMenuCard';
-import { useBalloonPopStore } from '../balloonPopStore';
+import { useBalloonPopGame } from '../useBalloonPopGame';
 
 export default function BalloonPopMenuScreen() {
-  const best      = useBalloonPopStore(s => s.best);
-  const startGame = useBalloonPopStore(s => s.startGame);
+  const { best, startGame } = useBalloonPopGame();
   return (
     <GameMenuCard
       emoji="🎈"

--- a/gamesformykids/app/games/balloon-pop/components/BalloonResultScreen.tsx
+++ b/gamesformykids/app/games/balloon-pop/components/BalloonResultScreen.tsx
@@ -1,12 +1,9 @@
 'use client';
-import { useBalloonPopStore } from '../balloonPopStore';
+import { useBalloonPopGame } from '../useBalloonPopGame';
 import GameResultCard from '@/components/game/shared/GameResultCard';
 
 export default function BalloonResultScreen() {
-  const score     = useBalloonPopStore(s => s.score);
-  const best      = useBalloonPopStore(s => s.best);
-  const lives     = useBalloonPopStore(s => s.lives);
-  const startGame = useBalloonPopStore(s => s.startGame);
+  const { score, best, lives, startGame } = useBalloonPopGame();
   return (
     <GameResultCard
       emoji={lives <= 0 ? '💔' : '🎉'}

--- a/gamesformykids/app/games/balloon-pop/useBalloonPopGame.ts
+++ b/gamesformykids/app/games/balloon-pop/useBalloonPopGame.ts
@@ -1,0 +1,5 @@
+'use client';
+import { createShallowHook } from '@/lib/stores/utils/sliceUtils';
+import { useBalloonPopStore } from './balloonPopStore';
+
+export const useBalloonPopGame = createShallowHook(useBalloonPopStore);

--- a/gamesformykids/app/games/chess/components/ChessBoard.tsx
+++ b/gamesformykids/app/games/chess/components/ChessBoard.tsx
@@ -1,13 +1,13 @@
 'use client';
 
-import { useChessStore } from '../store/useChessStore';
+import { useChessGame } from '../useChessGame';
 import ChessSquare from './ChessSquare';
 
 const FILES = ['א', 'ב', 'ג', 'ד', 'ה', 'ו', 'ז', 'ח'];
 const RANKS = ['8', '7', '6', '5', '4', '3', '2', '1'];
 
 export default function ChessBoard() {
-  const { board } = useChessStore();
+  const { board } = useChessGame();
 
   return (
     <div className="flex items-start gap-1">

--- a/gamesformykids/app/games/chess/components/ChessCaptured.tsx
+++ b/gamesformykids/app/games/chess/components/ChessCaptured.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { PIECE_SYMBOLS } from '../logic/chessTypes';
-import { useChessStore } from '../store/useChessStore';
+import { useChessGame } from '../useChessGame';
 
 const ORDER = ['Q', 'R', 'B', 'N', 'P'];
 const PIECE_VALUE: Record<string, number> = { Q: 9, R: 5, B: 3, N: 3, P: 1 };
@@ -17,7 +17,7 @@ function materialSum(pieces: string[]) {
 }
 
 export default function ChessCaptured() {
-  const { capturedByPlayer, capturedByComputer } = useChessStore();
+  const { capturedByPlayer, capturedByComputer } = useChessGame();
 
   const byPlayer = sortPieces(capturedByPlayer);
   const byComputer = sortPieces(capturedByComputer);

--- a/gamesformykids/app/games/chess/components/ChessGame.tsx
+++ b/gamesformykids/app/games/chess/components/ChessGame.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useChessStore } from '../store/useChessStore';
+import { useChessGame } from '../useChessGame';
 import ChessMenu from './ChessMenu';
 import ChessGameOver from './ChessGameOver';
 import ChessBoard from './ChessBoard';
@@ -9,7 +9,7 @@ import ChessCaptured from './ChessCaptured';
 import ChessMoveHistory from './ChessMoveHistory';
 
 export default function ChessGame() {
-  const { phase, message } = useChessStore();
+  const { phase, message } = useChessGame();
   const isPlaying = phase === 'playing' || phase === 'check';
 
   return (

--- a/gamesformykids/app/games/chess/components/ChessGameOver.tsx
+++ b/gamesformykids/app/games/chess/components/ChessGameOver.tsx
@@ -1,10 +1,10 @@
 'use client';
 
-import { useChessStore } from '../store/useChessStore';
+import { useChessGame } from '../useChessGame';
 import ChessScoreCards from './ChessScoreCards';
 
 export default function ChessGameOver() {
-  const { message, startGame } = useChessStore();
+  const { message, startGame } = useChessGame();
   const playerWon = message.includes('ניצחת');
   const isDraw = message.includes('תיקו') || message.includes('פאט');
 

--- a/gamesformykids/app/games/chess/components/ChessMenu.tsx
+++ b/gamesformykids/app/games/chess/components/ChessMenu.tsx
@@ -1,12 +1,12 @@
 'use client';
 
-import { useChessStore } from '../store/useChessStore';
+import { useChessGame } from '../useChessGame';
 import ChessTitleCard from './ChessTitleCard';
 import ChessScoreCards from './ChessScoreCards';
 import ChessPieceLegend from './ChessPieceLegend';
 
 export default function ChessMenu() {
-  const { playerScore, computerScore, startGame } = useChessStore();
+  const { playerScore, computerScore, startGame } = useChessGame();
   const hasHistory = playerScore > 0 || computerScore > 0;
 
   return (

--- a/gamesformykids/app/games/chess/components/ChessMoveHistory.tsx
+++ b/gamesformykids/app/games/chess/components/ChessMoveHistory.tsx
@@ -2,7 +2,7 @@
 
 import { useRef, useEffect } from 'react';
 import { type MoveRecord } from '../logic/chessTypes';
-import { useChessStore } from '../store/useChessStore';
+import { useChessGame } from '../useChessGame';
 
 const RATING_BADGE: Record<string, { label: string; cls: string }> = {
   excellent: { label: '⭐', cls: 'text-yellow-300' },
@@ -30,7 +30,7 @@ function MoveCell({ record, isLastRow }: { record: MoveRecord | undefined; isLas
 }
 
 export default function ChessMoveHistory() {
-  const { moveHistory } = useChessStore();
+  const { moveHistory } = useChessGame();
   const bottomRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {

--- a/gamesformykids/app/games/chess/components/ChessScoreCards.tsx
+++ b/gamesformykids/app/games/chess/components/ChessScoreCards.tsx
@@ -1,9 +1,9 @@
 'use client';
 
-import { useChessStore } from '../store/useChessStore';
+import { useChessGame } from '../useChessGame';
 
 export default function ChessScoreCards() {
-  const { playerScore, computerScore } = useChessStore();
+  const { playerScore, computerScore } = useChessGame();
 
   return (
     <div className="flex gap-3 w-full">

--- a/gamesformykids/app/games/chess/components/ChessSquare.tsx
+++ b/gamesformykids/app/games/chess/components/ChessSquare.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { PIECE_SYMBOLS } from '../logic/chessTypes';
-import { useChessStore } from '../store/useChessStore';
+import { useChessGame } from '../useChessGame';
 
 interface Props {
   row: number;
@@ -9,7 +9,7 @@ interface Props {
 }
 
 export default function ChessSquare({ row, col }: Props) {
-  const { board, selected, validMoves, lastMove, phase, turn, selectSquare } = useChessStore();
+  const { board, selected, validMoves, lastMove, phase, turn, selectSquare } = useChessGame();
 
   const piece = board[row][col];
   const isSelected = selected?.row === row && selected?.col === col;

--- a/gamesformykids/app/games/chess/components/ChessStatusBar.tsx
+++ b/gamesformykids/app/games/chess/components/ChessStatusBar.tsx
@@ -1,12 +1,10 @@
 'use client';
 
-import { useChessStore } from '../store/useChessStore';
+import { useChessGame } from '../useChessGame';
 import ChessPlayerPanel from './ChessPlayerPanel';
 
 export default function ChessStatusBar() {
-  const { turn, startGame } = useChessStore();
-  const playerScore = useChessStore(s => s.playerScore);
-  const computerScore = useChessStore(s => s.computerScore);
+  const { turn, startGame, playerScore, computerScore } = useChessGame();
 
   return (
     <div className="flex items-stretch gap-2 w-full">

--- a/gamesformykids/app/games/chess/useChessGame.ts
+++ b/gamesformykids/app/games/chess/useChessGame.ts
@@ -1,2 +1,5 @@
-// Re-export barrel - import from specific modules instead when possible
-export * from './logic';
+'use client';
+import { createShallowHook } from '@/lib/stores/utils/sliceUtils';
+import { useChessStore } from './store/useChessStore';
+
+export const useChessGame = createShallowHook(useChessStore);

--- a/gamesformykids/app/games/tetris/components/InfoPanels.tsx
+++ b/gamesformykids/app/games/tetris/components/InfoPanels.tsx
@@ -1,11 +1,8 @@
 import NextPieceDisplay from './NextPieceDisplay';
-import { useTetrisStore } from '@/lib/stores/tetrisStore';
+import { useTetrisState } from '../hooks/useTetrisState';
 
 export const MobileInfoPanel = () => {
-  const score = useTetrisStore(s => s.score);
-  const level = useTetrisStore(s => s.level);
-  const linesCleared = useTetrisStore(s => s.linesCleared);
-  const nextPiece = useTetrisStore(s => s.nextPiece);
+  const { score, level, linesCleared, nextPiece } = useTetrisState();
   
   return (
     <div className="xl:hidden flex flex-row gap-4 w-full justify-center">
@@ -33,10 +30,7 @@ export const MobileInfoPanel = () => {
 };
 
 export const DesktopInfoPanel = () => {
-  const score = useTetrisStore(s => s.score);
-  const level = useTetrisStore(s => s.level);
-  const linesCleared = useTetrisStore(s => s.linesCleared);
-  const nextPiece = useTetrisStore(s => s.nextPiece);
+  const { score, level, linesCleared, nextPiece } = useTetrisState();
   
   return (
     <div className="space-y-6">

--- a/gamesformykids/app/games/tetris/components/TetrisGame.tsx
+++ b/gamesformykids/app/games/tetris/components/TetrisGame.tsx
@@ -2,7 +2,7 @@
 
 import { GenericStartScreen } from '@/components/shared';
 import { useTetrisGame } from '../hooks/useTetrisGame';
-import { useTetrisStore } from '@/lib/stores/tetrisStore';
+import { useTetrisState } from '../hooks/useTetrisState';
 import GameBoard from './GameBoard';
 import { MobileInfoPanel, DesktopInfoPanel } from './InfoPanels';
 import TouchControls from './TouchControls';
@@ -13,10 +13,7 @@ function TetrisGame(){
   // רישום side-effects (game loop, מקלדת, טעינה)
   useTetrisGame();
 
-  const isLoading = useTetrisStore(s => s.isLoading);
-  const showStartScreen = useTetrisStore(s => s.showStartScreen);
-  const startNewGame = useTetrisStore(s => s.startNewGame);
-  const getBoardWithCurrentPiece = useTetrisStore(s => s.getBoardWithCurrentPiece);
+  const { isLoading, showStartScreen, startNewGame, getBoardWithCurrentPiece } = useTetrisState();
 
   if (isLoading) {
     return <LoadingScreen />;

--- a/gamesformykids/app/games/tetris/components/TouchControls.tsx
+++ b/gamesformykids/app/games/tetris/components/TouchControls.tsx
@@ -1,4 +1,4 @@
-import { useTetrisStore } from '@/lib/stores/tetrisStore';
+import { useTetrisState } from '../hooks/useTetrisState';
 import { useTouchControls } from './useTouchControls';
 
 interface TouchControlsProps {
@@ -6,10 +6,7 @@ interface TouchControlsProps {
 }
 
 const TouchControls = ({ isDesktop = false }: TouchControlsProps) => {
-  const isGameRunning = useTetrisStore(s => s.isGameRunning);
-  const gameOver = useTetrisStore(s => s.gameOver);
-  const score = useTetrisStore(s => s.score);
-  const onStartGame = useTetrisStore(s => s.startNewGame);
+  const { isGameRunning, gameOver, score, startNewGame: onStartGame } = useTetrisState();
   const { handleMove, handleRotate } = useTouchControls();
 
   // פריסה למחשב

--- a/gamesformykids/app/games/tetris/hooks/useTetrisState.ts
+++ b/gamesformykids/app/games/tetris/hooks/useTetrisState.ts
@@ -1,0 +1,5 @@
+'use client';
+import { createShallowHook } from '@/lib/stores/utils/sliceUtils';
+import { useTetrisStore } from '@/lib/stores/tetrisStore';
+
+export const useTetrisState = createShallowHook(useTetrisStore);


### PR DESCRIPTION
## Summary
- **Tetris**: create `hooks/useTetrisState = createShallowHook(useTetrisStore)`; collapse 4 individual `useTetrisStore(s => ...)` selectors per component into one destructure across `TetrisGame`, `InfoPanels`, `TouchControls`
- **Chess**: replace unused `useChessGame.ts` barrel with `createShallowHook(useChessStore)`; migrate all 9 chess components from `useChessStore()` / `useChessStore(s => ...)` to `useChessGame()` (adds shallow-equality optimization as a side effect)
- **Balloon-pop**: create `useBalloonPopGame = createShallowHook(useBalloonPopStore)`; migrate `BalloonPopGame` + 4 sub-components from individual selectors to single destructure

## Notes
Pre-existing TypeScript errors in `lib/supabase/server.ts` and `middleware.ts` are unrelated.

Closes #317

## Test plan
- [ ] TypeScript: `tsc --noEmit` — only pre-existing supabase/middleware errors
- [ ] Tetris game renders score, level, lines, next piece; controls work
- [ ] Chess game renders board, captures, status, move history; start/restart works
- [ ] Balloon-pop phases (menu → playing → result) work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)