### PR TITLE
refactor: extract QuizCategoryMenuScreen to replace 4 duplicate menu screens

### DIFF
--- a/gamesformykids/components/game/quiz/QuizCategoryMenuScreen.tsx
+++ b/gamesformykids/components/game/quiz/QuizCategoryMenuScreen.tsx
@@ -1,0 +1,67 @@
+'use client';
+
+import React from 'react';
+
+interface Props<T extends string> {
+  gradient: string;
+  titleColor: string;
+  emoji: string;
+  title: string;
+  description: string;
+  categories: readonly T[];
+  categoryClassName: (cat: T) => string;
+  categoryLabel?: (cat: T) => React.ReactNode;
+  gridCols?: 2 | 3;
+  withCard?: boolean;
+  onStart: (cat: T) => void;
+}
+
+export default function QuizCategoryMenuScreen<T extends string>({
+  gradient,
+  titleColor,
+  emoji,
+  title,
+  description,
+  categories,
+  categoryClassName,
+  categoryLabel,
+  gridCols = 3,
+  withCard = true,
+  onStart,
+}: Props<T>) {
+  const gridClass = gridCols === 3
+    ? 'grid grid-cols-3 gap-2 mb-6'
+    : 'grid grid-cols-2 gap-3 mb-8 w-full max-w-sm';
+
+  const grid = (
+    <div className={gridClass}>
+      {categories.map(cat => (
+        <button key={cat} onClick={() => onStart(cat)} className={categoryClassName(cat)}>
+          {categoryLabel ? categoryLabel(cat) : cat}
+        </button>
+      ))}
+    </div>
+  );
+
+  if (withCard) {
+    return (
+      <div className={`min-h-screen bg-gradient-to-br ${gradient} flex flex-col items-center justify-center p-4`} dir="rtl">
+        <div className="bg-white rounded-3xl shadow-2xl p-8 max-w-md w-full text-center">
+          <div className="text-8xl mb-6">{emoji}</div>
+          <h1 className={`text-3xl font-bold ${titleColor} mb-2`}>{title}</h1>
+          <p className="text-gray-500 mb-4">{description}</p>
+          {grid}
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className={`min-h-screen bg-gradient-to-br ${gradient} flex flex-col items-center justify-center p-6`} dir="rtl">
+      <div className="text-8xl mb-4">{emoji}</div>
+      <h1 className={`text-4xl font-bold ${titleColor} mb-2`}>{title}</h1>
+      <p className="text-gray-600 mb-8 text-center">{description}</p>
+      {grid}
+    </div>
+  );
+}

--- a/gamesformykids/components/game/quiz/games/transport/components/TransportMenuScreen.tsx
+++ b/gamesformykids/components/game/quiz/games/transport/components/TransportMenuScreen.tsx
@@ -1,7 +1,7 @@
 'use client';
-
 import type { TransportType } from '../data/transport';
 import { TYPE_STYLES } from '../data/transport';
+import QuizCategoryMenuScreen from '@/components/game/quiz/QuizCategoryMenuScreen';
 
 interface Props {
   types: readonly TransportType[];
@@ -10,21 +10,18 @@ interface Props {
 
 export default function TransportMenuScreen({ types, onStart }: Props) {
   return (
-    <div className="min-h-screen bg-gradient-to-br from-sky-50 to-blue-100 flex flex-col items-center justify-center p-6" dir="rtl">
-      <div className="text-8xl mb-4">🚗</div>
-      <h1 className="text-4xl font-bold text-blue-700 mb-2">כלי תחבורה</h1>
-      <p className="text-gray-600 mb-8 text-center">גלה כלי רכב מהיבשה, הים והאוויר!</p>
-      <div className="grid grid-cols-2 gap-3 w-full max-w-sm">
-        {types.map(type => {
-          const s = TYPE_STYLES[type];
-          return (
-            <button key={type} onClick={() => onStart(type)}
-              className={`py-3 px-4 rounded-xl font-bold text-white shadow-md active:scale-95 transition-all bg-gradient-to-r ${s.color} ${type === 'הכל' ? 'col-span-2' : ''}`}>
-              {s.icon} {type}
-            </button>
-          );
-        })}
-      </div>
-    </div>
+    <QuizCategoryMenuScreen
+      withCard={false}
+      gradient="from-sky-50 to-blue-100"
+      titleColor="text-blue-700"
+      emoji="🚗"
+      title="כלי תחבורה"
+      description="גלה כלי רכב מהיבשה, הים והאוויר!"
+      categories={types}
+      categoryClassName={type => `py-3 px-4 rounded-xl font-bold text-white shadow-md active:scale-95 transition-all bg-gradient-to-r ${TYPE_STYLES[type].color} ${type === 'הכל' ? 'col-span-2' : ''}`}
+      categoryLabel={type => `${TYPE_STYLES[type].icon} ${type}`}
+      gridCols={2}
+      onStart={onStart}
+    />
   );
 }

--- a/gamesformykids/components/game/quiz/screens/HumanBodyMenuScreen.tsx
+++ b/gamesformykids/components/game/quiz/screens/HumanBodyMenuScreen.tsx
@@ -1,6 +1,7 @@
 'use client';
 import type { BodyCategory } from '@/lib/quiz/data/body';
 import { BODY_CATEGORIES, CATEGORY_GRADIENT_COLORS, CATEGORY_LABELS } from '@/lib/quiz/data/body';
+import QuizCategoryMenuScreen from '@/components/game/quiz/QuizCategoryMenuScreen';
 
 interface Props {
   onStart: (category: BodyCategory) => void;
@@ -8,18 +9,18 @@ interface Props {
 
 export default function HumanBodyMenuScreen({ onStart }: Props) {
   return (
-    <div className="min-h-screen bg-gradient-to-br from-red-50 to-pink-100 flex flex-col items-center justify-center p-6" dir="rtl">
-      <div className="text-8xl mb-4">🦴</div>
-      <h1 className="text-4xl font-bold text-red-700 mb-2">גוף האדם</h1>
-      <p className="text-gray-600 mb-8 text-center">גלה את הפלאות של גוף האדם!</p>
-      <div className="grid grid-cols-2 gap-3 mb-8 w-full max-w-sm">
-        {BODY_CATEGORIES.map(cat => (
-          <button key={cat} onClick={() => onStart(cat)}
-            className={`py-3 px-4 rounded-xl font-bold text-white shadow-md active:scale-95 transition-all bg-gradient-to-r ${CATEGORY_GRADIENT_COLORS[cat] ?? 'from-gray-400 to-gray-600'} ${cat === 'הכל' ? 'col-span-2' : ''}`}>
-            {CATEGORY_LABELS[cat]}
-          </button>
-        ))}
-      </div>
-    </div>
+    <QuizCategoryMenuScreen
+      withCard={false}
+      gradient="from-red-50 to-pink-100"
+      titleColor="text-red-700"
+      emoji="🦴"
+      title="גוף האדם"
+      description="גלה את הפלאות של גוף האדם!"
+      categories={BODY_CATEGORIES}
+      categoryClassName={cat => `py-3 px-4 rounded-xl font-bold text-white shadow-md active:scale-95 transition-all bg-gradient-to-r ${CATEGORY_GRADIENT_COLORS[cat] ?? 'from-gray-400 to-gray-600'} ${cat === 'הכל' ? 'col-span-2' : ''}`}
+      categoryLabel={cat => CATEGORY_LABELS[cat]}
+      gridCols={2}
+      onStart={onStart}
+    />
   );
 }

--- a/gamesformykids/components/game/quiz/screens/IsraelMenuScreen.tsx
+++ b/gamesformykids/components/game/quiz/screens/IsraelMenuScreen.tsx
@@ -1,6 +1,7 @@
 'use client';
 import type { IsraelCategory } from '@/lib/quiz/data/israel';
 import { CATEGORIES, CATEGORY_COLORS } from '@/lib/quiz/data/israel';
+import QuizCategoryMenuScreen from '@/components/game/quiz/QuizCategoryMenuScreen';
 
 interface Props {
   onStart: (cat: IsraelCategory) => void;
@@ -8,20 +9,15 @@ interface Props {
 
 export default function IsraelMenuScreen({ onStart }: Props) {
   return (
-    <div className="min-h-screen bg-gradient-to-br from-blue-50 to-cyan-100 flex flex-col items-center justify-center p-4" dir="rtl">
-      <div className="bg-white rounded-3xl shadow-2xl p-8 max-w-md w-full text-center">
-        <div className="text-8xl mb-6">🇮🇱</div>
-        <h1 className="text-3xl font-bold text-blue-700 mb-2">ישראל שלי</h1>
-        <p className="text-gray-500 mb-4">בחר קטגוריה ובחן את הידע שלך!</p>
-        <div className="grid grid-cols-3 gap-2 mb-6">
-          {CATEGORIES.map(cat => (
-            <button key={cat} onClick={() => onStart(cat)}
-              className={`py-3 px-2 rounded-xl font-bold text-sm transition-all shadow hover:opacity-90 ${CATEGORY_COLORS[cat] ?? 'bg-gray-400 text-white'}`}>
-              {cat}
-            </button>
-          ))}
-        </div>
-      </div>
-    </div>
+    <QuizCategoryMenuScreen
+      gradient="from-blue-50 to-cyan-100"
+      titleColor="text-blue-700"
+      emoji="🇮🇱"
+      title="ישראל שלי"
+      description="בחר קטגוריה ובחן את הידע שלך!"
+      categories={CATEGORIES}
+      categoryClassName={cat => `py-3 px-2 rounded-xl font-bold text-sm transition-all shadow hover:opacity-90 ${CATEGORY_COLORS[cat] ?? 'bg-gray-400 text-white'}`}
+      onStart={onStart}
+    />
   );
 }

--- a/gamesformykids/components/game/quiz/screens/NatureMenuScreen.tsx
+++ b/gamesformykids/components/game/quiz/screens/NatureMenuScreen.tsx
@@ -1,6 +1,7 @@
 'use client';
 import type { NatureCategory } from '@/lib/quiz/data/nature';
 import { CATEGORIES, CATEGORY_COLORS } from '@/lib/quiz/data/nature';
+import QuizCategoryMenuScreen from '@/components/game/quiz/QuizCategoryMenuScreen';
 
 interface Props {
   onStart: (cat: NatureCategory) => void;
@@ -8,20 +9,15 @@ interface Props {
 
 export default function NatureMenuScreen({ onStart }: Props) {
   return (
-    <div className="min-h-screen bg-gradient-to-br from-green-50 to-emerald-100 flex flex-col items-center justify-center p-4" dir="rtl">
-      <div className="bg-white rounded-3xl shadow-2xl p-8 max-w-md w-full text-center">
-        <div className="text-8xl mb-6">🌱</div>
-        <h1 className="text-3xl font-bold text-green-700 mb-2">עולם הטבע</h1>
-        <p className="text-gray-500 mb-4">בחר קטגוריה ולמד על הטבע!</p>
-        <div className="grid grid-cols-3 gap-2 mb-6">
-          {CATEGORIES.map(cat => (
-            <button key={cat} onClick={() => onStart(cat)}
-              className={`py-3 rounded-xl font-bold text-sm transition-all shadow hover:opacity-90 ${CATEGORY_COLORS[cat] ?? 'bg-gray-400 text-white'}`}>
-              {cat}
-            </button>
-          ))}
-        </div>
-      </div>
-    </div>
+    <QuizCategoryMenuScreen
+      gradient="from-green-50 to-emerald-100"
+      titleColor="text-green-700"
+      emoji="🌱"
+      title="עולם הטבע"
+      description="בחר קטגוריה ולמד על הטבע!"
+      categories={CATEGORIES}
+      categoryClassName={cat => `py-3 rounded-xl font-bold text-sm transition-all shadow hover:opacity-90 ${CATEGORY_COLORS[cat] ?? 'bg-gray-400 text-white'}`}
+      onStart={onStart}
+    />
   );
 }


### PR DESCRIPTION
## Summary
- `NatureMenuScreen`, `IsraelMenuScreen`, `HumanBodyMenuScreen`, and `TransportMenuScreen` all shared the same structural pattern: full-screen gradient background, large emoji, title, description, and a grid of category buttons
- Extracted to a generic `QuizCategoryMenuScreen<T>` component in `components/game/quiz/QuizCategoryMenuScreen.tsx`
- Two layout variants covered: `withCard={true}` (white card wrapper, grid-cols-3, used by Nature + Israel) and `withCard={false}` (bare layout, grid-cols-2, used by HumanBody + Transport)
- Each consumer now passes data-specific props (`gradient`, `emoji`, `title`, `categoryClassName`, etc.) and the generic component handles all JSX

## Test plan
- [ ] `npx tsc --noEmit` → 0 errors ✅
- [ ] ESLint → 0 warnings ✅
- [ ] Nature quiz menu looks identical to original
- [ ] Israel quiz menu looks identical to original
- [ ] Human Body quiz menu looks identical to original
- [ ] Transport quiz menu looks identical to original

Closes #503

🤖 Generated with [Claude Code](https://claude.com/claude-code)