### PR TITLE
refactor: QuizAnswerGrid uses answerButtonClass utility

### DIFF
--- a/gamesformykids/components/game/quiz/QuizAnswerGrid.tsx
+++ b/gamesformykids/components/game/quiz/QuizAnswerGrid.tsx
@@ -3,6 +3,7 @@
 import { type ReactNode } from 'react';
 import { useQuizGameStore } from '@/lib/stores/quizGameStore';
 import { QUIZ_THEMES, type QuizTheme } from './quizTheme';
+import { answerButtonClass } from '@/lib/quiz/answerButtonClass';
 
 interface Props {
   choices: string[];
@@ -29,28 +30,21 @@ export function QuizAnswerGrid({
 
   return (
     <div className={gridClass}>
-      {choices.map((choice) => {
-        let cls = 'p-4 rounded-2xl border-2 font-bold text-base transition-all text-center ';
-        if (selected === null) {
-          cls += `${t.answerIdle} cursor-pointer`;
-        } else if (choice === correctValue) {
-          cls += 'border-green-500 bg-green-100 text-green-800';
-        } else if (choice === selected) {
-          cls += 'border-red-400 bg-red-100 text-red-700';
-        } else {
-          cls += 'border-gray-200 bg-gray-50 text-gray-400';
-        }
-        return (
-          <button
-            key={choice}
-            onClick={() => onSelect(choice)}
-            disabled={selected !== null}
-            className={cls}
-          >
-            {renderChoice ? renderChoice(choice) : choice}
-          </button>
-        );
-      })}
+      {choices.map((choice) => (
+        <button
+          key={choice}
+          onClick={() => onSelect(choice)}
+          disabled={selected !== null}
+          className={`p-4 rounded-2xl border-2 font-bold text-base transition-all text-center ${answerButtonClass(
+            choice === correctValue,
+            choice === selected,
+            selected !== null,
+            `${t.answerIdle} cursor-pointer`,
+          )}`}
+        >
+          {renderChoice ? renderChoice(choice) : choice}
+        </button>
+      ))}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Replaced inline `if/else` answer-color logic in `QuizAnswerGrid` with `answerButtonClass(isRight, isSelected, answered, idleClass)` — the same utility used by `HolidaysQuizScreen`, `TransportQuestion`, and `QuizView`
- Removes 10 lines of duplicated color logic

## Test plan
- [ ] `npx tsc --noEmit` → 0 errors ✅
- [ ] ESLint clean ✅
- [ ] Answer buttons still show correct (green), wrong (red), and dismissed (gray) states

Closes #514

🤖 Generated with [Claude Code](https://claude.com/claude-code)