### PR TITLE
feat: add search and category filter on homepage (#10)

### DIFF
--- a/gamesformykids/components/game/AllGamesView.tsx
+++ b/gamesformykids/components/game/AllGamesView.tsx
@@ -2,21 +2,38 @@
 
 import { useMemo } from "react";
 import GameCard from "./GameCard";
-import { GamesRegistry } from "@/lib/registry/gamesRegistry";
+import { GamesRegistry, GameRegistration } from "@/lib/registry/gamesRegistry";
 import { useGridFillers } from "@/hooks";
 
-export default function AllGamesView() {
+interface Props {
+  games?: GameRegistration[];
+  isFiltered?: boolean;
+}
+
+export default function AllGamesView({ games: gamesProp, isFiltered = false }: Props) {
   const allGameRegistrations = useMemo(() => GamesRegistry.getAllGameRegistrations(), []);
-  const totalGamesCount = allGameRegistrations.length;
-  const fillerCount = useGridFillers(totalGamesCount);
+  const games = gamesProp ?? allGameRegistrations;
+  const fillerCount = useGridFillers(games.length);
+
+  if (isFiltered && games.length === 0) {
+    return (
+      <div className="text-center py-16" dir="rtl">
+        <div className="text-5xl mb-4">🔍</div>
+        <p className="text-xl font-bold text-gray-600 mb-2">לא נמצאו משחקים</p>
+        <p className="text-gray-400 text-sm">נסה מילות חיפוש שונות או קטגוריה אחרת</p>
+      </div>
+    );
+  }
 
   return (
     <div>
       <h2 className="text-2xl md:text-3xl font-bold text-center text-gray-800 mb-5 md:mb-8">
-        כל המשחקים ({totalGamesCount})
+        {isFiltered
+          ? `נמצאו ${games.length} משחקים`
+          : `כל המשחקים (${games.length})`}
       </h2>
       <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-3 md:gap-4 lg:gap-6">
-        {allGameRegistrations.map((game) => (
+        {games.map((game) => (
           <GameCard key={game.id} game={game} />
         ))}
         {Array.from({ length: fillerCount }).map((_, i) => (

--- a/gamesformykids/components/game/GameSearchBar.tsx
+++ b/gamesformykids/components/game/GameSearchBar.tsx
@@ -1,0 +1,71 @@
+'use client';
+
+import { Search, X } from 'lucide-react';
+import { GAME_CATEGORIES } from '@/lib/constants/gameCategories';
+
+interface Props {
+  query: string;
+  onQueryChange: (q: string) => void;
+  activeCat: string | null;
+  onCatChange: (cat: string | null) => void;
+  hasFilter: boolean;
+  onClear: () => void;
+}
+
+export function GameSearchBar({
+  query,
+  onQueryChange,
+  activeCat,
+  onCatChange,
+  hasFilter,
+  onClear,
+}: Props) {
+  return (
+    <div dir="rtl" className="mb-4 md:mb-6 space-y-3">
+      <div className="relative max-w-md mx-auto">
+        <span className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-400 pointer-events-none">
+          <Search className="w-4 h-4" />
+        </span>
+        <input
+          type="search"
+          value={query}
+          onChange={(e) => onQueryChange(e.target.value)}
+          placeholder="חפש משחק..."
+          aria-label="חיפוש משחקים"
+          className="w-full pr-10 pl-10 py-2.5 rounded-full border border-gray-200 bg-white shadow-sm text-sm text-gray-800 placeholder:text-gray-400 focus:outline-none focus:ring-2 focus:ring-purple-400 focus:border-transparent"
+        />
+        {hasFilter && (
+          <button
+            onClick={onClear}
+            aria-label="נקה חיפוש"
+            className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-600 transition-colors"
+          >
+            <X className="w-4 h-4" />
+          </button>
+        )}
+      </div>
+
+      <div
+        className="flex gap-2 overflow-x-auto pb-1 px-1"
+        style={{ scrollbarWidth: 'none' }}
+        role="group"
+        aria-label="סינון לפי קטגוריה"
+      >
+        {Object.entries(GAME_CATEGORIES).map(([key, cat]) => (
+          <button
+            key={key}
+            onClick={() => onCatChange(activeCat === key ? null : key)}
+            aria-pressed={activeCat === key}
+            className={`flex-shrink-0 px-3 py-1.5 rounded-full text-xs font-semibold transition-all duration-200 ${
+              activeCat === key
+                ? 'bg-purple-600 text-white shadow-md'
+                : 'bg-white text-gray-600 hover:bg-purple-50 shadow-sm border border-gray-200'
+            }`}
+          >
+            {cat.title}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/gamesformykids/components/marketing/CategorizedGamesGrid.tsx
+++ b/gamesformykids/components/marketing/CategorizedGamesGrid.tsx
@@ -5,19 +5,31 @@ import CategoriesView from '../game/CategoriesView';
 import CategoryGamesView from '../game/CategoryGamesView';
 import AllGamesView from '../game/AllGamesView';
 import FavoritesView from '../game/FavoritesView';
+import { GameSearchBar } from '../game/GameSearchBar';
 import { useHomePageStore } from '@/lib/stores';
+import { useGameSearch } from '@/hooks/shared/search/useGameSearch';
 
 const CategorizedGamesGrid = () => {
   const selectedCategory = useHomePageStore((s) => s.selectedCategory);
   const showAllGames = useHomePageStore((s) => s.showAllGames);
   const showFavorites = useHomePageStore((s) => s.showFavorites);
+  const { query, setQuery, activeCat, setActiveCat, filteredGames, hasFilter, clearFilters } =
+    useGameSearch();
 
   return (
     <div className="max-w-6xl mx-auto px-4 pb-8">
+      <GameSearchBar
+        query={query}
+        onQueryChange={setQuery}
+        activeCat={activeCat}
+        onCatChange={setActiveCat}
+        hasFilter={hasFilter}
+        onClear={clearFilters}
+      />
       <CategoryNavigation />
       {!selectedCategory && !showAllGames && !showFavorites && <CategoriesView />}
       {selectedCategory && <CategoryGamesView />}
-      {showAllGames && <AllGamesView />}
+      {showAllGames && <AllGamesView games={filteredGames} isFiltered={hasFilter} />}
       {showFavorites && <FavoritesView />}
     </div>
   );

--- a/gamesformykids/hooks/shared/search/useGameSearch.ts
+++ b/gamesformykids/hooks/shared/search/useGameSearch.ts
@@ -1,0 +1,90 @@
+'use client';
+import { useState, useEffect, useMemo, useCallback } from 'react';
+import { useRouter } from 'next/navigation';
+import { GamesRegistry, GameRegistration } from '@/lib/registry/gamesRegistry';
+import { GAME_CATEGORIES } from '@/lib/constants/gameCategories';
+import { useHomePageStore } from '@/lib/stores';
+
+export function useGameSearch() {
+  const router = useRouter();
+  const showAllGamesView = useHomePageStore((s) => s.showAllGamesView);
+  const [query, setQueryState] = useState('');
+  const [activeCat, setActiveCatState] = useState<string | null>(null);
+
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    const q = params.get('q') ?? '';
+    const cat = params.get('cat') ?? null;
+    if (q) setQueryState(q);
+    if (cat) setActiveCatState(cat);
+    if (q || cat) showAllGamesView();
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const updateURL = useCallback(
+    (q: string, cat: string | null) => {
+      const params = new URLSearchParams();
+      if (q) params.set('q', q);
+      if (cat) params.set('cat', cat);
+      const search = params.toString();
+      const url = search
+        ? `${window.location.pathname}?${search}`
+        : window.location.pathname;
+      router.replace(url, { scroll: false });
+    },
+    [router],
+  );
+
+  const setQuery = useCallback(
+    (q: string) => {
+      setQueryState(q);
+      updateURL(q, activeCat);
+      if (q) showAllGamesView();
+    },
+    [activeCat, updateURL, showAllGamesView],
+  );
+
+  const setActiveCat = useCallback(
+    (cat: string | null) => {
+      setActiveCatState(cat);
+      updateURL(query, cat);
+      if (cat) showAllGamesView();
+    },
+    [query, updateURL, showAllGamesView],
+  );
+
+  const clearFilters = useCallback(() => {
+    setQueryState('');
+    setActiveCatState(null);
+    updateURL('', null);
+  }, [updateURL]);
+
+  const allGames = useMemo(() => GamesRegistry.getAllGameRegistrations(), []);
+
+  const filteredGames = useMemo((): GameRegistration[] => {
+    let games = allGames;
+    if (activeCat && GAME_CATEGORIES[activeCat]) {
+      const ids = new Set(GAME_CATEGORIES[activeCat].gameIds);
+      games = games.filter((g) => ids.has(g.id));
+    }
+    if (query.trim()) {
+      const q = query.trim().toLowerCase();
+      games = games.filter(
+        (g) =>
+          g.title.toLowerCase().includes(q) ||
+          g.description.toLowerCase().includes(q),
+      );
+    }
+    return games;
+  }, [allGames, query, activeCat]);
+
+  return {
+    query,
+    setQuery,
+    activeCat,
+    setActiveCat,
+    filteredGames,
+    hasFilter: Boolean(query || activeCat),
+    clearFilters,
+  };
+}


### PR DESCRIPTION
## Summary
- **GameSearchBar**: RTL text input with magnifier icon + horizontally scrollable category chips (13 categories from `GAME_CATEGORIES`). Shows a × clear button when any filter is active.
- **`useGameSearch` hook**: filters `GamesRegistry.getAllGameRegistrations()` by title/description text and by category `gameIds[]`; syncs active filter state to URL params (`?q=`, `?cat=`) via `router.replace` so filters survive page reload and are shareable.
- **`AllGamesView`**: accepts optional `games` prop (filtered list) + `isFiltered` flag; shows an empty-state card ("לא נמצאו משחקים") when the filtered list is empty; heading updates to "נמצאו N משחקים" during an active filter.
- **`CategorizedGamesGrid`**: adds `GameSearchBar` above `CategoryNavigation`; activating a filter automatically switches the view to All Games via `showAllGamesView()`.

## Test plan
- [ ] Type into the search box — game grid updates in real-time
- [ ] Click a category chip — grid narrows to that category's games; active chip highlighted purple
- [ ] Click an active chip again — deselects it (toggle)
- [ ] Both text + category chip active — intersection is shown
- [ ] No results → empty state message appears
- [ ] Press × — clears both text and category, URL returns to base path
- [ ] Refresh page with `?q=זיכרון&cat=games` in URL — filters restored, All Games view shown
- [ ] Switching to Categories or Favorites tab still works normally

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)