### PR TITLE
refactor: extract QuizTopicMenuScreen for Science and Trivia menus

### DIFF
--- a/gamesformykids/components/game/quiz/QuizTopicMenuScreen.tsx
+++ b/gamesformykids/components/game/quiz/QuizTopicMenuScreen.tsx
@@ -1,0 +1,61 @@
+'use client';
+
+interface Props<T extends string> {
+  gradient: string;
+  titleColor: string;
+  subtitleColor: string;
+  emoji: string;
+  title: string;
+  description: string;
+  topics: readonly T[];
+  topicEmoji: (topic: T) => string;
+  topicClassName: string;
+  allLabel: string;
+  allButtonClassName: string;
+  onStart: (topic: T | 'all') => void;
+}
+
+export default function QuizTopicMenuScreen<T extends string>({
+  gradient,
+  titleColor,
+  subtitleColor,
+  emoji,
+  title,
+  description,
+  topics,
+  topicEmoji,
+  topicClassName,
+  allLabel,
+  allButtonClassName,
+  onStart,
+}: Props<T>) {
+  return (
+    <div className={`min-h-screen bg-gradient-to-br ${gradient} p-4`} dir="rtl">
+      <div className="max-w-xl mx-auto">
+        <div className="text-center mb-8">
+          <div className="text-6xl mb-3">{emoji}</div>
+          <h1 className={`text-3xl font-bold ${titleColor} mb-2`}>{title}</h1>
+          <p className={subtitleColor}>{description}</p>
+        </div>
+        <button
+          onClick={() => onStart('all')}
+          className={`w-full mb-5 p-5 rounded-2xl text-white font-bold text-xl shadow-lg hover:scale-105 active:scale-95 transition-all bg-gradient-to-l ${allButtonClassName}`}
+        >
+          {allLabel}
+        </button>
+        <div className="grid grid-cols-2 gap-3">
+          {topics.map(t => (
+            <button
+              key={t}
+              onClick={() => onStart(t)}
+              className={`p-4 rounded-2xl font-bold text-right shadow-md hover:scale-105 active:scale-95 transition-all ${topicClassName}`}
+            >
+              <div className="text-3xl mb-1">{topicEmoji(t)}</div>
+              <div>{t}</div>
+            </button>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/gamesformykids/components/game/quiz/screens/ScienceMenuScreen.tsx
+++ b/gamesformykids/components/game/quiz/screens/ScienceMenuScreen.tsx
@@ -1,4 +1,5 @@
 'use client';
+import QuizTopicMenuScreen from '@/components/game/quiz/QuizTopicMenuScreen';
 import { TOPICS, TOPIC_EMOJIS, type ScienceTopic } from '@/lib/quiz/data/science';
 
 interface Props {
@@ -7,29 +8,19 @@ interface Props {
 
 export default function ScienceMenuScreen({ onStart }: Props) {
   return (
-    <div className="min-h-screen bg-gradient-to-br from-cyan-50 to-indigo-100 p-4" dir="rtl">
-      <div className="max-w-xl mx-auto">
-        <div className="text-center mb-8">
-          <div className="text-6xl mb-3">🔬</div>
-          <h1 className="text-3xl font-bold text-indigo-800 mb-2">מדע לילדים</h1>
-          <p className="text-indigo-600">גלה סודות המדע!</p>
-        </div>
-        <button
-          onClick={() => onStart('all')}
-          className="w-full mb-5 p-5 rounded-2xl text-white font-bold text-xl shadow-lg hover:scale-105 active:scale-95 transition-all bg-gradient-to-l from-cyan-500 to-indigo-600"
-        >
-          🌟 כל הנושאים
-        </button>
-        <div className="grid grid-cols-2 gap-3">
-          {TOPICS.map(t => (
-            <button key={t} onClick={() => onStart(t)}
-              className="p-4 rounded-2xl font-bold text-right shadow-md hover:scale-105 active:scale-95 transition-all bg-white border-2 border-indigo-200 hover:border-indigo-400 text-indigo-800">
-              <div className="text-3xl mb-1">{TOPIC_EMOJIS[t]}</div>
-              <div>{t}</div>
-            </button>
-          ))}
-        </div>
-      </div>
-    </div>
+    <QuizTopicMenuScreen
+      gradient="from-cyan-50 to-indigo-100"
+      titleColor="text-indigo-800"
+      subtitleColor="text-indigo-600"
+      emoji="🔬"
+      title="מדע לילדים"
+      description="גלה סודות המדע!"
+      topics={TOPICS}
+      topicEmoji={t => TOPIC_EMOJIS[t]}
+      topicClassName="bg-white border-2 border-indigo-200 hover:border-indigo-400 text-indigo-800"
+      allLabel="🌟 כל הנושאים"
+      allButtonClassName="from-cyan-500 to-indigo-600"
+      onStart={onStart}
+    />
   );
 }

--- a/gamesformykids/components/game/quiz/screens/TriviaMenuScreen.tsx
+++ b/gamesformykids/components/game/quiz/screens/TriviaMenuScreen.tsx
@@ -1,4 +1,5 @@
 'use client';
+import QuizTopicMenuScreen from '@/components/game/quiz/QuizTopicMenuScreen';
 import type { TriviaCategory } from '@/lib/quiz/data/trivia';
 import { CATEGORIES, CATEGORY_EMOJIS } from '@/lib/quiz/data/trivia';
 
@@ -8,34 +9,19 @@ interface Props {
 
 export default function TriviaMenuScreen({ onStart }: Props) {
   return (
-    <div className="min-h-screen bg-gradient-to-br from-amber-50 to-yellow-100 p-4" dir="rtl">
-      <div className="max-w-xl mx-auto">
-        <div className="text-center mb-8">
-          <div className="text-6xl mb-3">🎯</div>
-          <h1 className="text-3xl font-bold text-amber-800 mb-2">ידע כללי</h1>
-          <p className="text-amber-600">בחר נושא או שחק הכל!</p>
-        </div>
-        <div className="flex flex-col gap-3 mb-4">
-          <button
-            onClick={() => onStart('all')}
-            className="w-full py-5 rounded-2xl text-white font-bold text-xl bg-gradient-to-l from-amber-500 to-yellow-500 shadow-lg hover:opacity-90 active:scale-95 transition-all"
-          >
-            🎯 שאלות מכל הנושאים!
-          </button>
-        </div>
-        <div className="grid grid-cols-2 gap-3">
-          {CATEGORIES.map(cat => (
-            <button
-              key={cat}
-              onClick={() => onStart(cat)}
-              className="p-4 rounded-2xl font-bold text-gray-700 shadow bg-white border-2 border-amber-200 hover:border-amber-400 hover:bg-amber-50 active:scale-95 transition-all text-right"
-            >
-              <div className="text-3xl mb-1">{CATEGORY_EMOJIS[cat]}</div>
-              <div>{cat}</div>
-            </button>
-          ))}
-        </div>
-      </div>
-    </div>
+    <QuizTopicMenuScreen
+      gradient="from-amber-50 to-yellow-100"
+      titleColor="text-amber-800"
+      subtitleColor="text-amber-600"
+      emoji="🎯"
+      title="ידע כללי"
+      description="בחר נושא או שחק הכל!"
+      topics={CATEGORIES}
+      topicEmoji={cat => CATEGORY_EMOJIS[cat]}
+      topicClassName="bg-white border-2 border-amber-200 hover:border-amber-400 hover:bg-amber-50 text-gray-700"
+      allLabel="🎯 שאלות מכל הנושאים!"
+      allButtonClassName="from-amber-500 to-yellow-500"
+      onStart={onStart}
+    />
   );
 }


### PR DESCRIPTION
## Summary
- New `components/game/quiz/QuizTopicMenuScreen.tsx` — generic component covering the shared skeleton: full-screen gradient → header (emoji + title + description) → "all" button → 2-col topic grid
- `ScienceMenuScreen` and `TriviaMenuScreen` each shrink to ~20 lines of data-passing

## Test plan
- [ ] `npx tsc --noEmit` → 0 errors ✅
- [ ] ESLint clean ✅
- [ ] Science menu renders correctly with indigo theme
- [ ] Trivia menu renders correctly with amber theme

Closes #511

🤖 Generated with [Claude Code](https://claude.com/claude-code)