### PR TITLE
feat: add E2E tests with Playwright (#12)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,47 @@
+name: E2E Tests
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+jobs:
+  e2e:
+    name: Playwright E2E
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    defaults:
+      run:
+        working-directory: gamesformykids
+
+    env:
+      NEXT_PUBLIC_SUPABASE_URL: https://placeholder.supabase.co
+      NEXT_PUBLIC_SUPABASE_ANON_KEY: placeholder-anon-key
+      NEXT_PUBLIC_SENTRY_DSN: ""
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: gamesformykids/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci --prefer-offline
+
+      - name: Install Playwright browsers
+        run: npx playwright install chromium --with-deps
+
+      - name: Run E2E tests
+        run: npm run test:e2e
+
+      - name: Upload Playwright report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: gamesformykids/playwright-report/
+          retention-days: 14

--- a/gamesformykids/e2e/auth.spec.ts
+++ b/gamesformykids/e2e/auth.spec.ts
@@ -1,0 +1,31 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Auth flow', () => {
+  test('login page renders email and password fields', async ({ page }) => {
+    await page.goto('/login');
+    await expect(page.locator('input[type="email"], input[placeholder*="מייל"], input[placeholder*="email" i]').first()).toBeVisible({ timeout: 10_000 });
+    await expect(page.locator('input[type="password"]').first()).toBeVisible();
+  });
+
+  test('settings page redirects unauthenticated users', async ({ page }) => {
+    await page.goto('/settings');
+    // Should either redirect to login or show a login prompt
+    await page.waitForURL(/login|settings/, { timeout: 10_000 });
+    const url = page.url();
+    // Either on /login or on /settings (app may handle auth client-side)
+    expect(url).toMatch(/login|settings/);
+  });
+
+  test('dashboard page is reachable', async ({ page }) => {
+    await page.goto('/dashboard');
+    // Page should load without a 500 error
+    const response = await page.goto('/dashboard');
+    expect(response?.status()).not.toBe(500);
+  });
+
+  test('not-found page renders for unknown route', async ({ page }) => {
+    const response = await page.goto('/games/this-game-does-not-exist-xyz');
+    // Should return 200 (Next.js 404 page) or 404 — not a 500
+    expect(response?.status()).not.toBe(500);
+  });
+});

--- a/gamesformykids/e2e/game-animals.spec.ts
+++ b/gamesformykids/e2e/game-animals.spec.ts
@@ -1,0 +1,25 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Animals game', () => {
+  test('menu page loads with title', async ({ page }) => {
+    await page.goto('/games/animals');
+    await expect(page.getByText('בעלי חיים')).toBeVisible({ timeout: 10_000 });
+  });
+
+  test('shows category selection buttons', async ({ page }) => {
+    await page.goto('/games/animals');
+    // Category buttons are rendered from CATEGORY_ORDER — at least 2 should exist
+    const buttons = page.getByRole('button');
+    await expect(buttons.first()).toBeVisible({ timeout: 10_000 });
+    expect(await buttons.count()).toBeGreaterThanOrEqual(2);
+  });
+
+  test('clicking a category starts the game and leaves the menu', async ({ page }) => {
+    await page.goto('/games/animals');
+    const firstBtn = page.getByRole('button').first();
+    await firstBtn.waitFor({ state: 'visible', timeout: 10_000 });
+    await firstBtn.click();
+    // Menu heading should no longer be the only content — game UI takes over
+    await expect(page.getByText('בחר קטגוריה')).not.toBeVisible({ timeout: 5_000 });
+  });
+});

--- a/gamesformykids/e2e/game-memory.spec.ts
+++ b/gamesformykids/e2e/game-memory.spec.ts
@@ -1,0 +1,22 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Memory game', () => {
+  test('menu page loads with title', async ({ page }) => {
+    await page.goto('/games/memory');
+    await expect(page.getByText('משחק הזיכרון')).toBeVisible({ timeout: 10_000 });
+  });
+
+  test('shows easy, medium, and hard difficulty buttons', async ({ page }) => {
+    await page.goto('/games/memory');
+    await expect(page.getByRole('button', { name: /קל/ })).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByRole('button', { name: /בינוני/ })).toBeVisible();
+    await expect(page.getByRole('button', { name: /קשה/ })).toBeVisible();
+  });
+
+  test('easy mode starts the game and shows cards', async ({ page }) => {
+    await page.goto('/games/memory');
+    await page.getByRole('button', { name: /קל/ }).click();
+    // After starting, the start screen should not be visible and cards appear
+    await expect(page.getByText('משחק הזיכרון')).not.toBeVisible({ timeout: 5_000 });
+  });
+});

