### PR TITLE
feat: improve PWA offline support (#13)

### DIFF
--- a/gamesformykids/app/layout.tsx
+++ b/gamesformykids/app/layout.tsx
@@ -5,6 +5,7 @@ import ServiceWorkerRegistration from '@/components/analytics/ServiceWorkerRegis
 import GoogleAnalytics from '@/components/analytics/GoogleAnalytics';
 import { AuthProvider } from '@/lib/providers';
 import NotificationToast from '@/components/ui/NotificationToast';
+import { OfflineBanner } from '@/components/ui/OfflineBanner';
 import HeadLinks from '@/components/layout/HeadLinks';
 import StructuredData from '@/components/layout/StructuredData';
 import { siteMetadata, siteViewport } from '@/lib/constants/siteMetadata';
@@ -31,6 +32,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
           <GoogleAnalytics GA_MEASUREMENT_ID={process.env.NEXT_PUBLIC_GA_ID} />
         )}
         <ServiceWorkerRegistration />
+        <OfflineBanner />
         <AuthProvider>
           {children}
           <NotificationToast />

--- a/gamesformykids/app/offline/page.tsx
+++ b/gamesformykids/app/offline/page.tsx
@@ -1,0 +1,26 @@
+'use client';
+
+export default function OfflinePage() {
+  return (
+    <div
+      dir="rtl"
+      className="min-h-screen bg-gradient-to-br from-blue-50 to-indigo-100 flex items-center justify-center p-6"
+    >
+      <div className="bg-white rounded-3xl shadow-2xl p-10 text-center max-w-sm w-full">
+        <div className="text-6xl mb-4">📵</div>
+        <h1 className="text-2xl font-black text-gray-800 mb-3">אין חיבור לאינטרנט</h1>
+        <p className="text-gray-500 text-sm mb-6 leading-relaxed">
+          נראה שאתה לא מחובר לרשת.<br />
+          המשחקים שביקרת בהם עדיין זמינים!<br />
+          בדוק את החיבור ונסה שוב.
+        </p>
+        <button
+          onClick={() => window.location.reload()}
+          className="w-full py-3 rounded-2xl bg-gradient-to-r from-blue-500 to-indigo-600 text-white font-bold text-lg hover:opacity-90 active:scale-95 transition-all"
+        >
+          🔄 נסה שוב
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/gamesformykids/components/analytics/useServiceWorkerRegistration.ts
+++ b/gamesformykids/components/analytics/useServiceWorkerRegistration.ts
@@ -5,23 +5,9 @@ import { useEffect } from 'react';
 export function useServiceWorkerRegistration() {
   useEffect(() => {
     if ('serviceWorker' in navigator) {
-      navigator.serviceWorker
-        .register('/sw.js')
-        .then(async () => {
-          // Send CLEAR_CACHE message on every page load/refresh
-          const controller = navigator.serviceWorker.controller;
-          if (controller) {
-            controller.postMessage({ type: 'CLEAR_CACHE' });
-          } else {
-            // Wait for SW to take control then clear
-            navigator.serviceWorker.addEventListener('controllerchange', () => {
-              navigator.serviceWorker.controller?.postMessage({ type: 'CLEAR_CACHE' });
-            }, { once: true });
-          }
-        })
-        .catch(() => {
-          // Service Worker registration failed
-        });
+      navigator.serviceWorker.register('/sw.js').catch(() => {
+        // Service Worker registration failed silently
+      });
     }
   }, []);
 }

--- a/gamesformykids/components/ui/OfflineBanner.tsx
+++ b/gamesformykids/components/ui/OfflineBanner.tsx
@@ -1,0 +1,30 @@
+'use client';
+import { useState, useEffect } from 'react';
+
+export function OfflineBanner() {
+  const [isOffline, setIsOffline] = useState(false);
+
+  useEffect(() => {
+    setIsOffline(!navigator.onLine);
+    const off = () => setIsOffline(true);
+    const on  = () => setIsOffline(false);
+    window.addEventListener('offline', off);
+    window.addEventListener('online', on);
+    return () => {
+      window.removeEventListener('offline', off);
+      window.removeEventListener('online', on);
+    };
+  }, []);
+
+  if (!isOffline) return null;
+
+  return (
+    <div
+      role="alert"
+      dir="rtl"
+      className="fixed top-0 inset-x-0 z-[9999] bg-red-500 text-white text-center py-2 px-4 text-sm font-semibold"
+    >
+      📵 אין חיבור לאינטרנט — משחקים שנטענו בעבר עדיין זמינים
+    </div>
+  );
+}

--- a/gamesformykids/public/sw.js
+++ b/gamesformykids/public/sw.js
@@ -1,136 +1,111 @@
 // GamesForMyKids Service Worker
-const CACHE_NAME = 'games-for-my-kids-v1';
-const STATIC_ASSETS = [
-  '/',
-  '/manifest.json',
-  '/favicon.ico',
-  // Core app files will be cached dynamically
-];
+// Bump CACHE_VERSION on each deploy to invalidate old caches.
+const CACHE_VERSION = 'v2';
+const STATIC_CACHE  = `gfk-static-${CACHE_VERSION}`;   // _next/static/* — content-addressed, cache forever
+const PAGES_CACHE   = `gfk-pages-${CACHE_VERSION}`;    // HTML navigation — stale-while-revalidate
+const ASSETS_CACHE  = `gfk-assets-${CACHE_VERSION}`;   // images / audio — cache-first
+const ALL_CACHES    = [STATIC_CACHE, PAGES_CACHE, ASSETS_CACHE];
 
-// Install event - cache static assets
+const PRECACHE_URLS = ['/', '/offline', '/manifest.json', '/favicon.ico'];
+
+// ── Install: pre-cache critical pages ────────────────────────────────────────
 self.addEventListener('install', (event) => {
-  console.log('🎮 GamesForMyKids Service Worker installing...');
   event.waitUntil(
-    caches.open(CACHE_NAME)
-      .then(async (cache) => {
-        console.log('📦 Caching static assets');
-        // Cache assets one by one to avoid failures
-        const cachePromises = STATIC_ASSETS.map(async (asset) => {
-          try {
-            await cache.add(asset);
-            console.log(`✅ Cached: ${asset}`);
-          } catch (error) {
-            console.log(`❌ Failed to cache ${asset}:`, error);
-          }
-        });
-        await Promise.allSettled(cachePromises);
-      })
-      .catch((error) => {
-        console.log('❌ Cache install failed:', error);
-      })
+    caches.open(PAGES_CACHE).then((cache) =>
+      Promise.allSettled(PRECACHE_URLS.map((url) => cache.add(url)))
+    )
   );
   self.skipWaiting();
 });
 
-// Activate event - clean up old caches
+// ── Activate: delete stale caches ────────────────────────────────────────────
 self.addEventListener('activate', (event) => {
-  console.log('✅ GamesForMyKids Service Worker activated');
   event.waitUntil(
-    caches.keys().then((cacheNames) => {
-      return Promise.all(
-        cacheNames.map((cacheName) => {
-          if (cacheName !== CACHE_NAME) {
-            console.log('🗑️ Deleting old cache:', cacheName);
-            return caches.delete(cacheName);
-          }
-        })
-      );
-    })
+    caches.keys().then((keys) =>
+      Promise.all(
+        keys.filter((k) => !ALL_CACHES.includes(k)).map((k) => caches.delete(k))
+      )
+    )
   );
   self.clients.claim();
 });
 
-// Fetch event - serve from cache when possible
+// ── Fetch: strategy per request type ─────────────────────────────────────────
 self.addEventListener('fetch', (event) => {
-  // Skip non-HTTP requests
-  if (!event.request.url.startsWith('http')) {
+  const { request } = event;
+
+  // Only intercept same-origin GET requests
+  if (request.method !== 'GET') return;
+  let url;
+  try { url = new URL(request.url); } catch { return; }
+  if (url.origin !== self.location.origin) return;
+
+  // Skip API routes and Next.js image optimisation
+  if (url.pathname.startsWith('/api/') || url.pathname.startsWith('/_next/image')) return;
+
+  // Next.js static chunks — content-addressed → cache forever
+  if (url.pathname.startsWith('/_next/static/')) {
+    event.respondWith(cacheFirst(request, STATIC_CACHE));
     return;
   }
 
-  // Skip requests to external domains
-  if (!event.request.url.includes(self.location.origin)) {
+  // Images and audio — cache-first
+  if (/\.(png|jpe?g|svg|gif|webp|ico|mp3|wav|ogg)$/i.test(url.pathname)) {
+    event.respondWith(cacheFirst(request, ASSETS_CACHE));
     return;
   }
 
-  event.respondWith(
-    caches.match(event.request)
-      .then((response) => {
-        // Return cached version if available
-        if (response) {
-          return response;
-        }
-        
-        // Otherwise fetch from network
-        return fetch(event.request)
-          .then((response) => {
-            // Don't cache failed responses or non-basic responses
-            if (!response || response.status !== 200 || response.type !== 'basic') {
-              return response;
-            }
+  // HTML navigation and game pages — stale-while-revalidate with offline fallback
+  if (request.mode === 'navigate' || url.pathname.startsWith('/games/')) {
+    event.respondWith(staleWhileRevalidate(request, PAGES_CACHE));
+    return;
+  }
+});
 
-            // Don't cache authentication-related responses
-            if (response.status === 401 || response.status === 403) {
-              return response;
-            }
+// ── Strategy helpers ──────────────────────────────────────────────────────────
 
-            // Clone the response for caching
-            const responseToCache = response.clone();
-            
-            // Cache the response for future use (for GET requests only)
-            if (event.request.method === 'GET') {
-              caches.open(CACHE_NAME)
-                .then((cache) => {
-                  cache.put(event.request, responseToCache);
-                })
-                .catch((error) => {
-                  console.log('❌ Failed to cache response:', error);
-                });
-            }
+async function cacheFirst(request, cacheName) {
+  const cached = await caches.match(request);
+  if (cached) return cached;
+  try {
+    const response = await fetch(request);
+    if (response.ok) {
+      const cache = await caches.open(cacheName);
+      cache.put(request, response.clone());
+    }
+    return response;
+  } catch {
+    return new Response('Offline', { status: 503 });
+  }
+}
 
-            return response;
-          })
-          .catch((error) => {
-            console.log('🌐 Network request failed:', error);
-            
-            // For manifest.json specifically, try to serve from cache
-            if (event.request.url.includes('manifest.json')) {
-              return caches.match('/manifest.json');
-            }
-            
-            // For other requests, return a custom offline response
-            return new Response('אופס! נראה שאין חיבור לאינטרנט', {
-              status: 503,
-              statusText: 'Service Unavailable',
-              headers: new Headers({
-                'Content-Type': 'text/plain; charset=utf-8'
-              })
-            });
-          });
-      })
+async function staleWhileRevalidate(request, cacheName) {
+  const cache  = await caches.open(cacheName);
+  const cached = await cache.match(request);
+
+  const networkFetch = fetch(request)
+    .then((response) => {
+      if (response.ok) cache.put(request, response.clone());
+      return response;
+    })
+    .catch(() => null);
+
+  if (cached) {
+    networkFetch; // update cache in background
+    return cached;
+  }
+
+  // Nothing cached — wait for network
+  const response = await networkFetch;
+  if (response) return response;
+
+  // Both failed — serve offline page
+  return (
+    (await cache.match('/offline')) ??
+    (await caches.match('/offline')) ??
+    new Response('אופס! אין חיבור לאינטרנט', {
+      status: 503,
+      headers: { 'Content-Type': 'text/plain; charset=utf-8' },
+    })
   );
-});
-
-// Message event - handle commands from the page
-self.addEventListener('message', (event) => {
-  if (event.data && event.data.type === 'CLEAR_CACHE') {
-    event.waitUntil(
-      caches.keys().then((cacheNames) => {
-        return Promise.all(cacheNames.map((name) => caches.delete(name)));
-      }).then(() => {
-        if (event.ports && event.ports[0]) {
-          event.ports[0].postMessage({ success: true });
-        }
-      })
-    );
-  }
-});
+}


### PR DESCRIPTION
## Summary
- **Service worker rewrite**: three separate cache buckets with appropriate strategies
  - `gfk-static-v2` — `_next/static/*` content-addressed chunks → cache-first, kept forever
  - `gfk-pages-v2` — HTML navigation + `/games/*` → stale-while-revalidate (serve cache instantly, update background)
  - `gfk-assets-v2` — images + audio files → cache-first
- **Remove CLEAR_CACHE on every page load** — the old SW cleared the entire cache on each visit, making offline support impossible
- **Offline fallback page** at `/offline` — pre-cached during SW install, served for navigation failures when offline
- **`OfflineBanner`** — fixed red top bar that appears whenever `navigator.onLine` is false; disappears automatically when connection returns

## Test plan
- [ ] Visit the app, open DevTools → Application → Service Workers → confirm `gfk-pages-v2` cache contains `/`, `/offline`
- [ ] Visit `/games/math-race`, then go offline (DevTools → Network → Offline) and reload — game loads from cache
- [ ] Navigate to an uncached route while offline → `/offline` fallback page appears
- [ ] Go offline → red banner at top appears; re-enable network → banner disappears
- [ ] `tsc --noEmit` passes ✅

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)