### PR TITLE
refactor: extract createPhaseGameHook factory (#531)

### DIFF
--- a/gamesformykids/app/games/balloon-pop/useBalloonPopGame.ts
+++ b/gamesformykids/app/games/balloon-pop/useBalloonPopGame.ts
@@ -1,13 +1,10 @@
 'use client';
-import { useShallow } from 'zustand/react/shallow';
 import { useBalloonPopStore } from './balloonPopStore';
-import { useGameCompletion, usePhaseGameCompletion } from '@/hooks/shared/progress';
+import { createPhaseGameHook } from '@/hooks/shared/progress';
 
-export function useBalloonPopGame() {
-  const state = useBalloonPopStore(useShallow((s) => s));
-  const { saveGameResultRef } = useGameCompletion('balloon-pop');
-
-  usePhaseGameCompletion(state.phase, saveGameResultRef, () => ({ score: state.score, level: 1 }), ['result']);
-
-  return state;
-}
+export const useBalloonPopGame = createPhaseGameHook(
+  useBalloonPopStore,
+  'balloon-pop',
+  (s) => ({ score: s.score, level: 1 }),
+  ['result'],
+);

--- a/gamesformykids/app/games/color-tap/useColorTapGame.ts
+++ b/gamesformykids/app/games/color-tap/useColorTapGame.ts
@@ -1,16 +1,12 @@
 'use client';
-import { useShallow } from 'zustand/react/shallow';
 import { useColorTapStore } from './colorTapStore';
-import { useGameCompletion, usePhaseGameCompletion } from '@/hooks/shared/progress';
+import { createPhaseGameHook } from '@/hooks/shared/progress';
 
 export type { ColorItem, Question } from './colorTapStore';
 export { COLORS, TIME_PER_Q } from './colorTapStore';
 
-export function useColorTapGame() {
-  const state = useColorTapStore(useShallow((s) => s));
-  const { saveGameResultRef } = useGameCompletion('color-tap');
-
-  usePhaseGameCompletion(state.phase, saveGameResultRef, () => ({ score: state.score, level: 1 }));
-
-  return state;
-}
+export const useColorTapGame = createPhaseGameHook(
+  useColorTapStore,
+  'color-tap',
+  (s) => ({ score: s.score, level: 1 }),
+);

--- a/gamesformykids/app/games/emoji-math/useEmojiMathGame.ts
+++ b/gamesformykids/app/games/emoji-math/useEmojiMathGame.ts
@@ -1,16 +1,12 @@
 'use client';
-import { useShallow } from 'zustand/react/shallow';
 import { useEmojiMathStore } from './emojiMathStore';
-import { useGameCompletion, usePhaseGameCompletion } from '@/hooks/shared/progress';
+import { createPhaseGameHook } from '@/hooks/shared/progress';
 
 export type { Op, Question } from './emojiMathStore';
 export { makeQuestion, TIME_PER_Q } from './emojiMathStore';
 
-export function useEmojiMathGame() {
-  const state = useEmojiMathStore(useShallow((s) => s));
-  const { saveGameResultRef } = useGameCompletion('emoji-math');
-
-  usePhaseGameCompletion(state.phase, saveGameResultRef, () => ({ score: state.score, level: state.level }));
-
-  return state;
-}
+export const useEmojiMathGame = createPhaseGameHook(
+  useEmojiMathStore,
+  'emoji-math',
+  (s) => ({ score: s.score, level: s.level }),
+);

--- a/gamesformykids/app/games/word-scramble/useWordScrambleGame.ts
+++ b/gamesformykids/app/games/word-scramble/useWordScrambleGame.ts
@@ -1,16 +1,13 @@
 'use client';
-import { useShallow } from 'zustand/react/shallow';
 import { useWordScrambleStore } from './wordScrambleStore';
-import { useGameCompletion, usePhaseGameCompletion } from '@/hooks/shared/progress';
+import { createPhaseGameHook } from '@/hooks/shared/progress';
 
 export type { WordEntry, LetterSlot, PickedLetter } from './wordScrambleStore';
 export { WORD_LIST } from './wordScrambleStore';
 
-export function useWordScrambleGame() {
-  const state = useWordScrambleStore(useShallow((s) => s));
-  const { saveGameResultRef } = useGameCompletion('word-scramble');
-
-  usePhaseGameCompletion(state.phase, saveGameResultRef, () => ({ score: state.score, level: 1 }), ['results']);
-
-  return state;
-}
+export const useWordScrambleGame = createPhaseGameHook(
+  useWordScrambleStore,
+  'word-scramble',
+  (s) => ({ score: s.score, level: 1 }),
+  ['results'],
+);

--- a/gamesformykids/hooks/shared/progress/createPhaseGameHook.ts
+++ b/gamesformykids/hooks/shared/progress/createPhaseGameHook.ts
@@ -1,0 +1,26 @@
+'use client';
+
+import type { StoreApi, UseBoundStore } from 'zustand';
+import { useShallow } from 'zustand/react/shallow';
+import type { GameType } from '@/lib/types';
+import { useGameCompletion, type GameResult } from './useGameCompletion';
+import { usePhaseGameCompletion } from './usePhaseGameCompletion';
+
+/**
+ * Factory for game hooks that use phase-based completion tracking.
+ * Eliminates the repeated useShallow + useGameCompletion + usePhaseGameCompletion
+ * boilerplate found in balloon-pop, color-tap, emoji-math, and word-scramble.
+ */
+export function createPhaseGameHook<S extends { phase: string; score: number }>(
+  store: UseBoundStore<StoreApi<S>>,
+  gameId: GameType,
+  getPayload: (state: S) => Omit<GameResult, 'durationSeconds'>,
+  completionPhases?: string[],
+): () => S {
+  return function useGameHook() {
+    const state = store(useShallow((s) => s));
+    const { saveGameResultRef } = useGameCompletion(gameId);
+    usePhaseGameCompletion(state.phase, saveGameResultRef, () => getPayload(state), completionPhases);
+    return state;
+  };
+}

--- a/gamesformykids/hooks/shared/progress/index.ts
+++ b/gamesformykids/hooks/shared/progress/index.ts
@@ -4,3 +4,4 @@ export { useAchievements } from './useAchievements';
 export { useGameCompletion } from './useGameCompletion';
 export type { GameResult } from './useGameCompletion';
 export { usePhaseGameCompletion } from './usePhaseGameCompletion';
+export { createPhaseGameHook } from './createPhaseGameHook';


### PR DESCRIPTION
## Summary
- Creates `hooks/shared/progress/createPhaseGameHook.ts` factory
- Exports it from `hooks/shared/progress/index.ts`
- Migrates `useBalloonPopGame`, `useColorTapGame`, `useEmojiMathGame`, `useWordScrambleGame` to use the factory
- Each hook shrinks from 13 lines to 6 lines of config

## Test plan
- [ ] `npx tsc --noEmit` — passes
- [ ] `npx eslint [changed files] --max-warnings=0` — clean
- [ ] No runtime changes — same behavior

Closes #531

🤖 Generated with [Claude Code](https://claude.com/claude-code)