### PR TITLE
fix: wire useGameActions barrel to real implementation (#312)

### DIFF
--- a/gamesformykids/components/shared/buttons/SimpleGameStartButton.tsx
+++ b/gamesformykids/components/shared/buttons/SimpleGameStartButton.tsx
@@ -16,13 +16,13 @@ export default function SimpleGameStartButton({
   text = "🎮 בואו נתחיל לשחק! 🎮",
   customOnStart
 }: SimpleGameStartButtonProps) {
-  const { start } = useGameActions();
-  
+  const { startGame } = useGameActions();
+
   const handleStart = () => {
     if (customOnStart) {
       customOnStart();
     } else {
-      start();
+      startGame();
     }
   };
   

--- a/gamesformykids/components/shared/cards/GameCardGrid.tsx
+++ b/gamesformykids/components/shared/cards/GameCardGrid.tsx
@@ -1,5 +1,5 @@
 import { ComponentTypes } from "@/lib/types";
-import { useGameActions, useGridFillers } from "@/hooks";
+import { useGridFillers } from "@/hooks";
 
 // Use the new organized type from ComponentTypes
 type GameItemType = ComponentTypes.GameItemType;
@@ -16,28 +16,14 @@ export function GameCardGrid<T extends GameItemType>({
   compareKey = 'name' as keyof T,
   renderCustomCard,
   cardClassName = "",
-  useContext = false,
 }: GameCardGridProps<T>) {
-  
-  // 🎮 שימוש בקונטקסט אם מבוקש
-  const gameActions = useGameActions();
   // 🔢 fillers להשלמת שורה אחרונה
   const fillerCount = useGridFillers(
     items.length,
     typeof gridCols === 'string' ? gridCols : { mobile: gridCols, tablet: gridCols, desktop: gridCols }
   );
-  
-  // החלטה על הפונקציה הסופית לטיפול בקליק
-  const handleItemClick = propOnItemClick || (useContext ? ((item: T) => {
-    // לוגיקה חכמה - בדיקה אם הפריט נכון
-    const isCorrect = currentChallenge ? isCurrentItem(item, currentChallenge) : false;
-    
-    if (isCorrect && gameActions?.onCorrect) {
-      gameActions.onCorrect();
-    } else if (!isCorrect && gameActions?.onWrong) {
-      gameActions.onWrong();
-    }
-  }) : () => {});
+
+  const handleItemClick = propOnItemClick ?? (() => {});
   // Helper function to determine if an item is the current challenge
   const isCurrentItem = (item: T, challenge?: T | null): boolean => {
     if (!challenge) return false;

--- a/gamesformykids/hooks/shared/game-state/index.ts
+++ b/gamesformykids/hooks/shared/game-state/index.ts
@@ -1,6 +1,6 @@
 export { useBaseGame } from './useBaseGame';
 export { useAutoGame } from './useAutoGame';
-export { useGameActions } from './useGameContext';
+export { useGameActions } from './useGameLogic';
 
 // Zustand-backed hooks (migrated from contexts)
 export { useGameType } from './useGameType';

--- a/gamesformykids/hooks/shared/game-state/useGameContext.ts
+++ b/gamesformykids/hooks/shared/game-state/useGameContext.ts
@@ -119,18 +119,3 @@ export function useGameInfo() {
   };
 }
 
-/**
- * Hook מקוצר לפעולות בלבד
- */
-export function useGameActions() {
-  // נשתמש בזכירה של הפונקציות במקום try-catch
-  const defaultActions = {
-    onCorrect: () => {},
-    onWrong: () => {},
-    start: () => {},
-    pause: () => {},
-  };
-  
-  // אם הקונטקסט לא זמין, נחזיר פעולות ריקות
-  return defaultActions;
-}


### PR DESCRIPTION
## Summary
- `hooks/shared/game-state/index.ts`: re-export `useGameActions` from `useGameLogic` (reads `gameActionsStore`) instead of `useGameContext` (returned hardcoded no-ops)
- `SimpleGameStartButton`: use `startGame` instead of the now-gone `start` property
- Removed the no-op `useGameActions` stub from `useGameContext.ts` to eliminate the name collision
- `GameCardGrid`: removed dead `useContext` code path that relied on the stub's `onCorrect`/`onWrong` API — no caller ever passed `useContext=true`

Closes #312

## Test plan
- [ ] `tsc --noEmit` clean
- [ ] `SimpleGameStartButton` without `customOnStart` now calls the real `startGame` action
- [ ] `GameCardGrid` rendering unchanged (dead code path removed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)