### PR TITLE
feat: add difficulty selection to quiz games

### DIFF
--- a/gamesformykids/app/games/color-tap/colorTapStore.ts
+++ b/gamesformykids/app/games/color-tap/colorTapStore.ts
@@ -1,4 +1,5 @@
 import { makePersistStore } from '@/lib/stores/createStore';
+import { useGameDifficulty } from '@/lib/stores/gameDifficultyStore';
 import { setupLivesTimer } from '@/lib/stores/livesTimerHelpers';
 import { makeLivesInitial } from '@/lib/stores/utils/sliceUtils';
 import type { LivesGameState } from '@/lib/types';
@@ -32,6 +33,9 @@ function makeQuestion(): Question {
 
 export const TIME_PER_Q = 5;
 
+const DIFFICULTY_LIVES   = { easy: 5, medium: 3, hard: 2 } as const;
+const DIFFICULTY_TIME_CT = { easy: 8, medium: TIME_PER_Q, hard: 3 } as const;
+
 interface ColorTapState extends LivesGameState {
   question: Question;
 }
@@ -56,7 +60,11 @@ export const useColorTapStore = makePersistStore<ColorTapState & ColorTapActions
     return {
       ...INITIAL,
 
-      startGame: () => timer.startGame(() => ({ question: makeQuestion() })),
+      startGame: () => {
+        const diff = useGameDifficulty.getState().difficulty;
+        timer.startGame(() => ({ question: makeQuestion() }));
+        set({ lives: DIFFICULTY_LIVES[diff], timeLeft: DIFFICULTY_TIME_CT[diff] });
+      },
 
       handleTap: (color: ColorItem) => {
         const { phase, feedback, question } = get();

--- a/gamesformykids/app/games/color-tap/components/ColorTapMenuScreen.tsx
+++ b/gamesformykids/app/games/color-tap/components/ColorTapMenuScreen.tsx
@@ -1,20 +1,28 @@
 'use client';
 import GameMenuCard from '@/components/game/shared/GameMenuCard';
+import { DifficultyPicker } from '@/components/game/shared/DifficultyPicker';
 import { useColorTapGame } from '../useColorTapGame';
+import { useGameDifficulty } from '@/lib/stores/gameDifficultyStore';
+
+const LIVES_BY_DIFF = { easy: 5, medium: 3, hard: 2 } as const;
+const TIME_BY_DIFF  = { easy: 8, medium: 5, hard: 3 } as const;
 
 export default function ColorTapMenuScreen() {
   const { best, startGame } = useColorTapGame();
+  const { difficulty } = useGameDifficulty();
   return (
     <GameMenuCard
       emoji="🎨"
       title="צבע נכון"
       description="בחר את הצבע הנכון לפני שהזמן נגמר!"
-      hint="3 חיים · 5 שניות לכל שאלה"
+      hint={`${LIVES_BY_DIFF[difficulty]} חיים · ${TIME_BY_DIFF[difficulty]} שניות לכל שאלה`}
       gradientClass="from-pink-100 to-purple-200"
       buttonClass="from-pink-500 to-purple-600"
       onStart={startGame}
       startLabel="🎨 התחל!"
       best={best}
-    />
+    >
+      <DifficultyPicker />
+    </GameMenuCard>
   );
 }

--- a/gamesformykids/app/games/emoji-math/components/EmojiMathMenuScreen.tsx
+++ b/gamesformykids/app/games/emoji-math/components/EmojiMathMenuScreen.tsx
@@ -1,20 +1,28 @@
 'use client';
 import GameMenuCard from '@/components/game/shared/GameMenuCard';
+import { DifficultyPicker } from '@/components/game/shared/DifficultyPicker';
 import { useEmojiMathGame } from '../useEmojiMathGame';
+import { useGameDifficulty } from '@/lib/stores/gameDifficultyStore';
+
+const LIVES_BY_DIFF = { easy: 5, medium: 3, hard: 2 } as const;
+const TIME_BY_DIFF  = { easy: 12, medium: 8, hard: 5 } as const;
 
 export default function EmojiMathMenuScreen() {
   const { best, startGame } = useEmojiMathGame();
+  const { difficulty } = useGameDifficulty();
   return (
     <GameMenuCard
       emoji="🧮"
       title="מתמטיקה עם אמוג'י"
       description="ספור את האמוג'י ופתור את התרגיל!"
-      hint="3 חיים · רצף מנצח = +20 נקודות"
+      hint={`${LIVES_BY_DIFF[difficulty]} חיים · ${TIME_BY_DIFF[difficulty]} שניות · רצף מנצח = +20 נקודות`}
       gradientClass="from-yellow-100 to-orange-200"
       buttonClass="from-yellow-400 to-orange-500"
       onStart={startGame}
       startLabel="🧮 התחל!"
       best={best}
-    />
+    >
+      <DifficultyPicker />
+    </GameMenuCard>
   );
 }

--- a/gamesformykids/app/games/emoji-math/emojiMathStore.ts
+++ b/gamesformykids/app/games/emoji-math/emojiMathStore.ts
@@ -1,4 +1,5 @@
 import { makePersistStore } from '@/lib/stores/createStore';
+import { useGameDifficulty } from '@/lib/stores/gameDifficultyStore';
 import { setupLivesTimer } from '@/lib/stores/livesTimerHelpers';
 import { makeLivesInitial } from '@/lib/stores/utils/sliceUtils';
 import type { LivesGameState } from '@/lib/types';
@@ -41,6 +42,9 @@ export function makeQuestion(level: number): Question {
 
 export const TIME_PER_Q = 8;
 
+const DIFFICULTY_LIVES   = { easy: 5, medium: 3, hard: 2 } as const;
+const DIFFICULTY_TIME_EM = { easy: 12, medium: TIME_PER_Q, hard: 5 } as const;
+
 interface EmojiMathState extends LivesGameState {
   q:      Question;
   level:  number;
@@ -67,7 +71,11 @@ export const useEmojiMathStore = makePersistStore<EmojiMathState & EmojiMathActi
     return {
       ...INITIAL,
 
-      startGame: () => timer.startGame(() => ({ q: makeQuestion(1), level: 1, streak: 0 })),
+      startGame: () => {
+        const diff = useGameDifficulty.getState().difficulty;
+        timer.startGame(() => ({ q: makeQuestion(1), level: 1, streak: 0 }));
+        set({ lives: DIFFICULTY_LIVES[diff], timeLeft: DIFFICULTY_TIME_EM[diff] });
+      },
 
       tap: (choice: number) => {
         const { phase, feedback, q, streak, score, level } = get();

--- a/gamesformykids/app/games/math-race/components/MathRaceMenuScreen.tsx
+++ b/gamesformykids/app/games/math-race/components/MathRaceMenuScreen.tsx
@@ -1,20 +1,27 @@
 'use client';
 import GameMenuCard from '@/components/game/shared/GameMenuCard';
-import { useMathRaceGame, GAME_TIME } from '../useMathRaceGame';
+import { DifficultyPicker } from '@/components/game/shared/DifficultyPicker';
+import { useMathRaceGame } from '../useMathRaceGame';
+import { useGameDifficulty } from '@/lib/stores/gameDifficultyStore';
+
+const TIME_BY_DIFF = { easy: 45, medium: 30, hard: 20 } as const;
 
 export default function MathRaceMenuScreen() {
   const { best, startGame } = useMathRaceGame();
+  const { difficulty } = useGameDifficulty();
   return (
     <GameMenuCard
       emoji="🏎️"
       title="מרוץ מתמטיקה"
-      description={`פתור כמה שיותר תרגילים ב-${GAME_TIME} שניות!`}
+      description={`פתור כמה שיותר תרגילים ב-${TIME_BY_DIFF[difficulty]} שניות!`}
       hint="רצף 3+ = 20 נקודות · הקושי עולה עם הניקוד"
       gradientClass="from-blue-100 to-indigo-200"
       buttonClass="from-blue-500 to-indigo-600"
       onStart={startGame}
       startLabel="🏎️ התחל!"
       best={best}
-    />
+    >
+      <DifficultyPicker />
+    </GameMenuCard>
   );
 }

--- a/gamesformykids/app/games/math-race/mathRaceStore.ts
+++ b/gamesformykids/app/games/math-race/mathRaceStore.ts
@@ -1,6 +1,9 @@
 import { makePersistStore } from '@/lib/stores/createStore';
+import { useGameDifficulty } from '@/lib/stores/gameDifficultyStore';
 import type { ArithOp as Op, PhaseDead as Phase } from '@/lib/types';
 import { randInt as rnd } from '@/lib/utils';
+
+const DIFFICULTY_TIME = { easy: 45, medium: 30, hard: 20 } as const;
 
 // ── Question helpers ────────────────────────────────────────────────────────
 
@@ -86,8 +89,9 @@ export const useMathRaceStore = makePersistStore<MathRaceState & MathRaceActions
       ...INITIAL,
 
       startGame: () => {
+        const diff = useGameDifficulty.getState().difficulty;
         clearTimers();
-        set({ ...INITIAL, phase: 'playing', best: get().best, q: makeQ(0) }, false, 'mathRace/startGame');
+        set({ ...INITIAL, phase: 'playing', best: get().best, q: makeQ(0), timeLeft: DIFFICULTY_TIME[diff] }, false, 'mathRace/startGame');
         startGameTimer();
       },
 

--- a/gamesformykids/app/games/true-false/components/TrueFalseMenuScreen.tsx
+++ b/gamesformykids/app/games/true-false/components/TrueFalseMenuScreen.tsx
@@ -1,20 +1,28 @@
 'use client';
 import GameMenuCard from '@/components/game/shared/GameMenuCard';
-import { useTrueFalseGame, TIME_PER_Q } from '../useTrueFalseGame';
+import { DifficultyPicker } from '@/components/game/shared/DifficultyPicker';
+import { useTrueFalseGame } from '../useTrueFalseGame';
+import { useGameDifficulty } from '@/lib/stores/gameDifficultyStore';
+
+const LIVES_BY_DIFF = { easy: 5, medium: 3, hard: 2 } as const;
+const TIME_BY_DIFF  = { easy: 10, medium: 6, hard: 4 } as const;
 
 export default function TrueFalseMenuScreen() {
   const { best, startGame } = useTrueFalseGame();
+  const { difficulty } = useGameDifficulty();
   return (
     <GameMenuCard
       emoji="🤔"
       title="נכון או לא נכון?"
       description="קרא את המשפט ולחץ ✅ או ❌"
-      hint={`3 חיים · ${TIME_PER_Q} שניות לכל שאלה`}
+      hint={`${LIVES_BY_DIFF[difficulty]} חיים · ${TIME_BY_DIFF[difficulty]} שניות לכל שאלה`}
       gradientClass="from-teal-100 to-cyan-200"
       buttonClass="from-teal-500 to-cyan-600"
       onStart={startGame}
       startLabel="✅ התחל!"
       best={best}
-    />
+    >
+      <DifficultyPicker />
+    </GameMenuCard>
   );
 }

--- a/gamesformykids/app/games/true-false/trueFalseStore.ts
+++ b/gamesformykids/app/games/true-false/trueFalseStore.ts
@@ -1,4 +1,5 @@
 import { makePersistStore } from '@/lib/stores/createStore';
+import { useGameDifficulty } from '@/lib/stores/gameDifficultyStore';
 import { setupLivesTimer } from '@/lib/stores/livesTimerHelpers';
 import { makeLivesInitial } from '@/lib/stores/utils/sliceUtils';
 import type { LivesGameState } from '@/lib/types';
@@ -40,6 +41,9 @@ export type Fact = typeof FACTS[number];
 
 export const TIME_PER_Q = 6;
 
+const DIFFICULTY_LIVES   = { easy: 5, medium: 3, hard: 2 } as const;
+const DIFFICULTY_TIME_TF = { easy: 10, medium: TIME_PER_Q, hard: 4 } as const;
+
 interface TrueFalseState extends LivesGameState {
   deck: Fact[];
   idx:  number;
@@ -75,7 +79,9 @@ export const useTrueFalseStore = makePersistStore<TrueFalseState & TrueFalseActi
 
       startGame: () => {
         const deck = shuffle(FACTS);
+        const diff = useGameDifficulty.getState().difficulty;
         timer.startGame(() => ({ deck, idx: 0 }));
+        set({ lives: DIFFICULTY_LIVES[diff], timeLeft: DIFFICULTY_TIME_TF[diff] });
       },
 
       answer: (choice: boolean) => {

--- a/gamesformykids/components/game/shared/DifficultyPicker.tsx
+++ b/gamesformykids/components/game/shared/DifficultyPicker.tsx
@@ -1,0 +1,48 @@
+'use client';
+
+import { useGameDifficulty } from '@/lib/stores/gameDifficultyStore';
+import type { DifficultyLevel } from '@/lib/types/games/base';
+
+const LEVELS: { value: DifficultyLevel; label: string; active: string; inactive: string }[] = [
+  {
+    value: 'easy',
+    label: 'קל',
+    active: 'bg-green-500 text-white border-green-500',
+    inactive: 'bg-white text-green-600 border-green-300 hover:bg-green-50',
+  },
+  {
+    value: 'medium',
+    label: 'רגיל',
+    active: 'bg-yellow-500 text-white border-yellow-500',
+    inactive: 'bg-white text-yellow-600 border-yellow-300 hover:bg-yellow-50',
+  },
+  {
+    value: 'hard',
+    label: 'קשה',
+    active: 'bg-red-500 text-white border-red-500',
+    inactive: 'bg-white text-red-600 border-red-300 hover:bg-red-50',
+  },
+];
+
+export function DifficultyPicker() {
+  const { difficulty, setDifficulty } = useGameDifficulty();
+
+  return (
+    <div className="flex flex-col items-center gap-2 my-3">
+      <p className="text-sm text-gray-500 font-medium">רמת קושי</p>
+      <div className="flex gap-2">
+        {LEVELS.map(({ value, label, active, inactive }) => (
+          <button
+            key={value}
+            onClick={() => setDifficulty(value)}
+            className={`px-4 py-1.5 rounded-full border-2 text-sm font-bold transition-colors ${
+              difficulty === value ? active : inactive
+            }`}
+          >
+            {label}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/gamesformykids/lib/stores/gameDifficultyStore.ts
+++ b/gamesformykids/lib/stores/gameDifficultyStore.ts
@@ -1,0 +1,16 @@
+import { makePersistStore } from '@/lib/stores/createStore';
+import type { DifficultyLevel } from '@/lib/types/games/base';
+
+interface GameDifficultyState {
+  difficulty: DifficultyLevel;
+  setDifficulty: (difficulty: DifficultyLevel) => void;
+}
+
+export const useGameDifficulty = makePersistStore<GameDifficultyState>(
+  'GameDifficultyStore',
+  'gfk-difficulty',
+  (set) => ({
+    difficulty: 'medium',
+    setDifficulty: (difficulty) => set({ difficulty }, false, 'difficulty/set'),
+  }),
+);


### PR DESCRIPTION
Closes #96

## Summary
- **`gameDifficultyStore`** — new persisted Zustand store (`gfk-difficulty` in localStorage), default `medium`
- **`DifficultyPicker`** — three-button component (קל / רגיל / קשה) rendered inside `GameMenuCard` via `children`
- **4 game stores updated** — read difficulty at `startGame()` time and override `timeLeft` / `lives`:

| Game | Easy | Medium (default) | Hard |
|---|---|---|---|
| Math Race | 45 s | 30 s | 20 s |
| True/False | 5 lives · 10 s/q | 3 · 6 s | 2 · 4 s |
| Color Tap | 5 lives · 8 s/q | 3 · 5 s | 2 · 3 s |
| Emoji Math | 5 lives · 12 s/q | 3 · 8 s | 2 · 5 s |

- Hint text on each menu screen updates live to show current difficulty params
- `medium` exactly matches previous behaviour — no regression

## Test plan
- [ ] Difficulty picker renders in menu for all 4 games
- [ ] Selected difficulty persists across page reloads
- [ ] Easy mode gives more time / lives than medium
- [ ] Hard mode gives less time / lives than medium
- [ ] Existing unit tests still pass (medium = previous defaults)

🤖 Generated with [Claude Code](https://claude.com/claude-code)