### PR TITLE
refactor: GameMenuGrid accepts card config object, removing 6-prop pass-through chain

### DIFF
--- a/gamesformykids/components/game/shared/GameMenuGrid.tsx
+++ b/gamesformykids/components/game/shared/GameMenuGrid.tsx
@@ -20,15 +20,17 @@ const GAP_MAP = {
   6: 'gap-6',
 } as const;
 
-interface Props<T> {
-  // GameMenuCard passthrough
+export interface MenuCardConfig {
   emoji: string;
   title: string;
   description: string;
   gradientClass: string;
-  animateEmoji?: boolean;
-  hint?: string;
-  // Grid
+  animateEmoji?: boolean | undefined;
+  hint?: string | undefined;
+}
+
+interface Props<T> {
+  card: MenuCardConfig;
   items: T[];
   getKey: (item: T) => string | number;
   onSelect: (item: T) => void;
@@ -36,7 +38,6 @@ interface Props<T> {
   buttonClass: string;
   columns?: keyof typeof COLS_MAP;
   gap?: keyof typeof GAP_MAP;
-  // Optional footer rendered below the grid
   footer?: ReactNode;
 }
 
@@ -46,12 +47,7 @@ interface Props<T> {
  * Use for game lobby screens that offer a choice of levels/categories.
  */
 export default function GameMenuGrid<T>({
-  emoji,
-  title,
-  description,
-  gradientClass,
-  animateEmoji,
-  hint,
+  card,
   items,
   getKey,
   onSelect,
@@ -63,12 +59,12 @@ export default function GameMenuGrid<T>({
 }: Props<T>) {
   return (
     <GameMenuCard
-      emoji={emoji}
-      title={title}
-      description={description}
-      gradientClass={gradientClass}
-      animateEmoji={animateEmoji}
-      hint={hint}
+      emoji={card.emoji}
+      title={card.title}
+      description={card.description}
+      gradientClass={card.gradientClass}
+      animateEmoji={card.animateEmoji}
+      hint={card.hint}
     >
       <div className={`grid ${COLS_MAP[columns]} ${GAP_MAP[gap]}`}>
         {items.map((item) => (

--- a/gamesformykids/components/game/shared/TimedMathGame.tsx
+++ b/gamesformykids/components/game/shared/TimedMathGame.tsx
@@ -1,6 +1,6 @@
 'use client';
 import { ReactNode, useEffect } from 'react';
-import GameMenuGrid from './GameMenuGrid';
+import GameMenuGrid, { type MenuCardConfig } from './GameMenuGrid';
 import GameResultCard from './GameResultCard';
 
 interface TimedMathStore<Level, Q> {
@@ -71,12 +71,15 @@ export default function TimedMathGame<Level, Q extends { answer: number; choices
   }, []);
 
   if (phase === 'menu') {
+    const menuCard: MenuCardConfig = {
+      emoji: config.emoji,
+      title: config.title,
+      description: config.description,
+      gradientClass: config.gradient,
+    };
     return (
       <GameMenuGrid<Level>
-        emoji={config.emoji}
-        title={config.title}
-        description={config.description}
-        gradientClass={config.gradient}
+        card={menuCard}
         items={config.levels}
         getKey={config.getKey}
         onSelect={startGame}


### PR DESCRIPTION
## Summary
- `GameMenuGrid` had 6 display props (`emoji`, `title`, `description`, `gradientClass`, `animateEmoji`, `hint`) solely to forward them unchanged to `GameMenuCard`
- Replaced with a single `card: MenuCardConfig` object — `GameMenuGrid` spreads it to `GameMenuCard` internally
- `TimedMathGame` assembles the `MenuCardConfig` before passing it, removing the 3-layer prop drill for those fields
- `MenuCardConfig` is exported so callers can build and type the config object

## Test plan
- [ ] All timed math games (fraction, equation, etc.) show their menu screen correctly
- [ ] Level selection grid renders and starts the game

Closes #432
Closes #433

🤖 Generated with [Claude Code](https://claude.com/claude-code)