### PR TITLE
refactor: rename useProgressTracking → useSessionStats (#387)

### DIFF
--- a/GAME_CREATION_GUIDE.md
+++ b/GAME_CREATION_GUIDE.md
@@ -353,14 +353,14 @@ function MyGameComponent() {
 ## 📊 מעקב התקדמות
 
 ```typescript
-import { useProgressTracking } from "@/hooks/shared/useProgressTracking";
+import { useSessionStats } from "@/hooks/shared/useSessionStats";
 
 function MyGameComponent() {
   const { 
     progress, 
     updateProgress, 
     resetProgress 
-  } = useProgressTracking('my-game');
+  } = useSessionStats('my-game');
 
   const handleCorrectAnswer = () => {
     updateProgress({

--- a/gamesformykids/hooks/index.ts
+++ b/gamesformykids/hooks/index.ts
@@ -25,5 +25,20 @@ export * from './shared/user';
 // UI & Events
 export * from './shared/ui';
 
+// Auth
+export * from './shared/auth';
+
+// Search
+export * from './shared/search';
+
+// Social
+export * from './shared/social';
+
+// Game Controls
+export * from './shared/game-controls';
+
+// Canvas
+export * from './canvas';
+
 // Games Hooks
 export { useGenericGame } from "./games/useGenericGame";

--- a/gamesformykids/hooks/shared/game-controls/index.ts
+++ b/gamesformykids/hooks/shared/game-controls/index.ts
@@ -1,0 +1,1 @@
+export { useKeyboardControls } from './useKeyboardControls';

--- a/gamesformykids/hooks/shared/game-state/useBaseGame.ts
+++ b/gamesformykids/hooks/shared/game-state/useBaseGame.ts
@@ -6,7 +6,7 @@ import { useGameAudio } from "../audio/useGameAudio";
 import { useGameOptions } from "./useGameOptions";
 import { useGamePerformance } from "../analytics/useGamePerformance";
 import { useGameHints } from "../ui/useGameHints";
-import { useProgressTracking } from "../progress/useProgressTracking";
+import { useSessionStats } from "../progress/useSessionStats";
 import { 
   delay, 
   speakItemName as speakItemNameUtil,
@@ -62,7 +62,7 @@ export function useBaseGame<T extends BaseGameItem = BaseGameItem>(config: UseBa
   });
 
   // Progress tracking
-  const progressHooks = useProgressTracking(gameType);
+  const progressHooks = useSessionStats(gameType);
   
   const { getRandomChallenge, getOptionsForChallenge } = useGameOptions({
     allItems: items,

--- a/gamesformykids/hooks/shared/progress/index.ts
+++ b/gamesformykids/hooks/shared/progress/index.ts
@@ -1,3 +1,3 @@
 export { useGameProgress } from './useGameProgress';
-export { useProgressTracking } from './useProgressTracking';
+export { useSessionStats } from './useSessionStats';
 export { useAchievements } from './useAchievements';

--- a/gamesformykids/hooks/shared/progress/useSessionStats.ts
+++ b/gamesformykids/hooks/shared/progress/useSessionStats.ts
@@ -10,7 +10,7 @@ import { BaseGameItem, GameType } from '@/lib/types/core/base';
 import { GameSession, ProgressStats } from '@/lib/types/hooks/progress';
 import { useProgressTrackingStore } from '@/lib/stores/progressTrackingStore';
 
-export function useProgressTracking(gameType: GameType) {
+export function useSessionStats(gameType: GameType) {
   const allSessions = useProgressTrackingStore((s) => s.allSessions);
   const { addSession } = useProgressTrackingStore();
 

--- a/gamesformykids/hooks/shared/search/index.ts
+++ b/gamesformykids/hooks/shared/search/index.ts
@@ -1,0 +1,1 @@
+export { useGameSearch } from './useGameSearch';

--- a/gamesformykids/hooks/shared/social/index.ts
+++ b/gamesformykids/hooks/shared/social/index.ts
@@ -1,0 +1,1 @@
+export { useShareScore } from './useShareScore';


### PR DESCRIPTION
## Summary
Renames `useProgressTracking` → `useSessionStats` to make its purpose unmistakable.

## Why
`useProgressTracking` and `useGameProgress` sound like they do the same thing but serve opposite concerns:
- `useProgressTracking` (→ `useSessionStats`) — **ephemeral**, local Zustand store, no server calls, tracks current-session stats
- `useGameProgress` — **durable**, fetches from Supabase via `useAchievements`, involves async server I/O

The new name `useSessionStats` makes it immediately clear: session-scoped, local, no network.

## Changes
| File | Change |
|------|--------|
| `hooks/shared/progress/useProgressTracking.ts` | Renamed → `useSessionStats.ts` (function name updated) |
| `hooks/shared/progress/index.ts` | Barrel updated |
| `hooks/shared/game-state/useBaseGame.ts` | Import + variable updated |
| `GAME_CREATION_GUIDE.md` | Example code updated |

Also commits three previously-untracked hook barrel files (`auth`, `game-controls`, `search`, `social`) and their `hooks/index.ts` export entries.

## Test plan
- [ ] `npx tsc --noEmit` — no errors (confirmed locally)
- [ ] Game session stats still record correctly

Closes #387

🤖 Generated with [Claude Code](https://claude.com/claude-code)