### PR TITLE
feat: add keyboard shortcuts for game controls (#94)

### DIFF
--- a/gamesformykids/app/games/color-tap/components/ColorTapPlayArea.tsx
+++ b/gamesformykids/app/games/color-tap/components/ColorTapPlayArea.tsx
@@ -1,10 +1,22 @@
 'use client';
 import { useColorTapGame, TIME_PER_Q } from '../useColorTapGame';
 import LivesDisplay from '@/components/game/shared/LivesDisplay';
+import { useKeyboardControls } from '@/hooks/shared/game-controls/useKeyboardControls';
+import { KeyboardHint } from '@/components/game/shared/KeyboardHint';
 
 export default function ColorTapPlayArea() {
   const { question, feedback, timeLeft, score, lives, handleTap } =
     useColorTapGame();
+
+  useKeyboardControls(
+    {
+      '1': () => handleTap(question.options[0]),
+      '2': () => handleTap(question.options[1]),
+      '3': () => handleTap(question.options[2]),
+      '4': () => handleTap(question.options[3]),
+    },
+    !feedback,
+  );
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-pink-100 to-purple-200 flex flex-col items-center justify-center p-4 select-none" dir="rtl">
@@ -52,6 +64,9 @@ export default function ColorTapPlayArea() {
           </button>
         ))}
       </div>
+      <KeyboardHint
+        hints={question.options.map((c, i) => ({ key: String(i + 1), label: c.name }))}
+      />
     </div>
   );
 }

--- a/gamesformykids/app/games/emoji-math/components/EmojiMathPlayArea.tsx
+++ b/gamesformykids/app/games/emoji-math/components/EmojiMathPlayArea.tsx
@@ -1,6 +1,8 @@
 'use client';
 import { useEmojiMathGame, TIME_PER_Q } from '../useEmojiMathGame';
 import LivesDisplay from '@/components/game/shared/LivesDisplay';
+import { useKeyboardControls } from '@/hooks/shared/game-controls/useKeyboardControls';
+import { KeyboardHint } from '@/components/game/shared/KeyboardHint';
 
 function renderEmojis(count: number, emoji: string) {
   return Array.from({ length: Math.min(count, 15) }, (_, i) => (
@@ -11,6 +13,16 @@ function renderEmojis(count: number, emoji: string) {
 export default function EmojiMathPlayArea() {
   const { q, feedback, level, timeLeft, score, lives, streak, tap } =
     useEmojiMathGame();
+
+  useKeyboardControls(
+    {
+      '1': () => tap(q.choices[0]),
+      '2': () => tap(q.choices[1]),
+      '3': () => tap(q.choices[2]),
+      '4': () => tap(q.choices[3]),
+    },
+    !feedback,
+  );
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-yellow-100 to-orange-200 flex flex-col items-center justify-center p-4 select-none" dir="rtl">
@@ -69,6 +81,9 @@ export default function EmojiMathPlayArea() {
           </button>
         ))}
       </div>
+      <KeyboardHint
+        hints={q.choices.map((c, i) => ({ key: String(i + 1), label: String(c) }))}
+      />
     </div>
   );
 }

--- a/gamesformykids/app/games/math-race/components/MathRacePlayScreen.tsx
+++ b/gamesformykids/app/games/math-race/components/MathRacePlayScreen.tsx
@@ -2,15 +2,36 @@
 import { useMathRaceGame, GAME_TIME } from '../useMathRaceGame';
 import MathRaceProgressBar from './MathRaceProgressBar';
 import MathRaceQuestion from './MathRaceQuestion';
+import { useKeyboardControls } from '@/hooks/shared/game-controls/useKeyboardControls';
+import { KeyboardHint } from '@/components/game/shared/KeyboardHint';
 
 export default function MathRacePlayScreen() {
   const { q, score, timeLeft, feedback, streak, correct, total, tap, accuracy } = useMathRaceGame();
+
+  useKeyboardControls(
+    {
+      '1': () => tap(q.choices[0]),
+      '2': () => tap(q.choices[1]),
+      '3': () => tap(q.choices[2]),
+      '4': () => tap(q.choices[3]),
+    },
+    !feedback,
+  );
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-blue-100 to-indigo-200 flex flex-col items-center justify-center p-4 select-none" dir="rtl">
       <MathRaceProgressBar timeLeft={timeLeft} score={score} streak={streak} gameTime={GAME_TIME} />
       <MathRaceQuestion q={q} feedback={feedback} streak={streak} onTap={tap} />
       <p className="mt-4 text-xs text-indigo-400">{correct}/{total} נכון · {accuracy}% דיוק</p>
+      <KeyboardHint
+        hints={[
+          { key: '1', label: String(q.choices[0]) },
+          { key: '2', label: String(q.choices[1]) },
+          { key: '3', label: String(q.choices[2]) },
+          { key: '4', label: String(q.choices[3]) },
+        ]}
+        className="mt-1"
+      />
     </div>
   );
 }

