### PR TITLE
perf: add bundle analysis + Lighthouse CI performance budgets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,3 +35,36 @@ jobs:
 
       - name: Test
         run: npm test -- --run --reporter=verbose
+
+  bundle-size:
+    name: Bundle Size
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    defaults:
+      run:
+        working-directory: gamesformykids
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: gamesformykids/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci --prefer-offline
+
+      - name: Build (with bundle analysis)
+        run: ANALYZE=true npm run build
+        env:
+          NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL || 'https://placeholder.supabase.co' }}
+          NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY || 'placeholder' }}
+
+      - name: Upload bundle report
+        uses: actions/upload-artifact@v4
+        with:
+          name: bundle-report
+          path: gamesformykids/.next/analyze/
+          retention-days: 30

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -1,0 +1,44 @@
+name: Lighthouse CI
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  lighthouse:
+    name: Lighthouse
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    defaults:
+      run:
+        working-directory: gamesformykids
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: gamesformykids/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci --prefer-offline
+
+      - name: Build
+        run: npm run build
+        env:
+          NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL || 'https://placeholder.supabase.co' }}
+          NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY || 'placeholder' }}
+
+      - name: Start server
+        run: npm start &
+        env:
+          PORT: 3000
+
+      - name: Wait for server
+        run: npx --yes wait-on http://localhost:3000 --timeout 60000
+
+      - name: Run Lighthouse CI
+        run: npx --yes @lhci/cli@0.14.x autorun
+        working-directory: ${{ github.workspace }}

--- a/.lighthouserc.json
+++ b/.lighthouserc.json
@@ -1,0 +1,29 @@
+{
+  "ci": {
+    "collect": {
+      "url": [
+        "http://localhost:3000/",
+        "http://localhost:3000/games/arithmetic",
+        "http://localhost:3000/games/math-race"
+      ],
+      "numberOfRuns": 1,
+      "settings": {
+        "chromeFlags": "--no-sandbox --disable-dev-shm-usage"
+      }
+    },
+    "assert": {
+      "assertions": {
+        "categories:performance": ["warn", { "minScore": 0.8 }],
+        "categories:accessibility": ["warn", { "minScore": 0.9 }],
+        "first-contentful-paint": ["warn", { "maxNumericValue": 2000 }],
+        "largest-contentful-paint": ["warn", { "maxNumericValue": 4000 }],
+        "cumulative-layout-shift": ["warn", { "maxNumericValue": 0.1 }],
+        "total-blocking-time": ["warn", { "maxNumericValue": 300 }],
+        "interactive": ["warn", { "maxNumericValue": 5000 }]
+      }
+    },
+    "upload": {
+      "target": "temporary-public-storage"
+    }
+  }
+}

--- a/gamesformykids/next.config.ts
+++ b/gamesformykids/next.config.ts
@@ -1,6 +1,6 @@
 import type { NextConfig } from "next";
+import withBundleAnalyzer from "@next/bundle-analyzer";
 
-// Bundle analyzer configuration - disabled by default
 const nextConfig: NextConfig = {
   experimental: {
     reactCompiler: true,
@@ -103,6 +103,5 @@ const nextConfig: NextConfig = {
   },
 };
 
-// Export with bundle analyzer wrapper
-// To enable bundle analysis: npm run build:analyze
-export default nextConfig;
+// Enable with: npm run build:analyze (ANALYZE=true next build)
+export default withBundleAnalyzer({ enabled: process.env.ANALYZE === "true" })(nextConfig);


### PR DESCRIPTION
Closes #193

## Summary
- **`next.config.ts`**: Wire up `@next/bundle-analyzer` (already in devDeps) — `npm run build:analyze` now generates interactive reports in `.next/analyze/`
- **`ci.yml`**: New `bundle-size` job runs `ANALYZE=true next build` on every PR, uploads the analyzer report as a 30-day artifact for side-by-side diffing
- **`lighthouse.yml`**: New workflow builds the app, starts `next start`, and runs `@lhci/cli` against `/`, `/games/arithmetic`, `/games/math-race`
- **`.lighthouserc.json`**: Defines warn-level performance budgets — Perf ≥ 0.80, Accessibility ≥ 0.90, LCP ≤ 4 s, CLS ≤ 0.10, TBT ≤ 300 ms, TTI ≤ 5 s

## Test plan
- [ ] CI `bundle-size` job completes and artifact appears under Actions → Run → Artifacts
- [ ] Lighthouse workflow runs and posts results to temporary public storage (link in logs)
- [ ] `npm run build:analyze` locally opens the interactive bundle treemap

🤖 Generated with [Claude Code](https://claude.com/claude-code)