### PR TITLE
fix: persist best scores across page reloads (#305)

### DIFF
--- a/gamesformykids/app/games/balloon-pop/balloonPopStore.ts
+++ b/gamesformykids/app/games/balloon-pop/balloonPopStore.ts
@@ -12,7 +12,7 @@
  */
 
 import { create } from 'zustand';
-import { devtools } from 'zustand/middleware';
+import { devtools, persist } from 'zustand/middleware';
 import type { PhaseResult as Phase } from '@/lib/types';
 
 // ── Constants ──────────────────────────────────────────────
@@ -96,7 +96,8 @@ export interface BalloonPopActions {
 // ── Store ──────────────────────────────────────────────────
 export const useBalloonPopStore = create<BalloonPopState & BalloonPopActions>()(
   devtools(
-    (set, get) => {
+    persist(
+      (set, get) => {
       function endGame() {
         clearTimers();
         const { score, best } = get();
@@ -197,6 +198,8 @@ export const useBalloonPopStore = create<BalloonPopState & BalloonPopActions>()(
         },
       };
     },
+      { name: 'balloon-pop-best', partialize: (s) => ({ best: s.best }) },
+    ),
     { name: 'BalloonPopStore' },
   ),
 );

--- a/gamesformykids/app/games/brick-breaker/brickBreakerStore.ts
+++ b/gamesformykids/app/games/brick-breaker/brickBreakerStore.ts
@@ -1,4 +1,4 @@
-import { makeStore } from '@/lib/stores/createStore';
+import { makePersistStore } from '@/lib/stores/createStore';
 import type { PhaseWonDead } from '@/lib/types';
 
 interface BrickBreakerState {
@@ -17,8 +17,9 @@ interface BrickBreakerActions {
   setWon: (score: number, lives: number, level: number) => void;
 }
 
-export const useBrickBreakerStore = makeStore<BrickBreakerState & BrickBreakerActions>(
+export const useBrickBreakerStore = makePersistStore<BrickBreakerState & BrickBreakerActions>(
   'BrickBreakerStore',
+  'brick-breaker-best',
   (set, get) => ({
     phase: 'menu',
     score: 0,
@@ -38,4 +39,5 @@ export const useBrickBreakerStore = makeStore<BrickBreakerState & BrickBreakerAc
       set({ phase: 'won', score, best, lives, level }, false, 'brickBreaker/won');
     },
   }),
+  { partialize: (s) => ({ best: s.best }) },
 );

--- a/gamesformykids/app/games/color-tap/colorTapStore.ts
+++ b/gamesformykids/app/games/color-tap/colorTapStore.ts
@@ -1,4 +1,4 @@
-import { makeStore } from '@/lib/stores/createStore';
+import { makePersistStore } from '@/lib/stores/createStore';
 import { setupLivesTimer } from '@/lib/stores/livesTimerHelpers';
 import { makeLivesInitial } from '@/lib/stores/utils/sliceUtils';
 import type { LivesGameState } from '@/lib/types';
@@ -43,8 +43,9 @@ interface ColorTapActions {
 
 const INITIAL = makeLivesInitial(TIME_PER_Q, { question: makeQuestion() });
 
-export const useColorTapStore = makeStore<ColorTapState & ColorTapActions>(
+export const useColorTapStore = makePersistStore<ColorTapState & ColorTapActions>(
   'ColorTapStore',
+  'color-tap-best',
   (set, get) => {
     const timer = setupLivesTimer({
       name: 'ColorTapStore', timePerQ: TIME_PER_Q, feedbackMs: 700, initialLives: 3,
@@ -65,4 +66,5 @@ export const useColorTapStore = makeStore<ColorTapState & ColorTapActions>(
       },
     };
   },
+  { partialize: (s) => ({ best: s.best }) },
 );

--- a/gamesformykids/app/games/dino-runner/dinoRunnerStore.ts
+++ b/gamesformykids/app/games/dino-runner/dinoRunnerStore.ts
@@ -1,4 +1,4 @@
-import { makeStore } from '@/lib/stores/createStore';
+import { makePersistStore } from '@/lib/stores/createStore';
 import type { PhaseDead } from '@/lib/types';
 
 interface DinoState {
@@ -14,8 +14,9 @@ interface DinoActions {
   resetToMenu: () => void;
 }
 
-export const useDinoRunnerStore = makeStore<DinoState & DinoActions>(
+export const useDinoRunnerStore = makePersistStore<DinoState & DinoActions>(
   'DinoRunnerStore',
+  'dino-runner-best',
   (set, get) => ({
     phase: 'menu',
     score: 0,
@@ -28,4 +29,5 @@ export const useDinoRunnerStore = makeStore<DinoState & DinoActions>(
     },
     resetToMenu: () => set({ phase: 'menu' }, false, 'dino/resetToMenu'),
   }),
+  { partialize: (s) => ({ best: s.best }) },
 );

--- a/gamesformykids/app/games/emoji-math/emojiMathStore.ts
+++ b/gamesformykids/app/games/emoji-math/emojiMathStore.ts
@@ -1,4 +1,4 @@
-import { makeStore } from '@/lib/stores/createStore';
+import { makePersistStore } from '@/lib/stores/createStore';
 import { setupLivesTimer } from '@/lib/stores/livesTimerHelpers';
 import { makeLivesInitial } from '@/lib/stores/utils/sliceUtils';
 import type { LivesGameState } from '@/lib/types';
@@ -54,8 +54,9 @@ interface EmojiMathActions {
 
 const INITIAL = makeLivesInitial(TIME_PER_Q, { q: makeQuestion(1), level: 1, streak: 0 });
 
-export const useEmojiMathStore = makeStore<EmojiMathState & EmojiMathActions>(
+export const useEmojiMathStore = makePersistStore<EmojiMathState & EmojiMathActions>(
   'EmojiMathStore',
+  'emoji-math-best',
   (set, get) => {
     const timer = setupLivesTimer({
       name: 'EmojiMathStore', timePerQ: TIME_PER_Q, feedbackMs: 900, initialLives: 3,
@@ -84,4 +85,5 @@ export const useEmojiMathStore = makeStore<EmojiMathState & EmojiMathActions>(
       },
     };
   },
+  { partialize: (s) => ({ best: s.best }) },
 );

--- a/gamesformykids/app/games/flappy-bird/flappyBirdStore.ts
+++ b/gamesformykids/app/games/flappy-bird/flappyBirdStore.ts
@@ -1,4 +1,4 @@
-import { makeStore } from '@/lib/stores/createStore';
+import { makePersistStore } from '@/lib/stores/createStore';
 import type { PhaseDead } from '@/lib/types';
 
 interface FlappyState {
@@ -13,8 +13,9 @@ interface FlappyActions {
   endGame: (score: number) => void;
 }
 
-export const useFlappyBirdStore = makeStore<FlappyState & FlappyActions>(
+export const useFlappyBirdStore = makePersistStore<FlappyState & FlappyActions>(
   'FlappyBirdStore',
+  'flappy-bird-best',
   (set, get) => ({
     phase: 'menu',
     score: 0,
@@ -26,4 +27,5 @@ export const useFlappyBirdStore = makeStore<FlappyState & FlappyActions>(
       set({ phase: 'dead', score, best }, false, 'flappy/endGame');
     },
   }),
+  { partialize: (s) => ({ best: s.best }) },
 );

--- a/gamesformykids/app/games/frogger/froggerStore.ts
+++ b/gamesformykids/app/games/frogger/froggerStore.ts
@@ -1,4 +1,4 @@
-import { makeStore } from '@/lib/stores/createStore';
+import { makePersistStore } from '@/lib/stores/createStore';
 import type { PhaseDead } from '@/lib/types';
 
 interface FroggerState {
@@ -14,8 +14,9 @@ interface FroggerActions {
   endGame: (score: number) => void;
 }
 
-export const useFroggerStore = makeStore<FroggerState & FroggerActions>(
+export const useFroggerStore = makePersistStore<FroggerState & FroggerActions>(
   'FroggerStore',
+  'frogger-best',
   (set, get) => ({
     phase: 'menu',
     score: 0,
@@ -28,4 +29,5 @@ export const useFroggerStore = makeStore<FroggerState & FroggerActions>(
       set({ phase: 'dead', lives: 0, score, best }, false, 'frogger/endGame');
     },
   }),
+  { partialize: (s) => ({ best: s.best }) },
 );

--- a/gamesformykids/app/games/jumper/jumperStore.ts
+++ b/gamesformykids/app/games/jumper/jumperStore.ts
@@ -1,4 +1,4 @@
-import { makeStore } from '@/lib/stores/createStore';
+import { makePersistStore } from '@/lib/stores/createStore';
 import type { PhaseDead } from '@/lib/types';
 
 interface JumperState {
@@ -13,8 +13,9 @@ interface JumperActions {
   endGame: (score: number) => void;
 }
 
-export const useJumperStore = makeStore<JumperState & JumperActions>(
+export const useJumperStore = makePersistStore<JumperState & JumperActions>(
   'JumperStore',
+  'jumper-best',
   (set, get) => ({
     phase: 'menu',
     score: 0,
@@ -26,4 +27,5 @@ export const useJumperStore = makeStore<JumperState & JumperActions>(
       set({ phase: 'dead', score, best }, false, 'jumper/endGame');
     },
   }),
+  { partialize: (s) => ({ best: s.best }) },
 );

--- a/gamesformykids/app/games/math-race/mathRaceStore.ts
+++ b/gamesformykids/app/games/math-race/mathRaceStore.ts
@@ -1,4 +1,4 @@
-import { makeStore } from '@/lib/stores/createStore';
+import { makePersistStore } from '@/lib/stores/createStore';
 import type { ArithOp as Op, PhaseDead as Phase } from '@/lib/types';
 import { randInt as rnd } from '@/lib/utils';
 
@@ -57,8 +57,9 @@ const INITIAL: MathRaceState = {
   timeLeft: GAME_TIME, feedback: null, streak: 0, total: 0, correct: 0,
 };
 
-export const useMathRaceStore = makeStore<MathRaceState & MathRaceActions>(
+export const useMathRaceStore = makePersistStore<MathRaceState & MathRaceActions>(
   'MathRaceStore',
+  'math-race-best',
   (set, get) => {
     let gameTimerId:  ReturnType<typeof setInterval> | null = null;
     let feedbackId:   ReturnType<typeof setTimeout>  | null = null;
@@ -113,4 +114,5 @@ export const useMathRaceStore = makeStore<MathRaceState & MathRaceActions>(
       },
     };
   },
+  { partialize: (s) => ({ best: s.best }) },
 );

--- a/gamesformykids/app/games/meteor-dodge/meteorDodgeStore.ts
+++ b/gamesformykids/app/games/meteor-dodge/meteorDodgeStore.ts
@@ -1,4 +1,4 @@
-import { makeStore } from '@/lib/stores/createStore';
+import { makePersistStore } from '@/lib/stores/createStore';
 import type { PhaseDead } from '@/lib/types';
 
 interface MeteorState {
@@ -13,8 +13,9 @@ interface MeteorActions {
   endGame: (score: number) => void;
 }
 
-export const useMeteorDodgeStore = makeStore<MeteorState & MeteorActions>(
+export const useMeteorDodgeStore = makePersistStore<MeteorState & MeteorActions>(
   'MeteorDodgeStore',
+  'meteor-dodge-best',
   (set, get) => ({
     phase: 'menu',
     score: 0,
@@ -26,4 +27,5 @@ export const useMeteorDodgeStore = makeStore<MeteorState & MeteorActions>(
       set({ phase: 'dead', score, best }, false, 'meteor/endGame');
     },
   }),
+  { partialize: (s) => ({ best: s.best }) },
 );

--- a/gamesformykids/app/games/simon/simonStore.ts
+++ b/gamesformykids/app/games/simon/simonStore.ts
@@ -1,4 +1,4 @@
-import { makeStore } from '@/lib/stores/createStore';
+import { makePersistStore } from '@/lib/stores/createStore';
 import type { PhaseSimon as Phase } from '@/lib/types';
 
 export const BUTTONS = [
@@ -63,7 +63,7 @@ export async function showSequence(seq: ButtonId[]) {
   useSimonStore.getState().setPlayerIdx(0);
 }
 
-export const useSimonStore = makeStore<SimonState & SimonActions>('SimonStore', (set) => ({
+export const useSimonStore = makePersistStore<SimonState & SimonActions>('SimonStore', 'simon-best', (set) => ({
   ...INITIAL,
   setPhase:       (phase) => set({ phase }, false, 'simon/setPhase'),
   setActiveColor: (color) => set({ activeColor: color }, false, 'simon/setActiveColor'),
@@ -79,4 +79,4 @@ export const useSimonStore = makeStore<SimonState & SimonActions>('SimonStore', 
     useSimonStore.getState().setRoundScore(0);
     showSequence(seq);
   },
-}));
+}), { partialize: (s) => ({ best: s.best }) });

--- a/gamesformykids/app/games/stack/stackStore.ts
+++ b/gamesformykids/app/games/stack/stackStore.ts
@@ -1,4 +1,4 @@
-import { makeStore } from '@/lib/stores/createStore';
+import { makePersistStore } from '@/lib/stores/createStore';
 import type { PhaseDead } from '@/lib/types';
 
 interface StackState {
@@ -13,8 +13,9 @@ interface StackActions {
   endGame: (score: number) => void;
 }
 
-export const useStackStore = makeStore<StackState & StackActions>(
+export const useStackStore = makePersistStore<StackState & StackActions>(
   'StackStore',
+  'stack-best',
   (set, get) => ({
     phase: 'menu',
     score: 0,
@@ -26,4 +27,5 @@ export const useStackStore = makeStore<StackState & StackActions>(
       set({ phase: 'dead', score, best }, false, 'stack/endGame');
     },
   }),
+  { partialize: (s) => ({ best: s.best }) },
 );

--- a/gamesformykids/app/games/true-false/trueFalseStore.ts
+++ b/gamesformykids/app/games/true-false/trueFalseStore.ts
@@ -1,4 +1,4 @@
-import { makeStore } from '@/lib/stores/createStore';
+import { makePersistStore } from '@/lib/stores/createStore';
 import { setupLivesTimer } from '@/lib/stores/livesTimerHelpers';
 import { makeLivesInitial } from '@/lib/stores/utils/sliceUtils';
 import type { LivesGameState } from '@/lib/types';
@@ -52,8 +52,9 @@ interface TrueFalseActions {
 
 const INITIAL = makeLivesInitial(TIME_PER_Q, { deck: shuffle(FACTS), idx: 0 });
 
-export const useTrueFalseStore = makeStore<TrueFalseState & TrueFalseActions>(
+export const useTrueFalseStore = makePersistStore<TrueFalseState & TrueFalseActions>(
   'TrueFalseStore',
+  'true-false-best',
   (set, get) => {
     const timer = setupLivesTimer({
       name: 'TrueFalseStore', timePerQ: TIME_PER_Q, feedbackMs: 800, initialLives: 3,
@@ -85,4 +86,5 @@ export const useTrueFalseStore = makeStore<TrueFalseState & TrueFalseActions>(
       },
     };
   },
+  { partialize: (s) => ({ best: s.best }) },
 );

--- a/gamesformykids/app/games/whack-a-mole/whackAMoleStore.ts
+++ b/gamesformykids/app/games/whack-a-mole/whackAMoleStore.ts
@@ -1,4 +1,4 @@
-import { makeStore } from '@/lib/stores/createStore';
+import { makePersistStore } from '@/lib/stores/createStore';
 import { setupGameTimer } from '@/lib/stores/gameTimerHelpers';
 import type { PhaseResult as Phase } from '@/lib/types';
 
@@ -37,8 +37,9 @@ function freshState(best = 0): WhackAMoleState {
   };
 }
 
-export const useWhackAMoleStore = makeStore<WhackAMoleState & WhackAMoleActions>(
+export const useWhackAMoleStore = makePersistStore<WhackAMoleState & WhackAMoleActions>(
   'WhackAMoleStore',
+  'whack-a-mole-best',
   (set, get) => {
     let moleSpawnRef: ReturnType<typeof setTimeout>  | null = null;
     const moleTimers: (ReturnType<typeof setTimeout> | null)[] = Array(GRID).fill(null);
@@ -134,4 +135,5 @@ export const useWhackAMoleStore = makeStore<WhackAMoleState & WhackAMoleActions>
       },
     };
   },
+  { partialize: (s) => ({ best: s.best }) },
 );


### PR DESCRIPTION
## Summary
All 14 affected game stores had `best: 0` initialized in volatile `makeStore` — scores reset to zero on every page reload despite being correctly updated during play.

Switch each to `makePersistStore` with `partialize: (s) => ({ best: s.best })` so only the best score is written to localStorage. All other game state (phase, question, lives, timer, etc.) remains in-memory and resets normally between sessions.

**Stores fixed (14):** balloon-pop, brick-breaker, color-tap, dino-runner, emoji-math, flappy-bird, frogger, jumper, math-race, meteor-dodge, simon, stack, true-false, whack-a-mole.

`catch-fruit` and `space-defender` were already fixed in #330 (issue #308) via `makeCanvasGameStore`.

`balloon-pop` uses `create<>()` directly (not `makeStore`) — added `persist` middleware inline inside `devtools`.

## Test plan
- [ ] TypeScript: `tsc --noEmit` passes
- [ ] Play any affected game, achieve a score, reload page → best score persists
- [ ] Starting a new game resets score/lives but NOT best

Closes #305

🤖 Generated with [Claude Code](https://claude.com/claude-code)