### PR TITLE
refactor: remove renderCard from AutoGamePage - no caller passed it there

### DIFF
--- a/gamesformykids/components/game/universal/auto-game/AutoGamePage.tsx
+++ b/gamesformykids/components/game/universal/auto-game/AutoGamePage.tsx
@@ -11,24 +11,18 @@
 
 "use client";
 
-import { BaseGameItem } from "@/lib/types/core/base";
 import { useAutoGame } from "@/hooks";
 import { AutoStartScreen } from "../../../shared";
 import { ProgressDisplay } from "../../../shared";
 import { AutoGameHeader } from "./AutoGameHeader";
 import { AutoGameBody } from "./AutoGameBody";
 
-interface AutoGamePageProps {
-  /** רינדר מותאם אישית לכרטיס - אופציונלי */
-  renderCard?: (item: BaseGameItem, onClick: (item: BaseGameItem) => void) => React.ReactNode;
-}
-
 /**
  * 🎯 הקומפוננט הקסום שהופך כל משחק לאוטומטי
  * עכשיו ללא props drilling וכל הלוגיקה בhook מותאם!
  * 🚀 gameType אופציונלי - אם לא מועבר, יילקח מהקונטקסט
  */
-export function AutoGamePage({ renderCard }: AutoGamePageProps) {
+export function AutoGamePage() {
   const { gameState, isPlaying, config } = useAutoGame();
 
   // 🖥️ אם לא במשחק או gameState לא קיים, הראה StartScreen
@@ -43,7 +37,7 @@ export function AutoGamePage({ renderCard }: AutoGamePageProps) {
     >
       <div className="max-w-4xl mx-auto">
         <AutoGameHeader />
-        <AutoGameBody renderCard={renderCard} />
+        <AutoGameBody />
 
         {/* מודל סטטיסטיקות */}
         <ProgressDisplay


### PR DESCRIPTION
## Summary
- `AutoGamePage` accepted a `renderCard` prop exclusively to forward it unchanged to `AutoGameBody`
- No caller of `AutoGamePage` ever passed `renderCard` — it was dead at the `AutoGamePage` level
- `AutoGameBody` retains its own `renderCard` prop for components that compose it directly
- Removed unused `BaseGameItem` import from `AutoGamePage` as a result

## Test plan
- [ ] All auto-games load and play correctly (no rendering change)

Closes #430

🤖 Generated with [Claude Code](https://claude.com/claude-code)