### PR TITLE
fix: rename useGameHints to useHintActions in useGameLogic (#314)

### DIFF
--- a/gamesformykids/hooks/shared/game-state/useGameLogic.ts
+++ b/gamesformykids/hooks/shared/game-state/useGameLogic.ts
@@ -143,7 +143,7 @@ export function useGameConfigFromLogic() {
   return { config, items, CardComponent, gameType }
 }
 
-export function useGameHints() {
+export function useHintActions() {
   const hints           = useGameActionsStore((s) => s.hints)
   const hasMoreHints    = useGameActionsStore((s) => s.hasMoreHints)
   const showNextHint    = useGameActionsStore((s) => s.showNextHint)

--- a/gamesformykids/hooks/shared/game-state/useUniversalGame.ts
+++ b/gamesformykids/hooks/shared/game-state/useUniversalGame.ts
@@ -13,7 +13,7 @@ import {
   useGameState,
   useGameActions,
   useGameConfigFromLogic,
-  useGameHints,
+  useHintActions,
   useGameUI,
 } from './useGameLogic'
 
@@ -23,7 +23,7 @@ export function useUniversalGame(): UniversalGameContextValue {
     useGameState()
   const { startGame, resetGame, handleItemClick, speakItemName } = useGameActions()
   const { config, items, CardComponent, gameType } = useGameConfigFromLogic()
-  const { hints, hasMoreHints, showNextHint, currentAccuracy } = useGameHints()
+  const { hints, hasMoreHints, showNextHint, currentAccuracy } = useHintActions()
   const { showProgressModal, setShowProgressModal } = useGameUI()
 
   return {


### PR DESCRIPTION
## Summary
`useGameLogic.ts` exported a `useGameHints` selector that reads from `gameActionsStore` and returns `{hints, hasMoreHints, showNextHint, currentAccuracy}`. This shadowed the real `useGameHints` in `hooks/shared/ui/useGameHints.ts` which takes props, generates hints from `BaseGameItem` properties, and reads from `gameHintsStore`.

- Renamed the selector in `useGameLogic.ts` from `useGameHints` → `useHintActions`
- Updated `useUniversalGame.ts` to import and call `useHintActions`

The `useGameData` duplicate mentioned in #314 was already deleted in PR #326 (issue #315).

## Test plan
- [ ] TypeScript: `tsc --noEmit` passes
- [ ] `useGameHints` from `hooks/shared/ui/` still works (unchanged)
- [ ] `useUniversalGame` still resolves hints state correctly via `useHintActions`

Closes #314

🤖 Generated with [Claude Code](https://claude.com/claude-code)