### PR TITLE
docs: document driver vs reader distinction for useAutoGame/useUniversalGame (#318)

### DIFF
--- a/gamesformykids/hooks/shared/game-state/useAutoGame.ts
+++ b/gamesformykids/hooks/shared/game-state/useAutoGame.ts
@@ -8,8 +8,19 @@ import { useGameProgressStore } from '@/lib/stores/gameProgressStore';
 import { useUIStore } from '@/lib/stores/uiStore';
 
 /**
- * 🎮 Hook מותאם שמרכז את כל לוגיקת המשחק
- * קורא מ-Zustand stores ישירות — ללא props drilling
+ * DRIVER hook — use inside the auto-game component tree only.
+ *
+ * Calls `useAutoGameConfig().useGameHook()` which invokes the game-specific
+ * hook (looked up from GAME_HOOKS_MAP) and writes its results into the Zustand
+ * stores (gameSessionStore, gameProgressStore, gameActionsStore).
+ *
+ * Throws if the current game type is not registered in GAME_HOOKS_MAP — only
+ * use this in components guaranteed to be rendered under a valid game route.
+ *
+ * Callers: AutoGamePage, AutoGameHeader, AutoGameBody.
+ *
+ * For components that only need to *read* game state that another hook has
+ * already written, use `useUniversalGame` instead.
  */
 export function useAutoGame(): GameLogicState {
   // קבלת קונפיגורציה (Zustand-backed)

--- a/gamesformykids/hooks/shared/game-state/useUniversalGame.ts
+++ b/gamesformykids/hooks/shared/game-state/useUniversalGame.ts
@@ -1,7 +1,22 @@
 'use client'
 
 /**
- * useUniversalGame and sub-hooks — aggregates from useGameLogic sub-hooks.
+ * READER hook — use in shared UI components and the ultimate-game tree.
+ *
+ * Aggregates already-computed game state by reading from the Zustand stores
+ * via the useGameLogic sub-hooks. It does NOT call any game-specific hook and
+ * does NOT write to any store.
+ *
+ * This is safe to call from any component that is rendered inside a context
+ * where the game has already been driven (by useAutoGame or a game-specific
+ * hook). It never throws for an unrecognised game type.
+ *
+ * Callers: UltimateGamePage, UltimateStartScreen, AutoStartScreen, and all
+ * shared game UI components (GameChallengeSection, GameMainContent,
+ * GameStartButton, GameStatsButton, ColoredShapeCard, CelebrationBox, …).
+ *
+ * For the component tree that must also *drive* the game (invoke the
+ * game-specific hook), use `useAutoGame` instead.
  */
 
 import { GameType } from '@/lib/types/core/base'


### PR DESCRIPTION
## Summary
Adds precise JSDoc to both hooks that explains the driver/reader split — no functional changes.

**`useAutoGame` (DRIVER)**
- Calls `useAutoGameConfig().useGameHook()` — invokes the game-specific hook and writes to Zustand stores
- Throws if game type not in `GAME_HOOKS_MAP`
- Only for the `auto-game/` component tree

**`useUniversalGame` (READER)**
- Reads already-computed state from stores via `useGameLogic` sub-hooks
- Never calls a game-specific hook, never throws
- Safe for any shared UI component rendered under a valid game context

## Why this approach
The hooks have genuinely different responsibilities and different callers — merging them would lose the enforcement that `useAutoGame` provides. The documentation makes the split explicit so a developer reading `AutoStartScreen` (which uses `useUniversalGame`) immediately understands it is a reader, not a driver.

Closes #318

🤖 Generated with [Claude Code](https://claude.com/claude-code)