### PR TITLE
fix: show warning toast on SIGNED_OUT to notify of token expiry (#420)

### DIFF
--- a/gamesformykids/lib/providers/AuthProvider.tsx
+++ b/gamesformykids/lib/providers/AuthProvider.tsx
@@ -9,6 +9,7 @@ import { useEffect, ReactNode } from 'react'
 import type { AuthChangeEvent, Session } from '@supabase/supabase-js'
 import { supabase, isSupabaseConfigured } from '@/lib/supabase/client'
 import { useAuthStore } from '@/lib/stores/authStore'
+import { useUIStore } from '@/lib/stores/uiStore'
 
 export function AuthProvider({ children }: { children: ReactNode }) {
   useEffect(() => {
@@ -36,7 +37,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     })
 
     const { data: { subscription } } = supabase.auth.onAuthStateChange(
-      (_event: AuthChangeEvent, session: Session | null) => {
+      (event: AuthChangeEvent, session: Session | null) => {
         if (session) localStorage.removeItem('guestMode')
         const isGuest = !session && localStorage.getItem('guestMode') === 'true'
         useAuthStore.getState().setAuthState({
@@ -45,6 +46,13 @@ export function AuthProvider({ children }: { children: ReactNode }) {
           isGuest,
           loading: false,
         })
+
+        if (event === 'SIGNED_OUT' && !isGuest) {
+          useUIStore.getState().addNotification(
+            'פג תוקף ההתחברות — אנא התחבר שוב כדי לשמור את ההתקדמות',
+            'warning',
+          )
+        }
       },
     )
 


### PR DESCRIPTION
## Problem
When a Supabase access token expires mid-game, `supabase-js` fires a `SIGNED_OUT` event. The auth state was silently updated to logged-out, but users had no indication — the UI still showed the avatar, and subsequent Supabase writes (save progress, update profile) failed silently.

## Solution
In `AuthProvider.tsx`, check for `event === 'SIGNED_OUT'` in the `onAuthStateChange` callback. When detected for a non-guest session, show a warning notification via the existing `useUIStore.addNotification()` system:

> "פג תוקף ההתחברות — אנא התחבר שוב כדי לשמור את ההתקדמות"

The `NotificationToast` component (already mounted in layout) will display it.

## Test plan
- [ ] `tsc --noEmit` passes
- [ ] Manually expire a token (or simulate `SIGNED_OUT` event) → warning toast appears
- [ ] Guest mode sign-out does NOT show the toast

Closes #420

🤖 Generated with [Claude Code](https://claude.com/claude-code)