### PR TITLE
feat: add error.tsx and loading.tsx for login and settings (#355)

### DIFF
--- a/gamesformykids/app/login/error.tsx
+++ b/gamesformykids/app/login/error.tsx
@@ -1,0 +1,24 @@
+'use client';
+
+export default function LoginError({
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  return (
+    <div className="flex min-h-screen flex-col items-center justify-center bg-gradient-to-br from-blue-50 to-indigo-100 p-4">
+      <div className="bg-white rounded-2xl shadow-lg p-8 text-center max-w-sm w-full">
+        <div className="text-5xl mb-4">⚠️</div>
+        <h2 className="text-xl font-bold text-gray-800 mb-2">שגיאה בטעינת הדף</h2>
+        <p className="text-gray-500 text-sm mb-6">לא ניתן היה לטעון את דף ההתחברות</p>
+        <button
+          onClick={reset}
+          className="bg-blue-600 hover:bg-blue-700 text-white font-bold py-2 px-6 rounded-xl transition-colors"
+        >
+          נסה שוב
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/gamesformykids/app/login/loading.tsx
+++ b/gamesformykids/app/login/loading.tsx
@@ -1,0 +1,14 @@
+export default function LoginLoading() {
+  return (
+    <div className="flex min-h-screen flex-col items-center justify-center bg-gradient-to-br from-blue-50 to-indigo-100">
+      <div className="w-full max-w-md rounded-xl bg-white p-8 shadow-lg animate-pulse">
+        <div className="h-8 bg-blue-100 rounded w-3/4 mx-auto mb-6" />
+        <div className="space-y-4">
+          <div className="h-10 bg-gray-100 rounded-lg" />
+          <div className="h-10 bg-gray-100 rounded-lg" />
+          <div className="h-10 bg-blue-100 rounded-lg" />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/gamesformykids/app/settings/error.tsx
+++ b/gamesformykids/app/settings/error.tsx
@@ -1,0 +1,24 @@
+'use client';
+
+export default function SettingsError({
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-purple-100 to-blue-100 flex items-center justify-center p-4">
+      <div className="bg-white rounded-2xl shadow-lg p-8 text-center max-w-sm">
+        <div className="text-5xl mb-4">⚠️</div>
+        <h2 className="text-xl font-bold text-gray-800 mb-2">שגיאה בטעינת ההגדרות</h2>
+        <p className="text-gray-500 text-sm mb-6">לא ניתן היה לטעון את דף ההגדרות</p>
+        <button
+          onClick={reset}
+          className="bg-purple-600 hover:bg-purple-700 text-white font-bold py-2 px-6 rounded-xl transition-colors"
+        >
+          נסה שוב
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/gamesformykids/app/settings/loading.tsx
+++ b/gamesformykids/app/settings/loading.tsx
@@ -1,0 +1,22 @@
+export default function SettingsLoading() {
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-purple-100 to-blue-100 p-4">
+      <div className="max-w-2xl mx-auto animate-pulse">
+        <div className="text-center mb-8">
+          <div className="h-8 bg-purple-200 rounded w-32 mx-auto mb-2" />
+        </div>
+        <div className="space-y-6">
+          {[...Array(3)].map((_, i) => (
+            <div key={i} className="bg-white rounded-2xl shadow-md p-6">
+              <div className="h-5 bg-gray-200 rounded w-1/3 mb-4" />
+              <div className="space-y-3">
+                <div className="h-4 bg-gray-100 rounded" />
+                <div className="h-4 bg-gray-100 rounded w-4/5" />
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
Added Next.js route segment files for `app/login/` and `app/settings/` to match the pattern already established in `app/dashboard/` and `app/analytics/`.

| File | Description |
|------|-------------|
| `app/login/error.tsx` | Blue-themed error boundary with "נסה שוב" retry button |
| `app/login/loading.tsx` | Skeleton for the login form card (3 input placeholders) |
| `app/settings/error.tsx` | Purple-themed error boundary with "נסה שוב" retry button |
| `app/settings/loading.tsx` | Skeleton for 3 settings section cards |

## Test plan
- [ ] `tsc --noEmit` passes (confirmed locally)
- [ ] `/login` shows skeleton while auth state resolves (fast flash, hard to see locally)
- [ ] `/settings` shows skeleton while auth state resolves
- [ ] Simulating a thrown error on either page shows the error boundary instead of a blank white screen

Closes #355

🤖 Generated with [Claude Code](https://claude.com/claude-code)