### PR TITLE
refactor: extract QuizQuestionCard for HolidaysQuizScreen and QuizView

### DIFF
--- a/gamesformykids/components/game/quiz/QuizQuestionCard.tsx
+++ b/gamesformykids/components/game/quiz/QuizQuestionCard.tsx
@@ -1,0 +1,75 @@
+'use client';
+
+import { answerButtonClass } from '@/lib/quiz/answerButtonClass';
+
+interface Props {
+  question: string;
+  answers: string[];
+  correctIndex: number;
+  selected: number | null;
+  isCorrect: boolean | null;
+  onSelect: (idx: number) => void;
+  onNext: () => void;
+  isLast: boolean;
+  accentGradient: string;
+  correctMessage?: string;
+  idleButtonClass?: string;
+}
+
+export default function QuizQuestionCard({
+  question,
+  answers,
+  correctIndex,
+  selected,
+  isCorrect,
+  onSelect,
+  onNext,
+  isLast,
+  accentGradient,
+  correctMessage = '🌟 כל הכבוד! תשובה נכונה!',
+  idleButtonClass = 'bg-white border-2 border-gray-200 text-gray-700 hover:border-blue-400 hover:bg-blue-50',
+}: Props) {
+  const answered = selected !== null;
+
+  return (
+    <>
+      <div className="bg-white rounded-2xl shadow p-5 mb-4 text-center">
+        <p className="text-xl font-bold text-gray-800 leading-relaxed">{question}</p>
+      </div>
+
+      <div className="space-y-3 mb-4">
+        {answers.map((answer, idx) => (
+          <button
+            key={idx}
+            onClick={() => onSelect(idx)}
+            disabled={answered}
+            className={`w-full text-right py-4 px-5 rounded-2xl font-semibold text-lg transition-all duration-200 active:scale-95 ${answerButtonClass(
+              idx === correctIndex,
+              idx === selected,
+              answered,
+              idleButtonClass,
+            )}`}
+          >
+            {answered && idx === correctIndex ? '✅ ' : answered && idx === selected && !isCorrect ? '❌ ' : ''}
+            {answer}
+          </button>
+        ))}
+      </div>
+
+      {answered && (
+        <div className={`rounded-2xl p-4 mb-5 text-center font-bold text-lg ${isCorrect ? 'bg-green-100 text-green-700' : 'bg-orange-100 text-orange-700'}`}>
+          {isCorrect ? correctMessage : `💙 התשובה הנכונה: "${answers[correctIndex]}"`}
+        </div>
+      )}
+
+      {answered && (
+        <button
+          onClick={onNext}
+          className={`w-full py-4 rounded-2xl text-white font-bold text-xl shadow-lg bg-gradient-to-l ${accentGradient} hover:opacity-90 active:scale-95 transition-all duration-200`}
+        >
+          {isLast ? 'לתוצאות! 🎉' : 'שאלה הבאה ←'}
+        </button>
+      )}
+    </>
+  );
+}

