### PR TITLE
refactor: HolidaysCompleteScreen delegates to QuizResultScreen

### DIFF
--- a/gamesformykids/components/game/quiz/QuizResultScreen.tsx
+++ b/gamesformykids/components/game/quiz/QuizResultScreen.tsx
@@ -7,12 +7,13 @@ interface Props {
   onRestart: () => void;
   theme: QuizTheme;
   title?: string;
+  subtitle?: string;
   /** Override store values for games that don't use quizGameStore */
   correctCount?: number;
   total?: number;
 }
 
-export function QuizResultScreen({ onRestart, theme, title = 'כל הכבוד!', correctCount: correctCountProp, total: totalProp }: Props) {
+export function QuizResultScreen({ onRestart, theme, title = 'כל הכבוד!', subtitle, correctCount: correctCountProp, total: totalProp }: Props) {
   const storeScore = useQuizGameStore(s => s.score);
   const storeTotal = useQuizGameStore(s => s.total);
   const correctCount = correctCountProp ?? storeScore;
@@ -31,7 +32,7 @@ export function QuizResultScreen({ onRestart, theme, title = 'כל הכבוד!',
         <div className="text-8xl mb-4">{emoji}</div>
         <h2 className={`text-2xl font-bold ${t.text} mb-2`}>{title}</h2>
         <p className="text-gray-600 mb-4">
-          ענית נכון על {correctCount} מתוך {total} שאלות
+          {subtitle ?? `ענית נכון על ${correctCount} מתוך ${total} שאלות`}
         </p>
         <div className={`text-5xl font-black ${t.text} mb-1`}>{score}</div>
         <p className="text-gray-400 text-sm mb-6">נקודות</p>

--- a/gamesformykids/components/game/quiz/games/holidays/components/HolidaysCompleteScreen.tsx
+++ b/gamesformykids/components/game/quiz/games/holidays/components/HolidaysCompleteScreen.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+import { QuizResultScreen } from '@/components/game/quiz';
+
 interface Props {
   score: number;
   maxScore: number;
@@ -7,22 +9,14 @@ interface Props {
 }
 
 export default function HolidaysCompleteScreen({ score, maxScore, onRestart }: Props) {
-  const pct = Math.round((score / maxScore) * 100);
   return (
-    <div className="min-h-screen bg-gradient-to-br from-blue-50 to-purple-100 p-4 flex items-center" dir="rtl">
-      <div className="max-w-md mx-auto w-full bg-white rounded-3xl shadow-xl p-8 text-center">
-        <div className="text-7xl mb-4 animate-bounce">🏆</div>
-        <h1 className="text-3xl font-bold text-gray-800 mb-2">כל הכבוד!</h1>
-        <p className="text-gray-500 mb-4">עברת על כל חגי ישראל!</p>
-        <div className="bg-indigo-50 rounded-2xl p-5 mb-6">
-          <p className="text-4xl font-bold text-indigo-700">{score} / {maxScore}</p>
-          <div className="mt-2 h-3 bg-indigo-100 rounded-full">
-            <div className="h-full bg-indigo-400 rounded-full" style={{ width: `${pct}%` }} />
-          </div>
-          <p className="text-indigo-500 text-sm mt-1">{pct}%</p>
-        </div>
-        <button onClick={onRestart} className="w-full py-4 rounded-2xl text-white font-bold text-xl bg-gradient-to-l from-indigo-500 to-purple-500 hover:opacity-90 active:scale-95 transition-all">🔄 שחק שוב</button>
-      </div>
-    </div>
+    <QuizResultScreen
+      correctCount={score}
+      total={maxScore}
+      title="כל הכבוד!"
+      subtitle="עברת על כל חגי ישראל!"
+      onRestart={onRestart}
+      theme="sky"
+    />
   );
 }


### PR DESCRIPTION
## Summary
- Added `subtitle?: string` prop to `QuizResultScreen` — overrides the default "ענית נכון על X מתוך Y שאלות" sentence when provided
- `HolidaysCompleteScreen` replaced with a thin wrapper using `<QuizResultScreen correctCount={score} total={maxScore} subtitle="עברת על כל חגי ישראל!" theme="sky" />`

## Test plan
- [ ] `npx tsc --noEmit` → 0 errors ✅
- [ ] ESLint clean ✅
- [ ] HolidaysCompleteScreen renders score + "עברת על כל חגי ישראל!" subtitle

Closes #510

🤖 Generated with [Claude Code](https://claude.com/claude-code)