### PR TITLE
refactor: extract makeCanvasGameStore factory, persist best score (#308)

### DIFF
--- a/gamesformykids/app/games/catch-fruit/catchFruitStore.ts
+++ b/gamesformykids/app/games/catch-fruit/catchFruitStore.ts
@@ -1,39 +1,9 @@
-import { makeStore } from '@/lib/stores/createStore';
-import type { PhaseResult } from '@/lib/types';
+import { makeCanvasGameStore } from '@/lib/stores/utils/canvasGameStore';
 
 export const GAME_DURATION = 45;
 
-interface CatchFruitState {
-  phase: PhaseResult;
-  score: number;
-  best: number;
-  lives: number;
-  timeLeft: number;
-}
-
-interface CatchFruitActions {
-  startGame: () => void;
-  setScore: (score: number) => void;
-  setLives: (lives: number) => void;
-  setTimeLeft: (timeLeft: number) => void;
-  setGameResult: (score: number, lives: number, timeLeft: number) => void;
-}
-
-export const useCatchFruitStore = makeStore<CatchFruitState & CatchFruitActions>(
+export const useCatchFruitStore = makeCanvasGameStore(
   'CatchFruitStore',
-  (set, get) => ({
-    phase: 'menu',
-    score: 0,
-    best: 0,
-    lives: 3,
-    timeLeft: GAME_DURATION,
-    startGame: () => set({ phase: 'playing', score: 0, lives: 3, timeLeft: GAME_DURATION }, false, 'catchFruit/startGame'),
-    setScore: (score) => set({ score }, false, 'catchFruit/setScore'),
-    setLives: (lives) => set({ lives }, false, 'catchFruit/setLives'),
-    setTimeLeft: (timeLeft) => set({ timeLeft }, false, 'catchFruit/setTimeLeft'),
-    setGameResult: (score, lives, timeLeft) => {
-      const best = Math.max(score, get().best);
-      set({ phase: 'result', score, best, lives, timeLeft }, false, 'catchFruit/gameResult');
-    },
-  }),
+  'catch-fruit-best',
+  GAME_DURATION,
 );

--- a/gamesformykids/app/games/space-defender/spaceDefenderStore.ts
+++ b/gamesformykids/app/games/space-defender/spaceDefenderStore.ts
@@ -1,39 +1,9 @@
-import { makeStore } from '@/lib/stores/createStore';
-import type { PhaseResult } from '@/lib/types';
+import { makeCanvasGameStore } from '@/lib/stores/utils/canvasGameStore';
 
 export const GAME_DURATION = 60;
 
-interface SpaceDefenderState {
-  phase: PhaseResult;
-  score: number;
-  best: number;
-  lives: number;
-  timeLeft: number;
-}
-
-interface SpaceDefenderActions {
-  startGame: () => void;
-  setScore: (score: number) => void;
-  setLives: (lives: number) => void;
-  setTimeLeft: (timeLeft: number) => void;
-  setGameResult: (score: number, lives: number, timeLeft: number) => void;
-}
-
-export const useSpaceDefenderStore = makeStore<SpaceDefenderState & SpaceDefenderActions>(
+export const useSpaceDefenderStore = makeCanvasGameStore(
   'SpaceDefenderStore',
-  (set, get) => ({
-    phase: 'menu',
-    score: 0,
-    best: 0,
-    lives: 3,
-    timeLeft: GAME_DURATION,
-    startGame: () => set({ phase: 'playing', score: 0, lives: 3, timeLeft: GAME_DURATION }, false, 'spaceDefender/startGame'),
-    setScore: (score) => set({ score }, false, 'spaceDefender/setScore'),
-    setLives: (lives) => set({ lives }, false, 'spaceDefender/setLives'),
-    setTimeLeft: (timeLeft) => set({ timeLeft }, false, 'spaceDefender/setTimeLeft'),
-    setGameResult: (score, lives, timeLeft) => {
-      const best = Math.max(score, get().best);
-      set({ phase: 'result', score, best, lives, timeLeft }, false, 'spaceDefender/gameResult');
-    },
-  }),
+  'space-defender-best',
+  GAME_DURATION,
 );

--- a/gamesformykids/lib/stores/utils/canvasGameStore.ts
+++ b/gamesformykids/lib/stores/utils/canvasGameStore.ts
@@ -1,0 +1,49 @@
+import { makePersistStore } from '@/lib/stores/createStore';
+import type { PhaseResult } from '@/lib/types';
+
+export interface CanvasGameState {
+  phase: PhaseResult;
+  score: number;
+  best: number;
+  lives: number;
+  timeLeft: number;
+}
+
+export interface CanvasGameActions {
+  startGame: () => void;
+  setScore: (score: number) => void;
+  setLives: (lives: number) => void;
+  setTimeLeft: (timeLeft: number) => void;
+  setGameResult: (score: number, lives: number, timeLeft: number) => void;
+}
+
+/**
+ * Factory for canvas games that share the standard phase/score/best/lives/timeLeft shape.
+ * Persists only `best` to localStorage so high scores survive page reloads.
+ */
+export function makeCanvasGameStore(
+  name: string,
+  persistKey: string,
+  gameDuration: number,
+) {
+  return makePersistStore<CanvasGameState & CanvasGameActions>(
+    name,
+    persistKey,
+    (set, get) => ({
+      phase: 'menu',
+      score: 0,
+      best: 0,
+      lives: 3,
+      timeLeft: gameDuration,
+      startGame: () => set({ phase: 'playing', score: 0, lives: 3, timeLeft: gameDuration }, false, 'startGame'),
+      setScore: (score) => set({ score }, false, 'setScore'),
+      setLives: (lives) => set({ lives }, false, 'setLives'),
+      setTimeLeft: (timeLeft) => set({ timeLeft }, false, 'setTimeLeft'),
+      setGameResult: (score, lives, timeLeft) => {
+        const best = Math.max(score, get().best);
+        set({ phase: 'result', score, best, lives, timeLeft }, false, 'gameResult');
+      },
+    }),
+    { partialize: (s) => ({ best: s.best }) },
+  );
+}


### PR DESCRIPTION
## Summary
`catchFruitStore` and `spaceDefenderStore` were copy-paste identical — same 5-field state shape, same 5 actions, same `setGameResult` logic. Only `GAME_DURATION` differed.

- Created `lib/stores/utils/canvasGameStore.ts` with `makeCanvasGameStore(name, persistKey, gameDuration)` factory
- Factory uses `makePersistStore` with `partialize: s => ({ best: s.best })` — best scores now survive page reloads (partial fix for #305)
- Reduced `catchFruitStore.ts` and `spaceDefenderStore.ts` to 3-line factory calls (−68 lines of duplication)

## Test plan
- [ ] TypeScript: `tsc --noEmit` passes
- [ ] Catch-fruit game starts, score updates, best score persists across reload
- [ ] Space-defender game starts, score updates, best score persists across reload

Closes #308

🤖 Generated with [Claude Code](https://claude.com/claude-code)