### PR TITLE
feat: useGameCompletion hook — save Supabase progress in all custom games

### DIFF
--- a/gamesformykids/app/games/balloon-pop/useBalloonPopGame.ts
+++ b/gamesformykids/app/games/balloon-pop/useBalloonPopGame.ts
@@ -1,5 +1,28 @@
 'use client';
-import { createShallowHook } from '@/lib/stores/utils/sliceUtils';
+import { useEffect, useRef } from 'react';
+import { useShallow } from 'zustand/react/shallow';
 import { useBalloonPopStore } from './balloonPopStore';
+import { useGameCompletion } from '@/hooks/shared/progress';
 
-export const useBalloonPopGame = createShallowHook(useBalloonPopStore);
+export function useBalloonPopGame() {
+  const state = useBalloonPopStore(useShallow((s) => s));
+  const { saveGameResultRef } = useGameCompletion('balloon-pop');
+
+  const startTimeRef = useRef(0);
+  const prevPhaseRef = useRef<string>(state.phase);
+
+  useEffect(() => {
+    const prev = prevPhaseRef.current;
+    const curr = state.phase;
+    prevPhaseRef.current = curr;
+
+    if (curr === 'playing' && prev !== 'playing') {
+      startTimeRef.current = Date.now();
+    } else if (prev === 'playing' && curr === 'result') {
+      const elapsed = Math.round((Date.now() - startTimeRef.current) / 1000);
+      saveGameResultRef.current({ score: state.score, level: 1, durationSeconds: elapsed });
+    }
+  }, [state.phase]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  return state;
+}

--- a/gamesformykids/app/games/brick-breaker/useBrickBreakerGame.ts
+++ b/gamesformykids/app/games/brick-breaker/useBrickBreakerGame.ts
@@ -4,6 +4,7 @@ import { useEffect, useRef, useCallback } from 'react';
 import { useShallow } from 'zustand/react/shallow';
 import { useBrickBreakerStore } from './brickBreakerStore';
 import { useCanvasLoop } from '@/hooks/canvas';
+import { useGameCompletion } from '@/hooks/shared/progress';
 
 export const W = 360;
 export const H = 560;
@@ -41,11 +42,14 @@ function brickRect(i: number) {
 }
 
 export function useBrickBreakerGame() {
+  const { saveGameResultRef } = useGameCompletion('brick-breaker');
+
   const st = useRef({
     phase: 'menu' as Phase,
     padX: W / 2 - PAD_W / 2,
     ballX: W / 2, ballY: PAD_Y - BALL_R - 2, ballVX: 3, ballVY: -4, launched: false,
     bricks: makeBricks(), score: 0, lives: 3, level: 1, frame: 0,
+    startTime: 0,
     particles: [] as { x: number; y: number; vx: number; vy: number; life: number; color: string }[],
   });
   const startGame = useCallback((level = 1) => {
@@ -55,6 +59,7 @@ export function useBrickBreakerGame() {
     const spd = 3.5 + (level - 1) * 0.5;
     s.ballVX = spd; s.ballVY = -(spd + 0.5); s.launched = false;
     s.bricks = makeBricks();
+    if (level === 1) s.startTime = Date.now();
     s.score = level === 1 ? 0 : s.score;
     s.lives = level === 1 ? 3 : s.lives;
     s.level = level; s.particles = [];
@@ -110,8 +115,12 @@ export function useBrickBreakerGame() {
         if (s.ballY + BALL_R > H) {
           s.lives--;
           s.launched = false; s.ballX = s.padX + PAD_W / 2; s.ballY = PAD_Y - BALL_R - 2;
-          if (s.lives <= 0) { s.lives = 0; s.phase = 'dead'; useBrickBreakerStore.getState().setGameOver(s.score, s.level); }
-          else { useBrickBreakerStore.getState().setLives(s.lives); }
+          if (s.lives <= 0) {
+            s.lives = 0; s.phase = 'dead';
+            const elapsed = Math.round((Date.now() - s.startTime) / 1000);
+            saveGameResultRef.current({ score: s.score, level: s.level, durationSeconds: elapsed });
+            useBrickBreakerStore.getState().setGameOver(s.score, s.level);
+          } else { useBrickBreakerStore.getState().setLives(s.lives); }
         }
         for (let i = 0; i < s.bricks.length; i++) {
           if (!s.bricks[i].alive) continue;
@@ -128,7 +137,12 @@ export function useBrickBreakerGame() {
         }
         if (s.bricks.every(b => !b.alive)) {
           const nextLevel = s.level + 1;
-          if (nextLevel > 5) { s.phase = 'won'; useBrickBreakerStore.getState().setWon(s.score, s.lives, s.level); }
+          if (nextLevel > 5) {
+            s.phase = 'won';
+            const elapsed = Math.round((Date.now() - s.startTime) / 1000);
+            saveGameResultRef.current({ score: s.score, level: s.level, durationSeconds: elapsed });
+            useBrickBreakerStore.getState().setWon(s.score, s.lives, s.level);
+          }
           else { startGame(nextLevel); }
         }
       }

--- a/gamesformykids/app/games/color-tap/useColorTapGame.ts
+++ b/gamesformykids/app/games/color-tap/useColorTapGame.ts
@@ -1,8 +1,31 @@
 'use client';
-import { createShallowHook } from '@/lib/stores/utils/sliceUtils';
+import { useEffect, useRef } from 'react';
+import { useShallow } from 'zustand/react/shallow';
 import { useColorTapStore } from './colorTapStore';
+import { useGameCompletion } from '@/hooks/shared/progress';
 
 export type { ColorItem, Question } from './colorTapStore';
 export { COLORS, TIME_PER_Q } from './colorTapStore';
 
-export const useColorTapGame = createShallowHook(useColorTapStore);
+export function useColorTapGame() {
+  const state = useColorTapStore(useShallow((s) => s));
+  const { saveGameResultRef } = useGameCompletion('color-tap');
+
+  const startTimeRef = useRef(0);
+  const prevPhaseRef = useRef<string>(state.phase);
+
+  useEffect(() => {
+    const prev = prevPhaseRef.current;
+    const curr = state.phase;
+    prevPhaseRef.current = curr;
+
+    if (curr === 'playing' && prev !== 'playing') {
+      startTimeRef.current = Date.now();
+    } else if (prev === 'playing' && curr === 'dead') {
+      const elapsed = Math.round((Date.now() - startTimeRef.current) / 1000);
+      saveGameResultRef.current({ score: state.score, level: 1, durationSeconds: elapsed });
+    }
+  }, [state.phase]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  return state;
+}

--- a/gamesformykids/app/games/dino-runner/useDinoRunnerGame.ts
+++ b/gamesformykids/app/games/dino-runner/useDinoRunnerGame.ts
@@ -4,6 +4,7 @@ import { useEffect, useRef, useCallback } from 'react';
 import { useShallow } from 'zustand/react/shallow';
 import { useDinoRunnerStore } from './dinoRunnerStore';
 import { useCanvasLoop } from '@/hooks/canvas';
+import { useGameCompletion } from '@/hooks/shared/progress';
 
 export const W = 400;
 export const H = 220;
@@ -21,6 +22,8 @@ interface Obstacle { x: number; w: number; h: number; emoji: string; }
 const OBSTACLE_EMOJIS = ['🌵', '🪨', '🌴', '🌿', '🍄'];
 
 export function useDinoRunnerGame() {
+  const { saveGameResultRef } = useGameCompletion('dino-runner');
+
   const st = useRef({
     phase: 'menu' as Phase,
     dinoY: GROUND_Y - DINO_H,
@@ -32,6 +35,7 @@ export function useDinoRunnerGame() {
     frame: 0,
     speed: BASE_SPEED,
     nextObstacle: 80,
+    startTime: 0,
   });
   const jump = useCallback(() => {
     const s = st.current;
@@ -48,6 +52,7 @@ export function useDinoRunnerGame() {
       s.frame = 0;
       s.speed = BASE_SPEED;
       s.nextObstacle = 80;
+      s.startTime = Date.now();
       useDinoRunnerStore.getState().startGame();
     } else if (s.phase === 'dead') {
       s.phase = 'menu';
@@ -101,6 +106,8 @@ export function useDinoRunnerGame() {
           s.dinoY + DINO_H - margin > GROUND_Y - o.h + margin
         ) {
           s.phase = 'dead';
+          const elapsed = Math.round((Date.now() - s.startTime) / 1000);
+          saveGameResultRef.current({ score: s.score, level: 1, durationSeconds: elapsed });
           useDinoRunnerStore.getState().setGameOver(s.score);
         }
       }

--- a/gamesformykids/app/games/emoji-math/useEmojiMathGame.ts
+++ b/gamesformykids/app/games/emoji-math/useEmojiMathGame.ts
@@ -1,8 +1,31 @@
 'use client';
-import { createShallowHook } from '@/lib/stores/utils/sliceUtils';
+import { useEffect, useRef } from 'react';
+import { useShallow } from 'zustand/react/shallow';
 import { useEmojiMathStore } from './emojiMathStore';
+import { useGameCompletion } from '@/hooks/shared/progress';
 
 export type { Op, Question } from './emojiMathStore';
 export { makeQuestion, TIME_PER_Q } from './emojiMathStore';
 
-export const useEmojiMathGame = createShallowHook(useEmojiMathStore);
+export function useEmojiMathGame() {
+  const state = useEmojiMathStore(useShallow((s) => s));
+  const { saveGameResultRef } = useGameCompletion('emoji-math');
+
+  const startTimeRef = useRef(0);
+  const prevPhaseRef = useRef<string>(state.phase);
+
+  useEffect(() => {
+    const prev = prevPhaseRef.current;
+    const curr = state.phase;
+    prevPhaseRef.current = curr;
+
+    if (curr === 'playing' && prev !== 'playing') {
+      startTimeRef.current = Date.now();
+    } else if (prev === 'playing' && curr === 'dead') {
+      const elapsed = Math.round((Date.now() - startTimeRef.current) / 1000);
+      saveGameResultRef.current({ score: state.score, level: state.level, durationSeconds: elapsed });
+    }
+  }, [state.phase]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  return state;
+}

--- a/gamesformykids/app/games/flappy-bird/useFlappyBirdGame.ts
+++ b/gamesformykids/app/games/flappy-bird/useFlappyBirdGame.ts
@@ -4,6 +4,7 @@ import { useRef, useCallback } from 'react';
 import { useShallow } from 'zustand/react/shallow';
 import { useFlappyBirdStore } from './flappyBirdStore';
 import { useCanvasLoop } from '@/hooks/canvas';
+import { useGameCompletion } from '@/hooks/shared/progress';
 
 export const W = 360;
 export const H = 560;
@@ -36,6 +37,8 @@ function drawRoundRect(ctx: CanvasRenderingContext2D, x: number, y: number, w: n
 }
 
 export function useFlappyBirdGame() {
+  const { saveGameResultRef } = useGameCompletion('flappy-bird');
+
   const s = useRef({
     phase: 'menu' as Phase,
     birdY: H / 2,
@@ -44,6 +47,7 @@ export function useFlappyBirdGame() {
     score: 0,
     frame: 0,
     bgOffset: 0,
+    startTime: 0,
   });
   const resetGame = useCallback(() => {
     const st = s.current;
@@ -53,6 +57,7 @@ export function useFlappyBirdGame() {
     st.pipes = [];
     st.score = 0;
     st.frame = 0;
+    st.startTime = Date.now();
     useFlappyBirdStore.getState().setPhase('playing');
     useFlappyBirdStore.getState().setScore(0);
   }, []);
@@ -92,8 +97,12 @@ export function useFlappyBirdGame() {
       st.pipes = st.pipes.filter(p => p.x > -PIPE_W - 20);
 
       if (st.birdY + BIRD_R >= H - GROUND_H || st.birdY - BIRD_R <= 0) {
-        st.phase = 'dead';
-        useFlappyBirdStore.getState().endGame(st.score);
+        if (st.phase === 'playing') {
+          const elapsed = Math.round((Date.now() - st.startTime) / 1000);
+          saveGameResultRef.current({ score: st.score, level: 1, durationSeconds: elapsed });
+          st.phase = 'dead';
+          useFlappyBirdStore.getState().endGame(st.score);
+        }
       }
 
       for (const p of st.pipes) {
@@ -102,7 +111,9 @@ export function useFlappyBirdGame() {
         const bT = st.birdY - BIRD_R + 4;
         const bB = st.birdY + BIRD_R - 4;
         if (bR > p.x && bL < p.x + PIPE_W) {
-          if (bT < p.gapY || bB > p.gapY + PIPE_GAP) {
+          if ((bT < p.gapY || bB > p.gapY + PIPE_GAP) && st.phase === 'playing') {
+            const elapsed = Math.round((Date.now() - st.startTime) / 1000);
+            saveGameResultRef.current({ score: st.score, level: 1, durationSeconds: elapsed });
             st.phase = 'dead';
             useFlappyBirdStore.getState().endGame(st.score);
           }

--- a/gamesformykids/app/games/jumper/useJumperGame.ts
+++ b/gamesformykids/app/games/jumper/useJumperGame.ts
@@ -4,6 +4,7 @@ import { useEffect, useRef, useCallback } from 'react';
 import { useShallow } from 'zustand/react/shallow';
 import { useJumperStore } from './jumperStore';
 import { useCanvasLoop } from '@/hooks/canvas';
+import { useGameCompletion } from '@/hooks/shared/progress';
 
 export const W = 300;
 export const H = 500;
@@ -32,6 +33,8 @@ function generateInitial(): Array<Platform & { id: number }> {
 }
 
 export function useJumperGame() {
+  const { saveGameResultRef } = useGameCompletion('jumper');
+
   const st = useRef({
     phase: 'menu' as Phase,
     px: W / 2, py: H - 100,
@@ -43,6 +46,7 @@ export function useJumperGame() {
     frame: 0,
     leftDown: false, rightDown: false,
     nextPlatY: H - 60 - INIT_PLATS * (PLAT_GAP * 0.75),
+    startTime: 0,
   });
   const startGame = useCallback(() => {
     const s = st.current;
@@ -53,6 +57,7 @@ export function useJumperGame() {
     s.score = 0; s.frame = 0;
     s.platforms = generateInitial();
     s.nextPlatY = H - 60 - INIT_PLATS * (PLAT_GAP * 0.75);
+    s.startTime = Date.now();
     useJumperStore.getState().startPlaying();
   }, []);
 
@@ -118,6 +123,8 @@ export function useJumperGame() {
 
       if (s.py > H + 60) {
         s.phase = 'dead';
+        const elapsed = Math.round((Date.now() - s.startTime) / 1000);
+        saveGameResultRef.current({ score: s.score, level: 1, durationSeconds: elapsed });
         useJumperStore.getState().endGame(s.score);
       }
     }

--- a/gamesformykids/app/games/meteor-dodge/useMeteorDodgeGame.ts
+++ b/gamesformykids/app/games/meteor-dodge/useMeteorDodgeGame.ts
@@ -4,6 +4,7 @@ import { useEffect, useRef, useCallback } from 'react';
 import { useShallow } from 'zustand/react/shallow';
 import { useMeteorDodgeStore } from './meteorDodgeStore';
 import { useCanvasLoop } from '@/hooks/canvas';
+import { useGameCompletion } from '@/hooks/shared/progress';
 
 export const W = 360;
 export const H = 560;
@@ -19,18 +20,21 @@ interface StarPick { id: number; x: number; y: number; vy: number; emoji: string
 let uid = 0;
 
 export function useMeteorDodgeGame() {
+  const { saveGameResultRef } = useGameCompletion('meteor-dodge');
+
   const st = useRef({
     phase: 'menu' as Phase,
     playerX: W / 2,
     meteors: [] as Meteor[], stars: [] as StarPick[],
     score: 0, best: 0, frame: 0, nextMeteor: 50, nextStar: 120,
     bgStars: Array.from({ length: 50 }, () => ({ x: Math.random() * W, y: Math.random() * H, r: 0.5 + Math.random() * 1.5, twinkle: Math.random() * Math.PI * 2 })),
-    invincible: 0,
+    invincible: 0, startTime: 0,
   });
   const startGame = useCallback(() => {
     const s = st.current;
     s.phase = 'playing'; s.playerX = W / 2; s.meteors = []; s.stars = [];
     s.score = 0; s.frame = 0; s.nextMeteor = 50; s.nextStar = 120; s.invincible = 0;
+    s.startTime = Date.now();
     useMeteorDodgeStore.getState().startPlaying();
   }, []);
 
@@ -92,7 +96,11 @@ export function useMeteorDodgeGame() {
       if (s.invincible === 0) {
         for (const m of s.meteors) {
           const dx = m.x - s.playerX, dy = m.y - PLAYER_Y;
-          if (Math.sqrt(dx * dx + dy * dy) < PLAYER_R + m.r - 8) { s.phase = 'dead'; useMeteorDodgeStore.getState().endGame(s.score); break; }
+          if (Math.sqrt(dx * dx + dy * dy) < PLAYER_R + m.r - 8) {
+            const elapsed = Math.round((Date.now() - s.startTime) / 1000);
+            saveGameResultRef.current({ score: s.score, level: 1, durationSeconds: elapsed });
+            s.phase = 'dead'; useMeteorDodgeStore.getState().endGame(s.score); break;
+          }
         }
       }
 

--- a/gamesformykids/app/games/snake/useSnakeGame.ts
+++ b/gamesformykids/app/games/snake/useSnakeGame.ts
@@ -4,6 +4,7 @@ import { useEffect, useRef, useCallback } from 'react';
 import { useShallow } from 'zustand/react/shallow';
 import { useGameProgressStore, useGameStore } from '@/lib/stores';
 import { useSnakeStore } from './stores/useSnakeStore';
+import { useGameCompletion } from '@/hooks/shared/progress';
 
 const COLS = 20;
 const ROWS = 20;
@@ -22,6 +23,8 @@ function ptEq(a: Pt, b: Pt) { return a.x === b.x && a.y === b.y; }
 
 export function useSnakeGame() {
   const canvasRef = useRef<HTMLCanvasElement>(null);
+  const { saveGameResultRef } = useGameCompletion('snake');
+
   const st = useRef({
     phase: 'menu' as Phase,
     snake: [{ x: 10, y: 10 }] as Pt[],
@@ -31,6 +34,7 @@ export function useSnakeGame() {
     foodEmoji: '🍎',
     score: 0,
     level: 1,
+    startTime: 0,
     timer: 0 as ReturnType<typeof setTimeout> | number,
     raf: 0,
     animFrame: 0,
@@ -52,6 +56,8 @@ export function useSnakeGame() {
   function die() {
     const s = st.current;
     s.phase = 'dead';
+    const elapsed = Math.round((Date.now() - s.startTime) / 1000);
+    saveGameResultRef.current({ score: s.score, level: s.level, durationSeconds: elapsed });
     // endGame() automatically persists score as highScore['snake']
     useGameStore.getState().endGame();
     useGameProgressStore.getState().setGameActive(false);
@@ -103,6 +109,7 @@ export function useSnakeGame() {
     s.foodEmoji = EMOJIS[rnd(EMOJIS.length)];
     s.score = 0;
     s.level = 1;
+    s.startTime = Date.now();
     // אתחל store session + איפוס progress
     useGameProgressStore.getState().resetProgress();
     useGameProgressStore.getState().setGameActive(true);

--- a/gamesformykids/app/games/stack/useStackGame.ts
+++ b/gamesformykids/app/games/stack/useStackGame.ts
@@ -72,7 +72,7 @@ export function useStackGame() {
     const topWorldY = sliderWorldY;
     s.camOffset = Math.max(0, TARGET_TOP - topWorldY);
     useStackStore.getState().setScore(s.score);
-  }, []);
+  }, [saveGameResultRef]);
 
   const handleCanvasClick = useCallback(() => {
     if (st.current.phase === 'playing') drop();

--- a/gamesformykids/app/games/stack/useStackGame.ts
+++ b/gamesformykids/app/games/stack/useStackGame.ts
@@ -4,6 +4,7 @@ import { useEffect, useRef, useCallback } from 'react';
 import { useShallow } from 'zustand/react/shallow';
 import { useStackStore } from './stackStore';
 import { useCanvasLoop } from '@/hooks/canvas';
+import { useGameCompletion } from '@/hooks/shared/progress';
 
 export const W = 300;
 export const H = 480;
@@ -17,6 +18,8 @@ import type { PhaseDead as Phase } from '@/lib/types';
 interface Block { x: number; y: number; w: number; color: string; }
 
 export function useStackGame() {
+  const { saveGameResultRef } = useGameCompletion('stack');
+
   const st = useRef({
     phase: 'menu' as Phase,
     blocks: [] as Block[],
@@ -27,6 +30,7 @@ export function useStackGame() {
     score: 0, best: 0,
     colorIdx: 0,
     frame: 0,
+    startTime: 0,
   });
   const startGame = useCallback(() => {
     const s = st.current;
@@ -35,6 +39,7 @@ export function useStackGame() {
     s.curW = INIT_W; s.curX = (W - INIT_W) / 2;
     s.curDir = 1; s.curSpeed = 2.5; s.colorIdx = 0;
     s.blocks = [{ x: (W - INIT_W) / 2, y: FLOOR_Y, w: INIT_W, color: '#6b7280' }];
+    s.startTime = Date.now();
     useStackStore.getState().startPlaying();
   }, []);
 
@@ -50,6 +55,8 @@ export function useStackGame() {
 
     if (overlap <= 2) {
       s.phase = 'dead';
+      const elapsed = Math.round((Date.now() - s.startTime) / 1000);
+      saveGameResultRef.current({ score: s.score, level: 1, durationSeconds: elapsed });
       useStackStore.getState().endGame(s.score);
       return;
     }

--- a/gamesformykids/app/games/word-scramble/useWordScrambleGame.ts
+++ b/gamesformykids/app/games/word-scramble/useWordScrambleGame.ts
@@ -1,8 +1,31 @@
 'use client';
-import { createShallowHook } from '@/lib/stores/utils/sliceUtils';
+import { useEffect, useRef } from 'react';
+import { useShallow } from 'zustand/react/shallow';
 import { useWordScrambleStore } from './wordScrambleStore';
+import { useGameCompletion } from '@/hooks/shared/progress';
 
 export type { WordEntry, LetterSlot, PickedLetter } from './wordScrambleStore';
 export { WORD_LIST } from './wordScrambleStore';
 
-export const useWordScrambleGame = createShallowHook(useWordScrambleStore);
+export function useWordScrambleGame() {
+  const state = useWordScrambleStore(useShallow((s) => s));
+  const { saveGameResultRef } = useGameCompletion('word-scramble');
+
+  const startTimeRef = useRef(0);
+  const prevPhaseRef = useRef<string>(state.phase);
+
+  useEffect(() => {
+    const prev = prevPhaseRef.current;
+    const curr = state.phase;
+    prevPhaseRef.current = curr;
+
+    if (curr === 'playing' && prev !== 'playing') {
+      startTimeRef.current = Date.now();
+    } else if (prev === 'playing' && curr === 'results') {
+      const elapsed = Math.round((Date.now() - startTimeRef.current) / 1000);
+      saveGameResultRef.current({ score: state.score, level: 1, durationSeconds: elapsed });
+    }
+  }, [state.phase]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  return state;
+}

--- a/gamesformykids/hooks/shared/game-state/useBaseGame.ts
+++ b/gamesformykids/hooks/shared/game-state/useBaseGame.ts
@@ -85,7 +85,6 @@ export function useBaseGame<T extends BaseGameItem = BaseGameItem>(config: UseBa
         saveLevel(gt, l);
       }
     };
-  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []); // empty deps — run cleanup only on unmount
   
   const { getRandomChallenge, getOptionsForChallenge } = useGameOptions({

--- a/gamesformykids/hooks/shared/progress/index.ts
+++ b/gamesformykids/hooks/shared/progress/index.ts
@@ -1,3 +1,5 @@
 export { useGameProgress } from './useGameProgress';
 export { useSessionStats } from './useSessionStats';
 export { useAchievements } from './useAchievements';
+export { useGameCompletion } from './useGameCompletion';
+export type { GameResult } from './useGameCompletion';

--- a/gamesformykids/hooks/shared/progress/useGameCompletion.ts
+++ b/gamesformykids/hooks/shared/progress/useGameCompletion.ts
@@ -1,0 +1,55 @@
+'use client';
+
+import { useCallback, useRef, useEffect } from 'react';
+import type { GameType } from '@/lib/types';
+import { supabase } from '@/lib/supabase/client';
+import { useAuth } from '@/hooks/shared/auth/useAuth';
+import { useGameProgressDataStore } from '@/lib/stores/gameProgressDataStore';
+import { useAchievements } from './useAchievements';
+
+export interface GameResult {
+  score: number;
+  level: number;
+  durationSeconds: number;
+}
+
+export function useGameCompletion(gameType: GameType) {
+  const { user } = useAuth();
+  const { checkScoreAchievements, checkLevelAchievements } = useAchievements();
+
+  const saveGameResult = useCallback(async ({ score, level, durationSeconds }: GameResult) => {
+    if (!user) return;
+
+    const gt = gameType as string;
+    const progress = useGameProgressDataStore.getState().progress;
+    const cur = progress.find((p) => p.game_type === gt);
+
+    const { data, error } = await supabase
+      .from('game_progress')
+      .upsert({
+        user_id: user.id,
+        game_type: gt,
+        score,
+        best_score: Math.max(cur?.best_score ?? 0, score),
+        level,
+        completed_levels: Math.max(cur?.completed_levels ?? 0, level - 1),
+        total_play_time: (cur?.total_play_time ?? 0) + durationSeconds,
+        last_played_at: new Date().toISOString(),
+        updated_at: new Date().toISOString(),
+      })
+      .select()
+      .single();
+
+    if (!error && data) {
+      useGameProgressDataStore.getState().upsertProgressItem(data);
+    }
+
+    checkScoreAchievements(gt, score);
+    checkLevelAchievements(gt, level);
+  }, [gameType, user, checkScoreAchievements, checkLevelAchievements]);
+
+  const saveGameResultRef = useRef(saveGameResult);
+  useEffect(() => { saveGameResultRef.current = saveGameResult; }, [saveGameResult]);
+
+  return { saveGameResult, saveGameResultRef };
+}


### PR DESCRIPTION
## Summary

- Added `hooks/shared/progress/useGameCompletion.ts` — unified hook that writes a game session result (score, level, play time) directly to Supabase and fires achievement checks via `useAchievements`
- **Ref-based arcade games** (snake, flappy-bird, brick-breaker, meteor-dodge, dino-runner, jumper, stack): added `startTime` tracking to each game's internal state ref and call `saveGameResultRef.current` at every game-over/win point, guarded against double-fire
- **Store-based games** (balloon-pop, color-tap, emoji-math, word-scramble): converted thin `createShallowHook` wrappers to proper React hooks that watch phase transitions and call `saveGameResult` when a game session ends

## How it works

`useGameCompletion(gameType)` reads live store state at save time (avoids stale closures), performs a single Supabase `upsert` that increments `total_play_time` and updates `best_score`, then calls achievement checkers. A `saveGameResultRef` is exposed for use inside canvas game loops (rAF callbacks) where hook calls are not possible.

## Test plan

- [ ] Play snake, flappy-bird, brick-breaker, meteor-dodge, dino-runner, jumper, stack to game-over — verify score/level/play_time rows appear in `game_progress` table
- [ ] Play balloon-pop, color-tap, emoji-math, word-scramble to completion — verify same
- [ ] Revisit profile page — confirm `total_play_time` is no longer 0
- [ ] TypeScript: `tsc --noEmit` passes (verified locally)

Closes #419
Closes #414

🤖 Generated with [Claude Code](https://claude.com/claude-code)