--- a/gamesformykids/e2e/homepage.spec.ts
+++ b/gamesformykids/e2e/homepage.spec.ts
@@ -1,0 +1,29 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Homepage', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+  });
+
+  test('has page title', async ({ page }) => {
+    await expect(page).toHaveTitle(/GamesForMyKids|משחקים|Games/i);
+  });
+
+  test('shows at least one game card link', async ({ page }) => {
+    const gameLinks = page.locator('a[href*="/games/"]');
+    await expect(gameLinks.first()).toBeVisible({ timeout: 10_000 });
+  });
+
+  test('game card link navigates to a game page', async ({ page }) => {
+    const firstLink = page.locator('a[href*="/games/"]').first();
+    const href = await firstLink.getAttribute('href');
+    await firstLink.click();
+    await expect(page).toHaveURL(new RegExp(href ?? '/games/'));
+  });
+
+  test('offline page renders the offline message', async ({ page }) => {
+    await page.goto('/offline');
+    await expect(page.getByText('אין חיבור לאינטרנט')).toBeVisible();
+    await expect(page.getByRole('button', { name: /נסה שוב/ })).toBeVisible();
+  });
+});

--- a/gamesformykids/package-lock.json
+++ b/gamesformykids/package-lock.json
@@ -25,6 +25,7 @@
       "devDependencies": {
         "@eslint/eslintrc": "^3",
         "@next/bundle-analyzer": "^15.0.0",
+        "@playwright/test": "^1.59.1",
         "@tailwindcss/postcss": "^4",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
@@ -157,6 +158,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -2080,6 +2082,23 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "playwright": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@polka/url": {
@@ -9101,6 +9120,53 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/possible-typed-array-names": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
@@ -11546,29 +11612,6 @@
         "use-sync-external-store": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/core": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
-      "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/runtime": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
-      "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
       }
     }
   }

--- a/gamesformykids/package-lock.json
+++ b/gamesformykids/package-lock.json
@@ -11613,6 +11613,23 @@
           "optional": true
         }
       }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
+      "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
+      "dependencies": {
+        "tslib": "^2.4.0",
+        "@emnapi/wasi-threads": "1.2.1"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
+      "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
     }
   }
 }

--- a/gamesformykids/package.json
+++ b/gamesformykids/package.json
@@ -11,6 +11,7 @@
     "test": "vitest",
     "test:run": "vitest run",
     "test:coverage": "vitest run --coverage",
+    "test:e2e": "playwright test",
     "seo:sitemap": "next build && node -e \"console.log('Sitemap generated at /sitemap.xml')\"",
     "seo:check": "next build && echo 'SEO check complete - review sitemap.xml and robots.txt'",
     "supabase:create-tables": "node scripts/create-tables.js",
@@ -37,6 +38,7 @@
   "devDependencies": {
     "@eslint/eslintrc": "^3",
     "@next/bundle-analyzer": "^15.0.0",
+    "@playwright/test": "^1.59.1",
     "@tailwindcss/postcss": "^4",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",

--- a/gamesformykids/playwright.config.ts
+++ b/gamesformykids/playwright.config.ts
@@ -1,0 +1,32 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './e2e',
+  timeout: 30_000,
+  retries: process.env.CI ? 2 : 0,
+  ...(process.env.CI ? { workers: 1 } : {}),
+  reporter: process.env.CI ? 'github' : 'list',
+
+  use: {
+    baseURL: 'http://localhost:3000',
+    trace: 'on-first-retry',
+  },
+
+  projects: [
+    { name: 'chromium', use: { ...devices['Desktop Chrome'] } },
+  ],
+
+  webServer: {
+    command: 'npm run build && npm start',
+    url: 'http://localhost:3000',
+    reuseExistingServer: !process.env.CI,
+    timeout: 180_000,
+    env: {
+      NEXT_PUBLIC_SUPABASE_URL:
+        process.env.NEXT_PUBLIC_SUPABASE_URL ?? 'https://placeholder.supabase.co',
+      NEXT_PUBLIC_SUPABASE_ANON_KEY:
+        process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ?? 'placeholder-anon-key',
+      NEXT_PUBLIC_SENTRY_DSN: '',
+    },
+  },
+});

--- a/gamesformykids/vitest.config.ts
+++ b/gamesformykids/vitest.config.ts
@@ -7,6 +7,7 @@ export default defineConfig({
   test: {
     environment: 'node',
     globals: true,
+    exclude: ['**/node_modules/**', 'e2e/**'],
   },
   resolve: {
     alias: {


### PR DESCRIPTION
## Summary
- Install `@playwright/test` as devDependency
- `playwright.config.ts`: chromium, `webServer` builds + starts Next.js with placeholder Supabase env vars, 2 retries in CI
- **13 E2E scenarios** across 4 test suites:
  - `homepage.spec.ts` — page title, game card links, navigation, `/offline` page
  - `game-animals.spec.ts` — menu loads, category buttons present, clicking a category starts the game
  - `game-memory.spec.ts` — menu loads, difficulty buttons present, easy mode starts the game
  - `auth.spec.ts` — login form renders, settings/dashboard reachable without 500, unknown route handled
- `test:e2e` npm script added
- `.github/workflows/e2e.yml` — runs on every PR/push to main, uploads HTML report as 14-day artifact

## Test plan
- [ ] All 13 Playwright scenarios pass in CI
- [ ] `tsc --noEmit` passes ✅
- [ ] Playwright report artifact uploaded successfully

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)