### PR TITLE
fix: re-fetch progress on tab visibility to avoid stale profile data (#417)

### DIFF
--- a/gamesformykids/app/profile/ProfileClient.tsx
+++ b/gamesformykids/app/profile/ProfileClient.tsx
@@ -19,10 +19,18 @@ export default function ProfileClient() {
   const { refreshProgress } = useGameProgress();
   useAchievements();
 
-  // Always re-fetch progress from Supabase when the profile page mounts,
-  // so any progress saved during the last game session is reflected.
+  // Fetch on mount (user change) and on tab re-focus so progress saved
+  // during a game session is visible when navigating back to this page.
   useEffect(() => {
-    if (user) refreshProgress();
+    if (!user) return;
+    refreshProgress();
+
+    const onVisible = () => {
+      if (document.visibilityState === 'visible') refreshProgress();
+    };
+    document.addEventListener('visibilitychange', onVisible);
+    return () => document.removeEventListener('visibilitychange', onVisible);
+  // refreshProgress is stable (useCallback), user drives re-runs
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [user]);
 


### PR DESCRIPTION
## Problem
After SPA navigation away from `/profile` and back, the `useEffect([user])` doesn't re-run because `user` is unchanged. The user sees cached (stale) progress even though new game results were saved to Supabase during the session.

## Solution
Add a `visibilitychange` event listener that calls `refreshProgress()` whenever the tab becomes active. The listener is cleaned up on unmount.

```tsx
const onVisible = () => {
  if (document.visibilityState === 'visible') refreshProgress();
};
document.addEventListener('visibilitychange', onVisible);
return () => document.removeEventListener('visibilitychange', onVisible);
```

## Test plan
- [ ] `tsc --noEmit` passes
- [ ] Visit profile → play a game → navigate back to profile → data is fresh
- [ ] Switch to another tab → switch back → data refreshes

Closes #417

🤖 Generated with [Claude Code](https://claude.com/claude-code)