### PR TITLE
fix: avatar dropdown navigation and Supabase session cookies

### DIFF
--- a/gamesformykids/components/layout/StaticHeader.tsx
+++ b/gamesformykids/components/layout/StaticHeader.tsx
@@ -6,8 +6,10 @@ import { FeatureHighlights } from './header/FeatureHighlights';
 // Server Component - renders statically for better LCP
 export function StaticHeader() {
   return (
-    <header className="text-center py-6 md:py-8 lg:py-12 relative overflow-hidden">
-      <HeaderBackground />
+    <header className="text-center py-6 md:py-8 lg:py-12 relative">
+      <div className="absolute inset-0 overflow-hidden">
+        <HeaderBackground />
+      </div>
 
       <div className="relative z-10">
         <div className="flex justify-end px-4 mb-2">

--- a/gamesformykids/lib/supabase/client.ts
+++ b/gamesformykids/lib/supabase/client.ts
@@ -1,15 +1,16 @@
-import { createClient } from '@supabase/supabase-js'
+import { createBrowserClient } from '@supabase/ssr'
+import { createClient, type SupabaseClient } from '@supabase/supabase-js'
 
 const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
 const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
 
-// Create a real client only if credentials are present
-export const supabase = createClient(
-  supabaseUrl || 'https://placeholder.supabase.co',
-  supabaseAnonKey || 'placeholder-key'
-)
-
 // Whether Supabase is configured and (likely) available
 export const isSupabaseConfigured = !!supabaseUrl && !!supabaseAnonKey
+
+// Use createBrowserClient (SSR-safe, stores session in cookies) when configured,
+// otherwise fall back to a dummy client so imports don't break
+export const supabase: SupabaseClient = isSupabaseConfigured
+  ? createBrowserClient(supabaseUrl!, supabaseAnonKey!)
+  : createClient('https://placeholder.supabase.co', 'placeholder-key')
 
 export default supabase


### PR DESCRIPTION
## בעיות שתוקנו

### 1. תפריט dropdown של האווטאר לא היה ניתן ללחיצה
`StaticHeader` כלל `overflow-hidden` שחסם פיזית את תפריט ה-dropdown — לא ניתן היה ללחוץ על "פרופיל" ו"הגדרות".

**תיקון:** הועבר `overflow-hidden` לעטוף רק את `HeaderBackground` (div עם `absolute inset-0`), כך שהרקע עדיין נחתך, אבל ה-dropdown חופשי להופיע מחוץ לגבולות ה-header.

### 2. Middleware הפנה משתמשים מחוברים ל-`/login`
`createClient` מ-`@supabase/supabase-js` מאחסן session ב-**localStorage** — ה-middleware לא יכול לקרוא `localStorage` (רץ בצד שרת), ולכן לא הכיר את המשתמש וניתב אותו ל-`/login` בכל כניסה ל-`/profile` או `/settings`.

**תיקון:** הוחלף ל-`createBrowserClient` מ-`@supabase/ssr` שמאחסן session ב-**cookies** — ה-middleware קורא cookies ומזהה את המשתמש כמחובר.

## קבצים שהשתנו
- `components/layout/StaticHeader.tsx` — הוסר `overflow-hidden` מה-header
- `lib/supabase/client.ts` — החלפת `createClient` ב-`createBrowserClient` (עם fallback בטוח ל-placeholder)