--- a/gamesformykids/app/games/true-false/components/TrueFalsePlayScreen.tsx
+++ b/gamesformykids/app/games/true-false/components/TrueFalsePlayScreen.tsx
@@ -1,9 +1,16 @@
 'use client';
 import { useTrueFalseGame, TIME_PER_Q } from '../useTrueFalseGame';
 import LivesDisplay from '@/components/game/shared/LivesDisplay';
+import { useKeyboardControls } from '@/hooks/shared/game-controls/useKeyboardControls';
+import { KeyboardHint } from '@/components/game/shared/KeyboardHint';
 
 export default function TrueFalsePlayScreen() {
   const { score, lives, timeLeft, feedback, q, answer } = useTrueFalseGame();
+
+  useKeyboardControls(
+    { '1': () => answer(true), '2': () => answer(false) },
+    !feedback,
+  );
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-teal-100 to-cyan-200 flex flex-col items-center justify-center p-4 select-none" dir="rtl">
@@ -47,6 +54,12 @@ export default function TrueFalsePlayScreen() {
           className="flex-1 py-6 rounded-3xl bg-red-500 text-white font-black text-5xl shadow-xl active:scale-90 hover:bg-red-400 transition-all disabled:opacity-60"
         >❌</button>
       </div>
+      <KeyboardHint
+        hints={[
+          { key: '1', label: '✅ נכון' },
+          { key: '2', label: '❌ לא נכון' },
+        ]}
+      />
     </div>
   );
 }

--- a/gamesformykids/components/game/shared/KeyboardHint.tsx
+++ b/gamesformykids/components/game/shared/KeyboardHint.tsx
@@ -1,0 +1,24 @@
+interface HintEntry {
+  key: string;
+  label: string;
+}
+
+interface Props {
+  hints: HintEntry[];
+  className?: string;
+}
+
+export function KeyboardHint({ hints, className = '' }: Props) {
+  return (
+    <div className={`hidden sm:flex gap-3 justify-center flex-wrap mt-2 ${className}`}>
+      {hints.map(({ key, label }) => (
+        <span key={key} className="inline-flex items-center gap-1 text-xs text-gray-400">
+          <kbd className="px-1.5 py-0.5 rounded bg-white/80 border border-gray-300 font-mono text-xs text-gray-500 shadow-sm">
+            {key}
+          </kbd>
+          <span>{label}</span>
+        </span>
+      ))}
+    </div>
+  );
+}

--- a/gamesformykids/hooks/shared/game-controls/useKeyboardControls.ts
+++ b/gamesformykids/hooks/shared/game-controls/useKeyboardControls.ts
@@ -1,0 +1,25 @@
+'use client';
+import { useEffect, useRef } from 'react';
+
+export function useKeyboardControls(
+  bindings: Record<string, () => void>,
+  enabled = true,
+) {
+  const ref = useRef(bindings);
+  ref.current = bindings;
+
+  useEffect(() => {
+    if (!enabled) return;
+    const onKey = (e: KeyboardEvent) => {
+      const tag = (e.target as HTMLElement).tagName;
+      if (tag === 'INPUT' || tag === 'TEXTAREA') return;
+      const action = ref.current[e.key];
+      if (action) {
+        e.preventDefault();
+        action();
+      }
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [enabled]);
+}


### PR DESCRIPTION
## Summary
- Add `useKeyboardControls(bindings, enabled)` shared hook — stable-ref `keydown` listener, ignores input/textarea targets
- Add `KeyboardHint` component — renders `<kbd>` badges, visible on `sm+` screens only
- Wire keys `1`–`4` into Math Race, Color Tap, Emoji Math; keys `1`/`2` into True-False
- Hints are disabled (hook disabled) while feedback is showing to prevent double-fire

## Test plan
- [ ] Open Math Race on desktop → press 1/2/3/4 during a question, confirm correct answer registered
- [ ] Open True-False → press 1 for ✅ and 2 for ❌
- [ ] Open Color Tap → press 1-4 to select colors
- [ ] Open Emoji Math → press 1-4 for choices
- [ ] Confirm no key fires while feedback overlay is active
- [ ] Confirm hints are hidden on mobile (<640px) and visible on desktop
- [ ] `tsc --noEmit` passes ✅

Closes #94

🤖 Generated with [Claude Code](https://claude.com/claude-code)