### PR TITLE
chore: add root-level .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,22 @@
+# OS
+.DS_Store
+Thumbs.db
+Desktop.ini
+
+# Editors
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+
+# Claude Code local memory
+.claude/
+
+# Logs
+*.log
+logs/
+
+# Env files at root level
+.env
+.env.*


### PR DESCRIPTION
## Summary
- Adds `.gitignore` at the repo root (previously missing — only `gamesformykids/.gitignore` existed)
- Covers: OS files (`.DS_Store`, `Thumbs.db`), editor dirs (`.vscode/`, `.idea/`), Claude Code memory (`.claude/`), root-level env files

The project-level `gamesformykids/.gitignore` continues to handle `node_modules`, `.next/`, `.env*`, build output, etc.

## Test plan
- [ ] `git status` at repo root shows no unexpected untracked files after adding new OS/editor artifacts

🤖 Generated with [Claude Code](https://claude.com/claude-code)