### PR TITLE
refactor: extract shared LivesDisplay component (#309)

### DIFF
--- a/gamesformykids/app/games/catch-fruit/components/CatchFruitHUD.tsx
+++ b/gamesformykids/app/games/catch-fruit/components/CatchFruitHUD.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useCatchFruitGame } from '../useCatchFruitGame';
+import LivesDisplay from '@/components/game/shared/LivesDisplay';
 
 export default function CatchFruitHUD() {
   const { score, lives, timeLeft } = useCatchFruitGame();
@@ -11,7 +12,7 @@ export default function CatchFruitHUD() {
         <p className="text-xs text-yellow-500">ניקוד</p>
       </div>
       <div>
-        <p className="text-2xl font-black text-red-300">{'❤️'.repeat(Math.max(0, lives))}</p>
+        <LivesDisplay lives={lives} />
         <p className="text-xs text-red-400">חיים</p>
       </div>
       <div>

--- a/gamesformykids/app/games/color-tap/components/ColorTapPlayArea.tsx
+++ b/gamesformykids/app/games/color-tap/components/ColorTapPlayArea.tsx
@@ -1,5 +1,6 @@
 'use client';
 import { useColorTapGame, TIME_PER_Q } from '../useColorTapGame';
+import LivesDisplay from '@/components/game/shared/LivesDisplay';
 
 export default function ColorTapPlayArea() {
   const { question, feedback, timeLeft, score, lives, handleTap } =
@@ -13,9 +14,7 @@ export default function ColorTapPlayArea() {
           <p className="text-xs text-pink-400">ניקוד</p>
         </div>
         <div className="flex gap-1 items-center">
-          {[0, 1, 2].map(i => (
-            <span key={i} className={`text-2xl transition-all ${i < lives ? '' : 'opacity-20 grayscale'}`}>❤️</span>
-          ))}
+          <LivesDisplay lives={lives} />
         </div>
         <div>
           <p className={`text-2xl font-black ${timeLeft <= 2 ? 'text-red-500 animate-pulse' : 'text-purple-600'}`}>{timeLeft}</p>

--- a/gamesformykids/app/games/emoji-math/components/EmojiMathPlayArea.tsx
+++ b/gamesformykids/app/games/emoji-math/components/EmojiMathPlayArea.tsx
@@ -1,5 +1,6 @@
 'use client';
 import { useEmojiMathGame, TIME_PER_Q } from '../useEmojiMathGame';
+import LivesDisplay from '@/components/game/shared/LivesDisplay';
 
 function renderEmojis(count: number, emoji: string) {
   return Array.from({ length: Math.min(count, 15) }, (_, i) => (
@@ -19,9 +20,7 @@ export default function EmojiMathPlayArea() {
           <p className="text-xs text-orange-400">ניקוד</p>
         </div>
         <div className="flex gap-1 items-center">
-          {[0, 1, 2].map(i => (
-            <span key={i} className={`text-xl ${i < lives ? '' : 'opacity-20'}`}>❤️</span>
-          ))}
+          <LivesDisplay lives={lives} size="text-xl" />
         </div>
         <div>
           <p className={`text-2xl font-black ${timeLeft <= 2 ? 'text-red-500 animate-pulse' : 'text-orange-700'}`}>{timeLeft}</p>

--- a/gamesformykids/app/games/frogger/FroggerGame.tsx
+++ b/gamesformykids/app/games/frogger/FroggerGame.tsx
@@ -2,6 +2,7 @@
 
 import { useFroggerGame, W, H } from './useFroggerGame';
 import { CanvasScoreBar } from '@/components/game/shared/CanvasScoreBar';
+import LivesDisplay from '@/components/game/shared/LivesDisplay';
 import { CanvasMenuOverlay } from '@/components/game/shared/CanvasMenuOverlay';
 import FroggerGameOverOverlay from './components/FroggerGameOverOverlay';
 import { CanvasDPadControls } from '@/components/game/shared/CanvasDPadControls';
@@ -21,7 +22,7 @@ export default function FroggerGame() {
         <CanvasScoreBar
           stats={[
             { value: score, label: "ניקוד", valueClass: "text-xl font-black text-green-300", labelClass: "text-xs text-green-600" },
-            { value: <div className="flex gap-1 items-center justify-center">{[0,1,2].map(i => <span key={i} className={`text-xl ${i < lives ? '' : 'opacity-20'}`}>❤️</span>)}</div> },
+            { value: <LivesDisplay lives={lives} size="text-xl" /> },
           ]}
         />
       )}

--- a/gamesformykids/app/games/space-defender/components/SpaceDefenderHUD.tsx
+++ b/gamesformykids/app/games/space-defender/components/SpaceDefenderHUD.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useSpaceDefenderGame } from '../useSpaceDefenderGame';
+import LivesDisplay from '@/components/game/shared/LivesDisplay';
 
 export default function SpaceDefenderHUD() {
   const { score, lives, timeLeft } = useSpaceDefenderGame();
@@ -11,7 +12,7 @@ export default function SpaceDefenderHUD() {
         <p className="text-xs text-yellow-500">ניקוד</p>
       </div>
       <div>
-        <p className="text-2xl font-black text-red-300">{'❤️'.repeat(Math.max(0, lives))}</p>
+        <LivesDisplay lives={lives} />
         <p className="text-xs text-red-400">חיים</p>
       </div>
       <div>

--- a/gamesformykids/app/games/true-false/components/TrueFalsePlayScreen.tsx
+++ b/gamesformykids/app/games/true-false/components/TrueFalsePlayScreen.tsx
@@ -1,5 +1,6 @@
 'use client';
 import { useTrueFalseGame, TIME_PER_Q } from '../useTrueFalseGame';
+import LivesDisplay from '@/components/game/shared/LivesDisplay';
 
 export default function TrueFalsePlayScreen() {
   const { score, lives, timeLeft, feedback, q, answer } = useTrueFalseGame();
@@ -9,7 +10,7 @@ export default function TrueFalsePlayScreen() {
       <div className="flex gap-6 mb-5 text-center">
         <div><p className="text-2xl font-black text-teal-600">{score}</p><p className="text-xs text-teal-400">ניקוד</p></div>
         <div className="flex gap-1 items-center">
-          {[0, 1, 2].map(i => <span key={i} className={`text-2xl ${i < lives ? '' : 'opacity-20'}`}>❤️</span>)}
+          <LivesDisplay lives={lives} />
         </div>
         <div>
           <p className={`text-2xl font-black ${timeLeft <= 2 ? 'text-red-500 animate-pulse' : 'text-cyan-600'}`}>{timeLeft}</p>

--- a/gamesformykids/app/games/word-scramble/components/WordScramblePlayScreen.tsx
+++ b/gamesformykids/app/games/word-scramble/components/WordScramblePlayScreen.tsx
@@ -1,5 +1,6 @@
 'use client';
 import { useWordScrambleGame } from '../useWordScrambleGame';
+import LivesDisplay from '@/components/game/shared/LivesDisplay';
 
 export default function WordScramblePlayScreen() {
   const { words, wIdx, letters, picked, score, lives, shake, correct, pickLetter, unpick } =
@@ -12,7 +13,7 @@ export default function WordScramblePlayScreen() {
       <div className="flex items-center gap-6 mb-4 text-center">
         <div><p className="text-2xl font-black text-green-600">{score}</p><p className="text-xs text-green-400">ניקוד</p></div>
         <div><p className="text-lg font-bold text-gray-500">{wIdx + 1}/{words.length}</p></div>
-        <div className="flex gap-1">{Array.from({ length: 3 }).map((_, i) => <span key={i}>{i < lives ? '❤️' : '🖤'}</span>)}</div>
+        <LivesDisplay lives={lives} size="text-base" />
       </div>
       <div className={`bg-white rounded-3xl p-6 shadow-2xl max-w-sm w-full text-center transition-all duration-200 ${shake ? 'animate-shake' : ''}`}>
         <div className="text-7xl mb-2">{entry.emoji}</div>

--- a/gamesformykids/components/game/shared/LivesDisplay.tsx
+++ b/gamesformykids/components/game/shared/LivesDisplay.tsx
@@ -1,0 +1,15 @@
+interface Props {
+  lives: number;
+  max?: number;
+  size?: string;
+}
+
+export default function LivesDisplay({ lives, max = 3, size = 'text-2xl' }: Props) {
+  return (
+    <div className="flex gap-1">
+      {Array.from({ length: max }, (_, i) => (
+        <span key={i} className={`${size} transition-all ${i < lives ? '' : 'opacity-20 grayscale'}`}>❤️</span>
+      ))}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Creates `components/game/shared/LivesDisplay.tsx` — single source of truth for rendering lives as hearts
- Replaces 7 inline implementations: `ColorTapPlayArea`, `EmojiMathPlayArea`, `TrueFalsePlayScreen`, `WordScramblePlayScreen`, `FroggerGame`, `CatchFruitHUD`, `SpaceDefenderHUD`
- Fixes inconsistency: `EmojiMathPlayArea` and `TrueFalsePlayScreen` were missing `grayscale` on empty hearts; `CatchFruitHUD` and `SpaceDefenderHUD` didn't show depleted slots at all

## Test plan
- [ ] Color Tap: 3 hearts visible, deplete correctly with grayscale+opacity
- [ ] Emoji Math: hearts render at `text-xl`, deplete correctly
- [ ] True/False: hearts render and deplete correctly
- [ ] Word Scramble: hearts render and deplete correctly
- [ ] Frogger: hearts visible in score bar HUD
- [ ] Catch Fruit: hearts show with depleted slots visible
- [ ] Space Defender: hearts show with depleted slots visible

Closes #309

🤖 Generated with [Claude Code](https://claude.com/claude-code)