### PR TITLE
refactor: ClockResultScreen delegates to QuizResultScreen

### DIFF
--- a/gamesformykids/components/game/quiz/QuizResultScreen.tsx
+++ b/gamesformykids/components/game/quiz/QuizResultScreen.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { type ReactNode } from 'react';
 import { useQuizGameStore } from '@/lib/stores/quizGameStore';
 import { QUIZ_THEMES, type QuizTheme } from './quizTheme';
 
@@ -7,12 +8,14 @@ interface Props {
   onRestart: () => void;
   theme: QuizTheme;
   title?: string;
+  /** Replaces the default emoji header when provided */
+  headerContent?: ReactNode;
   /** Override store values for games that don't use quizGameStore */
   correctCount?: number;
   total?: number;
 }
 
-export function QuizResultScreen({ onRestart, theme, title = 'כל הכבוד!', correctCount: correctCountProp, total: totalProp }: Props) {
+export function QuizResultScreen({ onRestart, theme, title = 'כל הכבוד!', headerContent, correctCount: correctCountProp, total: totalProp }: Props) {
   const storeScore = useQuizGameStore(s => s.score);
   const storeTotal = useQuizGameStore(s => s.total);
   const correctCount = correctCountProp ?? storeScore;
@@ -28,7 +31,7 @@ export function QuizResultScreen({ onRestart, theme, title = 'כל הכבוד!',
       dir="rtl"
     >
       <div className="bg-white rounded-3xl shadow-2xl p-8 max-w-md w-full text-center">
-        <div className="text-8xl mb-4">{emoji}</div>
+        {headerContent ?? <div className="text-8xl mb-4">{emoji}</div>}
         <h2 className={`text-2xl font-bold ${t.text} mb-2`}>{title}</h2>
         <p className="text-gray-600 mb-4">
           ענית נכון על {correctCount} מתוך {total} שאלות

--- a/gamesformykids/components/game/quiz/screens/ClockResultScreen.tsx
+++ b/gamesformykids/components/game/quiz/screens/ClockResultScreen.tsx
@@ -1,26 +1,17 @@
 'use client';
-import { useQuizGameStore } from '@/lib/stores/quizGameStore';
 import ClockFace from './ClockFace';
+import { QuizResultScreen } from '@/components/game/quiz';
 
 export default function ClockResultScreen({ onRestart }: { onRestart: () => void }) {
-  const correct = useQuizGameStore(s => s.score);
-  const total   = useQuizGameStore(s => s.total);
-  const pct = total > 0 ? Math.round((correct / total) * 100) : 0;
-
   return (
-    <div className="min-h-screen bg-gradient-to-br from-violet-50 to-indigo-100 p-4 flex items-center" dir="rtl">
-      <div className="max-w-md mx-auto w-full bg-white rounded-3xl shadow-xl p-8 text-center">
-        <div className="flex justify-center mb-3"><ClockFace hour={12} minute={0} size={100} /></div>
-        <h1 className="text-2xl font-bold mb-4">{pct >= 80 ? '🏆 כל הכבוד!' : '💪 תמשיך להתאמן!'}</h1>
-        <div className="bg-indigo-50 rounded-2xl p-5 mb-6">
-          <p className="text-4xl font-black text-indigo-700">{correct} / {total}</p>
-          <div className="mt-2 h-3 bg-indigo-100 rounded-full">
-            <div className="h-full bg-indigo-400 rounded-full" style={{ width: `${pct}%` }} />
-          </div>
-          <p className="text-indigo-500 text-sm mt-1">{pct}%</p>
+    <QuizResultScreen
+      headerContent={
+        <div className="flex justify-center mb-3">
+          <ClockFace hour={12} minute={0} size={100} />
         </div>
-        <button onClick={onRestart} className="w-full py-4 rounded-2xl text-white font-bold bg-gradient-to-l from-violet-500 to-indigo-600 hover:opacity-90 active:scale-95 transition-all">🔄 שוב</button>
-      </div>
-    </div>
+      }
+      theme="violet"
+      onRestart={onRestart}
+    />
   );
 }


### PR DESCRIPTION
## Summary
- Added `headerContent?: ReactNode` to `QuizResultScreen` — when provided, replaces the default score-emoji header
- `ClockResultScreen` uses it to pass `<ClockFace hour={12} minute={0} size={100} />` and becomes a ~12-line thin wrapper, removing its own score/progress-bar/restart implementation

## Test plan
- [ ] `npx tsc --noEmit` → 0 errors ✅
- [ ] ESLint clean ✅
- [ ] Clock result screen shows ClockFace, score, and restart button

Closes #516

🤖 Generated with [Claude Code](https://claude.com/claude-code)