### PR TITLE
refactor(#466): extract createScoreBestResultScreen factory

### DIFF
--- a/gamesformykids/app/games/color-tap/components/ColorTapResultScreen.tsx
+++ b/gamesformykids/app/games/color-tap/components/ColorTapResultScreen.tsx
@@ -1,23 +1,17 @@
-'use client';
-import ScoreBestResultCard from '@/components/game/shared/ScoreBestResultCard';
+import { createScoreBestResultScreen } from '@/components/game/shared/createScoreBestResultScreen';
 import { useColorTapGame } from '../useColorTapGame';
 
-export default function ColorTapResultScreen() {
-  const { score, best, startGame } = useColorTapGame();
-  return (
-    <ScoreBestResultCard
-      emoji="😢"
-      title="נגמרו החיים!"
-      gradientClass="from-pink-100 to-purple-200"
-      buttonClass="from-pink-500 to-purple-600"
-      score={score}
-      best={best}
-      scoreBgClass="bg-pink-50"
-      scoreTextClass="text-pink-600"
-      scoreLabelClass="text-pink-400"
-      onRestart={startGame}
-      restartLabel="🔄 שוב!"
-      shareText={`🎨 קיבלתי ${score} נקודות בהקש צבע!`}
-    />
-  );
-}
+export default createScoreBestResultScreen(
+  {
+    emoji: '😢',
+    title: 'נגמרו החיים!',
+    gradientClass: 'from-pink-100 to-purple-200',
+    buttonClass: 'from-pink-500 to-purple-600',
+    scoreBgClass: 'bg-pink-50',
+    scoreTextClass: 'text-pink-600',
+    scoreLabelClass: 'text-pink-400',
+    restartLabel: '🔄 שוב!',
+    shareTextFn: (score) => `🎨 קיבלתי ${score} נקודות בהקש צבע!`,
+  },
+  useColorTapGame,
+);

--- a/gamesformykids/app/games/emoji-math/components/EmojiMathResultScreen.tsx
+++ b/gamesformykids/app/games/emoji-math/components/EmojiMathResultScreen.tsx
@@ -1,23 +1,17 @@
-'use client';
-import ScoreBestResultCard from '@/components/game/shared/ScoreBestResultCard';
+import { createScoreBestResultScreen } from '@/components/game/shared/createScoreBestResultScreen';
 import { useEmojiMathGame } from '../useEmojiMathGame';
 
-export default function EmojiMathResultScreen() {
-  const { score, best, startGame } = useEmojiMathGame();
-  return (
-    <ScoreBestResultCard
-      emoji="🤓"
-      title="כל הכבוד על המאמץ!"
-      gradientClass="from-yellow-100 to-orange-200"
-      buttonClass="from-yellow-400 to-orange-500"
-      score={score}
-      best={best}
-      scoreBgClass="bg-orange-50"
-      scoreTextClass="text-orange-600"
-      scoreLabelClass="text-orange-400"
-      onRestart={startGame}
-      restartLabel="🔄 שוב!"
-      shareText={`🤓 קיבלתי ${score} נקודות באימוג'י מתמטיקה!`}
-    />
-  );
-}
+export default createScoreBestResultScreen(
+  {
+    emoji: '🤓',
+    title: 'כל הכבוד על המאמץ!',
+    gradientClass: 'from-yellow-100 to-orange-200',
+    buttonClass: 'from-yellow-400 to-orange-500',
+    scoreBgClass: 'bg-orange-50',
+    scoreTextClass: 'text-orange-600',
+    scoreLabelClass: 'text-orange-400',
+    restartLabel: '🔄 שוב!',
+    shareTextFn: (score) => `🤓 קיבלתי ${score} נקודות באימוג'י מתמטיקה!`,
+  },
+  useEmojiMathGame,
+);

--- a/gamesformykids/app/games/true-false/components/TrueFalseResultScreen.tsx
+++ b/gamesformykids/app/games/true-false/components/TrueFalseResultScreen.tsx
@@ -1,23 +1,17 @@
-'use client';
-import ScoreBestResultCard from '@/components/game/shared/ScoreBestResultCard';
+import { createScoreBestResultScreen } from '@/components/game/shared/createScoreBestResultScreen';
 import { useTrueFalseGame } from '../useTrueFalseGame';
 
-export default function TrueFalseResultScreen() {
-  const { score, best, startGame } = useTrueFalseGame();
-  return (
-    <ScoreBestResultCard
-      emoji="🧠"
-      title="כל הכבוד על הניסיון!"
-      gradientClass="from-teal-100 to-cyan-200"
-      buttonClass="from-teal-500 to-cyan-600"
-      score={score}
-      best={best}
-      scoreBgClass="bg-teal-50"
-      scoreTextClass="text-teal-600"
-      scoreLabelClass="text-teal-400"
-      onRestart={startGame}
-      restartLabel="🔄 שוב!"
-      shareText={`🧠 קיבלתי ${score} נקודות בנכון או שקר!`}
-    />
-  );
-}
+export default createScoreBestResultScreen(
+  {
+    emoji: '🧠',
+    title: 'כל הכבוד על הניסיון!',
+    gradientClass: 'from-teal-100 to-cyan-200',
+    buttonClass: 'from-teal-500 to-cyan-600',
+    scoreBgClass: 'bg-teal-50',
+    scoreTextClass: 'text-teal-600',
+    scoreLabelClass: 'text-teal-400',
+    restartLabel: '🔄 שוב!',
+    shareTextFn: (score) => `🧠 קיבלתי ${score} נקודות בנכון או שקר!`,
+  },
+  useTrueFalseGame,
+);

--- a/gamesformykids/app/games/whack-a-mole/components/WhackAMoleResultScreen.tsx
+++ b/gamesformykids/app/games/whack-a-mole/components/WhackAMoleResultScreen.tsx
@@ -1,22 +1,16 @@
-'use client';
-import ScoreBestResultCard from '@/components/game/shared/ScoreBestResultCard';
+import { createScoreBestResultScreen } from '@/components/game/shared/createScoreBestResultScreen';
 import { useWhackAMoleGame } from '../useWhackAMoleGame';
 
-export default function WhackAMoleResultScreen() {
-  const { score, best, startGame } = useWhackAMoleGame();
-  return (
-    <ScoreBestResultCard
-      emoji="🔨"
-      title="הזמן נגמר!"
-      gradientClass="from-yellow-50 to-amber-100"
-      buttonClass="from-amber-500 to-orange-500"
-      score={score}
-      best={best}
-      scoreBgClass="bg-amber-50"
-      scoreTextClass="text-amber-600"
-      scoreLabelClass="text-amber-400"
-      onRestart={startGame}
-      shareText={`🔨 קיבלתי ${score} נקודות בהכאת עכברוש!`}
-    />
-  );
-}
+export default createScoreBestResultScreen(
+  {
+    emoji: '🔨',
+    title: 'הזמן נגמר!',
+    gradientClass: 'from-yellow-50 to-amber-100',
+    buttonClass: 'from-amber-500 to-orange-500',
+    scoreBgClass: 'bg-amber-50',
+    scoreTextClass: 'text-amber-600',
+    scoreLabelClass: 'text-amber-400',
+    shareTextFn: (score) => `🔨 קיבלתי ${score} נקודות בהכאת עכברוש!`,
+  },
+  useWhackAMoleGame,
+);

--- a/gamesformykids/components/game/shared/createScoreBestResultScreen.tsx
+++ b/gamesformykids/components/game/shared/createScoreBestResultScreen.tsx
@@ -1,0 +1,35 @@
+'use client';
+
+import ScoreBestResultCard from './ScoreBestResultCard';
+
+export interface ScoreBestResultScreenConfig {
+  emoji: string;
+  title: string;
+  gradientClass: string;
+  buttonClass: string;
+  scoreBgClass?: string;
+  scoreTextClass?: string;
+  scoreLabelClass?: string;
+  restartLabel?: string;
+  shareTextFn: (score: number) => string;
+}
+
+export function createScoreBestResultScreen(
+  config: ScoreBestResultScreenConfig,
+  useGameHook: () => { score: number; best: number; startGame: () => void },
+) {
+  function ScoreBestResultScreen() {
+    const { score, best, startGame } = useGameHook();
+    return (
+      <ScoreBestResultCard
+        {...config}
+        score={score}
+        best={best}
+        onRestart={startGame}
+        shareText={config.shareTextFn(score)}
+      />
+    );
+  }
+  ScoreBestResultScreen.displayName = `ScoreBestResultScreen(${config.title})`;
+  return ScoreBestResultScreen;
+}


### PR DESCRIPTION
Closes #466

## Changes
- Add \components/game/shared/createScoreBestResultScreen.tsx\ — factory parallel to \createGameMenuScreen\ for config-only result screens using \ScoreBestResultCard\
- Migrate 4 ResultScreens from manual wrappers to the factory:
  - \ColorTapResultScreen.tsx\
  - \EmojiMathResultScreen.tsx\
  - \TrueFalseResultScreen.tsx\
  - \WhackAMoleResultScreen.tsx\

## Stats
- 5 files changed, 94 insertions(+), 83 deletions(-)
- tsc --noEmit: 0 errors