### PR TITLE
fix: stop serving 404 for 5 advanced game sitemap URLs (#352)

### DIFF
--- a/gamesformykids/app/games/advanced/[gameType]/page.tsx
+++ b/gamesformykids/app/games/advanced/[gameType]/page.tsx
@@ -1,17 +1,20 @@
-import { notFound } from 'next/navigation';
+import { redirect } from 'next/navigation';
 
-export default function AdvancedGamePage() {
-  // For now, redirect to not found since advanced games are not implemented yet
-  // In the future, this could handle different advanced game types
-  
-  return notFound();
+interface Props {
+  params: Promise<{ gameType: string }>;
 }
 
-// Generate static params for known game types (if any)
+export default async function AdvancedGamePage({ params }: Props) {
+  const { gameType } = await params;
+  redirect(`/games/${gameType}`);
+}
+
 export async function generateStaticParams() {
   return [
-    // Add game types here when they are implemented
-    // { gameType: 'puzzle-advanced' },
-    // { gameType: 'memory-advanced' },
+    { gameType: 'memory' },
+    { gameType: 'puzzles' },
+    { gameType: 'math' },
+    { gameType: 'drawing' },
+    { gameType: 'builder' },
   ];
 }

--- a/gamesformykids/app/sitemap-page/page.tsx
+++ b/gamesformykids/app/sitemap-page/page.tsx
@@ -14,13 +14,6 @@ export const metadata: Metadata = {
 
 export default function SitemapPage() {
   const games = Object.entries(GAME_UI_CONFIGS);
-  const advancedGames = [
-    { id: 'memory', name: '🧠 משחק זיכרון מתקדם' },
-    { id: 'puzzles', name: '🧩 פאזלים מתקדמים' },
-    { id: 'math', name: '🔢 מתמטיקה מתקדמת' },
-    { id: 'drawing', name: '🎨 ציור דיגיטלי' },
-    { id: 'builder', name: '🏗️ בונה עולמות' },
-  ];
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-blue-100 via-purple-100 to-pink-100 p-4">
@@ -53,34 +46,10 @@ export default function SitemapPage() {
                 </Link>
               </li>
               <li>
-                <Link href="/games/advanced" className="text-blue-600 hover:text-blue-800 transition-colors">
-                  משחקים מתקדמים
-                </Link>
-              </li>
-              <li>
                 <Link href="/games/hebrew-letters" className="text-blue-600 hover:text-blue-800 transition-colors">
                   תרגול אותיות עבריות
                 </Link>
               </li>
-            </ul>
-          </div>
-
-          {/* משחקים מתקדמים */}
-          <div className="bg-white/70 backdrop-blur-sm rounded-2xl p-6 shadow-lg">
-            <h2 className="text-2xl font-bold text-purple-800 mb-4 flex items-center gap-2">
-              🎯 משחקים מתקדמים
-            </h2>
-            <ul className="space-y-2">
-              {advancedGames.map(game => (
-                <li key={game.id}>
-                  <Link 
-                    href={`/games/advanced/${game.id}`}
-                    className="text-blue-600 hover:text-blue-800 transition-colors"
-                  >
-                    {game.name}
-                  </Link>
-                </li>
-              ))}
             </ul>
           </div>
 

--- a/gamesformykids/app/sitemap.ts
+++ b/gamesformykids/app/sitemap.ts
@@ -25,17 +25,6 @@ export default function sitemap(): MetadataRoute.Sitemap {
     })
   })
 
-  // משחקים מתקדמים
-  const advancedGames = ['memory', 'puzzles', 'math', 'drawing', 'builder']
-  advancedGames.forEach((game) => {
-    routes.push({
-      url: `${baseUrl}/games/advanced/${game}`,
-      lastModified: new Date(),
-      changeFrequency: 'monthly',
-      priority: 0.7,
-    })
-  })
-
   // דפי אותיות עבריות
   hebrewLetters.forEach((letter) => {
     routes.push({
@@ -49,14 +38,6 @@ export default function sitemap(): MetadataRoute.Sitemap {
   // דף אותיות עבריות כללי
   routes.push({
     url: `${baseUrl}/games/hebrew-letters`,
-    lastModified: new Date(),
-    changeFrequency: 'monthly',
-    priority: 0.7,
-  })
-
-  // דף משחקים מתקדמים כללי  
-  routes.push({
-    url: `${baseUrl}/games/advanced`,
     lastModified: new Date(),
     changeFrequency: 'monthly',
     priority: 0.7,


### PR DESCRIPTION
## Summary
- `[gameType]/page.tsx`: replaced `notFound()` with `redirect('/games/${gameType}')` — visiting `/games/advanced/memory` now redirects to `/games/memory`. Added `generateStaticParams` with the 5 known types so they are pre-rendered as static redirects.
- `sitemap.ts`: removed all 6 advanced-game entries (`/games/advanced` index + 5 specific URLs). The same games are already in the sitemap under their canonical `/games/{id}` paths, so this avoids duplicate/broken entries.
- `sitemap-page/page.tsx`: removed the dead "משחקים מתקדמים" section and the `/games/advanced` navigation link.

## Test plan
- [ ] `tsc --noEmit` passes (confirmed locally)
- [ ] `/games/advanced/memory` redirects to `/games/memory`
- [ ] `/sitemap.xml` no longer contains `/games/advanced/*` URLs
- [ ] `/sitemap-page` no longer shows broken advanced game links

Closes #352

🤖 Generated with [Claude Code](https://claude.com/claude-code)