### PR TITLE
feat: add last_score to game_progress — show last session result on profile

### DIFF
--- a/gamesformykids/app/profile/components/GameProgressList.tsx
+++ b/gamesformykids/app/profile/components/GameProgressList.tsx
@@ -14,7 +14,10 @@ export function GameProgressList() {
                 <p className="text-sm text-gray-600">רמה {gameProgress.level}</p>
               </div>
               <div className="text-left">
-                <p className="font-bold text-purple-600">{gameProgress.best_score} נקודות</p>
+                <p className="font-bold text-purple-600">שיא: {gameProgress.best_score}</p>
+                {gameProgress.last_score > 0 && (
+                  <p className="text-sm text-blue-500">אחרון: {gameProgress.last_score}</p>
+                )}
                 <p className="text-sm text-gray-600">{Math.floor(gameProgress.total_play_time / 60)} דקות</p>
               </div>
             </div>

--- a/gamesformykids/hooks/shared/progress/useGameCompletion.ts
+++ b/gamesformykids/hooks/shared/progress/useGameCompletion.ts
@@ -30,6 +30,7 @@ export function useGameCompletion(gameType: GameType) {
         user_id: user.id,
         game_type: gt,
         score,
+        last_score: score,
         best_score: Math.max(cur?.best_score ?? 0, score),
         level,
         completed_levels: Math.max(cur?.completed_levels ?? 0, level - 1),

--- a/gamesformykids/hooks/shared/progress/useGameProgress.ts
+++ b/gamesformykids/hooks/shared/progress/useGameProgress.ts
@@ -11,6 +11,7 @@ export interface GameProgress {
   game_type: string
   level: number
   score: number
+  last_score: number
   best_score: number
   completed_levels: number
   total_play_time: number
@@ -106,6 +107,7 @@ export function useGameProgress(gameType?: string) {
 
     return updateProgress(gameType, {
       score: newScore,
+      last_score: newScore,
       best_score: bestScore,
       last_played_at: new Date().toISOString()
     })

--- a/gamesformykids/supabase/migrations/001_add_last_score.sql
+++ b/gamesformykids/supabase/migrations/001_add_last_score.sql
@@ -1,0 +1,3 @@
+-- Migration: add last_score to game_progress
+-- Run: ALTER TABLE public.game_progress ADD COLUMN IF NOT EXISTS last_score INTEGER DEFAULT 0;
+ALTER TABLE public.game_progress ADD COLUMN IF NOT EXISTS last_score INTEGER DEFAULT 0;

--- a/gamesformykids/supabase/schema.sql
+++ b/gamesformykids/supabase/schema.sql
@@ -14,6 +14,7 @@ CREATE TABLE IF NOT EXISTS public.game_progress (
   game_type TEXT NOT NULL,
   level INTEGER DEFAULT 1,
   score INTEGER DEFAULT 0,
+  last_score INTEGER DEFAULT 0,
   best_score INTEGER DEFAULT 0,
   completed_levels INTEGER DEFAULT 0,
   total_play_time INTEGER DEFAULT 0, -- in seconds


### PR DESCRIPTION
## Summary

- Added `last_score INTEGER DEFAULT 0` to the `game_progress` schema and migration file
- Added `last_score` field to the `GameProgress` TypeScript interface
- `useGameCompletion` upsert now sets `last_score: score` alongside `best_score`
- `useGameProgress.updateScore()` also sets `last_score: newScore`
- `GameProgressList.tsx` now renders **שיא: N** (best) and **אחרון: N** (last) per game row when `last_score > 0`

## Migration

The file `supabase/migrations/001_add_last_score.sql` must be applied to the live Supabase instance:
```sql
ALTER TABLE public.game_progress ADD COLUMN IF NOT EXISTS last_score INTEGER DEFAULT 0;
```

## Test plan

- [ ] Apply migration on Supabase dashboard
- [ ] Play any game to completion — verify `last_score` is saved in the DB
- [ ] Play again with a different score — verify `last_score` updates but `best_score` only updates when score improves
- [ ] Visit profile page — confirm "אחרון: N" line appears under the best score
- [ ] `tsc --noEmit` passes (verified locally)

Closes #421

🤖 Generated with [Claude Code](https://claude.com/claude-code)