### PR TITLE
refactor: UnifiedHeader reads score/level from store, removes 3-layer prop chain

### DIFF
--- a/gamesformykids/components/shared/headers/GameHeader.tsx
+++ b/gamesformykids/components/shared/headers/GameHeader.tsx
@@ -10,19 +10,13 @@ type GameHeaderProps = ComponentTypes.GameHeaderProps;
 /**
  * 🎯 GameHeader עם props אופציונליים
  */
-export default function GameHeader({
-  score = 0,
-  level = 1,
-  onHome,
-}: GameHeaderProps = {}) {
+export default function GameHeader({ onHome }: GameHeaderProps = {}) {
   const router = useRouter();
 
   return (
     <UnifiedHeader
       title="משחק"
       showScore={true}
-      score={score}
-      level={level}
       showBackButton={true}
       onBack={onHome ?? (() => router.push(ROUTES.HOME))}
     />

--- a/gamesformykids/components/shared/headers/GameHeaderSection.tsx
+++ b/gamesformykids/components/shared/headers/GameHeaderSection.tsx
@@ -1,17 +1,14 @@
 "use client";
 
-import { useGameProgressStore } from '@/lib/stores/gameProgressStore';
 import GameHeader from "./GameHeader";
 import GameStatsButton from "../buttons/GameStatsButton";
 import GameChallengeSection from "../GameChallengeSection";
 
 export default function GameHeaderSection() {
-  const score = useGameProgressStore((s) => s.score);
-  const level = useGameProgressStore((s) => s.level);
   return (
     <div className="text-center mb-8">
       <div className="flex justify-between items-center mb-6">
-        <GameHeader score={score} level={level} />
+        <GameHeader />
         <GameStatsButton />
       </div>
       <GameChallengeSection />

--- a/gamesformykids/components/shared/headers/UnifiedHeader.tsx
+++ b/gamesformykids/components/shared/headers/UnifiedHeader.tsx
@@ -1,4 +1,7 @@
+"use client";
+
 import type { ComponentTypes } from "@/lib/types";
+import { useGameProgressStore } from "@/lib/stores/gameProgressStore";
 
 /**
  * UnifiedHeader - קומפוננט Header אחוד
@@ -7,11 +10,11 @@ export default function UnifiedHeader({
   title,
   showBackButton = false,
   showScore = false,
-  score,
-  level,
   onBack,
   customActions
 }: ComponentTypes.UnifiedHeaderProps) {
+  const score = useGameProgressStore((s) => s.score);
+  const level = useGameProgressStore((s) => s.level);
   return (
     <header className="mb-8" dir="rtl">
       {title && (

--- a/gamesformykids/lib/types/components/headers.ts
+++ b/gamesformykids/lib/types/components/headers.ts
@@ -8,8 +8,6 @@ export interface UnifiedHeaderProps {
   title: string;
   showBackButton?: boolean;
   showScore?: boolean;
-  score?: number;
-  level?: number;
   onBack?: () => void;
   customActions?: React.ReactNode;
 }
@@ -27,8 +25,6 @@ export interface StartScreenHeaderProps {
 
 export interface GameHeaderProps {
   title?: string;
-  score?: number;
-  level?: number;
   showBackButton?: boolean;
   onBack?: () => void;
   onReset?: () => void;


### PR DESCRIPTION
## Summary
- `GameHeaderSection` was reading `score`/`level` from `useGameProgressStore` and passing them to `GameHeader`, which forwarded them unchanged to `UnifiedHeader`
- `UnifiedHeader` now reads `score`/`level` directly from `useGameProgressStore` when rendering the score display
- Removed `score`/`level` from `UnifiedHeaderProps` and `GameHeaderProps` — the chain no longer needs them
- Added `"use client"` to `UnifiedHeader` (required for the store hook)

## Test plan
- [ ] Play any auto-game — score and level should update correctly in the header
- [ ] Back button still navigates home

Closes #427

🤖 Generated with [Claude Code](https://claude.com/claude-code)