### PR TITLE
refactor: extract SectionContainer + centralise settings prop types (#339 #348)

### DIFF
--- a/gamesformykids/components/settings/AccountSection.tsx
+++ b/gamesformykids/components/settings/AccountSection.tsx
@@ -1,15 +1,10 @@
 import Link from 'next/link';
+import type { AccountSectionProps } from '@/lib/types/components';
+import { SectionContainer } from './SectionContainer';
 
-interface Props {
-  onSignOut: () => void;
-}
-
-export function AccountSection({ onSignOut }: Props) {
+export function AccountSection({ onSignOut }: AccountSectionProps) {
   return (
-    <div className="bg-white rounded-2xl shadow-lg p-6">
-      <h2 className="text-xl font-semibold text-gray-800 mb-4 flex items-center">
-        👤 חשבון
-      </h2>
+    <SectionContainer title="חשבון" emoji="👤">
       <div className="space-y-4">
         <Link
           href="/profile"
@@ -24,6 +19,6 @@ export function AccountSection({ onSignOut }: Props) {
           התנתק מהחשבון
         </button>
       </div>
-    </div>
+    </SectionContainer>
   );
 }

--- a/gamesformykids/components/settings/AppearanceSection.tsx
+++ b/gamesformykids/components/settings/AppearanceSection.tsx
@@ -1,20 +1,11 @@
+import type { AppearanceSectionProps } from '@/lib/types/components';
 import { SettingSelect } from './SettingSelect';
+import { SectionContainer } from './SectionContainer';
 
-interface Props {
-  difficulty: string;
-  theme: string;
-  language: string;
-  onChange: (key: string, value: string) => void;
-  disabled: boolean;
-}
-
-export function AppearanceSection({ difficulty, theme, language, onChange, disabled }: Props) {
+export function AppearanceSection({ difficulty, theme, language, onChange, disabled }: AppearanceSectionProps) {
   return (
     <>
-      <div className="bg-white rounded-2xl shadow-lg p-6">
-        <h2 className="text-xl font-semibold text-gray-800 mb-4 flex items-center">
-          🎮 הגדרות משחק
-        </h2>
+      <SectionContainer title="הגדרות משחק" emoji="🎮">
         <div className="space-y-4">
           <SettingSelect
             label="רמת קושי"
@@ -41,12 +32,9 @@ export function AppearanceSection({ difficulty, theme, language, onChange, disab
             disabled={disabled}
           />
         </div>
-      </div>
+      </SectionContainer>
 
-      <div className="bg-white rounded-2xl shadow-lg p-6">
-        <h2 className="text-xl font-semibold text-gray-800 mb-4 flex items-center">
-          🌐 שפה
-        </h2>
+      <SectionContainer title="שפה" emoji="🌐">
         <div className="space-y-4">
           <SettingSelect
             label="שפת האפליקציה"
@@ -60,7 +48,7 @@ export function AppearanceSection({ difficulty, theme, language, onChange, disab
             disabled={disabled}
           />
         </div>
-      </div>
+      </SectionContainer>
     </>
   );
 }

--- a/gamesformykids/components/settings/AudioSection.tsx
+++ b/gamesformykids/components/settings/AudioSection.tsx
@@ -1,20 +1,11 @@
+import type { AudioSectionProps } from '@/lib/types/components';
 import { SettingToggle } from './SettingToggle';
+import { SectionContainer } from './SectionContainer';
 
-interface Props {
-  soundEnabled: boolean;
-  musicEnabled: boolean;
-  notificationsEnabled: boolean;
-  onChange: (key: string, value: boolean) => void;
-  disabled: boolean;
-}
-
-export function AudioSection({ soundEnabled, musicEnabled, notificationsEnabled, onChange, disabled }: Props) {
+export function AudioSection({ soundEnabled, musicEnabled, notificationsEnabled, onChange, disabled }: AudioSectionProps) {
   return (
     <>
-      <div className="bg-white rounded-2xl shadow-lg p-6">
-        <h2 className="text-xl font-semibold text-gray-800 mb-4 flex items-center">
-          🔊 הגדרות שמע
-        </h2>
+      <SectionContainer title="הגדרות שמע" emoji="🔊">
         <div className="space-y-4">
           <SettingToggle
             label="צלילי משחק"
@@ -31,12 +22,9 @@ export function AudioSection({ soundEnabled, musicEnabled, notificationsEnabled,
             disabled={disabled}
           />
         </div>
-      </div>
+      </SectionContainer>
 
-      <div className="bg-white rounded-2xl shadow-lg p-6">
-        <h2 className="text-xl font-semibold text-gray-800 mb-4 flex items-center">
-          🔔 הגדרות התראות
-        </h2>
+      <SectionContainer title="הגדרות התראות" emoji="🔔">
         <div className="space-y-4">
           <SettingToggle
             label="התראות משחק"
@@ -46,7 +34,7 @@ export function AudioSection({ soundEnabled, musicEnabled, notificationsEnabled,
             disabled={disabled}
           />
         </div>
-      </div>
+      </SectionContainer>
     </>
   );
 }

--- a/gamesformykids/components/settings/SectionContainer.tsx
+++ b/gamesformykids/components/settings/SectionContainer.tsx
@@ -1,0 +1,13 @@
+import type { SectionContainerProps } from '@/lib/types/components';
+
+export function SectionContainer({ title, emoji, children }: SectionContainerProps) {
+  return (
+    <div className="bg-white rounded-2xl shadow-lg p-6">
+      <h2 className="text-xl font-semibold text-gray-800 mb-4 flex items-center gap-2">
+        <span>{emoji}</span>
+        <span>{title}</span>
+      </h2>
+      {children}
+    </div>
+  );
+}

--- a/gamesformykids/components/settings/SettingSelect.tsx
+++ b/gamesformykids/components/settings/SettingSelect.tsx
@@ -1,13 +1,6 @@
-interface Props {
-  label: string;
-  description: string;
-  value: string;
-  options: { value: string; label: string }[];
-  onChange: (value: string) => void;
-  disabled?: boolean;
-}
+import type { SettingSelectProps } from '@/lib/types/components';
 
-export function SettingSelect({ label, description, value, options, onChange, disabled }: Props) {
+export function SettingSelect({ label, description, value, options, onChange, disabled }: SettingSelectProps) {
   return (
     <div className="p-3 border border-gray-200 rounded-lg">
       <div className="mb-2">

--- a/gamesformykids/components/settings/SettingToggle.tsx
+++ b/gamesformykids/components/settings/SettingToggle.tsx
@@ -1,12 +1,6 @@
-interface Props {
-  label: string;
-  description: string;
-  checked: boolean;
-  onChange: (checked: boolean) => void;
-  disabled?: boolean;
-}
+import type { SettingToggleProps } from '@/lib/types/components';
 
-export function SettingToggle({ label, description, checked, onChange, disabled }: Props) {
+export function SettingToggle({ label, description, checked, onChange, disabled }: SettingToggleProps) {
   return (
     <div className="flex items-center justify-between p-3 border border-gray-200 rounded-lg">
       <div>

--- a/gamesformykids/lib/types/components/index.ts
+++ b/gamesformykids/lib/types/components/index.ts
@@ -27,6 +27,9 @@ export * from './feedback';
 // ===== מסכים =====
 export * from './screens';
 
+// ===== קומפוננטות הגדרות =====
+export * from './settings';
+
 // ===== ייצוא נקודתי של טיפוסים נפוצים =====
 export type { GameStep } from './game';
 

--- a/gamesformykids/lib/types/components/settings.ts
+++ b/gamesformykids/lib/types/components/settings.ts
@@ -1,0 +1,49 @@
+import type { ReactNode } from 'react';
+
+export interface SettingToggleProps {
+  label: string;
+  description: string;
+  checked: boolean;
+  onChange: (checked: boolean) => void;
+  disabled?: boolean;
+}
+
+export interface SettingSelectOption {
+  value: string;
+  label: string;
+}
+
+export interface SettingSelectProps {
+  label: string;
+  description: string;
+  value: string;
+  options: SettingSelectOption[];
+  onChange: (value: string) => void;
+  disabled?: boolean;
+}
+
+export interface AudioSectionProps {
+  soundEnabled: boolean;
+  musicEnabled: boolean;
+  notificationsEnabled: boolean;
+  onChange: (key: string, value: boolean) => void;
+  disabled: boolean;
+}
+
+export interface AppearanceSectionProps {
+  difficulty: string;
+  theme: string;
+  language: string;
+  onChange: (key: string, value: string) => void;
+  disabled: boolean;
+}
+
+export interface AccountSectionProps {
+  onSignOut: () => void;
+}
+
+export interface SectionContainerProps {
+  title: string;
+  emoji: string;
+  children: ReactNode;
+}


### PR DESCRIPTION
## Summary

Two related settings refactors in one PR:

### #348 — SectionContainer
Every settings section repeated the same 4-line card + heading block. Extracted to a single `SectionContainer` component:
```tsx
<SectionContainer title="הגדרות שמע" emoji="🔊">
  <div className="space-y-4">...</div>
</SectionContainer>
```
Used in `AudioSection` (×2), `AppearanceSection` (×2), `AccountSection` (×1). Changing the card style is now a 1-line edit.

### #339 — Centralised prop types
All 5 settings components had inline `interface Props`. Moved to `lib/types/components/settings.ts` and re-exported from the barrel index:
- `SettingToggleProps`, `SettingSelectProps`, `SettingSelectOption`
- `AudioSectionProps`, `AppearanceSectionProps`, `AccountSectionProps`
- `SectionContainerProps`

Each component now imports its type from `@/lib/types/components`, matching the rest of the codebase.

## Test plan
- [ ] `tsc --noEmit` passes (confirmed locally)
- [ ] `/settings` renders identically to before — same card styling, same functionality
- [ ] Sound, appearance, and account sections all save correctly

Closes #339
Closes #348

🤖 Generated with [Claude Code](https://claude.com/claude-code)