### PR TITLE
feat: add social sharing for game high scores (#15)

### DIFF
--- a/gamesformykids/app/games/animals/components/AnimalsResultScreen.tsx
+++ b/gamesformykids/app/games/animals/components/AnimalsResultScreen.tsx
@@ -14,6 +14,7 @@ export default function AnimalsResultScreen() {
       gradientClass="from-green-50 to-teal-100"
       buttonClass="from-green-500 to-teal-600"
       onRestart={restart}
+      shareText={`🦁 קיבלתי ${score} מתוך ${total} בחיות!`}
     >
       <div className="bg-green-50 rounded-2xl p-5">
         <p className="text-4xl font-black text-green-700">{score} / {total}</p>

--- a/gamesformykids/app/games/balloon-pop/components/BalloonResultScreen.tsx
+++ b/gamesformykids/app/games/balloon-pop/components/BalloonResultScreen.tsx
@@ -12,6 +12,7 @@ export default function BalloonResultScreen() {
       buttonClass="from-pink-500 to-rose-500"
       onRestart={startGame}
       restartLabel="🔄 שוב!"
+      shareText={`🎈 קיבלתי ${score} נקודות בפוצץ בלונים!`}
     >
       <div className="grid grid-cols-2 gap-3">
         <div className="bg-pink-50 rounded-2xl p-4">

--- a/gamesformykids/app/games/color-tap/components/ColorTapResultScreen.tsx
+++ b/gamesformykids/app/games/color-tap/components/ColorTapResultScreen.tsx
@@ -17,6 +17,7 @@ export default function ColorTapResultScreen() {
       scoreLabelClass="text-pink-400"
       onRestart={startGame}
       restartLabel="🔄 שוב!"
+      shareText={`🎨 קיבלתי ${score} נקודות בהקש צבע!`}
     />
   );
 }

--- a/gamesformykids/app/games/emoji-math/components/EmojiMathResultScreen.tsx
+++ b/gamesformykids/app/games/emoji-math/components/EmojiMathResultScreen.tsx
@@ -17,6 +17,7 @@ export default function EmojiMathResultScreen() {
       scoreLabelClass="text-orange-400"
       onRestart={startGame}
       restartLabel="🔄 שוב!"
+      shareText={`🤓 קיבלתי ${score} נקודות באימוג'י מתמטיקה!`}
     />
   );
 }

--- a/gamesformykids/app/games/math-race/components/MathRaceResultScreen.tsx
+++ b/gamesformykids/app/games/math-race/components/MathRaceResultScreen.tsx
@@ -14,6 +14,7 @@ export default function MathRaceResultScreen() {
       buttonClass="from-blue-500 to-indigo-600"
       onRestart={startGame}
       restartLabel="🔄 שוב!"
+      shareText={`🏁 קיבלתי ${score} נקודות במרוץ מתמטיקה!`}
     >
       <div className="grid grid-cols-2 gap-3">
         <div className="bg-blue-50 rounded-2xl p-3">

--- a/gamesformykids/app/games/number-bubbles/components/NumberBubblesResultScreen.tsx
+++ b/gamesformykids/app/games/number-bubbles/components/NumberBubblesResultScreen.tsx
@@ -14,6 +14,7 @@ export default function NumberBubblesResultScreen() {
       onRestart={() => nextLevel()}
       restartLabel={`➡️ רמה ${level + 1}`}
       secondaryAction={{ label: '🔄 מחדש', onClick: startGame }}
+      shareText={`🎈 הגעתי לרמה ${level} בבועות מספרים!`}
     >
       <p className="text-gray-500 mb-2">סיימת רמה {level} ב-{elapsed} שניות</p>
       <div className="grid grid-cols-2 gap-4">

--- a/gamesformykids/app/games/reflex/components/ReflexResultScreen.tsx
+++ b/gamesformykids/app/games/reflex/components/ReflexResultScreen.tsx
@@ -14,6 +14,7 @@ export default function ReflexResultScreen() {
       buttonClass="from-rose-500 to-red-600"
       onRestart={startGame}
       animateEmoji
+      shareText={`⚡ קיבלתי ${score} לחיצות ברפלקס!`}
     >
       <div className="grid grid-cols-3 gap-3">
         <div className="bg-yellow-50 rounded-2xl p-4">

--- a/gamesformykids/app/games/simon/components/SimonGameOverScreen.tsx
+++ b/gamesformykids/app/games/simon/components/SimonGameOverScreen.tsx
@@ -14,6 +14,7 @@ export default function SimonGameOverScreen() {
       buttonClass="from-gray-600 to-gray-800"
       onRestart={startGame}
       restartLabel="🔄 שוב!"
+      shareText={`🎮 הגעתי לרצף ${roundScore} צבעים בסימון!`}
     >
       <p className="text-gray-400 text-sm mb-4">הגעת לרצף של {roundScore} צבעים</p>
       <div className="grid grid-cols-2 gap-4">

--- a/gamesformykids/app/games/taki/components/TakiResultScreen.tsx
+++ b/gamesformykids/app/games/taki/components/TakiResultScreen.tsx
@@ -14,6 +14,7 @@ export default function TakiResultScreen() {
       buttonClass="from-teal-500 to-emerald-600"
       onRestart={startGame}
       restartLabel="🔄 שחק שוב"
+      shareText={`🃏 קיבלתי ${playerScore} נקודות בטקי!`}
     >
       {message && <p className="text-gray-500 text-base mb-3">{message}</p>}
       <div className="flex justify-center gap-6 text-gray-700 text-xl font-semibold">

--- a/gamesformykids/app/games/true-false/components/TrueFalseResultScreen.tsx
+++ b/gamesformykids/app/games/true-false/components/TrueFalseResultScreen.tsx
@@ -17,6 +17,7 @@ export default function TrueFalseResultScreen() {
       scoreLabelClass="text-teal-400"
       onRestart={startGame}
       restartLabel="🔄 שוב!"
+      shareText={`🧠 קיבלתי ${score} נקודות בנכון או שקר!`}
     />
   );
 }

--- a/gamesformykids/app/games/whack-a-mole/components/WhackAMoleResultScreen.tsx
+++ b/gamesformykids/app/games/whack-a-mole/components/WhackAMoleResultScreen.tsx
@@ -16,6 +16,7 @@ export default function WhackAMoleResultScreen() {
       scoreTextClass="text-amber-600"
       scoreLabelClass="text-amber-400"
       onRestart={startGame}
+      shareText={`🔨 קיבלתי ${score} נקודות בהכאת עכברוש!`}
     />
   );
 }

--- a/gamesformykids/app/games/word-scramble/components/WordScrambleResultScreen.tsx
+++ b/gamesformykids/app/games/word-scramble/components/WordScrambleResultScreen.tsx
@@ -14,6 +14,7 @@ export default function WordScrambleResultScreen() {
       buttonClass="from-green-500 to-emerald-600"
       onRestart={onRestart}
       restartLabel="🔄 שחק שוב"
+      shareText={`📝 קיבלתי ${score} נקודות בחילופי מילים!`}
     >
       <div className="grid grid-cols-2 gap-4">
         <div className="bg-green-50 rounded-2xl p-3">

--- a/gamesformykids/components/game/shared/GameResultCard.tsx
+++ b/gamesformykids/components/game/shared/GameResultCard.tsx
@@ -1,6 +1,7 @@
 'use client';
 import { ReactNode } from 'react';
 import { GameCompletionCelebration } from './GameCompletionCelebration';
+import { useShareScore } from '@/hooks/shared/social/useShareScore';
 
 interface SecondaryAction {
   label: string;
@@ -18,6 +19,8 @@ interface Props {
   restartLabel?: string;
   secondaryAction?: SecondaryAction;
   animateEmoji?: boolean;
+  /** Share text passed to Web Share API / clipboard. Omit to hide share button. */
+  shareText?: string;
   children: ReactNode;
 }
 
@@ -35,8 +38,10 @@ export default function GameResultCard({
   restartLabel = '🔄 שוב',
   secondaryAction,
   animateEmoji = false,
+  shareText,
   children,
 }: Props) {
+  const { share, copied } = useShareScore();
   return (
     <div
       className={`min-h-screen bg-gradient-to-br ${gradientClass} flex items-center justify-center p-4`}
@@ -63,6 +68,14 @@ export default function GameResultCard({
             </button>
           )}
         </div>
+        {shareText && (
+          <button
+            onClick={() => share(shareText)}
+            className="mt-3 w-full py-2.5 rounded-2xl border-2 border-gray-200 text-gray-500 font-semibold text-sm hover:bg-gray-50 active:scale-95 transition-all"
+          >
+            {copied ? '✅ הועתק!' : '📤 שתף את הניקוד'}
+          </button>
+        )}
       </div>
     </div>
   );

--- a/gamesformykids/components/game/shared/ScoreBestResultCard.tsx
+++ b/gamesformykids/components/game/shared/ScoreBestResultCard.tsx
@@ -19,6 +19,7 @@ interface Props {
   onRestart: () => void;
   restartLabel?: string;
   animateEmoji?: boolean;
+  shareText?: string;
 }
 
 /**

--- a/gamesformykids/hooks/shared/social/useShareScore.ts
+++ b/gamesformykids/hooks/shared/social/useShareScore.ts
@@ -1,0 +1,30 @@
+'use client';
+import { useState, useCallback } from 'react';
+
+export function useShareScore() {
+  const [copied, setCopied] = useState(false);
+
+  const share = useCallback(async (text: string) => {
+    const url = typeof window !== 'undefined' ? window.location.origin : '';
+    const fullText = `${text}\n${url}`;
+
+    if (typeof navigator !== 'undefined' && navigator.share) {
+      try {
+        await navigator.share({ text: fullText, url });
+        return;
+      } catch {
+        // User cancelled or API unavailable — fall through to clipboard
+      }
+    }
+
+    try {
+      await navigator.clipboard.writeText(fullText);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      // ignore
+    }
+  }, []);
+
+  return { share, copied };
+}


### PR DESCRIPTION
## Summary
- Add `useShareScore` hook: uses `navigator.share` (Web Share API) on mobile; falls back to `navigator.clipboard.writeText` on desktop with a 2s "✅ הועתק!" confirmation
- Add optional `shareText` prop to `GameResultCard` — renders a "📤 שתף את הניקוד" button below the restart row when provided
- Forward `shareText` through `ScoreBestResultCard` via `...cardProps`
- Wire `shareText` into all 12 result screens that use `GameResultCard`/`ScoreBestResultCard`

## Test plan
- [ ] Complete a Math Race game on mobile → share button triggers native share sheet
- [ ] Complete a True-False game on desktop → share button copies text to clipboard, button shows "✅ הועתק!" for 2s
- [ ] Verify share button absent on game screens that don't pass `shareText`
- [ ] `tsc --noEmit` passes ✅

Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)