### PR TITLE
refactor: replace {...rest} spread in UnifiedCard with explicit prop forwarding

### DIFF
--- a/gamesformykids/components/shared/cards/UnifiedCard.tsx
+++ b/gamesformykids/components/shared/cards/UnifiedCard.tsx
@@ -1,4 +1,4 @@
-﻿import { ComponentTypes } from "@/lib/types";
+import { ComponentTypes } from "@/lib/types";
 import { speakHebrew } from "@/lib/utils/speech/enhancedSpeechUtils";
 import { SimpleCard } from "./SimpleCard";
 import { AdvancedCard } from "./AdvancedCard";
@@ -13,8 +13,33 @@ export default function UnifiedCard({
   item,
   backgroundPattern = "none",
   customContent,
+  customDecoration,
   hebrewText,
-  ...rest
+  secondaryText,
+  name,
+  icon,
+  color,
+  gradientFrom,
+  gradientTo,
+  hoverFrom,
+  hoverTo,
+  borderColor,
+  borderWidth,
+  textColor,
+  size,
+  shape,
+  aspectRatio,
+  borderRadius,
+  showEmoji,
+  showHebrew,
+  showEnglish,
+  animation,
+  shadow,
+  hoverEffect,
+  description,
+  digit,
+  className,
+  isSelected,
 }: ComponentTypes.UnifiedCardProps) {
   let actualVariant = variant;
   if (variant === "auto") {
@@ -28,7 +53,7 @@ export default function UnifiedCard({
     showSoundIcon !== undefined ? showSoundIcon : !hideSoundIcon;
 
   const handleAudioClick = async () => {
-    const textToSpeak = hebrewText || item?.hebrew || rest.name;
+    const textToSpeak = hebrewText || item?.hebrew || name;
     if (textToSpeak && autoSpeak) await speakHebrew(textToSpeak);
     if (onSpeak) onSpeak();
   };
@@ -44,9 +69,20 @@ export default function UnifiedCard({
   if (actualVariant === "simple") {
     return (
       <SimpleCard
-        {...rest}
         item={item}
         hebrewText={hebrewText}
+        secondaryText={secondaryText}
+        name={name}
+        icon={icon}
+        color={color}
+        borderColor={borderColor}
+        borderWidth={borderWidth}
+        textColor={textColor}
+        size={size}
+        shape={shape}
+        shadow={shadow}
+        hoverEffect={hoverEffect}
+        className={className}
         finalShowSoundIcon={finalShowSoundIcon}
         handleClick={handleClick}
       />
@@ -55,11 +91,34 @@ export default function UnifiedCard({
 
   return (
     <AdvancedCard
-      {...rest}
       item={item}
       hebrewText={hebrewText}
+      secondaryText={secondaryText}
+      name={name}
+      icon={icon}
+      color={color}
+      gradientFrom={gradientFrom}
+      gradientTo={gradientTo}
+      hoverFrom={hoverFrom}
+      hoverTo={hoverTo}
+      borderColor={borderColor}
+      borderWidth={borderWidth}
+      size={size}
+      aspectRatio={aspectRatio}
+      borderRadius={borderRadius}
+      showEmoji={showEmoji}
+      showHebrew={showHebrew}
+      showEnglish={showEnglish}
+      animation={animation}
+      shadow={shadow}
+      hoverEffect={hoverEffect}
       backgroundPattern={backgroundPattern}
+      description={description}
+      digit={digit}
+      customDecoration={customDecoration}
       customContent={customContent}
+      className={className}
+      isSelected={isSelected}
       finalShowSoundIcon={finalShowSoundIcon}
       handleClick={handleClick}
     />

--- a/gamesformykids/lib/types/components/cards.ts
+++ b/gamesformykids/lib/types/components/cards.ts
@@ -49,52 +49,52 @@ export interface CardContent {
  * עיצוב הכרטיס
  */
 interface CardAppearance {
-  size?: "small" | "medium" | "large";
-  shape?: "rounded" | "circle" | "square";
-  variant?: 'default' | 'large' | 'compact' | 'simple' | 'advanced' | 'auto';
-  
+  size?: "small" | "medium" | "large" | undefined;
+  shape?: "rounded" | "circle" | "square" | undefined;
+  variant?: 'default' | 'large' | 'compact' | 'simple' | 'advanced' | 'auto' | undefined;
+
   // צבעים
-  color?: string;
-  gradientFrom?: string;
-  gradientTo?: string;
-  hoverFrom?: string;
-  hoverTo?: string;
-  borderColor?: string;
-  borderWidth?: string;
-  textColor?: string;
-  
+  color?: string | undefined;
+  gradientFrom?: string | undefined;
+  gradientTo?: string | undefined;
+  hoverFrom?: string | undefined;
+  hoverTo?: string | undefined;
+  borderColor?: string | undefined;
+  borderWidth?: string | undefined;
+  textColor?: string | undefined;
+
   // צורה ומבנה
-  aspectRatio?: "square" | "wide" | "tall";
-  borderRadius?: "sm" | "md" | "lg" | "xl" | "2xl" | "3xl" | "full";
-  
+  aspectRatio?: "square" | "wide" | "tall" | undefined;
+  borderRadius?: "sm" | "md" | "lg" | "xl" | "2xl" | "3xl" | "full" | undefined;
+
   // אפקטים
-  animation?: "bounce" | "pulse" | "none";
-  shadow?: "sm" | "md" | "lg" | "xl" | "2xl" | "none";
-  hoverEffect?: "scale" | "lift" | "glow" | "none";
-  backgroundPattern?: "stars" | "dots" | "none";
+  animation?: "bounce" | "pulse" | "none" | undefined;
+  shadow?: "sm" | "md" | "lg" | "xl" | "2xl" | "none" | undefined;
+  hoverEffect?: "scale" | "lift" | "glow" | "none" | undefined;
+  backgroundPattern?: "stars" | "dots" | "none" | undefined;
 }
 
 /**
  * התנהגות הכרטיס
  */
 interface CardBehavior {
-  animationEnabled?: boolean;
-  autoSpeak?: boolean;
-  onSpeak?: () => void;
-  useContext?: boolean;
+  animationEnabled?: boolean | undefined;
+  autoSpeak?: boolean | undefined;
+  onSpeak?: (() => void) | undefined;
+  useContext?: boolean | undefined;
 }
 
 /**
  * תוכן מותאם אישית
  */
 interface CardCustomContent {
-  customContent?: React.ReactNode;
-  customDecoration?: React.ReactNode;
-  icon?: React.ReactNode;
-  description?: string;
-  digit?: string;
-  svg?: string;
-  value?: string;
+  customContent?: React.ReactNode | undefined;
+  customDecoration?: React.ReactNode | undefined;
+  icon?: React.ReactNode | undefined;
+  description?: string | undefined;
+  digit?: string | undefined;
+  svg?: string | undefined;
+  value?: string | undefined;
 }
 
 // ===== MAIN CARD PROPS =====
@@ -103,7 +103,7 @@ interface CardCustomContent {
  * Props בסיסיים לכל כרטיס
  */
 interface BaseCardProps extends CardAppearance, CardBehavior, CardCustomContent {
-  className?: string;
+  className?: string | undefined;
   isSelected?: boolean | undefined;
 }
 
@@ -138,15 +138,15 @@ export interface UnifiedCardProps extends BaseCardProps {
 
   // Simple mode - for direct text input
   hebrewText?: string | undefined;
-  secondaryText?: string;
-  name?: string;
-  
+  secondaryText?: string | undefined;
+  name?: string | undefined;
+
   // Display control
-  showEmoji?: boolean;
-  showHebrew?: boolean;
-  showEnglish?: boolean;
-  showSoundIcon?: boolean;
-  hideSoundIcon?: boolean;
+  showEmoji?: boolean | undefined;
+  showHebrew?: boolean | undefined;
+  showEnglish?: boolean | undefined;
+  showSoundIcon?: boolean | undefined;
+  hideSoundIcon?: boolean | undefined;
 }
 
 // ===== GRID COMPONENTS =====


### PR DESCRIPTION
## Summary
- `UnifiedCard` was spreading `{...rest}` (20+ props) to `SimpleCard`/`AdvancedCard` making it impossible to audit which props each variant actually receives
- Now explicitly destructures and forwards only the props each variant needs
- Added `| undefined` to all optional card prop types in `cards.ts` to comply with `exactOptionalPropertyTypes: true`

## Test plan
- [ ] Auto-games with SimpleCard variant render correctly (alphabet, colors, shapes)
- [ ] Auto-games with AdvancedCard variant render correctly (letters, animals)
- [ ] Card click, sound icon visibility, and selection highlighting all work

Closes #431

🤖 Generated with [Claude Code](https://claude.com/claude-code)