### PR TITLE
refactor: NatureQuestion extends QuizQuestion base type

### DIFF
--- a/gamesformykids/lib/quiz/data/nature.ts
+++ b/gamesformykids/lib/quiz/data/nature.ts
@@ -1,9 +1,9 @@
 // עולם הטבע - שאלות מדעי הטבע לילדים
-export type NatureQuestion = {
+import type { QuizQuestion } from '@/lib/types';
+
+export type NatureQuestion = QuizQuestion & {
   id: number;
-  question: string;
   answers: [string, string, string, string];
-  correctIndex: number;
   emoji: string;
   category: 'בעלי חיים' | 'צמחים' | 'מזג אוויר' | 'חלל' | 'מים';
   funFact: string;
@@ -28,7 +28,7 @@ export const NATURE_QUESTIONS: NatureQuestion[] = [
 ];
 
 export const CATEGORIES = ['הכל', 'בעלי חיים', 'צמחים', 'מזג אוויר', 'חלל', 'מים'] as const;
-export type NatureCategory = typeof CATEGORIES[number];
+export type NatureCategory = (typeof CATEGORIES)[number];
 
 export const CATEGORY_COLORS: Record<NatureCategory, string> = {
   'הכל':       'bg-green-600 text-white',


### PR DESCRIPTION
## Summary
- `NatureQuestion` in `lib/quiz/data/nature.ts` now extends `QuizQuestion` via type intersection, eliminating the duplicate `question`/`answers`/`correctIndex` field declarations
- `answers` is narrowed from `string[]` to `[string, string, string, string]` (4-tuple) in the intersection

## Test plan
- [ ] `npx tsc --noEmit` → 0 errors ✅
- [ ] ESLint clean ✅
- [ ] No runtime changes (types only)

Closes #509

🤖 Generated with [Claude Code](https://claude.com/claude-code)