### PR TITLE
refactor(#441): remove props drilling in DashboardClient

### DIFF
--- a/gamesformykids/app/dashboard/DashboardClient.tsx
+++ b/gamesformykids/app/dashboard/DashboardClient.tsx
@@ -1,8 +1,6 @@
 'use client';
 
 import { useAuth } from '@/hooks/shared/auth/useAuth';
-import { useGameProgress } from '@/hooks/shared/progress/useGameProgress';
-import { useAchievements } from '@/hooks/shared/progress/useAchievements';
 import Link from 'next/link';
 import { DashboardHeader } from './components/DashboardHeader';
 import { ActivitySummaryCard } from './components/ActivitySummaryCard';
@@ -13,10 +11,6 @@ import { RecommendedGameCard } from './components/RecommendedGameCard';
 
 export default function DashboardClient() {
   const { user, loading: authLoading } = useAuth();
-  const { progress, loading: progressLoading } = useGameProgress();
-  const { achievements, loading: achievementsLoading } = useAchievements();
-
-  const loading = authLoading || progressLoading || achievementsLoading;
 
   if (authLoading) {
     return (
@@ -49,30 +43,15 @@ export default function DashboardClient() {
       <div className="max-w-4xl mx-auto">
         <DashboardHeader />
 
-        {loading ? (
+        <div className="space-y-6">
+          <ActivitySummaryCard />
           <div className="grid md:grid-cols-2 gap-6">
-            {[...Array(4)].map((_, i) => (
-              <div key={i} className="bg-white rounded-2xl shadow-md p-6 animate-pulse">
-                <div className="h-4 bg-gray-200 rounded w-1/2 mb-4" />
-                <div className="space-y-2">
-                  <div className="h-3 bg-gray-100 rounded" />
-                  <div className="h-3 bg-gray-100 rounded w-4/5" />
-                  <div className="h-3 bg-gray-100 rounded w-3/5" />
-                </div>
-              </div>
-            ))}
+            <MostPlayedCard />
+            <ScoreSummaryCard />
+            <RecentAchievementsCard />
+            <RecommendedGameCard />
           </div>
-        ) : (
-          <div className="space-y-6">
-            <ActivitySummaryCard progress={progress} />
-            <div className="grid md:grid-cols-2 gap-6">
-              <MostPlayedCard progress={progress} />
-              <ScoreSummaryCard progress={progress} />
-              <RecentAchievementsCard achievements={achievements} />
-              <RecommendedGameCard progress={progress} />
-            </div>
-          </div>
-        )}
+        </div>
       </div>
     </div>
   );

--- a/gamesformykids/app/dashboard/components/ActivitySummaryCard.tsx
+++ b/gamesformykids/app/dashboard/components/ActivitySummaryCard.tsx
@@ -1,10 +1,22 @@
 'use client';
 
-import type { GameProgress } from '@/hooks/shared/progress/useGameProgress';
+import { useGameProgress } from '@/hooks/shared/progress/useGameProgress';
 
 const SEVEN_DAYS_MS = 7 * 24 * 60 * 60 * 1000;
 
-export function ActivitySummaryCard({ progress }: { progress: GameProgress[] }) {
+export function ActivitySummaryCard() {
+  const { progress, loading } = useGameProgress();
+
+  if (loading) {
+    return (
+      <div className="bg-white rounded-2xl shadow-md p-6 animate-pulse">
+        <div className="h-4 bg-gray-200 rounded w-1/2 mb-4" />
+        <div className="grid grid-cols-3 gap-4">
+          {[...Array(3)].map((_, i) => <div key={i} className="h-16 bg-gray-100 rounded" />)}
+        </div>
+      </div>
+    );
+  }
   const now = Date.now();
   const gamesThisWeek = progress.filter(
     (p) => now - new Date(p.last_played_at).getTime() < SEVEN_DAYS_MS,

--- a/gamesformykids/app/dashboard/components/MostPlayedCard.tsx
+++ b/gamesformykids/app/dashboard/components/MostPlayedCard.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import type { GameProgress } from '@/hooks/shared/progress/useGameProgress';
+import { useGameProgress } from '@/hooks/shared/progress/useGameProgress';
 import { getGameLabel } from './gameLabels';
 
 const SEVEN_DAYS_MS = 7 * 24 * 60 * 60 * 1000;
@@ -11,7 +11,19 @@ function formatMinutes(seconds: number) {
   return `${m} דק׳`;
 }
 
-export function MostPlayedCard({ progress }: { progress: GameProgress[] }) {
+export function MostPlayedCard() {
+  const { progress, loading } = useGameProgress();
+
+  if (loading) {
+    return (
+      <div className="bg-white rounded-2xl shadow-md p-6 animate-pulse">
+        <div className="h-4 bg-gray-200 rounded w-1/2 mb-4" />
+        <div className="space-y-3">
+          {[...Array(3)].map((_, i) => <div key={i} className="h-8 bg-gray-100 rounded" />)}
+        </div>
+      </div>
+    );
+  }
   const now = Date.now();
   const recent = progress
     .filter((p) => now - new Date(p.last_played_at).getTime() < SEVEN_DAYS_MS)

--- a/gamesformykids/app/dashboard/components/RecentAchievementsCard.tsx
+++ b/gamesformykids/app/dashboard/components/RecentAchievementsCard.tsx
@@ -1,8 +1,21 @@
 'use client';
 
-import type { Achievement } from '@/hooks/shared/progress/useAchievements';
+import { useAchievements } from '@/hooks/shared/progress/useAchievements';
 
-export function RecentAchievementsCard({ achievements }: { achievements: Achievement[] }) {
+export function RecentAchievementsCard() {
+  const { achievements, loading } = useAchievements();
+
+  if (loading) {
+    return (
+      <div className="bg-white rounded-2xl shadow-md p-6 animate-pulse">
+        <div className="h-4 bg-gray-200 rounded w-1/2 mb-4" />
+        <div className="space-y-3">
+          {[...Array(3)].map((_, i) => <div key={i} className="h-8 bg-gray-100 rounded" />)}
+        </div>
+      </div>
+    );
+  }
+
   const recent = [...achievements]
     .sort((a, b) => new Date(b.earned_at).getTime() - new Date(a.earned_at).getTime())
     .slice(0, 5);

--- a/gamesformykids/app/dashboard/components/RecommendedGameCard.tsx
+++ b/gamesformykids/app/dashboard/components/RecommendedGameCard.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import Link from 'next/link';
+import { useGameProgress } from '@/hooks/shared/progress/useGameProgress';
 import type { GameProgress } from '@/hooks/shared/progress/useGameProgress';
 import { getGameLabel } from './gameLabels';
 
@@ -18,7 +19,18 @@ function getRecommended(progress: GameProgress[]): GameProgress | null {
   return pool.reduce((worst, p) => (p.best_score < worst.best_score ? p : worst), pool[0]);
 }
 
-export function RecommendedGameCard({ progress }: { progress: GameProgress[] }) {
+export function RecommendedGameCard() {
+  const { progress, loading } = useGameProgress();
+
+  if (loading) {
+    return (
+      <div className="bg-gradient-to-br from-pink-100 to-purple-100 rounded-2xl shadow-md p-6 animate-pulse">
+        <div className="h-4 bg-gray-200 rounded w-1/2 mb-4" />
+        <div className="h-16 bg-white/50 rounded" />
+      </div>
+    );
+  }
+
   const rec = getRecommended(progress);
 
   if (!rec) {

--- a/gamesformykids/app/dashboard/components/ScoreSummaryCard.tsx
+++ b/gamesformykids/app/dashboard/components/ScoreSummaryCard.tsx
@@ -1,9 +1,21 @@
 'use client';
 
-import type { GameProgress } from '@/hooks/shared/progress/useGameProgress';
+import { useGameProgress } from '@/hooks/shared/progress/useGameProgress';
 import { getGameLabel } from './gameLabels';
 
-export function ScoreSummaryCard({ progress }: { progress: GameProgress[] }) {
+export function ScoreSummaryCard() {
+  const { progress, loading } = useGameProgress();
+
+  if (loading) {
+    return (
+      <div className="bg-white rounded-2xl shadow-md p-6 animate-pulse">
+        <div className="h-4 bg-gray-200 rounded w-1/2 mb-4" />
+        <div className="space-y-3">
+          {[...Array(4)].map((_, i) => <div key={i} className="h-6 bg-gray-100 rounded" />)}
+        </div>
+      </div>
+    );
+  }
   const played = progress
     .filter((p) => p.best_score > 0)
     .sort((a, b) => b.best_score - a.best_score)


### PR DESCRIPTION
## Summary

Closes #441

### Problem
DashboardClient was calling useGameProgress() and useAchievements() then drilling the results as props to all 5 child cards. Adding any new data field to a card required touching DashboardClient too.

### Fix
Each card now owns its own data subscription:

| Card | Hook |
|------|------|
| ActivitySummaryCard | useGameProgress() |
| MostPlayedCard | useGameProgress() |
| ScoreSummaryCard | useGameProgress() |
| RecentAchievementsCard | useAchievements() |
| RecommendedGameCard | useGameProgress() |

DashboardClient is now a pure layout shell — auth check + grid, zero data dependencies.

### No duplicate fetches
Both hooks read from a shared Zustand store (gameProgressDataStore / chievementsStore). The store caches by loadedForUserId, so the first card to mount triggers the fetch and all subsequent hook calls read from the already-populated store.

### Each card also handles its own loading state
Skeleton shown inline per card, replacing the single combined skeleton in DashboardClient.