### PR TITLE
refactor(hooks): migrate soccer + number-bubbles to game hooks (#307)

### DIFF
--- a/gamesformykids/app/games/number-bubbles/NumberBubblesGame.tsx
+++ b/gamesformykids/app/games/number-bubbles/NumberBubblesGame.tsx
@@ -1,12 +1,12 @@
 'use client';
-import { useNumberBubblesStore } from './numberBubblesStore';
+import { useNumberBubblesGame } from './useNumberBubblesGame';
 import NumberBubblesMenuScreen from './components/NumberBubblesMenuScreen';
 import NumberBubblesResultScreen from './components/NumberBubblesResultScreen';
 import NumberBubblesHUD from './components/NumberBubblesHUD';
 import NumberBubbleGrid from './components/NumberBubbleGrid';
 
 export default function NumberBubblesGame() {
-  const { phase, wrong } = useNumberBubblesStore();
+  const { phase, wrong } = useNumberBubblesGame();
 
   if (phase === 'menu')    return <NumberBubblesMenuScreen />;
   if (phase === 'results') return <NumberBubblesResultScreen />;

--- a/gamesformykids/app/games/number-bubbles/components/NumberBubbleGrid.tsx
+++ b/gamesformykids/app/games/number-bubbles/components/NumberBubbleGrid.tsx
@@ -1,9 +1,9 @@
 'use client';
 
-import { useNumberBubblesStore } from '../numberBubblesStore';
+import { useNumberBubblesGame } from '../useNumberBubblesGame';
 
 export default function NumberBubbleGrid() {
-  const { bubbles, next, tap } = useNumberBubblesStore();
+  const { bubbles, next, tap } = useNumberBubblesGame();
 
   return (
     <div className="relative w-full" style={{ height: '70vh', maxWidth: 400 }}>

--- a/gamesformykids/app/games/number-bubbles/components/NumberBubblesHUD.tsx
+++ b/gamesformykids/app/games/number-bubbles/components/NumberBubblesHUD.tsx
@@ -1,9 +1,9 @@
 'use client';
 
-import { useNumberBubblesStore } from '../numberBubblesStore';
+import { useNumberBubblesGame } from '../useNumberBubblesGame';
 
 export default function NumberBubblesHUD() {
-  const { next, bubbles, level, elapsed } = useNumberBubblesStore();
+  const { next, bubbles, level, elapsed } = useNumberBubblesGame();
   const popped = next - 1;
   const total = bubbles.length;
 

--- a/gamesformykids/app/games/number-bubbles/components/NumberBubblesMenuScreen.tsx
+++ b/gamesformykids/app/games/number-bubbles/components/NumberBubblesMenuScreen.tsx
@@ -1,10 +1,10 @@
 'use client';
 
 import GameMenuCard from '@/components/game/shared/GameMenuCard';
-import { useNumberBubblesStore } from '../numberBubblesStore';
+import { useNumberBubblesGame } from '../useNumberBubblesGame';
 
 export default function NumberBubblesMenuScreen() {
-  const { best, startGame } = useNumberBubblesStore();
+  const { best, startGame } = useNumberBubblesGame();
 
   return (
     <GameMenuCard

--- a/gamesformykids/app/games/number-bubbles/components/NumberBubblesResultScreen.tsx
+++ b/gamesformykids/app/games/number-bubbles/components/NumberBubblesResultScreen.tsx
@@ -1,9 +1,9 @@
 'use client';
 import GameResultCard from '@/components/game/shared/GameResultCard';
-import { useNumberBubblesStore } from '../numberBubblesStore';
+import { useNumberBubblesGame } from '../useNumberBubblesGame';
 
 export default function NumberBubblesResultScreen() {
-  const { level, elapsed, nextLevel, startGame } = useNumberBubblesStore();
+  const { level, elapsed, nextLevel, startGame } = useNumberBubblesGame();
 
   return (
     <GameResultCard

--- a/gamesformykids/app/games/soccer/SoccerGame.tsx
+++ b/gamesformykids/app/games/soccer/SoccerGame.tsx
@@ -1,16 +1,16 @@
 'use client';
 
-import { useSoccerStore } from './store/soccerStore';
+import { useSoccerGame } from './useSoccerGame';
 import SoccerMenuScreen from './components/SoccerMenuScreen';
 import SoccerQuestion from './components/SoccerQuestion';
 import SoccerResultScreen from './components/SoccerResultScreen';
 
 export default function SoccerGame() {
-  const { phase, questions, currentIndex } = useSoccerStore();
+  const { phase, currentQuestion } = useSoccerGame();
 
   if (phase === 'menu') return <SoccerMenuScreen />;
   if (phase === 'finished') return <SoccerResultScreen />;
-  if (!questions[currentIndex]) return null;
+  if (!currentQuestion) return null;
   return <SoccerQuestion />;
 }
 

--- a/gamesformykids/app/games/soccer/components/SoccerCategoryGrid.tsx
+++ b/gamesformykids/app/games/soccer/components/SoccerCategoryGrid.tsx
@@ -1,11 +1,11 @@
 'use client';
 
 import type { SoccerCategory } from '../data/soccer';
-import { useSoccerStore } from '../store/soccerStore';
+import { useSoccerGame } from '../useSoccerGame';
 import { CATEGORY_COLORS, CATEGORY_ICONS } from './SoccerShared';
 
 export default function SoccerCategoryGrid() {
-  const { categories, startGame } = useSoccerStore();
+  const { categories, startGame } = useSoccerGame();
 
   return (
     <div className="grid grid-cols-2 gap-3 w-full max-w-sm mb-6">

--- a/gamesformykids/app/games/soccer/components/SoccerQuestion.tsx
+++ b/gamesformykids/app/games/soccer/components/SoccerQuestion.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useSoccerStore } from '../store/soccerStore';
+import { useSoccerGame } from '../useSoccerGame';
 import { PitchBackground, GoalAnimation } from './SoccerShared';
 import SoccerGameHeader from './SoccerGameHeader';
 import SoccerProgressBar from './SoccerProgressBar';
@@ -9,7 +9,7 @@ import SoccerAnswerGrid from './SoccerAnswerGrid';
 import SoccerNextButton from './SoccerNextButton';
 
 export default function SoccerQuestion() {
-  const { showGoal } = useSoccerStore();
+  const { showGoal } = useSoccerGame();
 
   return (
     <PitchBackground>

--- a/gamesformykids/app/games/soccer/useSoccerGame.ts
+++ b/gamesformykids/app/games/soccer/useSoccerGame.ts
@@ -1,26 +1,17 @@
 ﻿'use client';
 
+import { useShallow } from 'zustand/react/shallow';
 import { useSoccerStore } from './store/soccerStore';
 
 export function useSoccerGame() {
-  const store = useSoccerStore();
+  const store = useSoccerStore(useShallow(s => s));
   const currentQuestion = store.questions[store.currentIndex] ?? null;
   const total = store.questions.length;
 
   return {
-    phase: store.phase,
-    category: store.category,
-    categories: store.categories,
+    ...store,
     currentQuestion,
-    currentIndex: store.currentIndex,
     total,
-    selected: store.selected,
-    isCorrect: store.isCorrect,
-    score: store.score,
-    showGoal: store.showGoal,
-    startGame: store.startGame,
-    selectAnswer: store.selectAnswer,
-    nextQuestion: store.nextQuestion,
   };
 }
 


### PR DESCRIPTION
## Summary
- `useSoccerGame`: add `useShallow` for efficiency; expose computed `currentQuestion` and `total`
- `SoccerGame.tsx`, `SoccerCategoryGrid.tsx`, `SoccerQuestion.tsx`: switch from `useSoccerStore` to `useSoccerGame`
- `NumberBubblesGame.tsx` + 4 components: switch from `useNumberBubblesStore` to existing `useNumberBubblesGame` (already `createShallowHook`)

Chess was already migrated in PR #320.

Closes #307

## Test plan
- [ ] Soccer game plays end-to-end (menu → question → result)
- [ ] Number Bubbles game plays end-to-end (menu → game → result)
- [ ] `tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)