### PR TITLE
fix: remove fake aggregateRating from homepage JSON-LD (#368)

### DIFF
--- a/gamesformykids/app/page.tsx
+++ b/gamesformykids/app/page.tsx
@@ -19,12 +19,6 @@ const homePageStructuredData = {
     "price": "0",
     "priceCurrency": "ILS"
   },
-  "aggregateRating": {
-    "@type": "AggregateRating",
-    "ratingValue": "4.9",
-    "ratingCount": "127",
-    "bestRating": "5"
-  },
   "keywords": "משחקים לילדים, חינוכי, זיכרון, צבעים, עברית, מספרים, גיל 2-5, פעוטות",
   "inLanguage": "he"
 };


### PR DESCRIPTION
## Summary
- Removes fabricated `aggregateRating` block (`ratingValue: 4.9`, `ratingCount: 127`) from the homepage JSON-LD structured data
- The `Offer` block (price = 0) is genuine and retained
- All other schema fields (`name`, `description`, `author`, `keywords`, etc.) are unchanged

## Why
Google's structured data guidelines prohibit rating markup unless the ratings are real, user-generated, and verifiable. Fake ratings risk a manual action and removal of all rich results for the site.

## Test plan
- [ ] `npx tsc --noEmit` — no errors
- [ ] Deploy preview: validate JSON-LD with Google's Rich Results Test — no `aggregateRating` errors
- [ ] Confirm remaining structured data (WebApplication, Offer) still validates cleanly

Closes #368

🤖 Generated with [Claude Code](https://claude.com/claude-code)