### PR TITLE
refactor: extract createGameMenuScreen factory for pure-config menu screens (#356)

### DIFF
--- a/gamesformykids/app/games/balloon-pop/components/BalloonPopMenuScreen.tsx
+++ b/gamesformykids/app/games/balloon-pop/components/BalloonPopMenuScreen.tsx
@@ -1,19 +1,14 @@
-'use client';
-import GameMenuCard from '@/components/game/shared/GameMenuCard';
+import { createGameMenuScreen } from '@/components/game/shared/createGameMenuScreen';
 import { useBalloonPopGame } from '../useBalloonPopGame';
 
-export default function BalloonPopMenuScreen() {
-  const { best, startGame } = useBalloonPopGame();
-  return (
-    <GameMenuCard
-      emoji="🎈"
-      title="פוצץ בלונים!"
-      description="הקש על בלונים לפני שהם עפים · הימנע מפצצות 💣"
-      gradientClass="from-sky-200 to-blue-400"
-      buttonClass="from-pink-500 to-rose-500"
-      onStart={startGame}
-      startLabel="🎈 התחל!"
-      best={best}
-    />
-  );
-}
+export default createGameMenuScreen(
+  {
+    emoji: '🎈',
+    title: 'פוצץ בלונים!',
+    description: 'הקש על בלונים לפני שהם עפים · הימנע מפצצות 💣',
+    gradientClass: 'from-sky-200 to-blue-400',
+    buttonClass: 'from-pink-500 to-rose-500',
+    startLabel: '🎈 התחל!',
+  },
+  useBalloonPopGame,
+);

--- a/gamesformykids/app/games/simon/components/SimonMenuScreen.tsx
+++ b/gamesformykids/app/games/simon/components/SimonMenuScreen.tsx
@@ -1,20 +1,15 @@
-'use client';
-import GameMenuCard from '@/components/game/shared/GameMenuCard';
+import { createGameMenuScreen } from '@/components/game/shared/createGameMenuScreen';
 import { useSimonGame } from '../useSimonGame';
 
-export default function SimonMenuScreen() {
-  const { best, startGame } = useSimonGame();
-  return (
-    <GameMenuCard
-      emoji="🔴"
-      title="שיימון אומר"
-      description="צפה בסדר הצבעים וחזור עליהם בדיוק!"
-      hint="כל סיבוב — עוד צבע אחד"
-      gradientClass="from-gray-800 to-gray-900"
-      buttonClass="from-gray-600 to-gray-800"
-      onStart={startGame}
-      startLabel="🔴 התחל!"
-      best={best}
-    />
-  );
-}
+export default createGameMenuScreen(
+  {
+    emoji: '🔴',
+    title: 'שיימון אומר',
+    description: 'צפה בסדר הצבעים וחזור עליהם בדיוק!',
+    hint: 'כל סיבוב — עוד צבע אחד',
+    gradientClass: 'from-gray-800 to-gray-900',
+    buttonClass: 'from-gray-600 to-gray-800',
+    startLabel: '🔴 התחל!',
+  },
+  useSimonGame,
+);

--- a/gamesformykids/app/games/whack-a-mole/components/WhackAMoleMenuScreen.tsx
+++ b/gamesformykids/app/games/whack-a-mole/components/WhackAMoleMenuScreen.tsx
@@ -1,20 +1,15 @@
-'use client';
-import GameMenuCard from '@/components/game/shared/GameMenuCard';
+import { createGameMenuScreen } from '@/components/game/shared/createGameMenuScreen';
 import { useWhackAMoleGame } from '../useWhackAMoleGame';
 
-export default function WhackAMoleMenuScreen() {
-  const { best, startGame } = useWhackAMoleGame();
-  return (
-    <GameMenuCard
-      emoji="🐹"
-      title="חבט על החפרפרת!"
-      description="הקש על החפרפרות לפני שהן נעלמות · הימנע מהפצצות 💣"
-      gradientClass="from-yellow-50 to-amber-100"
-      buttonClass="from-amber-500 to-orange-500"
-      onStart={startGame}
-      startLabel="🔨 התחל!"
-      best={best}
-      animateEmoji
-    />
-  );
-}
+export default createGameMenuScreen(
+  {
+    emoji: '🐹',
+    title: 'חבט על החפרפרת!',
+    description: 'הקש על החפרפרות לפני שהן נעלמות · הימנע מהפצצות 💣',
+    gradientClass: 'from-yellow-50 to-amber-100',
+    buttonClass: 'from-amber-500 to-orange-500',
+    startLabel: '🔨 התחל!',
+    animateEmoji: true,
+  },
+  useWhackAMoleGame,
+);

--- a/gamesformykids/app/games/word-builder/components/WordBuilderMenuScreen.tsx
+++ b/gamesformykids/app/games/word-builder/components/WordBuilderMenuScreen.tsx
@@ -1,18 +1,14 @@
-'use client';
-import GameMenuCard from '@/components/game/shared/GameMenuCard';
+import { createGameMenuScreen } from '@/components/game/shared/createGameMenuScreen';
 import { useWordBuilderGame } from '../useWordBuilderGame';
 
-export default function WordBuilderMenuScreen() {
-  const { startGame } = useWordBuilderGame();
-  return (
-    <GameMenuCard
-      emoji="🔤"
-      title="בניית מילים"
-      description="סדר את האותיות ובנה את המילה הנכונה!"
-      gradientClass="from-orange-50 to-amber-100"
-      buttonClass="from-orange-500 to-amber-500"
-      onStart={startGame}
-      startLabel="🚀 התחל!"
-    />
-  );
-}
+export default createGameMenuScreen(
+  {
+    emoji: '🔤',
+    title: 'בניית מילים',
+    description: 'סדר את האותיות ובנה את המילה הנכונה!',
+    gradientClass: 'from-orange-50 to-amber-100',
+    buttonClass: 'from-orange-500 to-amber-500',
+    startLabel: '🚀 התחל!',
+  },
+  useWordBuilderGame,
+);

--- a/gamesformykids/app/games/word-scramble/components/WordScrambleMenuScreen.tsx
+++ b/gamesformykids/app/games/word-scramble/components/WordScrambleMenuScreen.tsx
@@ -1,18 +1,14 @@
-'use client';
-import GameMenuCard from '@/components/game/shared/GameMenuCard';
+import { createGameMenuScreen } from '@/components/game/shared/createGameMenuScreen';
 import { useWordScrambleGame } from '../useWordScrambleGame';
 
-export default function WordScrambleMenuScreen() {
-  const { startGame } = useWordScrambleGame();
-  return (
-    <GameMenuCard
-      emoji="🔡"
-      title="מילים מבולבלות"
-      description="לחצו על האותיות בסדר הנכון כדי לכתוב את המילה!"
-      gradientClass="from-green-100 to-emerald-200"
-      buttonClass="from-green-500 to-emerald-600"
-      onStart={startGame}
-      startLabel="🔡 התחל!"
-    />
-  );
-}
+export default createGameMenuScreen(
+  {
+    emoji: '🔡',
+    title: 'מילים מבולבלות',
+    description: 'לחצו על האותיות בסדר הנכון כדי לכתוב את המילה!',
+    gradientClass: 'from-green-100 to-emerald-200',
+    buttonClass: 'from-green-500 to-emerald-600',
+    startLabel: '🔡 התחל!',
+  },
+  useWordScrambleGame,
+);

--- a/gamesformykids/components/game/shared/createGameMenuScreen.tsx
+++ b/gamesformykids/components/game/shared/createGameMenuScreen.tsx
@@ -1,0 +1,32 @@
+'use client';
+
+import GameMenuCard from './GameMenuCard';
+
+export interface GameMenuScreenConfig {
+  emoji: string;
+  title: string;
+  description: string;
+  gradientClass: string;
+  buttonClass?: string;
+  startLabel?: string;
+  hint?: string;
+  animateEmoji?: boolean;
+}
+
+export function createGameMenuScreen(
+  config: GameMenuScreenConfig,
+  useGameHook: () => { startGame: () => void; best?: number },
+) {
+  function GameMenuScreen() {
+    const { startGame, best } = useGameHook();
+    return (
+      <GameMenuCard
+        {...config}
+        onStart={startGame}
+        {...(best !== undefined && { best })}
+      />
+    );
+  }
+  GameMenuScreen.displayName = `GameMenuScreen(${config.title})`;
+  return GameMenuScreen;
+}


### PR DESCRIPTION
## Summary
Created `createGameMenuScreen(config, useHook)` factory in `components/game/shared/createGameMenuScreen.tsx` and applied it to the 5 `GameMenuCard` wrappers that have no children and no dynamic logic.

### Factory signature
```ts
createGameMenuScreen(config: GameMenuScreenConfig, useGameHook: () => { startGame: () => void; best?: number })
```

### Before → After (example)
```tsx
// Before: ~20 lines
'use client';
import GameMenuCard from '@/components/game/shared/GameMenuCard';
import { useSimonGame } from '../useSimonGame';

export default function SimonMenuScreen() {
  const { best, startGame } = useSimonGame();
  return (
    <GameMenuCard emoji="🔴" title="שיימון אומר" ... onStart={startGame} best={best} />
  );
}

// After: pure config data
import { createGameMenuScreen } from '@/components/game/shared/createGameMenuScreen';
import { useSimonGame } from '../useSimonGame';

export default createGameMenuScreen({ emoji: '🔴', title: 'שיימון אומר', ... }, useSimonGame);
```

### Applied to 5 files
`BalloonPopMenuScreen`, `SimonMenuScreen`, `WordBuilderMenuScreen`, `WordScrambleMenuScreen`, `WhackAMoleMenuScreen`

### NOT applied (intentionally)
The remaining 8 GameMenuCard files (`Taki`, `Damka`, `Reflex`, `ColorTap`, `EmojiMath`, `MathRace`, `TrueFalse`, `NumberBubbles`) have children slots or dynamic hints/descriptions — they stay as named components.

## Test plan
- [ ] `tsc --noEmit` passes (confirmed locally)
- [ ] BalloonPop, Simon, WordBuilder, WordScramble, WhackAMole menu screens render and start game correctly
- [ ] `best` score shows correctly where applicable (Simon, WhackAMole)

Closes #356

🤖 Generated with [Claude Code](https://claude.com/claude-code)