--- a/gamesformykids/components/game/quiz/games/holidays/components/HolidaysQuizScreen.tsx
+++ b/gamesformykids/components/game/quiz/games/holidays/components/HolidaysQuizScreen.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import type { Holiday, HolidayQuestion } from '../data/holidays';
-import { answerButtonClass } from '@/lib/quiz/answerButtonClass';
+import QuizQuestionCard from '@/components/game/quiz/QuizQuestionCard';
 
 interface Props {
   current: Holiday;
@@ -10,7 +10,7 @@ interface Props {
   totalQuestions: number;
   score: number;
   selected: number | null;
-  isCorrect: boolean;
+  isCorrect: boolean | null;
   onSelect: (i: number) => void;
   onNext: () => void;
 }
@@ -32,33 +32,19 @@ export default function HolidaysQuizScreen({ current, currentQuestion, questionI
           <div className={`h-full rounded-full bg-gradient-to-l ${current.color} transition-all`}
             style={{ width: `${(questionIndex / totalQuestions) * 100}%` }} />
         </div>
-        <div className="bg-white rounded-2xl shadow p-5 mb-4 text-center">
-          <p className="text-xl font-bold text-gray-800">{currentQuestion.question}</p>
-        </div>
-        <div className="space-y-3 mb-4">
-          {currentQuestion.answers.map((ans, i) => (
-            <button key={i} onClick={() => onSelect(i)} disabled={selected !== null}
-              className={`w-full text-right py-4 px-5 rounded-2xl font-semibold text-lg transition-all active:scale-95 ${answerButtonClass(
-                i === currentQuestion.correctIndex,
-                i === selected,
-                selected !== null,
-                'bg-white border-2 border-gray-200 text-gray-700 hover:border-indigo-400',
-              )}`}>
-              {selected !== null && i === currentQuestion.correctIndex ? '✅ ' : selected === i && !isCorrect ? '❌ ' : ''}{ans}
-            </button>
-          ))}
-        </div>
-        {selected !== null && (
-          <>
-            <div className={`rounded-2xl p-3 mb-4 text-center font-bold ${isCorrect ? 'bg-green-100 text-green-700' : 'bg-orange-100 text-orange-700'}`}>
-              {isCorrect ? '🌟 נכון מאוד!' : `💙 התשובה הנכונה: "${currentQuestion.answers[currentQuestion.correctIndex]}"`}
-            </div>
-            <button onClick={onNext}
-              className={`w-full py-4 rounded-2xl text-white font-bold text-xl bg-gradient-to-l ${current.color} shadow-lg hover:opacity-90 active:scale-95 transition-all`}>
-              {questionIndex < totalQuestions - 1 ? 'שאלה הבאה ←' : 'לתוצאות! 🎉'}
-            </button>
-          </>
-        )}
+        <QuizQuestionCard
+          question={currentQuestion.question}
+          answers={currentQuestion.answers}
+          correctIndex={currentQuestion.correctIndex}
+          selected={selected}
+          isCorrect={isCorrect}
+          onSelect={onSelect}
+          onNext={onNext}
+          isLast={questionIndex >= totalQuestions - 1}
+          accentGradient={current.color}
+          correctMessage="🌟 נכון מאוד!"
+          idleButtonClass="bg-white border-2 border-gray-200 text-gray-700 hover:border-indigo-400"
+        />
       </div>
     </div>
   );

--- a/gamesformykids/components/game/quiz/games/tzadikim/components/QuizView.tsx
+++ b/gamesformykids/components/game/quiz/games/tzadikim/components/QuizView.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { TzaddikStory, QuizQuestion } from '../data/tzadikim';
-import { answerButtonClass } from '@/lib/quiz/answerButtonClass';
+import QuizQuestionCard from '@/components/game/quiz/QuizQuestionCard';
 
 interface QuizViewProps {
   story: TzaddikStory;
@@ -26,81 +26,34 @@ export default function QuizView({
   onSelectAnswer,
   onNext,
 }: QuizViewProps) {
-  const answered = selected !== null;
-
   return (
     <div className={`min-h-screen bg-gradient-to-br ${story.bgGradient} p-4`} dir="rtl">
       <div className="max-w-2xl mx-auto">
-
-        {/* כותרת חידון */}
         <div className="text-center mb-6">
           <div className="text-4xl mb-2">{story.emoji}</div>
           <h2 className="text-xl font-bold text-gray-700">{story.name}</h2>
           <p className="text-gray-500 text-sm">שאלה {questionIndex + 1} מתוך {totalQuestions}</p>
-
-          {/* פס התקדמות */}
           <div className="mt-3 h-2.5 bg-gray-200 rounded-full overflow-hidden">
             <div
               className={`h-full rounded-full bg-gradient-to-l ${story.color} transition-all duration-500`}
-              style={{ width: `${((questionIndex) / totalQuestions) * 100}%` }}
+              style={{ width: `${(questionIndex / totalQuestions) * 100}%` }}
             />
           </div>
         </div>
 
-        {/* כרטיס השאלה */}
-        <div className="bg-white rounded-3xl shadow-lg p-6 mb-5">
-          <p className="text-xl font-bold text-gray-800 leading-relaxed text-center">
-            {question.question}
-          </p>
-        </div>
+        <QuizQuestionCard
+          question={question.question}
+          answers={question.answers}
+          correctIndex={question.correctIndex}
+          selected={selected}
+          isCorrect={isCorrect}
+          onSelect={onSelectAnswer}
+          onNext={onNext}
+          isLast={questionIndex >= totalQuestions - 1}
+          accentGradient={story.color}
+          idleButtonClass="bg-white border-2 border-gray-200 text-gray-700 hover:border-amber-400 hover:bg-amber-50"
+        />
 
-        {/* תשובות */}
-        <div className="space-y-3 mb-5">
-          {question.answers.map((answer, index) => (
-            <button
-              key={index}
-              onClick={() => onSelectAnswer(index)}
-              disabled={answered}
-              className={`w-full text-right py-4 px-5 rounded-2xl font-semibold text-lg transition-all duration-200 active:scale-95 ${answerButtonClass(
-                index === question.correctIndex,
-                index === selected,
-                answered,
-                'bg-white border-2 border-gray-200 text-gray-700 hover:border-amber-400 hover:bg-amber-50',
-              )}`}
-            >
-              {answered && index === question.correctIndex ? '✅ ' : answered && index === selected && !isCorrect ? '❌ ' : ''}{answer}
-            </button>
-          ))}
-        </div>
-
-        {/* פידבק */}
-        {answered && (
-          <div className={`
-            rounded-2xl p-4 mb-5 text-center font-bold text-lg
-            ${isCorrect ? 'bg-green-100 text-green-700' : 'bg-orange-100 text-orange-700'}
-          `}>
-            {isCorrect
-              ? '🌟 כל הכבוד! תשובה נכונה!'
-              : `💙 התשובה הנכונה: "${question.answers[question.correctIndex]}"`
-            }
-          </div>
-        )}
-
-        {/* כפתור הבא */}
-        {answered && (
-          <button
-            onClick={onNext}
-            className={`
-              w-full py-4 rounded-2xl text-white font-bold text-xl shadow-lg
-              bg-gradient-to-l ${story.color}
-              hover:opacity-90 active:scale-95 transition-all duration-200
-            `}
-          >
-            {questionIndex < totalQuestions - 1 ? 'שאלה הבאה ←' : 'לתוצאות! 🎉'}
-          </button>
-        )}
-
-        {/* ניקוד שוטף */}
         <div className="text-center mt-4 text-gray-500 text-sm">
           ⭐ {score} נקודות עד כה
         </div>


### PR DESCRIPTION
## Summary
- New `components/game/quiz/QuizQuestionCard.tsx` — handles question text card, vertical answer buttons (via `answerButtonClass`), correct/wrong feedback, and next/finish button
- `HolidaysQuizScreen` and `QuizView` (Tzadikim) delegate to it; each retains only its own header/chrome and progress bar
- `HolidaysQuizScreen` also gets the `isCorrect: boolean | null` type fix (was `boolean`)
- `TransportQuestion` (which uses a 2x2 grid and reads from `transportStore`) is left for a follow-up issue

## Test plan
- [ ] `npx tsc --noEmit` → 0 errors ✅
- [ ] ESLint clean ✅
- [ ] Holidays quiz: answers, feedback, and next button render correctly
- [ ] Tzadikim quiz: same as above

Closes #517

🤖 Generated with [Claude Code](https://claude.com/claude-code)