### PR TITLE
fix: remove non-existent OG/Twitter image refs from hebrew-letters pages (#369)

### DIFF
--- a/gamesformykids/app/games/hebrew-letters/[letter]/page.tsx
+++ b/gamesformykids/app/games/hebrew-letters/[letter]/page.tsx
@@ -26,20 +26,11 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
       description: `דף תרגול אינטראקטיבי לכתיבת האות ${letterData.letter} בעברית`,
       type: 'article',
       url: `https://gamesformykids.vercel.app/games/hebrew-letters/${letter}`,
-      images: [
-        {
-          url: `/images/letters/${letterData.name}-og.png`,
-          width: 1200,
-          height: 630,
-          alt: `תרגול האות ${letterData.letter}`,
-        },
-      ],
     },
     twitter: {
-      card: 'summary_large_image',
+      card: 'summary',
       title: `תרגול האות ${letterData.letter} - ${letterData.name}`,
       description: `דף תרגול אינטראקטיבי לכתיבת האות ${letterData.letter} בעברית`,
-      images: [`/images/letters/${letterData.name}-twitter.png`],
     },
     alternates: {
       canonical: `/games/hebrew-letters/${letter}`,


### PR DESCRIPTION
## Summary
- Removed `images` array from `openGraph` in `app/games/hebrew-letters/[letter]/page.tsx`
- Downgraded Twitter card from `summary_large_image` to `summary` (no image field)

## Why
The metadata referenced 44 non-existent image files (`/images/letters/{name}-og.png`, `{name}-twitter.png`). Crawlers hitting these paths get 404s, breaking social sharing previews for every individual letter practice page.

## Test plan
- [ ] `npx tsc --noEmit` — no errors
- [ ] Confirm letter pages (e.g. `/games/hebrew-letters/alef`) still render correctly
- [ ] Twitter Card Validator shows `summary` card with no broken image

Closes #369

🤖 Generated with [Claude Code](https://claude.com/claude-code)