### PR TITLE
feat: sync Supabase user settings to game stores on load and update

### DIFF
--- a/gamesformykids/hooks/shared/user/useUserProfile.ts
+++ b/gamesformykids/hooks/shared/user/useUserProfile.ts
@@ -4,6 +4,20 @@ import { useEffect, useCallback } from 'react'
 import { useAuth } from '@/hooks/shared/auth/useAuth'
 import { supabase } from '@/lib/supabase/client'
 import { useUserProfileStore } from '@/lib/stores/userProfileStore'
+import { useAudioSettingsStore } from '@/lib/stores/audioSettingsStore'
+import { useGameDifficulty } from '@/lib/stores/gameDifficultyStore'
+import type { DifficultyLevel } from '@/lib/types'
+
+const DIFFICULTY_MAP: Record<string, DifficultyLevel> = {
+  easy: 'easy', medium: 'medium', hard: 'hard', normal: 'medium',
+}
+
+function syncSettingsToLocalStores(settings: { sound_enabled: boolean; difficulty_level: string } | null) {
+  if (!settings) return
+  useAudioSettingsStore.getState().saveSettings({ enabled: settings.sound_enabled })
+  const difficulty = DIFFICULTY_MAP[settings.difficulty_level] ?? 'medium'
+  useGameDifficulty.getState().setDifficulty(difficulty)
+}
 
 export interface UserProfile {
   id: string
@@ -70,6 +84,7 @@ export function useUserProfile() {
 
       setProfile(profileData)
       setSettings(settingsData)
+      syncSettingsToLocalStores(settingsData)
       setLoadedForUserId(user.id)
     } catch (err) {
       setError(err instanceof Error ? err.message : 'שגיאה בטעינת הפרופיל')
@@ -130,6 +145,7 @@ export function useUserProfile() {
       if (error) throw error
 
       setSettings(data)
+      syncSettingsToLocalStores(data)
       return data
     } catch (err) {
       setError(err instanceof Error ? err.message : 'שגיאה בעדכון ההגדרות')


### PR DESCRIPTION
## Summary

After `useUserProfile` loads `user_settings` from Supabase (or when settings are saved from the Settings page), the local Zustand stores that games read are now seeded:

| Supabase field | Local store | Mapping |
|---|---|---|
| `sound_enabled` | `useAudioSettingsStore.enabled` | direct boolean |
| `difficulty_level` | `useGameDifficulty.difficulty` | `'normal'` → `'medium'`, rest pass-through |

The sync helper `syncSettingsToLocalStores` is called in two places:
1. `fetchProfile()` — on login / first load
2. `updateSettings()` — immediately after the Settings page saves changes

## Why not a new hook

A separate `useUserSettingsSync` hook would need to be mounted somewhere in the component tree. Calling `getState()` directly in the existing fetch/update functions avoids the extra component and is equivalent.

## Test plan

- [ ] Log in with an account that has `sound_enabled = false` — verify audio is muted in games
- [ ] Log in with `difficulty_level = 'hard'` — verify games use hard difficulty
- [ ] Change difficulty in Settings page — verify games immediately use the new difficulty
- [ ] `tsc --noEmit` passes (verified locally)

Closes #418

🤖 Generated with [Claude Code](https://claude.com/claude-code)