### PR TITLE
refactor: extract dedicated ResultScreen components for 4 games (#306)

### DIFF
--- a/gamesformykids/app/games/color-tap/ColorTapGame.tsx
+++ b/gamesformykids/app/games/color-tap/ColorTapGame.tsx
@@ -1,27 +1,13 @@
 'use client';
 import { useColorTapGame } from './useColorTapGame';
-import ScoreBestResultCard from '@/components/game/shared/ScoreBestResultCard';
 import ColorTapMenuScreen from './components/ColorTapMenuScreen';
 import ColorTapPlayArea from './components/ColorTapPlayArea';
+import ColorTapResultScreen from './components/ColorTapResultScreen';
 
 export default function ColorTapGame() {
-  const { phase, score, best, startGame } = useColorTapGame();
+  const { phase } = useColorTapGame();
 
   if (phase === 'menu') return <ColorTapMenuScreen />;
-  if (phase === 'dead') return (
-    <ScoreBestResultCard
-      emoji="😢"
-      title="נגמרו החיים!"
-      gradientClass="from-pink-100 to-purple-200"
-      buttonClass="from-pink-500 to-purple-600"
-      score={score}
-      best={best}
-      scoreBgClass="bg-pink-50"
-      scoreTextClass="text-pink-600"
-      scoreLabelClass="text-pink-400"
-      onRestart={startGame}
-      restartLabel="🔄 שוב!"
-    />
-  );
+  if (phase === 'dead') return <ColorTapResultScreen />;
   return <ColorTapPlayArea />;
 }

--- a/gamesformykids/app/games/color-tap/components/ColorTapResultScreen.tsx
+++ b/gamesformykids/app/games/color-tap/components/ColorTapResultScreen.tsx
@@ -1,0 +1,22 @@
+'use client';
+import ScoreBestResultCard from '@/components/game/shared/ScoreBestResultCard';
+import { useColorTapGame } from '../useColorTapGame';
+
+export default function ColorTapResultScreen() {
+  const { score, best, startGame } = useColorTapGame();
+  return (
+    <ScoreBestResultCard
+      emoji="😢"
+      title="נגמרו החיים!"
+      gradientClass="from-pink-100 to-purple-200"
+      buttonClass="from-pink-500 to-purple-600"
+      score={score}
+      best={best}
+      scoreBgClass="bg-pink-50"
+      scoreTextClass="text-pink-600"
+      scoreLabelClass="text-pink-400"
+      onRestart={startGame}
+      restartLabel="🔄 שוב!"
+    />
+  );
+}

--- a/gamesformykids/app/games/emoji-math/EmojiMathGame.tsx
+++ b/gamesformykids/app/games/emoji-math/EmojiMathGame.tsx
@@ -1,27 +1,13 @@
 'use client';
 import { useEmojiMathGame } from './useEmojiMathGame';
-import ScoreBestResultCard from '@/components/game/shared/ScoreBestResultCard';
 import EmojiMathMenuScreen from './components/EmojiMathMenuScreen';
 import EmojiMathPlayArea from './components/EmojiMathPlayArea';
+import EmojiMathResultScreen from './components/EmojiMathResultScreen';
 
 export default function EmojiMathGame() {
-  const { phase, score, best, startGame } = useEmojiMathGame();
+  const { phase } = useEmojiMathGame();
 
   if (phase === 'menu') return <EmojiMathMenuScreen />;
-  if (phase === 'dead') return (
-    <ScoreBestResultCard
-      emoji="🤓"
-      title="כל הכבוד על המאמץ!"
-      gradientClass="from-yellow-100 to-orange-200"
-      buttonClass="from-yellow-400 to-orange-500"
-      score={score}
-      best={best}
-      scoreBgClass="bg-orange-50"
-      scoreTextClass="text-orange-600"
-      scoreLabelClass="text-orange-400"
-      onRestart={startGame}
-      restartLabel="🔄 שוב!"
-    />
-  );
+  if (phase === 'dead') return <EmojiMathResultScreen />;
   return <EmojiMathPlayArea />;
 }

--- a/gamesformykids/app/games/emoji-math/components/EmojiMathResultScreen.tsx
+++ b/gamesformykids/app/games/emoji-math/components/EmojiMathResultScreen.tsx
@@ -1,0 +1,22 @@
+'use client';
+import ScoreBestResultCard from '@/components/game/shared/ScoreBestResultCard';
+import { useEmojiMathGame } from '../useEmojiMathGame';
+
+export default function EmojiMathResultScreen() {
+  const { score, best, startGame } = useEmojiMathGame();
+  return (
+    <ScoreBestResultCard
+      emoji="🤓"
+      title="כל הכבוד על המאמץ!"
+      gradientClass="from-yellow-100 to-orange-200"
+      buttonClass="from-yellow-400 to-orange-500"
+      score={score}
+      best={best}
+      scoreBgClass="bg-orange-50"
+      scoreTextClass="text-orange-600"
+      scoreLabelClass="text-orange-400"
+      onRestart={startGame}
+      restartLabel="🔄 שוב!"
+    />
+  );
+}

--- a/gamesformykids/app/games/true-false/TrueFalseGame.tsx
+++ b/gamesformykids/app/games/true-false/TrueFalseGame.tsx
@@ -2,26 +2,12 @@
 import { useTrueFalseGame } from './useTrueFalseGame';
 import TrueFalseMenuScreen from './components/TrueFalseMenuScreen';
 import TrueFalsePlayScreen from './components/TrueFalsePlayScreen';
-import ScoreBestResultCard from '@/components/game/shared/ScoreBestResultCard';
+import TrueFalseResultScreen from './components/TrueFalseResultScreen';
 
 export default function TrueFalseGame() {
-  const { phase, score, best, startGame } = useTrueFalseGame();
+  const { phase } = useTrueFalseGame();
 
   if (phase === 'menu') return <TrueFalseMenuScreen />;
-  if (phase === 'dead') return (
-    <ScoreBestResultCard
-      emoji="🧠"
-      title="כל הכבוד על הניסיון!"
-      gradientClass="from-teal-100 to-cyan-200"
-      buttonClass="from-teal-500 to-cyan-600"
-      score={score}
-      best={best}
-      scoreBgClass="bg-teal-50"
-      scoreTextClass="text-teal-600"
-      scoreLabelClass="text-teal-400"
-      onRestart={startGame}
-      restartLabel="🔄 שוב!"
-    />
-  );
+  if (phase === 'dead') return <TrueFalseResultScreen />;
   return <TrueFalsePlayScreen />;
 }

--- a/gamesformykids/app/games/true-false/components/TrueFalseResultScreen.tsx
+++ b/gamesformykids/app/games/true-false/components/TrueFalseResultScreen.tsx
@@ -1,0 +1,22 @@
+'use client';
+import ScoreBestResultCard from '@/components/game/shared/ScoreBestResultCard';
+import { useTrueFalseGame } from '../useTrueFalseGame';
+
+export default function TrueFalseResultScreen() {
+  const { score, best, startGame } = useTrueFalseGame();
+  return (
+    <ScoreBestResultCard
+      emoji="🧠"
+      title="כל הכבוד על הניסיון!"
+      gradientClass="from-teal-100 to-cyan-200"
+      buttonClass="from-teal-500 to-cyan-600"
+      score={score}
+      best={best}
+      scoreBgClass="bg-teal-50"
+      scoreTextClass="text-teal-600"
+      scoreLabelClass="text-teal-400"
+      onRestart={startGame}
+      restartLabel="🔄 שוב!"
+    />
+  );
+}

--- a/gamesformykids/app/games/whack-a-mole/WhackAMoleGame.tsx
+++ b/gamesformykids/app/games/whack-a-mole/WhackAMoleGame.tsx
@@ -2,29 +2,15 @@
 
 import { useWhackAMoleGame } from './useWhackAMoleGame';
 import WhackAMoleMenuScreen from './components/WhackAMoleMenuScreen';
-import ScoreBestResultCard from '@/components/game/shared/ScoreBestResultCard';
+import WhackAMoleResultScreen from './components/WhackAMoleResultScreen';
 import WhackHUD from './components/WhackHUD';
 import WhackGrid from './components/WhackGrid';
 
 export default function WhackAMoleGame() {
-  const { phase, score, best, bgColor, startGame } = useWhackAMoleGame();
+  const { phase, bgColor } = useWhackAMoleGame();
 
   if (phase === 'menu') return <WhackAMoleMenuScreen />;
-
-  if (phase === 'result') return (
-    <ScoreBestResultCard
-      emoji="🔨"
-      title="הזמן נגמר!"
-      gradientClass="from-yellow-50 to-amber-100"
-      buttonClass="from-amber-500 to-orange-500"
-      score={score}
-      best={best}
-      scoreBgClass="bg-amber-50"
-      scoreTextClass="text-amber-600"
-      scoreLabelClass="text-amber-400"
-      onRestart={startGame}
-    />
-  );
+  if (phase === 'result') return <WhackAMoleResultScreen />;
 
   return (
     <div className={`min-h-screen bg-gradient-to-br ${bgColor} flex flex-col items-center justify-center p-4 select-none`} dir="rtl">

--- a/gamesformykids/app/games/whack-a-mole/components/WhackAMoleResultScreen.tsx
+++ b/gamesformykids/app/games/whack-a-mole/components/WhackAMoleResultScreen.tsx
@@ -1,0 +1,21 @@
+'use client';
+import ScoreBestResultCard from '@/components/game/shared/ScoreBestResultCard';
+import { useWhackAMoleGame } from '../useWhackAMoleGame';
+
+export default function WhackAMoleResultScreen() {
+  const { score, best, startGame } = useWhackAMoleGame();
+  return (
+    <ScoreBestResultCard
+      emoji="🔨"
+      title="הזמן נגמר!"
+      gradientClass="from-yellow-50 to-amber-100"
+      buttonClass="from-amber-500 to-orange-500"
+      score={score}
+      best={best}
+      scoreBgClass="bg-amber-50"
+      scoreTextClass="text-amber-600"
+      scoreLabelClass="text-amber-400"
+      onRestart={startGame}
+    />
+  );
+}


### PR DESCRIPTION
## Summary
- Creates `*ResultScreen` components for ColorTap, EmojiMath, TrueFalse, WhackAMole — each owns its own styling props
- Root `*Game.tsx` files are now clean single-line phase routers (`if (phase === 'dead') return <XResultScreen />;`)
- Brings these 4 games in line with the established pattern already used by MathRace, WordScramble, Animals, Arithmetic

## Test plan
- [ ] Color Tap: result screen shows score + best with pink gradient
- [ ] Emoji Math: result screen shows score + best with orange gradient
- [ ] True/False: result screen shows score + best with teal gradient
- [ ] Whack-a-Mole: result screen shows score + best with amber gradient
- [ ] All 4: restart button returns to menu correctly

Closes #306

🤖 Generated with [Claude Code](https://claude.com/claude-code)