### PR TITLE
feat: add metadata to dashboard, login, profile, settings pages (#353 #354)

### DIFF
--- a/gamesformykids/app/dashboard/DashboardClient.tsx
+++ b/gamesformykids/app/dashboard/DashboardClient.tsx
@@ -1,0 +1,79 @@
+'use client';
+
+import { useAuth } from '@/hooks/shared/auth/useAuth';
+import { useGameProgress } from '@/hooks/shared/progress/useGameProgress';
+import { useAchievements } from '@/hooks/shared/progress/useAchievements';
+import Link from 'next/link';
+import { DashboardHeader } from './components/DashboardHeader';
+import { ActivitySummaryCard } from './components/ActivitySummaryCard';
+import { MostPlayedCard } from './components/MostPlayedCard';
+import { ScoreSummaryCard } from './components/ScoreSummaryCard';
+import { RecentAchievementsCard } from './components/RecentAchievementsCard';
+import { RecommendedGameCard } from './components/RecommendedGameCard';
+
+export default function DashboardClient() {
+  const { user, loading: authLoading } = useAuth();
+  const { progress, loading: progressLoading } = useGameProgress();
+  const { achievements, loading: achievementsLoading } = useAchievements();
+
+  const loading = authLoading || progressLoading || achievementsLoading;
+
+  if (authLoading) {
+    return (
+      <div className="min-h-screen bg-gradient-to-br from-purple-100 via-pink-100 to-blue-100 flex items-center justify-center">
+        <div className="animate-pulse text-purple-600 text-xl">טוען...</div>
+      </div>
+    );
+  }
+
+  if (!user) {
+    return (
+      <div className="min-h-screen bg-gradient-to-br from-purple-100 via-pink-100 to-blue-100 flex items-center justify-center p-4">
+        <div className="bg-white rounded-2xl shadow-lg p-8 text-center max-w-sm">
+          <div className="text-5xl mb-4">🔒</div>
+          <h2 className="text-xl font-bold text-gray-800 mb-2">נדרשת התחברות</h2>
+          <p className="text-gray-500 text-sm mb-6">התחבר כדי לצפות בלוח ההורים</p>
+          <Link
+            href="/auth"
+            className="inline-block bg-purple-600 hover:bg-purple-700 text-white font-bold py-2 px-6 rounded-xl transition-colors"
+          >
+            התחברות
+          </Link>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-purple-100 via-pink-100 to-blue-100 p-4">
+      <div className="max-w-4xl mx-auto">
+        <DashboardHeader />
+
+        {loading ? (
+          <div className="grid md:grid-cols-2 gap-6">
+            {[...Array(4)].map((_, i) => (
+              <div key={i} className="bg-white rounded-2xl shadow-md p-6 animate-pulse">
+                <div className="h-4 bg-gray-200 rounded w-1/2 mb-4" />
+                <div className="space-y-2">
+                  <div className="h-3 bg-gray-100 rounded" />
+                  <div className="h-3 bg-gray-100 rounded w-4/5" />
+                  <div className="h-3 bg-gray-100 rounded w-3/5" />
+                </div>
+              </div>
+            ))}
+          </div>
+        ) : (
+          <div className="space-y-6">
+            <ActivitySummaryCard progress={progress} />
+            <div className="grid md:grid-cols-2 gap-6">
+              <MostPlayedCard progress={progress} />
+              <ScoreSummaryCard progress={progress} />
+              <RecentAchievementsCard achievements={achievements} />
+              <RecommendedGameCard progress={progress} />
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/gamesformykids/app/dashboard/page.tsx
+++ b/gamesformykids/app/dashboard/page.tsx
@@ -1,79 +1,12 @@
-'use client';
+import { Metadata } from 'next';
+import DashboardClient from './DashboardClient';
 
-import { useAuth } from '@/hooks/shared/auth/useAuth';
-import { useGameProgress } from '@/hooks/shared/progress/useGameProgress';
-import { useAchievements } from '@/hooks/shared/progress/useAchievements';
-import Link from 'next/link';
-import { DashboardHeader } from './components/DashboardHeader';
-import { ActivitySummaryCard } from './components/ActivitySummaryCard';
-import { MostPlayedCard } from './components/MostPlayedCard';
-import { ScoreSummaryCard } from './components/ScoreSummaryCard';
-import { RecentAchievementsCard } from './components/RecentAchievementsCard';
-import { RecommendedGameCard } from './components/RecommendedGameCard';
+export const metadata: Metadata = {
+  title: 'לוח המחוונים | GamesForMyKids',
+  description: 'עקוב אחר ההתקדמות, הישגים וניקודים',
+  robots: { index: false, follow: false },
+};
 
 export default function DashboardPage() {
-  const { user, loading: authLoading } = useAuth();
-  const { progress, loading: progressLoading } = useGameProgress();
-  const { achievements, loading: achievementsLoading } = useAchievements();
-
-  const loading = authLoading || progressLoading || achievementsLoading;
-
-  if (authLoading) {
-    return (
-      <div className="min-h-screen bg-gradient-to-br from-purple-100 via-pink-100 to-blue-100 flex items-center justify-center">
-        <div className="animate-pulse text-purple-600 text-xl">טוען...</div>
-      </div>
-    );
-  }
-
-  if (!user) {
-    return (
-      <div className="min-h-screen bg-gradient-to-br from-purple-100 via-pink-100 to-blue-100 flex items-center justify-center p-4">
-        <div className="bg-white rounded-2xl shadow-lg p-8 text-center max-w-sm">
-          <div className="text-5xl mb-4">🔒</div>
-          <h2 className="text-xl font-bold text-gray-800 mb-2">נדרשת התחברות</h2>
-          <p className="text-gray-500 text-sm mb-6">התחבר כדי לצפות בלוח ההורים</p>
-          <Link
-            href="/auth"
-            className="inline-block bg-purple-600 hover:bg-purple-700 text-white font-bold py-2 px-6 rounded-xl transition-colors"
-          >
-            התחברות
-          </Link>
-        </div>
-      </div>
-    );
-  }
-
-  return (
-    <div className="min-h-screen bg-gradient-to-br from-purple-100 via-pink-100 to-blue-100 p-4">
-      <div className="max-w-4xl mx-auto">
-        <DashboardHeader />
-
-        {loading ? (
-          <div className="grid md:grid-cols-2 gap-6">
-            {[...Array(4)].map((_, i) => (
-              <div key={i} className="bg-white rounded-2xl shadow-md p-6 animate-pulse">
-                <div className="h-4 bg-gray-200 rounded w-1/2 mb-4" />
-                <div className="space-y-2">
-                  <div className="h-3 bg-gray-100 rounded" />
-                  <div className="h-3 bg-gray-100 rounded w-4/5" />
-                  <div className="h-3 bg-gray-100 rounded w-3/5" />
-                </div>
-              </div>
-            ))}
-          </div>
-        ) : (
-          <div className="space-y-6">
-            <ActivitySummaryCard progress={progress} />
-            <div className="grid md:grid-cols-2 gap-6">
-              <MostPlayedCard progress={progress} />
-              <ScoreSummaryCard progress={progress} />
-              <RecentAchievementsCard achievements={achievements} />
-              <RecommendedGameCard progress={progress} />
-            </div>
-          </div>
-        )}
-      </div>
-    </div>
-  );
+  return <DashboardClient />;
 }

--- a/gamesformykids/app/login/LoginClient.tsx
+++ b/gamesformykids/app/login/LoginClient.tsx
@@ -1,0 +1,54 @@
+'use client';
+
+import { useLoginPage } from './useLoginPage';
+import LoginHeader        from './components/LoginHeader';
+import GuestButton        from './components/GuestButton';
+import EmailAuthForm      from './components/EmailAuthForm';
+import AuthToggle         from './components/AuthToggle';
+import GoogleSignInButton from './components/GoogleSignInButton';
+import LoginFooter        from './components/LoginFooter';
+
+export default function LoginClient() {
+  const { vm, isLoading, isAuthenticated } = useLoginPage();
+
+  if (isLoading) {
+    return (
+      <div className="flex min-h-screen items-center justify-center">
+        <div className="text-lg">טוען...</div>
+      </div>
+    );
+  }
+
+  if (isAuthenticated) return null;
+
+  return (
+    <div className="flex min-h-screen flex-col items-center justify-center bg-gradient-to-br from-blue-50 to-indigo-100">
+      <div className="w-full max-w-md space-y-8 rounded-xl bg-white p-8 shadow-lg">
+        <LoginHeader isRegistering={vm.isRegistering} />
+
+        <div className="space-y-6">
+          <GuestButton onContinueAsGuest={vm.continueAsGuest} />
+
+          <EmailAuthForm
+            isRegistering={vm.isRegistering}
+            email={vm.email}
+            password={vm.password}
+            name={vm.name}
+            error={vm.error}
+            isSubmitting={vm.isSubmitting}
+            setEmail={vm.setEmail}
+            setPassword={vm.setPassword}
+            setName={vm.setName}
+            onSubmit={vm.handleEmailAuth}
+          />
+
+          <AuthToggle isRegistering={vm.isRegistering} onToggle={vm.toggleMode} />
+
+          <GoogleSignInButton onSignIn={vm.signInWithGoogle} />
+        </div>
+
+        <LoginFooter />
+      </div>
+    </div>
+  );
+}

--- a/gamesformykids/app/login/page.tsx
+++ b/gamesformykids/app/login/page.tsx
@@ -1,54 +1,12 @@
-'use client'
+import { Metadata } from 'next';
+import LoginClient from './LoginClient';
 
-import { useLoginPage } from './useLoginPage'
-import LoginHeader        from './components/LoginHeader'
-import GuestButton        from './components/GuestButton'
-import EmailAuthForm      from './components/EmailAuthForm'
-import AuthToggle         from './components/AuthToggle'
-import GoogleSignInButton from './components/GoogleSignInButton'
-import LoginFooter        from './components/LoginFooter'
+export const metadata: Metadata = {
+  title: 'התחברות | GamesForMyKids',
+  description: 'התחבר כדי לשמור את ההתקדמות שלך ולגשת לכל המשחקים',
+  robots: { index: false },
+};
 
 export default function LoginPage() {
-  const { vm, isLoading, isAuthenticated } = useLoginPage()
-
-  if (isLoading) {
-    return (
-      <div className="flex min-h-screen items-center justify-center">
-        <div className="text-lg">טוען...</div>
-      </div>
-    )
-  }
-
-  if (isAuthenticated) return null
-
-  return (
-    <div className="flex min-h-screen flex-col items-center justify-center bg-gradient-to-br from-blue-50 to-indigo-100">
-      <div className="w-full max-w-md space-y-8 rounded-xl bg-white p-8 shadow-lg">
-        <LoginHeader isRegistering={vm.isRegistering} />
-
-        <div className="space-y-6">
-          <GuestButton onContinueAsGuest={vm.continueAsGuest} />
-
-          <EmailAuthForm
-            isRegistering={vm.isRegistering}
-            email={vm.email}
-            password={vm.password}
-            name={vm.name}
-            error={vm.error}
-            isSubmitting={vm.isSubmitting}
-            setEmail={vm.setEmail}
-            setPassword={vm.setPassword}
-            setName={vm.setName}
-            onSubmit={vm.handleEmailAuth}
-          />
-
-          <AuthToggle isRegistering={vm.isRegistering} onToggle={vm.toggleMode} />
-
-          <GoogleSignInButton onSignIn={vm.signInWithGoogle} />
-        </div>
-
-        <LoginFooter />
-      </div>
-    </div>
-  )
+  return <LoginClient />;
 }

--- a/gamesformykids/app/profile/ProfileClient.tsx
+++ b/gamesformykids/app/profile/ProfileClient.tsx
@@ -1,0 +1,35 @@
+'use client';
+
+import { useUserProfile, useGameProgress, useAchievements } from '@/hooks';
+import { useAuth } from '@/hooks/shared/auth/useAuth';
+import { ProfileLoadingScreen } from './components/ProfileLoadingScreen';
+import { ProfileUnauthenticated } from './components/ProfileUnauthenticated';
+import { ProfilePageHeader } from './components/ProfilePageHeader';
+import { ProfileCard } from './components/ProfileCard';
+import { ProfileStatCards } from './components/ProfileStatCards';
+import { GameProgressList } from './components/GameProgressList';
+import { AchievementsList } from './components/AchievementsList';
+
+export default function ProfileClient() {
+  const { user, loading: authLoading } = useAuth();
+  const { loading: profileLoading } = useUserProfile();
+
+  // Trigger data fetches so child components find data in the stores
+  useGameProgress();
+  useAchievements();
+
+  if (authLoading || profileLoading) return <ProfileLoadingScreen />;
+  if (!user) return <ProfileUnauthenticated />;
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-purple-100 to-blue-100 p-4">
+      <div className="max-w-4xl mx-auto">
+        <ProfilePageHeader />
+        <ProfileCard />
+        <ProfileStatCards />
+        <GameProgressList />
+        <AchievementsList />
+      </div>
+    </div>
+  );
+}

--- a/gamesformykids/app/profile/page.tsx
+++ b/gamesformykids/app/profile/page.tsx
@@ -1,35 +1,12 @@
-'use client'
+import { Metadata } from 'next';
+import ProfileClient from './ProfileClient';
 
-import { useUserProfile, useGameProgress, useAchievements } from '@/hooks'
-import { useAuth } from '@/hooks/shared/auth/useAuth'
-import { ProfileLoadingScreen } from './components/ProfileLoadingScreen'
-import { ProfileUnauthenticated } from './components/ProfileUnauthenticated'
-import { ProfilePageHeader } from './components/ProfilePageHeader'
-import { ProfileCard } from './components/ProfileCard'
-import { ProfileStatCards } from './components/ProfileStatCards'
-import { GameProgressList } from './components/GameProgressList'
-import { AchievementsList } from './components/AchievementsList'
+export const metadata: Metadata = {
+  title: 'הפרופיל שלי | GamesForMyKids',
+  description: 'נהל את פרטי החשבון שלך',
+  robots: { index: false },
+};
 
 export default function ProfilePage() {
-  const { user, loading: authLoading } = useAuth()
-  const { loading: profileLoading } = useUserProfile()
-
-  // Trigger data fetches so child components find data in the stores
-  useGameProgress()
-  useAchievements()
-
-  if (authLoading || profileLoading) return <ProfileLoadingScreen />
-  if (!user) return <ProfileUnauthenticated />
-
-  return (
-    <div className="min-h-screen bg-gradient-to-br from-purple-100 to-blue-100 p-4">
-      <div className="max-w-4xl mx-auto">
-        <ProfilePageHeader />
-        <ProfileCard />
-        <ProfileStatCards />
-        <GameProgressList />
-        <AchievementsList />
-      </div>
-    </div>
-  )
+  return <ProfileClient />;
 }

--- a/gamesformykids/app/settings/SettingsClient.tsx
+++ b/gamesformykids/app/settings/SettingsClient.tsx
@@ -1,0 +1,87 @@
+'use client';
+
+import { useState } from 'react';
+import Link from 'next/link';
+import { useUserProfile } from '@/hooks';
+import { useAuth } from '@/hooks/shared/auth/useAuth';
+import { AudioSection } from '@/components/settings/AudioSection';
+import { AppearanceSection } from '@/components/settings/AppearanceSection';
+import { AccountSection } from '@/components/settings/AccountSection';
+
+export default function SettingsClient() {
+  const { user, loading: authLoading, signOut } = useAuth();
+  const { settings, loading: settingsLoading, updateSettings } = useUserProfile();
+  const [saving, setSaving] = useState(false);
+
+  if (authLoading || settingsLoading) {
+    return (
+      <div className="min-h-screen bg-gradient-to-br from-purple-100 to-blue-100 flex items-center justify-center">
+        <div className="text-xl">טוען...</div>
+      </div>
+    );
+  }
+
+  if (!user) {
+    return (
+      <div className="min-h-screen bg-gradient-to-br from-purple-100 to-blue-100 flex items-center justify-center">
+        <div className="text-center">
+          <h1 className="text-2xl font-bold mb-4">נדרשת התחברות</h1>
+          <Link href="/login" className="bg-blue-500 text-white px-6 py-3 rounded-lg hover:bg-blue-600">
+            התחבר כעת
+          </Link>
+        </div>
+      </div>
+    );
+  }
+
+  const handleSettingChange = async (key: string, value: boolean | string) => {
+    setSaving(true);
+    await updateSettings({ [key]: value });
+    setSaving(false);
+  };
+
+  const handleSignOut = async () => {
+    try {
+      await signOut();
+    } catch (error) {
+      console.error('שגיאה בהתנתקות:', error);
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-purple-100 to-blue-100 p-4">
+      <div className="max-w-2xl mx-auto">
+        <div className="text-center mb-8">
+          <Link href="/" className="inline-flex items-center text-purple-600 hover:text-purple-800 mb-4">
+            ← חזור לדף הבית
+          </Link>
+          <h1 className="text-3xl font-bold text-purple-800">הגדרות</h1>
+        </div>
+
+        <div className="space-y-6">
+          <AudioSection
+            soundEnabled={settings?.sound_enabled ?? true}
+            musicEnabled={settings?.music_enabled ?? true}
+            notificationsEnabled={settings?.notifications_enabled ?? true}
+            onChange={handleSettingChange}
+            disabled={saving}
+          />
+          <AppearanceSection
+            difficulty={settings?.difficulty_level ?? 'normal'}
+            theme={settings?.theme ?? 'light'}
+            language={settings?.preferred_language ?? 'he'}
+            onChange={handleSettingChange}
+            disabled={saving}
+          />
+          <AccountSection onSignOut={handleSignOut} />
+        </div>
+
+        {saving && (
+          <div className="fixed bottom-4 right-4 bg-purple-600 text-white px-4 py-2 rounded-lg shadow-lg">
+            שומר...
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/gamesformykids/app/settings/page.tsx
+++ b/gamesformykids/app/settings/page.tsx
@@ -1,87 +1,12 @@
-'use client'
+import { Metadata } from 'next';
+import SettingsClient from './SettingsClient';
 
-import { useState } from 'react'
-import Link from 'next/link'
-import { useUserProfile } from '@/hooks'
-import { useAuth } from '@/hooks/shared/auth/useAuth'
-import { AudioSection } from '@/components/settings/AudioSection'
-import { AppearanceSection } from '@/components/settings/AppearanceSection'
-import { AccountSection } from '@/components/settings/AccountSection'
+export const metadata: Metadata = {
+  title: 'הגדרות | GamesForMyKids',
+  description: 'התאם אישית את חווית המשחק שלך',
+  robots: { index: false },
+};
 
 export default function SettingsPage() {
-  const { user, loading: authLoading, signOut } = useAuth()
-  const { settings, loading: settingsLoading, updateSettings } = useUserProfile()
-  const [saving, setSaving] = useState(false)
-
-  if (authLoading || settingsLoading) {
-    return (
-      <div className="min-h-screen bg-gradient-to-br from-purple-100 to-blue-100 flex items-center justify-center">
-        <div className="text-xl">טוען...</div>
-      </div>
-    )
-  }
-
-  if (!user) {
-    return (
-      <div className="min-h-screen bg-gradient-to-br from-purple-100 to-blue-100 flex items-center justify-center">
-        <div className="text-center">
-          <h1 className="text-2xl font-bold mb-4">נדרשת התחברות</h1>
-          <Link href="/login" className="bg-blue-500 text-white px-6 py-3 rounded-lg hover:bg-blue-600">
-            התחבר כעת
-          </Link>
-        </div>
-      </div>
-    )
-  }
-
-  const handleSettingChange = async (key: string, value: boolean | string) => {
-    setSaving(true)
-    await updateSettings({ [key]: value })
-    setSaving(false)
-  }
-
-  const handleSignOut = async () => {
-    try {
-      await signOut()
-    } catch (error) {
-      console.error('שגיאה בהתנתקות:', error)
-    }
-  }
-
-  return (
-    <div className="min-h-screen bg-gradient-to-br from-purple-100 to-blue-100 p-4">
-      <div className="max-w-2xl mx-auto">
-        <div className="text-center mb-8">
-          <Link href="/" className="inline-flex items-center text-purple-600 hover:text-purple-800 mb-4">
-            ← חזור לדף הבית
-          </Link>
-          <h1 className="text-3xl font-bold text-purple-800">הגדרות</h1>
-        </div>
-
-        <div className="space-y-6">
-          <AudioSection
-            soundEnabled={settings?.sound_enabled ?? true}
-            musicEnabled={settings?.music_enabled ?? true}
-            notificationsEnabled={settings?.notifications_enabled ?? true}
-            onChange={handleSettingChange}
-            disabled={saving}
-          />
-          <AppearanceSection
-            difficulty={settings?.difficulty_level ?? 'normal'}
-            theme={settings?.theme ?? 'light'}
-            language={settings?.preferred_language ?? 'he'}
-            onChange={handleSettingChange}
-            disabled={saving}
-          />
-          <AccountSection onSignOut={handleSignOut} />
-        </div>
-
-        {saving && (
-          <div className="fixed bottom-4 right-4 bg-purple-600 text-white px-4 py-2 rounded-lg shadow-lg">
-            שומר...
-          </div>
-        )}
-      </div>
-    </div>
-  )
+  return <SettingsClient />;
 }


### PR DESCRIPTION
## Summary
Four pages were `'use client'` at the top, which causes Next.js to silently ignore any `export const metadata`. Split each into a thin server `page.tsx` (exports metadata) + a co-located `*Client.tsx` (holds all hooks and JSX). Pattern mirrors `app/page.tsx` → `HomePageClient.tsx`.

| File | Before | After |
|------|--------|-------|
| `dashboard/page.tsx` | `'use client'` + hooks | Server component, exports metadata |
| `dashboard/DashboardClient.tsx` | — | New — all hook usage + JSX |
| `login/page.tsx` | `'use client'` + hooks | Server component, exports metadata |
| `login/LoginClient.tsx` | — | New |
| `profile/page.tsx` | `'use client'` + hooks | Server component, exports metadata |
| `profile/ProfileClient.tsx` | — | New |
| `settings/page.tsx` | `'use client'` + hooks | Server component, exports metadata |
| `settings/SettingsClient.tsx` | — | New |

All four pages set `robots: { index: false }` since they are private/authenticated pages.

Also closes #340 — `GoogleAnalytics.tsx` had no `'use client'` directive already.

## Test plan
- [ ] `tsc --noEmit` passes (confirmed locally)
- [ ] Browser tab title shows "התחברות | GamesForMyKids" on `/login`
- [ ] Browser tab title shows "הגדרות | GamesForMyKids" on `/settings`
- [ ] Browser tab title shows "הפרופיל שלי | GamesForMyKids" on `/profile`
- [ ] Browser tab title shows "לוח המחוונים | GamesForMyKids" on `/dashboard`
- [ ] All four pages still render and function correctly

Closes #353
Closes #354
Closes #340

🤖 Generated with [Claude Code](https://claude.com/claude-code)