### PR TITLE
refactor(hooks): migrate taki, puzzles, arithmetic to game hooks (#321)

### DIFF
--- a/gamesformykids/app/games/arithmetic/ArithmeticGame.tsx
+++ b/gamesformykids/app/games/arithmetic/ArithmeticGame.tsx
@@ -1,12 +1,13 @@
 'use client';
 import { useEffect } from 'react';
 import { useArithmeticGameStore, stopArithmeticTimer } from './arithmeticGameStore';
+import { useArithmeticGame } from './useArithmeticGame';
 import ArithmeticMenuScreen from './components/ArithmeticMenuScreen';
 import ArithmeticQuestion from './components/ArithmeticQuestion';
 import ArithmeticResultScreen from './components/ArithmeticResultScreen';
 
 export default function ArithmeticGame() {
-  const phase = useArithmeticGameStore(s => s.phase);
+  const { phase } = useArithmeticGame();
 
   useEffect(() => {
     // Reset to menu whenever the component mounts (e.g. after client-side

--- a/gamesformykids/app/games/arithmetic/components/ArithmeticMenuScreen.tsx
+++ b/gamesformykids/app/games/arithmetic/components/ArithmeticMenuScreen.tsx
@@ -1,11 +1,11 @@
 'use client';
 
 import GameMenuGrid from '@/components/game/shared/GameMenuGrid';
-import { useArithmeticGameStore } from '../arithmeticGameStore';
+import { useArithmeticGame } from '../useArithmeticGame';
 import { LEVELS, LEVEL_EMOJIS, ArithmeticLevel } from '../data/questions';
 
 export default function ArithmeticMenuScreen() {
-  const startGame = useArithmeticGameStore(s => s.startGame);
+  const { startGame } = useArithmeticGame();
 
   return (
     <GameMenuGrid<ArithmeticLevel>

--- a/gamesformykids/app/games/arithmetic/components/ArithmeticQuestion.tsx
+++ b/gamesformykids/app/games/arithmetic/components/ArithmeticQuestion.tsx
@@ -1,19 +1,10 @@
 'use client';
-import { useArithmeticGameStore } from '../arithmeticGameStore';
+import { useArithmeticGame } from '../useArithmeticGame';
 import { TIME_PER_QUESTION } from '../data/questions';
 import { QUESTIONS_PER_GAME } from '@/lib/quiz/constants';
 
 export default function ArithmeticQuestion() {
-  const level       = useArithmeticGameStore(s => s.level);
-  const question    = useArithmeticGameStore(s => s.question);
-  const questionNum = useArithmeticGameStore(s => s.questionNum);
-  const score       = useArithmeticGameStore(s => s.score);
-  const selected    = useArithmeticGameStore(s => s.selected);
-  const isCorrect   = useArithmeticGameStore(s => s.isCorrect);
-  const timeLeft    = useArithmeticGameStore(s => s.timeLeft);
-  const selectAnswer = useArithmeticGameStore(s => s.selectAnswer);
-  const advance      = useArithmeticGameStore(s => s.advance);
-  const goMenu       = useArithmeticGameStore(s => s.goMenu);
+  const { level, question, questionNum, score, selected, isCorrect, timeLeft, selectAnswer, advance, goMenu } = useArithmeticGame();
 
   if (!question) return null;
 

--- a/gamesformykids/app/games/arithmetic/components/ArithmeticResultScreen.tsx
+++ b/gamesformykids/app/games/arithmetic/components/ArithmeticResultScreen.tsx
@@ -1,14 +1,10 @@
 'use client';
-import { useArithmeticGameStore } from '../arithmeticGameStore';
+import { useArithmeticGame } from '../useArithmeticGame';
 import { QUESTIONS_PER_GAME } from '@/lib/quiz/constants';
 import GameResultCard from '@/components/game/shared/GameResultCard';
 
 export default function ArithmeticResultScreen() {
-  const level     = useArithmeticGameStore(s => s.level);
-  const correct   = useArithmeticGameStore(s => s.correct);
-  const score     = useArithmeticGameStore(s => s.score);
-  const startGame = useArithmeticGameStore(s => s.startGame);
-  const goMenu    = useArithmeticGameStore(s => s.goMenu);
+  const { level, correct, score, startGame, goMenu } = useArithmeticGame();
   const pct = Math.round((correct / QUESTIONS_PER_GAME) * 100);
   return (
     <GameResultCard

--- a/gamesformykids/app/games/arithmetic/useArithmeticGame.ts
+++ b/gamesformykids/app/games/arithmetic/useArithmeticGame.ts
@@ -1,0 +1,5 @@
+'use client';
+import { createShallowHook } from '@/lib/stores/utils/sliceUtils';
+import { useArithmeticGameStore } from './arithmeticGameStore';
+
+export const useArithmeticGame = createShallowHook(useArithmeticGameStore);

--- a/gamesformykids/app/games/puzzles/custom/CustomControls.tsx
+++ b/gamesformykids/app/games/puzzles/custom/CustomControls.tsx
@@ -2,7 +2,7 @@
 
 import { useRef } from 'react';
 import { RotateCcw, Eye, Settings, Shuffle, Upload } from 'lucide-react';
-import { usePuzzleStore } from '@/app/games/puzzles/store/puzzleStore';
+import { usePuzzleGame } from '../usePuzzleGame';
 import DifficultySelector from '../shared/DifficultySelector';
 
 export default function CustomControls() {
@@ -10,7 +10,7 @@ export default function CustomControls() {
   const {
     gameStarted, showHints: hintsEnabled, showDebug: debugMode,
     resetGame, shufflePieces, toggleHints, toggleDebug, handleImageUpload,
-  } = usePuzzleStore();
+  } = usePuzzleGame();
 
   return (
     <div className="mb-8">

--- a/gamesformykids/app/games/puzzles/custom/CustomGameArea.tsx
+++ b/gamesformykids/app/games/puzzles/custom/CustomGameArea.tsx
@@ -1,13 +1,13 @@
 'use client';
 
-import { usePuzzleStore } from '@/app/games/puzzles/store/puzzleStore';
+import { usePuzzleGame } from '../usePuzzleGame';
 import PuzzleGrid from '../shared/PuzzleGrid';
 import PiecesPool from '../shared/PiecesPool';
 import PuzzleStats from '../shared/PuzzleStats';
 import ReferenceImage from '../shared/ReferenceImage';
 
 export default function CustomGameArea() {
-  const image = usePuzzleStore(s => s.image);
+  const { image } = usePuzzleGame();
   return (
     <>
     

--- a/gamesformykids/app/games/puzzles/custom/CustomHelpModal.tsx
+++ b/gamesformykids/app/games/puzzles/custom/CustomHelpModal.tsx
@@ -1,10 +1,10 @@
 'use client';
 
 import { RotateCcw, Eye, Settings, Upload, Shuffle } from 'lucide-react';
-import { usePuzzleStore } from '@/app/games/puzzles/store/puzzleStore';
+import { usePuzzleGame } from '../usePuzzleGame';
 
 export default function CustomHelpModal() {
-  const { showHelp, toggleHelp } = usePuzzleStore();
+  const { showHelp, toggleHelp } = usePuzzleGame();
   if (!showHelp) return null;
   return (
     <div

--- a/gamesformykids/app/games/puzzles/custom/CustomPuzzleGame.tsx
+++ b/gamesformykids/app/games/puzzles/custom/CustomPuzzleGame.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { usePuzzleStore } from '@/app/games/puzzles/store/puzzleStore';
+import { usePuzzleGame } from '../usePuzzleGame';
 import { usePuzzleSetup } from '../usePuzzleSetup';
 import CustomHeader from './CustomHeader';
 import FeedbackMessage from '../shared/FeedbackMessage';
@@ -12,8 +12,7 @@ import CustomGameArea from './CustomGameArea';
 
 export default function CustomPuzzleGame() {
   usePuzzleSetup();
-  const image = usePuzzleStore(s => s.image);
-  const gameStarted = usePuzzleStore(s => s.gameStarted);
+  const { image, gameStarted } = usePuzzleGame();
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-purple-50 via-blue-50 to-pink-50">

--- a/gamesformykids/app/games/puzzles/custom/FileUploadButton.tsx
+++ b/gamesformykids/app/games/puzzles/custom/FileUploadButton.tsx
@@ -2,11 +2,11 @@
 
 import { useRef } from 'react';
 import { Upload } from 'lucide-react';
-import { usePuzzleStore } from '@/app/games/puzzles/store/puzzleStore';
+import { usePuzzleGame } from '../usePuzzleGame';
 
 export default function FileUploadButton() {
   const inputRef = useRef<HTMLInputElement>(null);
-  const { handleImageUpload } = usePuzzleStore();
+  const { handleImageUpload } = usePuzzleGame();
 
   return (
     <div className="border-t border-gray-200 pt-8">

--- a/gamesformykids/app/games/puzzles/custom/PreMadeImagesPicker.tsx
+++ b/gamesformykids/app/games/puzzles/custom/PreMadeImagesPicker.tsx
@@ -1,11 +1,11 @@
 'use client';
 
 import Image from 'next/image';
-import { usePuzzleStore } from '@/app/games/puzzles/store/puzzleStore';
+import { usePuzzleGame } from '../usePuzzleGame';
 import { PREVIEW_IMAGES } from '../constants/previewImages';
 
 export default function PreMadeImagesPicker() {
-  const { difficulty, handlePreMadeImageSelect } = usePuzzleStore();
+  const { difficulty, handlePreMadeImageSelect } = usePuzzleGame();
 
   return (
     <div className="mb-8">

--- a/gamesformykids/app/games/puzzles/shared/DifficultySelector.tsx
+++ b/gamesformykids/app/games/puzzles/shared/DifficultySelector.tsx
@@ -1,9 +1,9 @@
 'use client';
 
-import { usePuzzleStore } from '@/app/games/puzzles/store/puzzleStore';
+import { usePuzzleGame } from '../usePuzzleGame';
 
 export default function DifficultySelector({ variant = 'buttons' }: { variant?: 'buttons' | 'select' }) {
-  const { difficulty, changeDifficulty } = usePuzzleStore();
+  const { difficulty, changeDifficulty } = usePuzzleGame();
 
   if (variant === 'select') {
     return (

--- a/gamesformykids/app/games/puzzles/shared/FeedbackMessage.tsx
+++ b/gamesformykids/app/games/puzzles/shared/FeedbackMessage.tsx
@@ -1,10 +1,9 @@
 'use client';
 
-import { usePuzzleStore } from '@/app/games/puzzles/store/puzzleStore';
+import { usePuzzleGame } from '../usePuzzleGame';
 
 export default function FeedbackMessage() {
-  const message = usePuzzleStore(s => s.feedbackMessage);
-  const type = usePuzzleStore(s => s.feedbackType);
+  const { feedbackMessage: message, feedbackType: type } = usePuzzleGame();
   if (!message) return null;
   return (
     <div className={`fixed top-20 left-1/2 transform -translate-x-1/2 z-50 px-6 py-3 rounded-full text-white font-bold text-lg shadow-lg animate-bounce ${

--- a/gamesformykids/app/games/puzzles/shared/FloatingDragPiece.tsx
+++ b/gamesformykids/app/games/puzzles/shared/FloatingDragPiece.tsx
@@ -1,10 +1,10 @@
 'use client';
 
 import Image from 'next/image';
-import { usePuzzleStore } from '@/app/games/puzzles/store/puzzleStore';
+import { usePuzzleGame } from '../usePuzzleGame';
 
 export default function FloatingDragPiece() {
-  const { touchState } = usePuzzleStore();
+  const { touchState } = usePuzzleGame();
   const { isDragging, draggedPiece, dragPosition } = touchState;
   if (!isDragging || !draggedPiece) return null;
   return (

--- a/gamesformykids/app/games/puzzles/shared/GridCell.tsx
+++ b/gamesformykids/app/games/puzzles/shared/GridCell.tsx
@@ -3,7 +3,7 @@
 import Image from 'next/image';
 import { Star } from 'lucide-react';
 import type { PuzzlePiece } from '@/app/games/puzzles/utils/puzzleUtils';
-import { usePuzzleStore } from '@/app/games/puzzles/store/puzzleStore';
+import { usePuzzleGame } from '../usePuzzleGame';
 
 interface GridCellProps {
   index: number;
@@ -13,7 +13,7 @@ interface GridCellProps {
 }
 
 export default function GridCell({ index, row, col, piece }: GridCellProps) {
-  const { showHints, showDebug, handleDragOver, handleDrop, handleDragStart, handleTouchStart, handleTouchMove, handleTouchEnd } = usePuzzleStore();
+  const { showHints, showDebug, handleDragOver, handleDrop, handleDragStart, handleTouchStart, handleTouchMove, handleTouchEnd } = usePuzzleGame();
 
   return (
     <div

--- a/gamesformykids/app/games/puzzles/shared/PiecesPool.tsx
+++ b/gamesformykids/app/games/puzzles/shared/PiecesPool.tsx
@@ -1,10 +1,10 @@
 'use client';
 
-import { usePuzzleStore } from '@/app/games/puzzles/store/puzzleStore';
+import { usePuzzleGame } from '../usePuzzleGame';
 import PuzzlePieceItem from './PuzzlePieceItem';
 
 export default function PiecesPool() {
-  const pieces = usePuzzleStore(s => s.pieces);
+  const { pieces } = usePuzzleGame();
   const availablePieces = pieces.filter(p => !p.isPlaced);
   const totalPieces = pieces.length;
   const placedOnGrid = pieces.filter(p => p.isPlaced).length;

--- a/gamesformykids/app/games/puzzles/shared/PuzzleGrid.tsx
+++ b/gamesformykids/app/games/puzzles/shared/PuzzleGrid.tsx
@@ -1,10 +1,10 @@
 'use client';
 
-import { usePuzzleStore } from '@/app/games/puzzles/store/puzzleStore';
+import { usePuzzleGame } from '../usePuzzleGame';
 import GridCell from './GridCell';
 
 export default function PuzzleGrid() {
-  const { selectedPuzzle, difficulty, placedPieces } = usePuzzleStore();
+  const { selectedPuzzle, difficulty, placedPieces } = usePuzzleGame();
 
   const gridSize = selectedPuzzle?.gridSize || difficulty;
   const gridSide = Math.sqrt(gridSize);

--- a/gamesformykids/app/games/puzzles/shared/PuzzleHeader.tsx
+++ b/gamesformykids/app/games/puzzles/shared/PuzzleHeader.tsx
@@ -1,10 +1,10 @@
 'use client';
 
 import { HelpCircle } from 'lucide-react';
-import { usePuzzleStore } from '@/app/games/puzzles/store/puzzleStore';
+import { usePuzzleGame } from '../usePuzzleGame';
 
 export default function PuzzleHeader({ title, subtitle }: { title: string; subtitle: string }) {
-  const { toggleHelp } = usePuzzleStore();
+  const { toggleHelp } = usePuzzleGame();
   return (
     <div className="text-center mb-6 sm:mb-8">
       <div className="flex flex-col sm:flex-row justify-between items-center gap-3 sm:gap-4 mb-6">

--- a/gamesformykids/app/games/puzzles/shared/PuzzlePieceItem.tsx
+++ b/gamesformykids/app/games/puzzles/shared/PuzzlePieceItem.tsx
@@ -1,11 +1,11 @@
 'use client';
 
 import Image from 'next/image';
-import { usePuzzleStore } from '@/app/games/puzzles/store/puzzleStore';
+import { usePuzzleGame } from '../usePuzzleGame';
 import type { PuzzlePiece } from '@/app/games/puzzles/utils/puzzleUtils';
 
 export default function PuzzlePieceItem({ piece }: { piece: PuzzlePiece }) {
-  const { handleDragStart, handleTouchStart, handleTouchMove, handleTouchEnd } = usePuzzleStore();
+  const { handleDragStart, handleTouchStart, handleTouchMove, handleTouchEnd } = usePuzzleGame();
   return (
     <div
       className="cursor-grab active:cursor-grabbing hover:scale-105 transition-transform duration-200 rounded-lg overflow-hidden shadow-md hover:shadow-lg touch-none min-w-[80px] min-h-[80px]"

--- a/gamesformykids/app/games/puzzles/shared/PuzzleStats.tsx
+++ b/gamesformykids/app/games/puzzles/shared/PuzzleStats.tsx
@@ -1,12 +1,12 @@
 'use client';
 
 import { Clock, Trophy, Star, CheckCircle, Target } from 'lucide-react';
-import { usePuzzleStore } from '@/app/games/puzzles/store/puzzleStore';
+import { usePuzzleGame } from '../usePuzzleGame';
 import StatCard from './StatCard';
 import CompletionBanner from './CompletionBanner';
 
 export default function PuzzleStats({ className = '' }: { className?: string }) {
-  const { placedPieces, selectedPuzzle, difficulty, timer, score, isCompleted } = usePuzzleStore();
+  const { placedPieces, selectedPuzzle, difficulty, timer, score, isCompleted } = usePuzzleGame();
   const correctPieces = placedPieces.filter(p => p?.isCorrect).length;
   const totalPieces = selectedPuzzle?.gridSize || difficulty;
   const completionPercentage = Math.round((correctPieces / totalPieces) * 100);

--- a/gamesformykids/app/games/puzzles/shared/ReferenceImage.tsx
+++ b/gamesformykids/app/games/puzzles/shared/ReferenceImage.tsx
@@ -1,10 +1,10 @@
 'use client';
 
 import Image from 'next/image';
-import { usePuzzleStore } from '@/app/games/puzzles/store/puzzleStore';
+import { usePuzzleGame } from '../usePuzzleGame';
 
 export default function ReferenceImage() {
-  const displayImage = usePuzzleStore(s => s.image);
+  const { image: displayImage } = usePuzzleGame();
   if (!displayImage) return null;
   return (
     <div className="bg-white/90 backdrop-blur-sm rounded-2xl border border-gray-200 shadow-xl p-4 lg:p-6">

--- a/gamesformykids/app/games/puzzles/simple/PuzzleCard.tsx
+++ b/gamesformykids/app/games/puzzles/simple/PuzzleCard.tsx
@@ -1,12 +1,12 @@
 'use client';
 
 import Image from 'next/image';
-import { usePuzzleStore } from '@/app/games/puzzles/store/puzzleStore';
+import { usePuzzleGame } from '../usePuzzleGame';
 import type { SimplePuzzle } from '../constants/simplePuzzlesData';
 import { DIFFICULTY_TEXT, DIFFICULTY_COLOR } from '../constants/difficultyConfig';
 
 export default function PuzzleCard({ puzzle }: { puzzle: SimplePuzzle }) {
-  const { handlePuzzleSelect } = usePuzzleStore();
+  const { handlePuzzleSelect } = usePuzzleGame();
   return (
     <div
       className="bg-white rounded-2xl p-6 shadow-xl hover:shadow-2xl transition-all duration-300 cursor-pointer hover:scale-105 transform"

--- a/gamesformykids/app/games/puzzles/simple/SimpleControls.tsx
+++ b/gamesformykids/app/games/puzzles/simple/SimpleControls.tsx
@@ -1,13 +1,13 @@
 'use client';
 
 import { Home, RotateCcw, Eye, Settings } from 'lucide-react';
-import { usePuzzleStore } from '@/app/games/puzzles/store/puzzleStore';
+import { usePuzzleGame } from '../usePuzzleGame';
 
 export default function SimpleControls() {
   const {
     gameStarted, showHints: hintsEnabled, showDebug: debugMode,
     resetGame, toggleHints, toggleDebug, goToMenu,
-  } = usePuzzleStore();
+  } = usePuzzleGame();
 
   return (
     <div className="flex justify-center gap-4 mb-6 flex-wrap">

--- a/gamesformykids/app/games/puzzles/simple/SimpleHelpModal.tsx
+++ b/gamesformykids/app/games/puzzles/simple/SimpleHelpModal.tsx
@@ -1,10 +1,10 @@
 'use client';
 
 import { X, Mouse, RotateCcw, HelpCircle, Eye, Settings } from 'lucide-react';
-import { usePuzzleStore } from '@/app/games/puzzles/store/puzzleStore';
+import { usePuzzleGame } from '../usePuzzleGame';
 
 export default function SimpleHelpModal() {
-  const { showHelp, toggleHelp } = usePuzzleStore();
+  const { showHelp, toggleHelp } = usePuzzleGame();
   if (!showHelp) return null;
   return (
     <div

--- a/gamesformykids/app/games/puzzles/simple/SimplePuzzleGame.tsx
+++ b/gamesformykids/app/games/puzzles/simple/SimplePuzzleGame.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { usePuzzleStore } from '@/app/games/puzzles/store/puzzleStore';
+import { usePuzzleGame } from '../usePuzzleGame';
 import { usePuzzleSetup } from '../usePuzzleSetup';
 import SimpleHeader from './SimpleHeader';
 import FeedbackMessage from '../shared/FeedbackMessage';
@@ -12,9 +12,7 @@ import SimpleGameArea from './SimpleGameArea';
 
 export default function SimplePuzzleGame() {
   usePuzzleSetup();
-  const selectedPuzzle = usePuzzleStore(s => s.selectedPuzzle);
-  const gameStarted = usePuzzleStore(s => s.gameStarted);
-  const imageLoaded = usePuzzleStore(s => s.imageLoaded);
+  const { selectedPuzzle, gameStarted, imageLoaded } = usePuzzleGame();
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-blue-100 to-green-100 p-4">

--- a/gamesformykids/app/games/puzzles/usePuzzleGame.ts
+++ b/gamesformykids/app/games/puzzles/usePuzzleGame.ts
@@ -1,0 +1,5 @@
+'use client';
+import { createShallowHook } from '@/lib/stores/utils/sliceUtils';
+import { usePuzzleStore } from './store/puzzleStore';
+
+export const usePuzzleGame = createShallowHook(usePuzzleStore);

--- a/gamesformykids/app/games/taki/TakiGame.tsx
+++ b/gamesformykids/app/games/taki/TakiGame.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useTakiStore } from './takiGameStore';
+import { useTakiGame } from './useTakiGame';
 import {
   TakiMenuScreen,
   TakiResultScreen,
@@ -10,9 +10,7 @@ import {
 import TakiComputerAI from './components/TakiComputerAI';
 
 export default function TakiGame() {
-  const phase = useTakiStore(s => s.phase);
-  const needsColorChoice = useTakiStore(s => s.needsColorChoice);
-  const currentTurn = useTakiStore(s => s.currentTurn);
+  const { phase, needsColorChoice, currentTurn } = useTakiGame();
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-green-900 via-emerald-950 to-teal-950 select-none" dir="rtl">

--- a/gamesformykids/app/games/taki/components/TakiActionButtons.tsx
+++ b/gamesformykids/app/games/taki/components/TakiActionButtons.tsx
@@ -1,14 +1,9 @@
 'use client';
 
-import { useTakiStore } from '../takiGameStore';
+import { useTakiGame } from '../useTakiGame';
 
 export default function TakiActionButtons() {
-  const currentTurn = useTakiStore(s => s.currentTurn);
-  const inTakiSequence = useTakiStore(s => s.inTakiSequence);
-  const needsColorChoice = useTakiStore(s => s.needsColorChoice);
-  const deck = useTakiStore(s => s.deck);
-  const drawCard = useTakiStore(s => s.drawCard);
-  const closeTaki = useTakiStore(s => s.closeTaki);
+  const { currentTurn, inTakiSequence, needsColorChoice, deck, drawCard, closeTaki } = useTakiGame();
 
   if (currentTurn !== 'player') return null;
 

--- a/gamesformykids/app/games/taki/components/TakiColorPicker.tsx
+++ b/gamesformykids/app/games/taki/components/TakiColorPicker.tsx
@@ -10,10 +10,10 @@ const COLORS: { color: CardColor; label: string; cls: string }[] = [
   { color: 'yellow', label: '🟡 צהוב',  cls: 'bg-yellow-400 hover:bg-yellow-300 text-gray-900' },
 ];
 
-import { useTakiStore } from '../takiGameStore';
+import { useTakiGame } from '../useTakiGame';
 
 export default function TakiColorPicker() {
-  const onPick = useTakiStore(s => s.chooseColor);
+  const { chooseColor: onPick } = useTakiGame();
   return (
     <div className="fixed inset-0 bg-black/60 flex items-center justify-center z-50" dir="rtl">
       <div className="bg-gray-900 rounded-2xl p-6 shadow-2xl text-center max-w-xs w-full mx-4">

--- a/gamesformykids/app/games/taki/components/TakiComputerAI.tsx
+++ b/gamesformykids/app/games/taki/components/TakiComputerAI.tsx
@@ -1,14 +1,10 @@
 'use client';
 
 import { useEffect, useRef } from 'react';
-import { useTakiStore } from '../takiGameStore';
+import { useTakiGame } from '../useTakiGame';
 
 export default function TakiComputerAI() {
-  const phase = useTakiStore(s => s.phase);
-  const currentTurn = useTakiStore(s => s.currentTurn);
-  const turnId = useTakiStore(s => s.turnId);
-  const inTakiSequence = useTakiStore(s => s.inTakiSequence);
-  const computerTurn = useTakiStore(s => s.computerTurn);
+  const { phase, currentTurn, turnId, inTakiSequence, computerTurn } = useTakiGame();
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useEffect(() => {

--- a/gamesformykids/app/games/taki/components/TakiComputerHand.tsx
+++ b/gamesformykids/app/games/taki/components/TakiComputerHand.tsx
@@ -1,10 +1,10 @@
 'use client';
 
-import { useTakiStore } from '../takiGameStore';
+import { useTakiGame } from '../useTakiGame';
 import { FaceDownCard } from './TakiCardView';
 
 export default function TakiComputerHand() {
-  const computerHand = useTakiStore(s => s.computerHand);
+  const { computerHand } = useTakiGame();
 
   return (
     <div className="flex flex-col items-center gap-1">

--- a/gamesformykids/app/games/taki/components/TakiMenuScreen.tsx
+++ b/gamesformykids/app/games/taki/components/TakiMenuScreen.tsx
@@ -1,12 +1,10 @@
 'use client';
 
 import GameMenuCard from '@/components/game/shared/GameMenuCard';
-import { useTakiStore } from '../takiGameStore';
+import { useTakiGame } from '../useTakiGame';
 
 export default function TakiMenuScreen() {
-  const playerScore = useTakiStore(s => s.playerScore);
-  const computerScore = useTakiStore(s => s.computerScore);
-  const startGame = useTakiStore(s => s.startGame);
+  const { playerScore, computerScore, startGame } = useTakiGame();
 
   return (
     <GameMenuCard

--- a/gamesformykids/app/games/taki/components/TakiMessageArea.tsx
+++ b/gamesformykids/app/games/taki/components/TakiMessageArea.tsx
@@ -1,10 +1,9 @@
 'use client';
 
-import { useTakiStore } from '../takiGameStore';
+import { useTakiGame } from '../useTakiGame';
 
 export default function TakiMessageArea() {
-  const message = useTakiStore(s => s.message);
-  const playerHand = useTakiStore(s => s.playerHand);
+  const { message, playerHand } = useTakiGame();
 
   return (
     <div className="text-center px-4">

--- a/gamesformykids/app/games/taki/components/TakiPlayerHand.tsx
+++ b/gamesformykids/app/games/taki/components/TakiPlayerHand.tsx
@@ -1,17 +1,11 @@
 'use client';
 
-import { canPlay, useTakiStore } from '../takiGameStore';
+import { canPlay } from '../takiGameStore';
+import { useTakiGame } from '../useTakiGame';
 import TakiCardView from './TakiCardView';
 
 export default function TakiPlayerHand() {
-  const playerHand = useTakiStore(s => s.playerHand);
-  const topCard = useTakiStore(s => s.topCard);
-  const effectiveColor = useTakiStore(s => s.effectiveColor);
-  const inTakiSequence = useTakiStore(s => s.inTakiSequence);
-  const takiColor = useTakiStore(s => s.takiColor);
-  const needsColorChoice = useTakiStore(s => s.needsColorChoice);
-  const currentTurn = useTakiStore(s => s.currentTurn);
-  const playCard = useTakiStore(s => s.playCard);
+  const { playerHand, topCard, effectiveColor, inTakiSequence, takiColor, needsColorChoice, currentTurn, playCard } = useTakiGame();
 
   const playableIds = new Set(
     currentTurn === 'player' && !needsColorChoice

--- a/gamesformykids/app/games/taki/components/TakiResultScreen.tsx
+++ b/gamesformykids/app/games/taki/components/TakiResultScreen.tsx
@@ -1,14 +1,10 @@
 'use client';
 
 import GameResultCard from '@/components/game/shared/GameResultCard';
-import { useTakiStore } from '../takiGameStore';
+import { useTakiGame } from '../useTakiGame';
 
 export default function TakiResultScreen() {
-  const phase = useTakiStore(s => s.phase);
-  const message = useTakiStore(s => s.message);
-  const playerScore = useTakiStore(s => s.playerScore);
-  const computerScore = useTakiStore(s => s.computerScore);
-  const startGame = useTakiStore(s => s.startGame);
+  const { phase, message, playerScore, computerScore, startGame } = useTakiGame();
 
   return (
     <GameResultCard

--- a/gamesformykids/app/games/taki/components/TakiScoreBar.tsx
+++ b/gamesformykids/app/games/taki/components/TakiScoreBar.tsx
@@ -1,11 +1,9 @@
 'use client';
 
-import { useTakiStore } from '../takiGameStore';
+import { useTakiGame } from '../useTakiGame';
 
 export default function TakiScoreBar() {
-  const playerScore = useTakiStore(s => s.playerScore);
-  const computerScore = useTakiStore(s => s.computerScore);
-  const currentTurn = useTakiStore(s => s.currentTurn);
+  const { playerScore, computerScore, currentTurn } = useTakiGame();
 
   return (
     <div className="flex justify-between items-center text-white text-sm font-semibold px-1">

--- a/gamesformykids/app/games/taki/components/TakiTable.tsx
+++ b/gamesformykids/app/games/taki/components/TakiTable.tsx
@@ -1,17 +1,11 @@
 'use client';
 
-import { COLOR_BG, useTakiStore } from '../takiGameStore';
+import { COLOR_BG } from '../takiGameStore';
+import { useTakiGame } from '../useTakiGame';
 import TakiCardView, { FaceDownCard } from './TakiCardView';
 
 export default function TakiTable() {
-  const topCard = useTakiStore(s => s.topCard);
-  const effectiveColor = useTakiStore(s => s.effectiveColor);
-  const inTakiSequence = useTakiStore(s => s.inTakiSequence);
-  const takiColor = useTakiStore(s => s.takiColor);
-  const needsColorChoice = useTakiStore(s => s.needsColorChoice);
-  const currentTurn = useTakiStore(s => s.currentTurn);
-  const deck = useTakiStore(s => s.deck);
-  const drawCard = useTakiStore(s => s.drawCard);
+  const { topCard, effectiveColor, inTakiSequence, takiColor, needsColorChoice, currentTurn, deck, drawCard } = useTakiGame();
 
   const displayColor = (inTakiSequence && takiColor) ? takiColor : effectiveColor ?? topCard.color;
 

--- a/gamesformykids/app/games/taki/useTakiGame.ts
+++ b/gamesformykids/app/games/taki/useTakiGame.ts
@@ -1,0 +1,5 @@
+'use client';
+import { createShallowHook } from '@/lib/stores/utils/sliceUtils';
+import { useTakiStore } from './takiGameStore';
+
+export const useTakiGame = createShallowHook(useTakiStore);


### PR DESCRIPTION
## Summary
- Create `useTakiGame`, `usePuzzleGame`, `useArithmeticGame` hooks via `createShallowHook`
- Replace direct `useTakiStore`/`usePuzzleStore`/`useArithmeticGameStore` subscriptions in 35 component files with the new hooks
- Consolidate multiple per-field selector calls into single destructures

Closes #321

## Test plan
- [ ] `tsc --noEmit` passes (no new errors)
- [ ] Taki game plays correctly end-to-end
- [ ] Puzzle (simple + custom) game plays correctly
- [ ] Arithmetic quiz plays correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)