### PR TITLE
feat: add parent dashboard to track child progress

### DIFF
--- a/gamesformykids/app/dashboard/components/ActivitySummaryCard.tsx
+++ b/gamesformykids/app/dashboard/components/ActivitySummaryCard.tsx
@@ -1,0 +1,39 @@
+'use client';
+
+import type { GameProgress } from '@/hooks/shared/progress/useGameProgress';
+
+const SEVEN_DAYS_MS = 7 * 24 * 60 * 60 * 1000;
+
+export function ActivitySummaryCard({ progress }: { progress: GameProgress[] }) {
+  const now = Date.now();
+  const gamesThisWeek = progress.filter(
+    (p) => now - new Date(p.last_played_at).getTime() < SEVEN_DAYS_MS,
+  ).length;
+
+  const totalMinutes = Math.floor(
+    progress.reduce((sum, p) => sum + p.total_play_time, 0) / 60,
+  );
+
+  const totalGames = progress.filter((p) => p.total_play_time > 0).length;
+
+  const stats = [
+    { label: 'משחקים פעילים השבוע', value: gamesThisWeek, icon: '📅' },
+    { label: 'סה"כ זמן משחק', value: `${totalMinutes} דק׳`, icon: '⏱️' },
+    { label: 'סה"כ משחקים ניסה', value: totalGames, icon: '🎯' },
+  ];
+
+  return (
+    <div className="bg-white rounded-2xl shadow-md p-6">
+      <h2 className="text-lg font-bold text-gray-800 mb-4">📈 סיכום פעילות</h2>
+      <div className="grid grid-cols-3 gap-4">
+        {stats.map(({ label, value, icon }) => (
+          <div key={label} className="text-center">
+            <div className="text-3xl mb-1">{icon}</div>
+            <div className="text-2xl font-bold text-purple-700">{value}</div>
+            <div className="text-xs text-gray-500 mt-1">{label}</div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/gamesformykids/app/dashboard/components/DashboardHeader.tsx
+++ b/gamesformykids/app/dashboard/components/DashboardHeader.tsx
@@ -1,0 +1,18 @@
+'use client';
+
+import Link from 'next/link';
+
+export function DashboardHeader() {
+  return (
+    <div className="text-center mb-8">
+      <h1 className="text-4xl font-bold text-purple-800 mb-2">📊 לוח הורים</h1>
+      <p className="text-gray-600">מעקב אחר ההתקדמות של ילדך</p>
+      <Link
+        href="/"
+        className="inline-block mt-4 text-purple-600 hover:text-purple-800 text-sm font-medium transition-colors"
+      >
+        ← חזרה לעמוד הראשי
+      </Link>
+    </div>
+  );
+}

--- a/gamesformykids/app/dashboard/components/MostPlayedCard.tsx
+++ b/gamesformykids/app/dashboard/components/MostPlayedCard.tsx
@@ -1,0 +1,53 @@
+'use client';
+
+import type { GameProgress } from '@/hooks/shared/progress/useGameProgress';
+import { getGameLabel } from './gameLabels';
+
+const SEVEN_DAYS_MS = 7 * 24 * 60 * 60 * 1000;
+
+function formatMinutes(seconds: number) {
+  const m = Math.floor(seconds / 60);
+  if (m < 1) return 'פחות מדקה';
+  return `${m} דק׳`;
+}
+
+export function MostPlayedCard({ progress }: { progress: GameProgress[] }) {
+  const now = Date.now();
+  const recent = progress
+    .filter((p) => now - new Date(p.last_played_at).getTime() < SEVEN_DAYS_MS)
+    .sort((a, b) => b.total_play_time - a.total_play_time)
+    .slice(0, 5);
+
+  return (
+    <div className="bg-white rounded-2xl shadow-md p-6">
+      <h2 className="text-lg font-bold text-gray-800 mb-4">🕹️ הכי משחקים (7 ימים אחרונים)</h2>
+      {recent.length === 0 ? (
+        <p className="text-gray-400 text-sm text-center py-4">אין נתונים לשבוע האחרון</p>
+      ) : (
+        <ul className="space-y-3">
+          {recent.map((p) => {
+            const { name, emoji } = getGameLabel(p.game_type);
+            const maxTime = recent[0].total_play_time || 1;
+            const pct = Math.round((p.total_play_time / maxTime) * 100);
+            return (
+              <li key={p.game_type}>
+                <div className="flex items-center justify-between mb-1">
+                  <span className="text-sm font-medium text-gray-700">
+                    {emoji} {name}
+                  </span>
+                  <span className="text-xs text-gray-400">{formatMinutes(p.total_play_time)}</span>
+                </div>
+                <div className="w-full bg-gray-100 rounded-full h-2">
+                  <div
+                    className="bg-purple-400 h-2 rounded-full transition-all"
+                    style={{ width: `${pct}%` }}
+                  />
+                </div>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/gamesformykids/app/dashboard/components/RecentAchievementsCard.tsx
+++ b/gamesformykids/app/dashboard/components/RecentAchievementsCard.tsx
@@ -1,0 +1,32 @@
+'use client';
+
+import type { Achievement } from '@/hooks/shared/progress/useAchievements';
+
+export function RecentAchievementsCard({ achievements }: { achievements: Achievement[] }) {
+  const recent = [...achievements]
+    .sort((a, b) => new Date(b.earned_at).getTime() - new Date(a.earned_at).getTime())
+    .slice(0, 5);
+
+  return (
+    <div className="bg-white rounded-2xl shadow-md p-6">
+      <h2 className="text-lg font-bold text-gray-800 mb-4">🥇 הישגים אחרונים</h2>
+      {recent.length === 0 ? (
+        <p className="text-gray-400 text-sm text-center py-4">עדיין אין הישגים</p>
+      ) : (
+        <ul className="space-y-3">
+          {recent.map((a) => (
+            <li key={a.id} className="flex items-center gap-3">
+              <span className="text-2xl">{a.icon ?? '🏅'}</span>
+              <div>
+                <p className="text-sm font-medium text-gray-800">{a.achievement_name}</p>
+                {a.description && (
+                  <p className="text-xs text-gray-400">{a.description}</p>
+                )}
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/gamesformykids/app/dashboard/components/RecommendedGameCard.tsx
+++ b/gamesformykids/app/dashboard/components/RecommendedGameCard.tsx
@@ -1,0 +1,53 @@
+'use client';
+
+import Link from 'next/link';
+import type { GameProgress } from '@/hooks/shared/progress/useGameProgress';
+import { getGameLabel } from './gameLabels';
+
+const SEVEN_DAYS_MS = 7 * 24 * 60 * 60 * 1000;
+
+function getRecommended(progress: GameProgress[]): GameProgress | null {
+  if (progress.length === 0) return null;
+  const now = Date.now();
+
+  // Prefer games played recently but with room to improve (lowest best_score among recent)
+  const recent = progress.filter(
+    (p) => now - new Date(p.last_played_at).getTime() < SEVEN_DAYS_MS,
+  );
+  const pool = recent.length > 0 ? recent : progress;
+  return pool.reduce((worst, p) => (p.best_score < worst.best_score ? p : worst), pool[0]);
+}
+
+export function RecommendedGameCard({ progress }: { progress: GameProgress[] }) {
+  const rec = getRecommended(progress);
+
+  if (!rec) {
+    return (
+      <div className="bg-gradient-to-br from-pink-100 to-purple-100 rounded-2xl shadow-md p-6">
+        <h2 className="text-lg font-bold text-gray-800 mb-2">💡 המשחק הבא</h2>
+        <p className="text-gray-500 text-sm">שחקו כדי לקבל המלצה!</p>
+      </div>
+    );
+  }
+
+  const { name, emoji } = getGameLabel(rec.game_type);
+
+  return (
+    <div className="bg-gradient-to-br from-pink-100 to-purple-100 rounded-2xl shadow-md p-6">
+      <h2 className="text-lg font-bold text-gray-800 mb-3">💡 מומלץ לאימון</h2>
+      <div className="flex items-center gap-4">
+        <span className="text-5xl">{emoji}</span>
+        <div>
+          <p className="font-bold text-purple-800 text-lg">{name}</p>
+          <p className="text-sm text-gray-500">שיא: {rec.best_score} נקודות</p>
+        </div>
+      </div>
+      <Link
+        href={`/games/${rec.game_type}`}
+        className="mt-4 inline-block w-full text-center bg-purple-600 hover:bg-purple-700 text-white font-bold py-2 px-4 rounded-xl transition-colors"
+      >
+        בואו נשחק!
+      </Link>
+    </div>
+  );
+}

--- a/gamesformykids/app/dashboard/components/ScoreSummaryCard.tsx
+++ b/gamesformykids/app/dashboard/components/ScoreSummaryCard.tsx
@@ -1,0 +1,34 @@
+'use client';
+
+import type { GameProgress } from '@/hooks/shared/progress/useGameProgress';
+import { getGameLabel } from './gameLabels';
+
+export function ScoreSummaryCard({ progress }: { progress: GameProgress[] }) {
+  const played = progress
+    .filter((p) => p.best_score > 0)
+    .sort((a, b) => b.best_score - a.best_score)
+    .slice(0, 6);
+
+  return (
+    <div className="bg-white rounded-2xl shadow-md p-6">
+      <h2 className="text-lg font-bold text-gray-800 mb-4">🏆 שיא ניקוד</h2>
+      {played.length === 0 ? (
+        <p className="text-gray-400 text-sm text-center py-4">עדיין אין משחקים עם ניקוד</p>
+      ) : (
+        <ul className="space-y-3">
+          {played.map((p) => {
+            const { name, emoji } = getGameLabel(p.game_type);
+            return (
+              <li key={p.game_type} className="flex items-center justify-between">
+                <span className="text-sm text-gray-700">
+                  {emoji} {name}
+                </span>
+                <span className="text-sm font-bold text-purple-700">{p.best_score}</span>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/gamesformykids/app/dashboard/components/gameLabels.ts
+++ b/gamesformykids/app/dashboard/components/gameLabels.ts
@@ -1,0 +1,24 @@
+export const GAME_LABELS: Record<string, { name: string; emoji: string }> = {
+  arithmetic: { name: 'חשבון', emoji: '➕' },
+  multiplication: { name: 'כפל', emoji: '✖️' },
+  'math-race': { name: 'מרוץ מתמטיקה', emoji: '🏎️' },
+  'true-false': { name: 'נכון / לא נכון', emoji: '✅' },
+  simon: { name: 'סיימון', emoji: '🎮' },
+  'color-tap': { name: 'הקש צבע', emoji: '🎨' },
+  'emoji-math': { name: 'מתמטיקה אימוג׳י', emoji: '😀' },
+  'whack-a-mole': { name: 'הכה חפרפרת', emoji: '🦔' },
+  'word-scramble': { name: 'מילים מעורבות', emoji: '🔤' },
+  'catch-fruit': { name: 'תפוס פירות', emoji: '🍎' },
+  'space-defender': { name: 'מגן החלל', emoji: '🚀' },
+  frogger: { name: 'צפרדע', emoji: '🐸' },
+  building: { name: 'בנייה', emoji: '🏗️' },
+  counting: { name: 'ספירה', emoji: '🔢' },
+  'hebrew-letters': { name: 'אותיות עברית', emoji: 'א' },
+  bubbles: { name: 'בועות', emoji: '🫧' },
+  memory: { name: 'זיכרון', emoji: '🧠' },
+  tetris: { name: 'טטריס', emoji: '🟦' },
+};
+
+export function getGameLabel(gameType: string) {
+  return GAME_LABELS[gameType] ?? { name: gameType, emoji: '🎮' };
+}

--- a/gamesformykids/app/dashboard/error.tsx
+++ b/gamesformykids/app/dashboard/error.tsx
@@ -1,0 +1,24 @@
+'use client';
+
+export default function DashboardError({
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-purple-100 via-pink-100 to-blue-100 flex items-center justify-center p-4">
+      <div className="bg-white rounded-2xl shadow-lg p-8 text-center max-w-sm">
+        <div className="text-5xl mb-4">⚠️</div>
+        <h2 className="text-xl font-bold text-gray-800 mb-2">שגיאה בטעינת הנתונים</h2>
+        <p className="text-gray-500 text-sm mb-6">לא ניתן היה לטעון את לוח ההורים</p>
+        <button
+          onClick={reset}
+          className="bg-purple-600 hover:bg-purple-700 text-white font-bold py-2 px-6 rounded-xl transition-colors"
+        >
+          נסה שוב
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/gamesformykids/app/dashboard/loading.tsx
+++ b/gamesformykids/app/dashboard/loading.tsx
@@ -1,0 +1,24 @@
+export default function DashboardLoading() {
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-purple-100 via-pink-100 to-blue-100 p-4">
+      <div className="max-w-4xl mx-auto">
+        <div className="text-center mb-8 animate-pulse">
+          <div className="h-8 bg-purple-200 rounded w-48 mx-auto mb-2" />
+          <div className="h-4 bg-purple-100 rounded w-64 mx-auto" />
+        </div>
+        <div className="grid md:grid-cols-2 gap-6">
+          {[...Array(4)].map((_, i) => (
+            <div key={i} className="bg-white rounded-2xl shadow-md p-6 animate-pulse">
+              <div className="h-4 bg-gray-200 rounded w-1/2 mb-4" />
+              <div className="space-y-2">
+                <div className="h-3 bg-gray-100 rounded" />
+                <div className="h-3 bg-gray-100 rounded w-4/5" />
+                <div className="h-3 bg-gray-100 rounded w-3/5" />
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/gamesformykids/app/dashboard/page.tsx
+++ b/gamesformykids/app/dashboard/page.tsx
@@ -1,0 +1,79 @@
+'use client';
+
+import { useAuth } from '@/hooks/shared/auth/useAuth';
+import { useGameProgress } from '@/hooks/shared/progress/useGameProgress';
+import { useAchievements } from '@/hooks/shared/progress/useAchievements';
+import Link from 'next/link';
+import { DashboardHeader } from './components/DashboardHeader';
+import { ActivitySummaryCard } from './components/ActivitySummaryCard';
+import { MostPlayedCard } from './components/MostPlayedCard';
+import { ScoreSummaryCard } from './components/ScoreSummaryCard';
+import { RecentAchievementsCard } from './components/RecentAchievementsCard';
+import { RecommendedGameCard } from './components/RecommendedGameCard';
+
+export default function DashboardPage() {
+  const { user, loading: authLoading } = useAuth();
+  const { progress, loading: progressLoading } = useGameProgress();
+  const { achievements, loading: achievementsLoading } = useAchievements();
+
+  const loading = authLoading || progressLoading || achievementsLoading;
+
+  if (authLoading) {
+    return (
+      <div className="min-h-screen bg-gradient-to-br from-purple-100 via-pink-100 to-blue-100 flex items-center justify-center">
+        <div className="animate-pulse text-purple-600 text-xl">טוען...</div>
+      </div>
+    );
+  }
+
+  if (!user) {
+    return (
+      <div className="min-h-screen bg-gradient-to-br from-purple-100 via-pink-100 to-blue-100 flex items-center justify-center p-4">
+        <div className="bg-white rounded-2xl shadow-lg p-8 text-center max-w-sm">
+          <div className="text-5xl mb-4">🔒</div>
+          <h2 className="text-xl font-bold text-gray-800 mb-2">נדרשת התחברות</h2>
+          <p className="text-gray-500 text-sm mb-6">התחבר כדי לצפות בלוח ההורים</p>
+          <Link
+            href="/auth"
+            className="inline-block bg-purple-600 hover:bg-purple-700 text-white font-bold py-2 px-6 rounded-xl transition-colors"
+          >
+            התחברות
+          </Link>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-purple-100 via-pink-100 to-blue-100 p-4">
+      <div className="max-w-4xl mx-auto">
+        <DashboardHeader />
+
+        {loading ? (
+          <div className="grid md:grid-cols-2 gap-6">
+            {[...Array(4)].map((_, i) => (
+              <div key={i} className="bg-white rounded-2xl shadow-md p-6 animate-pulse">
+                <div className="h-4 bg-gray-200 rounded w-1/2 mb-4" />
+                <div className="space-y-2">
+                  <div className="h-3 bg-gray-100 rounded" />
+                  <div className="h-3 bg-gray-100 rounded w-4/5" />
+                  <div className="h-3 bg-gray-100 rounded w-3/5" />
+                </div>
+              </div>
+            ))}
+          </div>
+        ) : (
+          <div className="space-y-6">
+            <ActivitySummaryCard progress={progress} />
+            <div className="grid md:grid-cols-2 gap-6">
+              <MostPlayedCard progress={progress} />
+              <ScoreSummaryCard progress={progress} />
+              <RecentAchievementsCard achievements={achievements} />
+              <RecommendedGameCard progress={progress} />
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
Closes #97

## Summary
New `/dashboard` route giving parents a simple overview of their child's game activity:

- **Activity Summary** — games active this week · total play time · total games tried
- **Most Played (7 days)** — top 5 games by `total_play_time` with relative progress bars
- **Best Scores** — per-game high scores sorted descending
- **Recent Achievements** — last 5 unlocked achievements from Supabase
- **Recommended Game** — the most recently played game with the most room to improve (lowest `best_score`)

## Implementation
- Follows the same `'use client'` + Zustand hooks pattern as `/profile`
- Data from `useGameProgress()` + `useAchievements()` + `useAuth()` — no new API calls
- Includes loading skeleton, error boundary (`error.tsx`), and unauthenticated guard
- `gameLabels.ts` maps all 18 game types to Hebrew names + emoji

## Test plan
- [ ] `/dashboard` loads and shows data when signed in
- [ ] Shows "התחברות" screen when signed out
- [ ] Skeleton shows during data load
- [ ] Recommended game links to correct `/games/[gameType]` route

🤖 Generated with [Claude Code](https://claude.com/claude-code)