### PR TITLE
feat: WCAG 2.1 keyboard navigation and accessibility improvements (#14)

### DIFF
--- a/gamesformykids/app/globals.css
+++ b/gamesformykids/app/globals.css
@@ -381,3 +381,10 @@ body {
     min-height: 44px; /* Apple's recommended minimum touch target size */
   }
 }
+
+/* WCAG 2.1 — visible focus rings for keyboard navigation */
+:focus-visible {
+  outline: 2px solid #6366f1;
+  outline-offset: 2px;
+  border-radius: 4px;
+}

--- a/gamesformykids/components/game/CategoryCard.tsx
+++ b/gamesformykids/components/game/CategoryCard.tsx
@@ -10,9 +10,11 @@ export default function CategoryCard({
   const Icon = category.icon;
 
   return (
-    <div
+    <button
+      type="button"
       onClick={onClick}
-      className={`relative p-3 md:p-4 lg:p-6 rounded-2xl md:rounded-3xl shadow-lg md:shadow-xl transition-all duration-300 transform hover:scale-105 cursor-pointer hover:shadow-2xl bg-gradient-to-br ${category.gradient}`}
+      aria-label={`${category.title} — ${gamesCount} משחקים`}
+      className={`w-full relative p-3 md:p-4 lg:p-6 rounded-2xl md:rounded-3xl shadow-lg md:shadow-xl transition-all duration-300 transform hover:scale-105 cursor-pointer hover:shadow-2xl bg-gradient-to-br ${category.gradient}`}
     >
       <div className="text-center text-white">
         <div className="mb-2 md:mb-4 flex justify-center">
@@ -30,6 +32,6 @@ export default function CategoryCard({
           </span>
         </div>
       </div>
-    </div>
+    </button>
   );
 }

--- a/gamesformykids/components/game/GameCard.tsx
+++ b/gamesformykids/components/game/GameCard.tsx
@@ -12,7 +12,7 @@ export default function GameCard({ game }: ComponentTypes.GameCardProps) {
   if (game.available) {
     return (
       <div className="relative">
-        <Link href={game.href}>
+        <Link href={game.href} aria-label={game.title}>
           <div
             className={`
               relative p-3 md:p-4 lg:p-6 rounded-2xl md:rounded-3xl shadow-lg md:shadow-xl transition-all duration-300 transform hover:scale-105 cursor-pointer hover:shadow-2xl overflow-hidden
@@ -59,8 +59,12 @@ export default function GameCard({ game }: ComponentTypes.GameCardProps) {
 
   return (
     <div className="relative">
-      <div className="relative p-3 md:p-4 lg:p-6 rounded-2xl md:rounded-3xl shadow-lg bg-gray-300 cursor-not-allowed overflow-hidden">
-        <div className="absolute inset-0 bg-gray-400 bg-opacity-50 rounded-2xl md:rounded-3xl flex items-center justify-center">
+      <div
+        className="relative p-3 md:p-4 lg:p-6 rounded-2xl md:rounded-3xl shadow-lg bg-gray-300 cursor-not-allowed overflow-hidden"
+        aria-label={`${game.title} — בקרוב`}
+        aria-disabled="true"
+      >
+        <div className="absolute inset-0 bg-gray-400 bg-opacity-50 rounded-2xl md:rounded-3xl flex items-center justify-center" aria-hidden="true">
           <span className="text-white text-sm md:text-base lg:text-xl font-bold">בקרוב!</span>
         </div>
         <div className="text-center text-white">

--- a/gamesformykids/components/game/shared/GameMenuCard.tsx
+++ b/gamesformykids/components/game/shared/GameMenuCard.tsx
@@ -1,5 +1,7 @@
 'use client';
 import { ReactNode } from 'react';
+import { useRouter } from 'next/navigation';
+import { useKeyboardControls } from '@/hooks/shared/game-controls/useKeyboardControls';
 
 interface Props {
   emoji: string;
@@ -39,6 +41,9 @@ export default function GameMenuCard({
   best,
   children,
 }: Props) {
+  const router = useRouter();
+  useKeyboardControls({ Escape: () => router.back() });
+
   return (
     <div
       className={`min-h-screen bg-gradient-to-br ${gradientClass} flex items-center justify-center p-4`}


### PR DESCRIPTION
## Summary
- **Global focus ring**: `:focus-visible { outline: 2px solid #6366f1; outline-offset: 2px }` in `globals.css` — applies to every interactive element not already overriding it, ensuring keyboard users always see focus position
- **CategoryCard**: Converted `<div onClick>` → `<button type="button">` with `aria-label` — fixes WCAG 4.1.2 (Name, Role, Value); now keyboard-reachable and announces correctly to screen readers
- **GameCard**: Added `aria-label={game.title}` to available `<Link>`; `aria-label` + `aria-disabled="true"` + `aria-hidden` on overlay for unavailable cards
- **GameMenuCard**: Wires `Escape → router.back()` via `useKeyboardControls` — lets keyboard users exit any game menu without a mouse

## Test plan
- [ ] Tab through homepage — every card/button gets a visible indigo focus ring
- [ ] Tab to a category card, press Enter/Space → category opens
- [ ] Screen reader announces "מרוץ מתמטיקה" on game card focus
- [ ] Open any game menu (e.g. Math Race), press Escape → navigates back
- [ ] `tsc --noEmit` passes ✅
- [ ] Lighthouse accessibility ≥ 90

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)