### PR TITLE
feat: add game completion celebration animation

### DIFF
--- a/gamesformykids/components/game/shared/GameCompletionCelebration.tsx
+++ b/gamesformykids/components/game/shared/GameCompletionCelebration.tsx
@@ -1,0 +1,59 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { useGameAudio } from '@/hooks/shared/audio/useGameAudio';
+
+const EMOJIS = ['🎉', '⭐', '🌟', '🎊', '✨', '🎈', '🏆', '💫'];
+
+const PARTICLES = Array.from({ length: 20 }, (_, i) => ({
+  id: i,
+  emoji: EMOJIS[i % EMOJIS.length],
+  left: `${5 + i * 4.5}%`,
+  delay: `${i * 0.1}s`,
+  size: 1.5 + (i % 3) * 0.4,
+}));
+
+const KEYFRAMES = `
+@keyframes gfk-confetti-fall {
+  0%   { transform: translateY(-60px) rotate(0deg); opacity: 1; }
+  80%  { opacity: 1; }
+  100% { transform: translateY(110vh) rotate(720deg); opacity: 0; }
+}
+`;
+
+export function GameCompletionCelebration() {
+  const [visible, setVisible] = useState(true);
+  const { playSuccessSound } = useGameAudio();
+
+  useEffect(() => {
+    playSuccessSound();
+    const id = setTimeout(() => setVisible(false), 2500);
+    return () => clearTimeout(id);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  if (!visible) return null;
+
+  return (
+    <>
+      <style>{KEYFRAMES}</style>
+      <div className="fixed inset-0 pointer-events-none overflow-hidden z-50" aria-hidden>
+        {PARTICLES.map(({ id, emoji, left, delay, size }) => (
+          <span
+            key={id}
+            style={{
+              position: 'absolute',
+              top: 0,
+              left,
+              fontSize: `${size}rem`,
+              animation: `gfk-confetti-fall 2s ease-in forwards`,
+              animationDelay: delay,
+            }}
+          >
+            {emoji}
+          </span>
+        ))}
+      </div>
+    </>
+  );
+}

--- a/gamesformykids/components/game/shared/GameResultCard.tsx
+++ b/gamesformykids/components/game/shared/GameResultCard.tsx
@@ -1,5 +1,6 @@
 'use client';
 import { ReactNode } from 'react';
+import { GameCompletionCelebration } from './GameCompletionCelebration';
 
 interface SecondaryAction {
   label: string;
@@ -41,6 +42,7 @@ export default function GameResultCard({
       className={`min-h-screen bg-gradient-to-br ${gradientClass} flex items-center justify-center p-4`}
       dir="rtl"
     >
+      <GameCompletionCelebration />
       <div className="bg-white rounded-3xl shadow-2xl p-8 text-center max-w-sm w-full">
         <div className={`text-6xl mb-3 ${animateEmoji ? 'animate-bounce' : ''}`}>{emoji}</div>
         <h2 className="text-2xl font-bold text-gray-800 mb-4">{title}</h2>

--- a/gamesformykids/components/game/shared/ScoreBestResultCard.tsx
+++ b/gamesformykids/components/game/shared/ScoreBestResultCard.tsx
@@ -1,4 +1,5 @@
 'use client';
+import { useState, useEffect } from 'react';
 import GameResultCard from './GameResultCard';
 
 interface Props {
@@ -34,11 +35,30 @@ export default function ScoreBestResultCard({
   scoreLabel = 'ניקוד',
   ...cardProps
 }: Props) {
+  const [displayed, setDisplayed] = useState(0);
+
+  useEffect(() => {
+    if (score === 0) return;
+    const steps = 20;
+    const increment = score / steps;
+    let current = 0;
+    const id = setInterval(() => {
+      current += increment;
+      if (current >= score) {
+        setDisplayed(score);
+        clearInterval(id);
+      } else {
+        setDisplayed(Math.round(current));
+      }
+    }, 600 / steps);
+    return () => clearInterval(id);
+  }, [score]);
+
   return (
     <GameResultCard {...cardProps}>
       <div className="grid grid-cols-2 gap-4">
         <div className={`${scoreBgClass} rounded-2xl p-3`}>
-          <p className={`text-3xl font-black ${scoreTextClass}`}>{score}</p>
+          <p className={`text-3xl font-black ${scoreTextClass} tabular-nums`}>{displayed}</p>
           <p className={`text-xs ${scoreLabelClass}`}>{scoreLabel}</p>
         </div>
         <div className="bg-yellow-50 rounded-2xl p-3">


### PR DESCRIPTION
Closes #95

## Summary
- **`GameCompletionCelebration`** — pure-CSS confetti overlay: 20 emoji particles (🎉⭐🌟🎊✨🎈🏆💫) fall from top to bottom with staggered `animationDelay` (0.1s increments), auto-dismiss after 2.5 s, plays `playSuccessSound` via `useGameAudio` on mount. `pointer-events-none` so the result card is immediately interactive.
- **`GameResultCard`** — now renders `<GameCompletionCelebration />` inside its wrapper. All 4 quiz result screens (math-race, true-false, color-tap, emoji-math) and any future `GameResultCard` users get confetti with zero extra code.
- **`ScoreBestResultCard`** — score counts up from 0 to final over 600 ms (20 steps via `setInterval`). Uses `tabular-nums` to prevent layout shift during count.

## Implementation notes
- No extra dependencies — uses WebAudio API already in the project and a CSS `@keyframes` block injected via `<style>`
- Confetti positions are deterministic (no `Math.random()` at render time → no hydration mismatch)
- `medium` difficulty = previous behaviour throughout; all existing tests unaffected

## Test plan
- [ ] Open any of the 4 quiz games → play until game over → confetti drops for ~2.5 s
- [ ] Score counts up from 0 on result screen
- [ ] Success sound plays on result screen (requires audio permission)
- [ ] After 2.5 s confetti stops; restart button works normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)