### PR TITLE
refactor: GenericStartScreen reads config from store, collapses AutoStartScreen adapter

### DIFF
--- a/gamesformykids/components/shared/screens/AutoStartScreen.tsx
+++ b/gamesformykids/components/shared/screens/AutoStartScreen.tsx
@@ -1,30 +1,13 @@
 'use client';
 
-/**
- * ===============================================
- * AutoStartScreen - קומפוננט StartScreen עם קונטקסט
- * ===============================================
- * 
- * 🎯 אפס props - הכל מהקונטקסט!
- */
-
 import { useUniversalGame } from '@/hooks/shared/game-state/useUniversalGame';
-import { BaseGameItem } from '@/lib/types';
+import type { BaseGameItem } from '@/lib/types';
 import GenericStartScreen from "./GenericStartScreen";
 import UnifiedCard from "../cards/UnifiedCard";
 
-/**
- * 🎯 AutoStartScreen עם קונטקסט - ללא props!
- */
 export default function AutoStartScreen() {
-  const { 
-    gameType, 
-    items, 
-    startGame, 
-    speakItemName, 
-    config 
-  } = useUniversalGame();
-  
+  const { config, speakItemName, gameType } = useUniversalGame();
+
   if (!config) {
     return (
       <div className="text-center p-8">
@@ -34,29 +17,9 @@ export default function AutoStartScreen() {
   }
 
   return (
-    <>
-      {/* הניווט מוסר מכאן - הוא עכשיו ב-layout */}
-      
-      <GenericStartScreen
-      title={config.title}
-      subTitle={config.subTitle}
-      textColorHeader={config.colors?.header}
-      textColorSubHeader={config.colors?.subHeader}
-      gameSteps={config.steps ? [...config.steps] : undefined}
-      gameStepsBgClass={config.colors?.stepsBg}
-      items={items as BaseGameItem[]}
-      customOnStart={startGame}
-      buttonFromColor={config.colors?.button?.from}
-      buttonToColor={config.colors?.button?.to}
-      backgroundStyle={config.colors?.background}
-      itemsTitle={config.itemsTitle}
-      itemsDescription={config.itemsDescription}
-      itemsDescriptionColor={config.colors?.itemsDescription}
-      itemsGridClass={config.grid?.className}
+    <GenericStartScreen<BaseGameItem>
       renderItem={(item) => {
-        // Safe check for item properties
         if (!item || typeof item !== 'object') return null;
-        
         return (
           <UnifiedCard
             key={item.name || String(item)}
@@ -73,6 +36,5 @@ export default function AutoStartScreen() {
         );
       }}
     />
-    </>
   );
 }

--- a/gamesformykids/components/shared/screens/GenericStartScreen.tsx
+++ b/gamesformykids/components/shared/screens/GenericStartScreen.tsx
@@ -1,63 +1,84 @@
+"use client";
+
 import { SimpleGameInstructions } from "@/components/shared";
 import { SimpleGameStartButton } from "@/components/shared";
 import { StartScreenHeader } from "@/components/shared";
 import { ButtonCheckAudio } from "@/components/shared";
 import { ComponentTypes } from "@/lib/types";
+import { useUniversalGame } from "@/hooks/shared/game-state/useUniversalGame";
 
 type GenericStartScreenProps<T> = ComponentTypes.GenericStartScreenProps<T>;
 
 /**
  * GenericStartScreen - מסך התחלה גנרי וגמיש
  * תומך בכל סוגי המשחקים עם אפשרויות עיצוב מלאות
+ * כשלא מועברים props, קורא ישירות מ-useUniversalGame
  */
 
 export default function GenericStartScreen<T>({
   title,
-  subTitle = "",
-  textColorHeader = "text-purple-800",
-  textColorSubHeader = "text-purple-600",
-  gameSteps = [],
+  subTitle,
+  textColorHeader,
+  textColorSubHeader,
+  gameSteps,
   items,
   customOnStart,
-  buttonFromColor = "blue-400",
-  buttonToColor = "blue-600",
+  buttonFromColor,
+  buttonToColor,
   backgroundStyle,
   itemsTitle,
   itemsDescription,
-  itemsDescriptionColor = "text-gray-100",
-  itemsGridClass = "grid grid-cols-3 md:grid-cols-4 gap-4 max-w-4xl mx-auto",
+  itemsDescriptionColor,
+  itemsGridClass,
   renderItem,
   customItemsRenderer,
   showAudioCheck = true,
   className = "",
 }: GenericStartScreenProps<T>) {
+  const { config, items: hookItems, startGame } = useUniversalGame();
+
+  const resolvedTitle          = title               ?? config?.title          ?? "";
+  const resolvedSubTitle       = subTitle            ?? config?.subTitle        ?? "";
+  const resolvedTextHeader     = textColorHeader      ?? "text-purple-800";
+  const resolvedTextSubHeader  = textColorSubHeader   ?? "text-purple-600";
+  const resolvedSteps          = gameSteps            ?? (config?.steps ? [...config.steps] : []);
+  const resolvedOnStart        = customOnStart        ?? startGame;
+  const resolvedFromColor      = buttonFromColor      ?? config?.colors?.button?.from ?? "blue-400";
+  const resolvedToColor        = buttonToColor        ?? config?.colors?.button?.to   ?? "blue-600";
+  const resolvedBackground     = backgroundStyle      ?? config?.colors?.background;
+  const resolvedItemsTitle     = itemsTitle           ?? config?.itemsTitle;
+  const resolvedItemsDesc      = itemsDescription     ?? config?.itemsDescription;
+  const resolvedItemsDescColor = itemsDescriptionColor ?? config?.colors?.itemsDescription ?? "text-gray-100";
+  const resolvedItemsGridClass = itemsGridClass       ?? config?.grid?.className ?? "grid grid-cols-3 md:grid-cols-4 gap-4 max-w-4xl mx-auto";
+  const resolvedItems          = (items               ?? hookItems) as T[];
+
   return (
     <div
       className={`min-h-screen p-4 ${className}`}
-      style={{ background: backgroundStyle }}
+      style={{ background: resolvedBackground }}
     >
       <div className="max-w-4xl mx-auto text-center">
         {/* Header */}
         <StartScreenHeader
-          title={title}
-          subTitle={subTitle}
-          textColorHeader={textColorHeader}
-          textColorSubHeader={textColorSubHeader}
+          title={resolvedTitle}
+          subTitle={resolvedSubTitle}
+          textColorHeader={resolvedTextHeader}
+          textColorSubHeader={resolvedTextSubHeader}
         />
 
         {/* הסבר המשחק */}
         <SimpleGameInstructions
           title="איך משחקים?"
-          instructions={gameSteps.map(step => step.description || step.stepText || "")}
+          instructions={resolvedSteps.map(step => step.description || step.stepText || "")}
           showSteps={true}
           variant="detailed"
         />
 
         {/* כפתור התחלה */}
         <SimpleGameStartButton
-          customOnStart={customOnStart}
-          fromColor={buttonFromColor}
-          toColor={buttonToColor}
+          customOnStart={resolvedOnStart}
+          fromColor={resolvedFromColor}
+          toColor={resolvedToColor}
         />
 
         {/* כפתור בדיקת שמע */}
@@ -66,23 +87,22 @@ export default function GenericStartScreen<T>({
         {/* דוגמת פריטים */}
         <div className="mt-12">
           <h3 className="text-2xl font-bold text-white mb-6">
-            {itemsTitle}
+            {resolvedItemsTitle}
           </h3>
-          
+
           {customItemsRenderer ? (
             customItemsRenderer()
           ) : (
-            <div className={itemsGridClass}>
-              {renderItem && items.map((item, index) => renderItem(item, index))}
+            <div className={resolvedItemsGridClass}>
+              {renderItem && resolvedItems.map((item, index) => renderItem(item, index))}
             </div>
           )}
-          
-          <p className={`${itemsDescriptionColor} mt-4`}>
-            {itemsDescription}
+
+          <p className={`${resolvedItemsDescColor} mt-4`}>
+            {resolvedItemsDesc}
           </p>
         </div>
       </div>
     </div>
   );
 }
-

--- a/gamesformykids/lib/types/components/screens.ts
+++ b/gamesformykids/lib/types/components/screens.ts
@@ -6,14 +6,14 @@
 
 export interface GenericStartScreenProps<T> {
   // Header props
-  title: string;
+  title?: string | undefined;
   subtitle?: string | undefined;
   subTitle?: string | undefined;
   textColorHeader?: string | undefined;
   textColorSubHeader?: string | undefined;
 
   // Game props
-  items: T[];
+  items?: T[] | undefined;
   gameSteps?: Array<{
     stepNumber?: number;
     stepText?: string;


### PR DESCRIPTION
## Summary
- `AutoStartScreen` was a pure adapter that forwarded 15+ props from `useUniversalGame()` to `GenericStartScreen` — it added no logic of its own
- `GenericStartScreen` now calls `useUniversalGame()` directly and uses hook values as fallbacks when props are omitted
- `AutoStartScreen` is reduced to passing a single `renderItem` prop (the `UnifiedCard` renderer)
- `title` and `items` in `GenericStartScreenProps` are now optional — Tetris and other explicit-prop callers are unaffected
- Adding a new config field to the start screen no longer requires threading it through two adapter layers

## Test plan
- [ ] Start screen renders correctly for an auto-game (e.g. alphabet, colors)
- [ ] Tetris start screen renders correctly with its explicit props unchanged
- [ ] Items grid and step instructions display correctly

Closes #428
Closes #429

🤖 Generated with [Claude Code](https://claude.com/claude-code)