### PR TITLE
fix: remove duplicate 'use client' directive in useHomePage.ts (#351)

### DIFF
--- a/gamesformykids/app/useHomePage.ts
+++ b/gamesformykids/app/useHomePage.ts
@@ -1,5 +1,3 @@
-"use client";
-
 'use client';
 
 import { useEffect, useCallback } from "react";


### PR DESCRIPTION
## Summary
- Removed the redundant `"use client";` on line 1; kept the single-quoted `'use client';` on line 3 (consistent with rest of codebase)

## Test plan
- [ ] `tsc --noEmit` passes
- [ ] `next build` succeeds
- [ ] Homepage loads normally

Closes #351

🤖 Generated with [Claude Code](https://claude.com/claude-code)