### PR TITLE
fix: game progress not saving to Supabase (onConflict + race condition)

### DIFF
--- a/gamesformykids/hooks/shared/game-state/useBaseGame.ts
+++ b/gamesformykids/hooks/shared/game-state/useBaseGame.ts
@@ -81,8 +81,8 @@ export function useBaseGame<T extends BaseGameItem = BaseGameItem>(config: UseBa
       const { score: s, level: l, isGameActive } = useGameProgressStore.getState();
       if (isGameActive && (s > 0 || l > 1)) {
         const { updateScore: save, updateLevel: saveLevel, gameType: gt } = saveProgressRef.current;
-        save(gt, s);
-        saveLevel(gt, l);
+        // Sequential to avoid race condition on the same upsert row
+        save(gt, s).then(() => saveLevel(gt, l));
       }
     };
   }, []); // empty deps — run cleanup only on unmount
@@ -200,10 +200,12 @@ export function useBaseGame<T extends BaseGameItem = BaseGameItem>(config: UseBa
     useGameProgressStore.getState().resetProgress();
     useGameSessionStore.getState().resetSession();
 
-    // Persist progress to Supabase
+    // Persist progress to Supabase (single upsert to avoid race condition)
     if (finalScore > 0 || finalLevel > 1) {
-      updateScore(gameType, finalScore);
-      updateLevel(gameType, finalLevel);
+      const currentProgress = saveProgressRef.current;
+      currentProgress.updateScore(gameType, finalScore).then(() =>
+        currentProgress.updateLevel(gameType, finalLevel)
+      );
     }
   };
 

--- a/gamesformykids/hooks/shared/progress/useGameProgress.ts
+++ b/gamesformykids/hooks/shared/progress/useGameProgress.ts
@@ -75,7 +75,7 @@ export function useGameProgress(gameType?: string) {
           game_type: gameType,
           ...updates,
           updated_at: new Date().toISOString()
-        })
+        }, { onConflict: 'user_id,game_type' })
         .select()
         .single()
 


### PR DESCRIPTION
Fixes #442

## Changes
- **\useGameProgress.ts\**: Added \{ onConflict: 'user_id,game_type' }\ to the Supabase \upsert\ call. Without this, after the first play session the row already exists and every subsequent upsert failed silently (no data ever saved).
- **\useBaseGame.ts\**: Made \updateScore\ + \updateLevel\ calls sequential in both \esetGame()\ and the unmount cleanup effect. Previously they ran in parallel causing a race condition where two concurrent upserts on the same row would clobber each other.