### PR TITLE
fix: HolidaysQuizScreen isCorrect prop type boolean | null

### DIFF
--- a/gamesformykids/components/game/quiz/games/holidays/components/HolidaysQuizScreen.tsx
+++ b/gamesformykids/components/game/quiz/games/holidays/components/HolidaysQuizScreen.tsx
@@ -10,7 +10,7 @@ interface Props {
   totalQuestions: number;
   score: number;
   selected: number | null;
-  isCorrect: boolean;
+  isCorrect: boolean | null;
   onSelect: (i: number) => void;
   onNext: () => void;
 }


### PR DESCRIPTION
## Summary
- Changed `isCorrect: boolean` → `isCorrect: boolean | null` in `HolidaysQuizScreen` Props interface
- Matches the actual value from `useQuizQuestionState` (null before any answer is selected)

## Test plan
- [ ] `npx tsc --noEmit` → 0 errors ✅
- [ ] No runtime changes (types only)

Closes #520

🤖 Generated with [Claude Code](https://claude.com/claude-code)