### PR TITLE
refactor: extract useQuizQuestionState to remove duplicate quiz question lifecycle

### DIFF
--- a/gamesformykids/components/game/quiz/games/holidays/useHolidaysGame.ts
+++ b/gamesformykids/components/game/quiz/games/holidays/useHolidaysGame.ts
@@ -2,69 +2,56 @@
 
 import { useState, useCallback } from 'react';
 import { HOLIDAYS, Holiday } from './data/holidays';
+import { useQuizQuestionState } from '@/lib/quiz/useQuizQuestionState';
 
 export type HolidayPhase = 'menu' | 'quiz' | 'result' | 'complete';
 
 export function useHolidaysGame() {
   const [phase, setPhase] = useState<HolidayPhase>('menu');
   const [holidayIndex, setHolidayIndex] = useState(0);
-  const [questionIndex, setQuestionIndex] = useState(0);
   const [score, setScore] = useState(0);
-  const [selected, setSelected] = useState<number | null>(null);
-  const [isCorrect, setIsCorrect] = useState<boolean | null>(null);
 
   const current: Holiday = HOLIDAYS[holidayIndex];
-  const currentQuestion = current.questions[questionIndex];
   const totalHolidays = HOLIDAYS.length;
-  const totalQuestions = current.questions.length;
   const maxScore = HOLIDAYS.reduce((s, h) => s + h.questions.length, 0);
+
+  const {
+    questionIndex,
+    selected,
+    isCorrect,
+    currentQuestion,
+    totalQuestions,
+    selectAnswer,
+    nextQuestion: next,
+    resetQuestionState,
+  } = useQuizQuestionState({
+    questions: current.questions,
+    onCorrect: () => setScore(s => s + 1),
+    onComplete: () => setPhase('result'),
+  });
 
   const startHoliday = useCallback((index: number) => {
     setHolidayIndex(index);
-    setQuestionIndex(0);
-    setSelected(null);
-    setIsCorrect(null);
+    resetQuestionState();
     setPhase('quiz');
-  }, []);
-
-  const selectAnswer = useCallback((idx: number) => {
-    if (selected !== null) return;
-    setSelected(idx);
-    const correct = idx === currentQuestion.correctIndex;
-    setIsCorrect(correct);
-    if (correct) setScore(s => s + 1);
-  }, [selected, currentQuestion]);
-
-  const next = useCallback(() => {
-    if (questionIndex < totalQuestions - 1) {
-      setQuestionIndex(q => q + 1);
-      setSelected(null);
-      setIsCorrect(null);
-    } else {
-      setPhase('result');
-    }
-  }, [questionIndex, totalQuestions]);
+  }, [resetQuestionState]);
 
   const nextHoliday = useCallback(() => {
     if (holidayIndex < totalHolidays - 1) {
       setHolidayIndex(h => h + 1);
-      setQuestionIndex(0);
-      setSelected(null);
-      setIsCorrect(null);
+      resetQuestionState();
       setPhase('quiz');
     } else {
       setPhase('complete');
     }
-  }, [holidayIndex, totalHolidays]);
+  }, [holidayIndex, totalHolidays, resetQuestionState]);
 
   const restart = useCallback(() => {
     setPhase('menu');
     setHolidayIndex(0);
-    setQuestionIndex(0);
     setScore(0);
-    setSelected(null);
-    setIsCorrect(null);
-  }, []);
+    resetQuestionState();
+  }, [resetQuestionState]);
 
   return {
     phase, holidayIndex, questionIndex, score, maxScore,

--- a/gamesformykids/components/game/quiz/games/tzadikim/TzadikimGame.tsx
+++ b/gamesformykids/components/game/quiz/games/tzadikim/TzadikimGame.tsx
@@ -14,8 +14,8 @@ export default function TzadikimGame() {
     questionIndex,
     score,
     maxScore,
-    selectedAnswer,
-    feedback,
+    selected,
+    isCorrect,
     currentStory,
     currentQuestion,
     totalStories,
@@ -61,8 +61,8 @@ export default function TzadikimGame() {
         question={currentQuestion}
         questionIndex={questionIndex}
         totalQuestions={totalQuestions}
-        selectedAnswer={selectedAnswer}
-        feedback={feedback}
+        selected={selected}
+        isCorrect={isCorrect}
         score={score}
         onSelectAnswer={selectAnswer}
         onNext={nextQuestion}

--- a/gamesformykids/components/game/quiz/games/tzadikim/components/QuizView.tsx
+++ b/gamesformykids/components/game/quiz/games/tzadikim/components/QuizView.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { TzaddikStory, QuizQuestion } from '../data/tzadikim';
-import { AnswerFeedback } from '../useTzadikimGame';
 import { answerButtonClass } from '@/lib/quiz/answerButtonClass';
 
 interface QuizViewProps {
@@ -9,8 +8,8 @@ interface QuizViewProps {
   question: QuizQuestion;
   questionIndex: number;
   totalQuestions: number;
-  selectedAnswer: number | null;
-  feedback: AnswerFeedback | null;
+  selected: number | null;
+  isCorrect: boolean | null;
   score: number;
   onSelectAnswer: (index: number) => void;
   onNext: () => void;
@@ -21,12 +20,14 @@ export default function QuizView({
   question,
   questionIndex,
   totalQuestions,
-  selectedAnswer,
-  feedback,
+  selected,
+  isCorrect,
   score,
   onSelectAnswer,
   onNext,
 }: QuizViewProps) {
+  const answered = selected !== null;
+
   return (
     <div className={`min-h-screen bg-gradient-to-br ${story.bgGradient} p-4`} dir="rtl">
       <div className="max-w-2xl mx-auto">
@@ -59,26 +60,26 @@ export default function QuizView({
             <button
               key={index}
               onClick={() => onSelectAnswer(index)}
-              disabled={selectedAnswer !== null}
+              disabled={answered}
               className={`w-full text-right py-4 px-5 rounded-2xl font-semibold text-lg transition-all duration-200 active:scale-95 ${answerButtonClass(
                 index === question.correctIndex,
-                index === selectedAnswer,
-                !!feedback,
+                index === selected,
+                answered,
                 'bg-white border-2 border-gray-200 text-gray-700 hover:border-amber-400 hover:bg-amber-50',
               )}`}
             >
-              {feedback && index === question.correctIndex ? '✅ ' : feedback && index === selectedAnswer && !feedback.isCorrect ? '❌ ' : ''}{answer}
+              {answered && index === question.correctIndex ? '✅ ' : answered && index === selected && !isCorrect ? '❌ ' : ''}{answer}
             </button>
           ))}
         </div>
 
         {/* פידבק */}
-        {feedback && (
+        {answered && (
           <div className={`
             rounded-2xl p-4 mb-5 text-center font-bold text-lg
-            ${feedback.isCorrect ? 'bg-green-100 text-green-700' : 'bg-orange-100 text-orange-700'}
+            ${isCorrect ? 'bg-green-100 text-green-700' : 'bg-orange-100 text-orange-700'}
           `}>
-            {feedback.isCorrect
+            {isCorrect
               ? '🌟 כל הכבוד! תשובה נכונה!'
               : `💙 התשובה הנכונה: "${question.answers[question.correctIndex]}"`
             }
@@ -86,7 +87,7 @@ export default function QuizView({
         )}
 
         {/* כפתור הבא */}
-        {feedback && (
+        {answered && (
           <button
             onClick={onNext}
             className={`

--- a/gamesformykids/components/game/quiz/games/tzadikim/useTzadikimGame.ts
+++ b/gamesformykids/components/game/quiz/games/tzadikim/useTzadikimGame.ts
@@ -2,95 +2,63 @@
 
 import { useState, useCallback } from 'react';
 import { TZADIKIM_STORIES, TzaddikStory } from './data/tzadikim';
+import { useQuizQuestionState } from '@/lib/quiz/useQuizQuestionState';
 
 export type GamePhase = 'menu' | 'story' | 'quiz' | 'result' | 'complete';
-
-export interface AnswerFeedback {
-  questionIndex: number;
-  selectedIndex: number;
-  isCorrect: boolean;
-}
 
 export function useTzadikimGame() {
   const [phase, setPhase] = useState<GamePhase>('menu');
   const [storyIndex, setStoryIndex] = useState(0);
-  const [questionIndex, setQuestionIndex] = useState(0);
   const [score, setScore] = useState(0);
-  const [selectedAnswer, setSelectedAnswer] = useState<number | null>(null);
-  const [feedback, setFeedback] = useState<AnswerFeedback | null>(null);
-  const [storyScores, setStoryScores] = useState<number[]>([]);
 
   const currentStory: TzaddikStory = TZADIKIM_STORIES[storyIndex];
   const totalStories = TZADIKIM_STORIES.length;
-  const currentQuestion = currentStory.questions[questionIndex];
-  const totalQuestions = currentStory.questions.length;
-  const maxScore = totalStories * 3; // 3 questions per story
+  const maxScore = totalStories * 3;
+
+  const {
+    questionIndex,
+    selected,
+    isCorrect,
+    currentQuestion,
+    totalQuestions,
+    selectAnswer,
+    nextQuestion,
+    resetQuestionState,
+  } = useQuizQuestionState({
+    questions: currentStory.questions,
+    onCorrect: () => setScore(prev => prev + 1),
+    onComplete: () => setPhase('result'),
+  });
 
   const startStory = useCallback((index: number) => {
     setStoryIndex(index);
-    setQuestionIndex(0);
-    setSelectedAnswer(null);
-    setFeedback(null);
+    resetQuestionState();
     setPhase('story');
-  }, []);
+  }, [resetQuestionState]);
 
   const startQuiz = useCallback(() => {
-    setQuestionIndex(0);
-    setSelectedAnswer(null);
-    setFeedback(null);
+    resetQuestionState();
     setPhase('quiz');
-  }, []);
-
-  const selectAnswer = useCallback((answerIndex: number) => {
-    if (selectedAnswer !== null) return; // already answered
-    setSelectedAnswer(answerIndex);
-    const isCorrect = answerIndex === currentQuestion.correctIndex;
-    setFeedback({ questionIndex, selectedIndex: answerIndex, isCorrect });
-    if (isCorrect) {
-      setScore(prev => prev + 1);
-    }
-  }, [selectedAnswer, currentQuestion, questionIndex]);
-
-  const nextQuestion = useCallback(() => {
-    if (questionIndex < totalQuestions - 1) {
-      setQuestionIndex(prev => prev + 1);
-      setSelectedAnswer(null);
-      setFeedback(null);
-    } else {
-      // end of quiz for this story
-      setPhase('result');
-    }
-  }, [questionIndex, totalQuestions]);
+  }, [resetQuestionState]);
 
   const nextStory = useCallback(() => {
-    // record story score
-    const storyCorrect = feedback
-      ? storyScores.length
-      : storyScores.length;
-    setStoryScores(prev => [...prev, storyCorrect]);
-
     if (storyIndex < totalStories - 1) {
       setStoryIndex(prev => prev + 1);
-      setQuestionIndex(0);
-      setSelectedAnswer(null);
-      setFeedback(null);
+      resetQuestionState();
       setPhase('story');
     } else {
       setPhase('complete');
     }
-  }, [storyIndex, totalStories, feedback, storyScores]);
+  }, [storyIndex, totalStories, resetQuestionState]);
 
   const backToMenu = useCallback(() => setPhase('menu'), []);
 
   const restartGame = useCallback(() => {
     setPhase('menu');
     setStoryIndex(0);
-    setQuestionIndex(0);
     setScore(0);
-    setSelectedAnswer(null);
-    setFeedback(null);
-    setStoryScores([]);
-  }, []);
+    resetQuestionState();
+  }, [resetQuestionState]);
 
   const progressPercent = Math.round((storyIndex / totalStories) * 100);
 
@@ -100,8 +68,8 @@ export function useTzadikimGame() {
     questionIndex,
     score,
     maxScore,
-    selectedAnswer,
-    feedback,
+    selected,
+    isCorrect,
     currentStory,
     currentQuestion,
     totalStories,

--- a/gamesformykids/lib/quiz/useQuizQuestionState.ts
+++ b/gamesformykids/lib/quiz/useQuizQuestionState.ts
@@ -1,0 +1,57 @@
+'use client';
+
+import { useState, useCallback } from 'react';
+
+interface Config<Q extends { correctIndex: number }> {
+  questions: Q[];
+  onCorrect?: () => void;
+  onComplete: () => void;
+}
+
+export function useQuizQuestionState<Q extends { correctIndex: number }>({
+  questions,
+  onCorrect,
+  onComplete,
+}: Config<Q>) {
+  const [questionIndex, setQuestionIndex] = useState(0);
+  const [selected, setSelected] = useState<number | null>(null);
+  const [isCorrect, setIsCorrect] = useState<boolean | null>(null);
+
+  const currentQuestion = questions[questionIndex];
+  const totalQuestions = questions.length;
+
+  const selectAnswer = useCallback((idx: number) => {
+    if (selected !== null) return;
+    setSelected(idx);
+    const correct = idx === currentQuestion.correctIndex;
+    setIsCorrect(correct);
+    if (correct) onCorrect?.();
+  }, [selected, currentQuestion, onCorrect]);
+
+  const nextQuestion = useCallback(() => {
+    if (questionIndex < totalQuestions - 1) {
+      setQuestionIndex(q => q + 1);
+      setSelected(null);
+      setIsCorrect(null);
+    } else {
+      onComplete();
+    }
+  }, [questionIndex, totalQuestions, onComplete]);
+
+  const resetQuestionState = useCallback(() => {
+    setQuestionIndex(0);
+    setSelected(null);
+    setIsCorrect(null);
+  }, []);
+
+  return {
+    questionIndex,
+    selected,
+    isCorrect,
+    currentQuestion,
+    totalQuestions,
+    selectAnswer,
+    nextQuestion,
+    resetQuestionState,
+  };
+}


### PR DESCRIPTION
## Summary
- `useHolidaysGame` and `useTzadikimGame` both contained identical logic: `questionIndex`, `selected`, `isCorrect` state; a guarded `selectAnswer`; and a `nextQuestion` that either advances or calls `onComplete`
- Extracted to a generic `useQuizQuestionState<Q>` hook in `lib/quiz/useQuizQuestionState.ts` — takes `questions`, `onCorrect?`, and `onComplete` callbacks
- Both game hooks now delegate to it and only keep game-specific state (phase, holidayIndex/storyIndex, score)
- Removed `AnswerFeedback` object from Tzadikim — `QuizView` now receives plain `selected` + `isCorrect` props, which are simpler and match the Holidays game pattern
- Also removed `storyScores` state from Tzadikim which was tracked but never returned or used correctly

## Test plan
- [ ] `npx tsc --noEmit` → 0 errors ✅
- [ ] ESLint → 0 warnings ✅
- [ ] Holidays game: correct/wrong answer feedback and score increment work identically
- [ ] Tzadikim game: correct/wrong answer feedback and score increment work identically
- [ ] Question progression and phase transitions (quiz → result → next story → complete) work correctly in both games

Closes #504

🤖 Generated with [Claude Code](https://claude.com/claude-code)