### PR TITLE
refactor: extract GameModeMenuScreen for Geography and Sequences menus

### DIFF
--- a/gamesformykids/components/game/quiz/GameModeMenuScreen.tsx
+++ b/gamesformykids/components/game/quiz/GameModeMenuScreen.tsx
@@ -1,0 +1,76 @@
+'use client';
+
+interface ModeItem {
+  emoji: string;
+  label: string;
+  desc: string;
+}
+
+interface Props<T extends ModeItem> {
+  gradient: string;
+  titleColor: string;
+  subtitleColor: string;
+  emoji: string;
+  title: string;
+  description: string;
+  items: readonly T[];
+  buttonClassName: string;
+  layout?: 'flex' | 'grid-2';
+  /** When true, renders emoji as a large side icon; otherwise inline with label */
+  sideIcon?: boolean;
+  onStart: (item: T) => void;
+}
+
+export default function GameModeMenuScreen<T extends ModeItem>({
+  gradient,
+  titleColor,
+  subtitleColor,
+  emoji,
+  title,
+  description,
+  items,
+  buttonClassName,
+  layout = 'flex',
+  sideIcon = false,
+  onStart,
+}: Props<T>) {
+  const listClass = layout === 'grid-2'
+    ? 'grid grid-cols-2 gap-4'
+    : 'flex flex-col gap-4';
+
+  return (
+    <div className={`min-h-screen bg-gradient-to-br ${gradient} p-4`} dir="rtl">
+      <div className="max-w-xl mx-auto">
+        <div className="text-center mb-8">
+          <div className="text-6xl mb-3">{emoji}</div>
+          <h1 className={`text-3xl font-bold ${titleColor} mb-2`}>{title}</h1>
+          <p className={subtitleColor}>{description}</p>
+        </div>
+        <div className={listClass}>
+          {items.map((item, i) => (
+            <button
+              key={i}
+              onClick={() => onStart(item)}
+              className={`p-5 rounded-2xl text-white shadow-lg hover:scale-105 active:scale-95 transition-all text-right ${sideIcon ? 'flex items-center gap-4' : ''} ${buttonClassName}`}
+            >
+              {sideIcon ? (
+                <>
+                  <span className="text-4xl">{item.emoji}</span>
+                  <div>
+                    <div className="text-xl font-bold">{item.label}</div>
+                    <div className="text-sm opacity-80">{item.desc}</div>
+                  </div>
+                </>
+              ) : (
+                <>
+                  <div className="text-2xl font-black mb-1">{item.emoji} {item.label}</div>
+                  <div className="text-sm opacity-80">{item.desc}</div>
+                </>
+              )}
+            </button>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/gamesformykids/components/game/quiz/screens/GeographyMenuScreen.tsx
+++ b/gamesformykids/components/game/quiz/screens/GeographyMenuScreen.tsx
@@ -1,30 +1,23 @@
 'use client';
+import GameModeMenuScreen from '@/components/game/quiz/GameModeMenuScreen';
 import { type QuestionMode, MODES } from '@/lib/quiz/data/geography';
 
 interface Props { onStart: (mode: QuestionMode) => void; }
 
 export default function GeographyMenuScreen({ onStart }: Props) {
   return (
-    <div className="min-h-screen bg-gradient-to-br from-teal-50 to-cyan-100 p-4" dir="rtl">
-      <div className="max-w-xl mx-auto">
-        <div className="text-center mb-8">
-          <div className="text-6xl mb-3">🌍</div>
-          <h1 className="text-3xl font-bold text-teal-800 mb-2">גאוגרפיה</h1>
-          <p className="text-teal-600">בחר סוג שאלות</p>
-        </div>
-        <div className="flex flex-col gap-4">
-          {MODES.map(m => (
-            <button key={m.mode} onClick={() => onStart(m.mode)}
-              className="p-5 rounded-2xl text-white shadow-lg hover:scale-105 active:scale-95 transition-all bg-gradient-to-l from-teal-500 to-cyan-600 text-right flex items-center gap-4">
-              <span className="text-4xl">{m.emoji}</span>
-              <div>
-                <div className="text-xl font-bold">{m.label}</div>
-                <div className="text-sm opacity-80">{m.desc}</div>
-              </div>
-            </button>
-          ))}
-        </div>
-      </div>
-    </div>
+    <GameModeMenuScreen
+      gradient="from-teal-50 to-cyan-100"
+      titleColor="text-teal-800"
+      subtitleColor="text-teal-600"
+      emoji="🌍"
+      title="גאוגרפיה"
+      description="בחר סוג שאלות"
+      items={MODES}
+      buttonClassName="bg-gradient-to-l from-teal-500 to-cyan-600"
+      layout="flex"
+      sideIcon
+      onStart={item => onStart(item.mode)}
+    />
   );
 }

--- a/gamesformykids/components/game/quiz/screens/SequencesMenuScreen.tsx
+++ b/gamesformykids/components/game/quiz/screens/SequencesMenuScreen.tsx
@@ -1,4 +1,5 @@
 'use client';
+import GameModeMenuScreen from '@/components/game/quiz/GameModeMenuScreen';
 import type { SequenceLevel } from '@/lib/quiz/data/sequences';
 
 interface Props {
@@ -8,23 +9,17 @@ interface Props {
 
 export default function SequencesMenuScreen({ levels, onStart }: Props) {
   return (
-    <div className="min-h-screen bg-gradient-to-br from-sky-50 to-cyan-100 p-6" dir="rtl">
-      <div className="max-w-lg mx-auto">
-        <div className="text-center mb-8">
-          <div className="text-6xl mb-3">🔢</div>
-          <h1 className="text-3xl font-bold text-cyan-800 mb-2">סדרות מספרים</h1>
-          <p className="text-cyan-600">מה המספר הבא בסדרה?</p>
-        </div>
-        <div className="grid grid-cols-2 gap-4">
-          {levels.map(lv => (
-            <button key={lv.id} onClick={() => onStart(lv)}
-              className="p-5 rounded-2xl text-white font-bold shadow-lg hover:scale-105 active:scale-95 transition-all bg-gradient-to-br from-cyan-500 to-sky-600 text-right">
-              <div className="text-2xl font-black mb-1">{lv.emoji} {lv.label}</div>
-              <div className="text-sm opacity-80">{lv.desc}</div>
-            </button>
-          ))}
-        </div>
-      </div>
-    </div>
+    <GameModeMenuScreen
+      gradient="from-sky-50 to-cyan-100"
+      titleColor="text-cyan-800"
+      subtitleColor="text-cyan-600"
+      emoji="🔢"
+      title="סדרות מספרים"
+      description="מה המספר הבא בסדרה?"
+      items={levels}
+      buttonClassName="bg-gradient-to-br from-cyan-500 to-sky-600 font-bold"
+      layout="grid-2"
+      onStart={onStart}
+    />
   );
 }


### PR DESCRIPTION
## Summary
- New `components/game/quiz/GameModeMenuScreen.tsx` — generic component with `layout` (`flex` | `grid-2`) and `sideIcon` props
- `GeographyMenuScreen` and `SequencesMenuScreen` each shrink to ~15 lines of prop-passing
- `sideIcon` prop preserves Geography's large-emoji side-icon button layout

## Test plan
- [ ] `npx tsc --noEmit` → 0 errors ✅
- [ ] ESLint clean ✅
- [ ] Geography menu renders with large side emoji + flex layout
- [ ] Sequences menu renders with 2-col grid layout

Closes #515

🤖 Generated with [Claude Code](https://claude.com/claude-code)