### PR TITLE
refactor(#467): extract usePhaseGameCompletion hook

### DIFF
--- a/gamesformykids/app/games/balloon-pop/useBalloonPopGame.ts
+++ b/gamesformykids/app/games/balloon-pop/useBalloonPopGame.ts
@@ -1,28 +1,13 @@
 'use client';
-import { useEffect, useRef } from 'react';
 import { useShallow } from 'zustand/react/shallow';
 import { useBalloonPopStore } from './balloonPopStore';
-import { useGameCompletion } from '@/hooks/shared/progress';
+import { useGameCompletion, usePhaseGameCompletion } from '@/hooks/shared/progress';
 
 export function useBalloonPopGame() {
   const state = useBalloonPopStore(useShallow((s) => s));
   const { saveGameResultRef } = useGameCompletion('balloon-pop');
 
-  const startTimeRef = useRef(0);
-  const prevPhaseRef = useRef<string>(state.phase);
-
-  useEffect(() => {
-    const prev = prevPhaseRef.current;
-    const curr = state.phase;
-    prevPhaseRef.current = curr;
-
-    if (curr === 'playing' && prev !== 'playing') {
-      startTimeRef.current = Date.now();
-    } else if (prev === 'playing' && curr === 'result') {
-      const elapsed = Math.round((Date.now() - startTimeRef.current) / 1000);
-      saveGameResultRef.current({ score: state.score, level: 1, durationSeconds: elapsed });
-    }
-  }, [state.phase]); // eslint-disable-line react-hooks/exhaustive-deps
+  usePhaseGameCompletion(state.phase, saveGameResultRef, () => ({ score: state.score, level: 1 }), ['result']);
 
   return state;
 }

--- a/gamesformykids/app/games/color-tap/useColorTapGame.ts
+++ b/gamesformykids/app/games/color-tap/useColorTapGame.ts
@@ -1,8 +1,7 @@
 'use client';
-import { useEffect, useRef } from 'react';
 import { useShallow } from 'zustand/react/shallow';
 import { useColorTapStore } from './colorTapStore';
-import { useGameCompletion } from '@/hooks/shared/progress';
+import { useGameCompletion, usePhaseGameCompletion } from '@/hooks/shared/progress';
 
 export type { ColorItem, Question } from './colorTapStore';
 export { COLORS, TIME_PER_Q } from './colorTapStore';
@@ -11,21 +10,7 @@ export function useColorTapGame() {
   const state = useColorTapStore(useShallow((s) => s));
   const { saveGameResultRef } = useGameCompletion('color-tap');
 
-  const startTimeRef = useRef(0);
-  const prevPhaseRef = useRef<string>(state.phase);
-
-  useEffect(() => {
-    const prev = prevPhaseRef.current;
-    const curr = state.phase;
-    prevPhaseRef.current = curr;
-
-    if (curr === 'playing' && prev !== 'playing') {
-      startTimeRef.current = Date.now();
-    } else if (prev === 'playing' && curr === 'dead') {
-      const elapsed = Math.round((Date.now() - startTimeRef.current) / 1000);
-      saveGameResultRef.current({ score: state.score, level: 1, durationSeconds: elapsed });
-    }
-  }, [state.phase]); // eslint-disable-line react-hooks/exhaustive-deps
+  usePhaseGameCompletion(state.phase, saveGameResultRef, () => ({ score: state.score, level: 1 }));
 
   return state;
 }

--- a/gamesformykids/app/games/emoji-math/useEmojiMathGame.ts
+++ b/gamesformykids/app/games/emoji-math/useEmojiMathGame.ts
@@ -1,8 +1,7 @@
 'use client';
-import { useEffect, useRef } from 'react';
 import { useShallow } from 'zustand/react/shallow';
 import { useEmojiMathStore } from './emojiMathStore';
-import { useGameCompletion } from '@/hooks/shared/progress';
+import { useGameCompletion, usePhaseGameCompletion } from '@/hooks/shared/progress';
 
 export type { Op, Question } from './emojiMathStore';
 export { makeQuestion, TIME_PER_Q } from './emojiMathStore';
@@ -11,21 +10,7 @@ export function useEmojiMathGame() {
   const state = useEmojiMathStore(useShallow((s) => s));
   const { saveGameResultRef } = useGameCompletion('emoji-math');
 
-  const startTimeRef = useRef(0);
-  const prevPhaseRef = useRef<string>(state.phase);
-
-  useEffect(() => {
-    const prev = prevPhaseRef.current;
-    const curr = state.phase;
-    prevPhaseRef.current = curr;
-
-    if (curr === 'playing' && prev !== 'playing') {
-      startTimeRef.current = Date.now();
-    } else if (prev === 'playing' && curr === 'dead') {
-      const elapsed = Math.round((Date.now() - startTimeRef.current) / 1000);
-      saveGameResultRef.current({ score: state.score, level: state.level, durationSeconds: elapsed });
-    }
-  }, [state.phase]); // eslint-disable-line react-hooks/exhaustive-deps
+  usePhaseGameCompletion(state.phase, saveGameResultRef, () => ({ score: state.score, level: state.level }));
 
   return state;
 }

--- a/gamesformykids/app/games/word-scramble/useWordScrambleGame.ts
+++ b/gamesformykids/app/games/word-scramble/useWordScrambleGame.ts
@@ -1,8 +1,7 @@
 'use client';
-import { useEffect, useRef } from 'react';
 import { useShallow } from 'zustand/react/shallow';
 import { useWordScrambleStore } from './wordScrambleStore';
-import { useGameCompletion } from '@/hooks/shared/progress';
+import { useGameCompletion, usePhaseGameCompletion } from '@/hooks/shared/progress';
 
 export type { WordEntry, LetterSlot, PickedLetter } from './wordScrambleStore';
 export { WORD_LIST } from './wordScrambleStore';
@@ -11,21 +10,7 @@ export function useWordScrambleGame() {
   const state = useWordScrambleStore(useShallow((s) => s));
   const { saveGameResultRef } = useGameCompletion('word-scramble');
 
-  const startTimeRef = useRef(0);
-  const prevPhaseRef = useRef<string>(state.phase);
-
-  useEffect(() => {
-    const prev = prevPhaseRef.current;
-    const curr = state.phase;
-    prevPhaseRef.current = curr;
-
-    if (curr === 'playing' && prev !== 'playing') {
-      startTimeRef.current = Date.now();
-    } else if (prev === 'playing' && curr === 'results') {
-      const elapsed = Math.round((Date.now() - startTimeRef.current) / 1000);
-      saveGameResultRef.current({ score: state.score, level: 1, durationSeconds: elapsed });
-    }
-  }, [state.phase]); // eslint-disable-line react-hooks/exhaustive-deps
+  usePhaseGameCompletion(state.phase, saveGameResultRef, () => ({ score: state.score, level: 1 }), ['results']);
 
   return state;
 }

--- a/gamesformykids/hooks/shared/progress/index.ts
+++ b/gamesformykids/hooks/shared/progress/index.ts
@@ -3,3 +3,4 @@ export { useSessionStats } from './useSessionStats';
 export { useAchievements } from './useAchievements';
 export { useGameCompletion } from './useGameCompletion';
 export type { GameResult } from './useGameCompletion';
+export { usePhaseGameCompletion } from './usePhaseGameCompletion';

--- a/gamesformykids/hooks/shared/progress/usePhaseGameCompletion.ts
+++ b/gamesformykids/hooks/shared/progress/usePhaseGameCompletion.ts
@@ -1,0 +1,38 @@
+'use client';
+import { useEffect, useRef } from 'react';
+import type { GameResult } from './useGameCompletion';
+
+type SaveFn = (result: GameResult) => void;
+
+/**
+ * Tracks phase transitions (menu → playing → dead/result/results) and calls
+ * `saveResult` once when the game completes. Eliminates the repeated 15-line
+ * startTimeRef / prevPhaseRef boilerplate found in multiple game hooks.
+ *
+ * @param phase        - current game phase string
+ * @param saveResult   - stable ref or callback to persist the result
+ * @param getPayload   - returns { score, level } at the moment of completion
+ * @param completionPhases - phase strings that indicate game-over (default: common set)
+ */
+export function usePhaseGameCompletion(
+  phase: string,
+  saveResult: React.MutableRefObject<SaveFn>,
+  getPayload: () => Omit<GameResult, 'durationSeconds'>,
+  completionPhases: string[] = ['dead', 'result', 'results'],
+) {
+  const startTimeRef = useRef(0);
+  const prevPhaseRef = useRef(phase);
+
+  useEffect(() => {
+    const prev = prevPhaseRef.current;
+    const curr = phase;
+    prevPhaseRef.current = curr;
+
+    if (curr === 'playing' && prev !== 'playing') {
+      startTimeRef.current = Date.now();
+    } else if (prev === 'playing' && completionPhases.includes(curr)) {
+      const elapsed = Math.round((Date.now() - startTimeRef.current) / 1000);
+      saveResult.current({ ...getPayload(), durationSeconds: elapsed });
+    }
+  }, [phase]); // eslint-disable-line react-hooks/exhaustive-deps
+}


### PR DESCRIPTION
Closes #467

## Changes
- Add \hooks/shared/progress/usePhaseGameCompletion.ts\ — shared hook that tracks \playing → done\ phase transitions and calls \saveGameResultRef\ with elapsed time
- Export from \hooks/shared/progress/index.ts\
- Refactor 4 game hooks to use it (removes 15-line inline boilerplate from each):
  - \useColorTapGame.ts\
  - \useEmojiMathGame.ts\
  - \useWordScrambleGame.ts\
  - \useBalloonPopGame.ts\

## Stats
- 6 files changed, 47 insertions(+), 68 deletions(-)
- tsc --noEmit: 0 errors