### PR TITLE
refactor: migrate 4 start screens to GameMenuCard

### DIFF
--- a/gamesformykids/app/games/bubbles/components/BubbleStartScreen.tsx
+++ b/gamesformykids/app/games/bubbles/components/BubbleStartScreen.tsx
@@ -1,4 +1,5 @@
-"use client";
+'use client';
+import GameMenuCard from '@/components/game/shared/GameMenuCard';
 
 interface BubbleStartScreenProps {
   startGame: () => void;
@@ -6,20 +7,14 @@ interface BubbleStartScreenProps {
 
 export default function BubbleStartScreen({ startGame }: BubbleStartScreenProps) {
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-sky-200 via-blue-200 to-cyan-200">
-      <div className="text-center p-8 bg-white/80 rounded-3xl shadow-xl max-w-md mx-4">
-        <div className="text-6xl mb-4">🫧</div>
-        <h1 className="text-3xl font-bold text-purple-800 mb-4">משחק הבועות</h1>
-        <p className="text-lg text-purple-600 mb-6">
-          לחצו על הבועות כשהן מופיעות על המסך!
-        </p>
-        <button
-          onClick={startGame}
-          className="bg-gradient-to-r from-purple-500 to-pink-500 hover:from-purple-600 hover:to-pink-600 text-white font-bold py-3 px-8 rounded-full text-xl transition-all duration-300 transform hover:scale-105 shadow-lg"
-        >
-          🚀 התחל משחק
-        </button>
-      </div>
-    </div>
+    <GameMenuCard
+      emoji="🫧"
+      title="משחק הבועות"
+      description="לחצו על הבועות כשהן מופיעות על המסך!"
+      gradientClass="from-sky-200 via-blue-200 to-cyan-200"
+      buttonClass="from-purple-500 to-pink-500"
+      startLabel="🚀 התחל משחק"
+      onStart={startGame}
+    />
   );
 }

--- a/gamesformykids/app/games/building/BuildingStartScreen.tsx
+++ b/gamesformykids/app/games/building/BuildingStartScreen.tsx
@@ -1,48 +1,41 @@
-"use client";
-
+'use client';
 import { useBuildingStore } from '@/app/games/building/store/buildingStore';
+import GameMenuCard from '@/components/game/shared/GameMenuCard';
 
 export default function BuildingStartScreen() {
   const startGame = useBuildingStore((s) => s.startGame);
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-purple-600 via-pink-500 to-blue-600">
-      <div className="text-center p-8 bg-white/90 rounded-3xl shadow-xl max-w-lg mx-4">
-        <div className="text-6xl mb-4">🏗️</div>
-        <h1 className="text-3xl font-bold text-purple-800 mb-4">משחק הבנייה</h1>
-        <p className="text-lg text-purple-600 mb-6">
-          בנו עולמות מדהימים עם צורות, צבעים ויצירתיות!
-        </p>
-        
-        <div className="mb-6">
-          <h3 className="text-lg font-semibold text-purple-700 mb-3">מה תוכלו לבנות:</h3>
-          <div className="grid grid-cols-2 gap-4 text-sm">
-            <div className="bg-purple-100 p-3 rounded-lg">
-              <div className="text-2xl mb-1">🟦</div>
-              <div>צורות גיאומטריות</div>
-            </div>
-            <div className="bg-pink-100 p-3 rounded-lg">
-              <div className="text-2xl mb-1">🎨</div>
-              <div>בחירת צבעים</div>
-            </div>
-            <div className="bg-blue-100 p-3 rounded-lg">
-              <div className="text-2xl mb-1">✨</div>
-              <div>אפקטים מיוחדים</div>
-            </div>
-            <div className="bg-green-100 p-3 rounded-lg">
-              <div className="text-2xl mb-1">🏰</div>
-              <div>מבנים מורכבים</div>
-            </div>
+    <GameMenuCard
+      emoji="🏗️"
+      title="משחק הבנייה"
+      description="בנו עולמות מדהימים עם צורות, צבעים ויצירתיות!"
+      gradientClass="from-purple-600 via-pink-500 to-blue-600"
+      buttonClass="from-purple-500 to-pink-500"
+      startLabel="🚀 בואו נבנה!"
+      onStart={startGame}
+    >
+      <div>
+        <h3 className="text-lg font-semibold text-purple-700 mb-3">מה תוכלו לבנות:</h3>
+        <div className="grid grid-cols-2 gap-4 text-sm">
+          <div className="bg-purple-100 p-3 rounded-lg">
+            <div className="text-2xl mb-1">🟦</div>
+            <div>צורות גיאומטריות</div>
+          </div>
+          <div className="bg-pink-100 p-3 rounded-lg">
+            <div className="text-2xl mb-1">🎨</div>
+            <div>בחירת צבעים</div>
+          </div>
+          <div className="bg-blue-100 p-3 rounded-lg">
+            <div className="text-2xl mb-1">✨</div>
+            <div>אפקטים מיוחדים</div>
+          </div>
+          <div className="bg-green-100 p-3 rounded-lg">
+            <div className="text-2xl mb-1">🏰</div>
+            <div>מבנים מורכבים</div>
           </div>
         </div>
-        
-        <button
-          onClick={startGame}
-          className="bg-gradient-to-r from-purple-500 to-pink-500 hover:from-purple-600 hover:to-pink-600 text-white font-bold py-4 px-8 rounded-full text-xl transition-all duration-300 transform hover:scale-105 shadow-lg w-full"
-        >
-          🚀 בואו נבנה!
-        </button>
       </div>
-    </div>
+    </GameMenuCard>
   );
 }

--- a/gamesformykids/app/games/drawing/components/DrawingStartScreen.tsx
+++ b/gamesformykids/app/games/drawing/components/DrawingStartScreen.tsx
@@ -1,50 +1,41 @@
-"use client";
-
-import styles from '../drawing.module.css';
+'use client';
+import GameMenuCard from '@/components/game/shared/GameMenuCard';
 import { useDrawingGame } from '../hooks/useDrawingGame';
 
 export default function DrawingStartScreen() {
   const { startGame } = useDrawingGame();
+
   return (
-    <div className={`min-h-screen bg-gradient-to-br from-purple-400 via-pink-400 to-orange-400 flex items-center justify-center ${styles.drawingContainer}`}>
-        <div className="bg-white rounded-3xl shadow-2xl p-8 max-w-lg w-full mx-4 text-center">
-        <div className="text-8xl mb-6 animate-bounce">🎨</div>
-        <h1 className="text-4xl font-bold text-gray-800 mb-4">
-          משחק ציורים
-        </h1>
-        <p className="text-gray-600 mb-6 text-lg leading-relaxed">
-          בואו ניצור יצירות אמנות יפות!<br />
-          בחרו צבעים, ציירו ומחקו כל מה שבא לכם
-        </p>
-        
-        <div className="bg-gradient-to-r from-blue-50 to-purple-50 rounded-2xl p-4 mb-6">
-          <div className="text-sm text-gray-600 space-y-2">
-            <div className="flex items-center justify-center gap-2">
-              <span>🖌️</span>
-              <span>ציור עם מברשות בגדלים שונים</span>
-            </div>
-            <div className="flex items-center justify-center gap-2">
-              <span>🧹</span>
-              <span>מחיקה מדויקת בגדלים שונים</span>
-            </div>
-            <div className="flex items-center justify-center gap-2">
-              <span>🎨</span>
-              <span>12 צבעים יפים לבחירה</span>
-            </div>
-            <div className="flex items-center justify-center gap-2">
-              <span>💾</span>
-              <span>שמירת הציור למחשב</span>
-            </div>
+    <GameMenuCard
+      emoji="🎨"
+      title="משחק ציורים"
+      description="בואו ניצור יצירות אמנות יפות! בחרו צבעים, ציירו ומחקו כל מה שבא לכם"
+      gradientClass="from-purple-400 via-pink-400 to-orange-400"
+      buttonClass="from-blue-500 to-purple-600"
+      startLabel="🎨 בואו נתחיל לצייר!"
+      animateEmoji
+      onStart={() => startGame()}
+    >
+      <div className="bg-gradient-to-r from-blue-50 to-purple-50 rounded-2xl p-4">
+        <div className="text-sm text-gray-600 space-y-2">
+          <div className="flex items-center justify-center gap-2">
+            <span>🖌️</span>
+            <span>ציור עם מברשות בגדלים שונים</span>
+          </div>
+          <div className="flex items-center justify-center gap-2">
+            <span>🧹</span>
+            <span>מחיקה מדויקת בגדלים שונים</span>
+          </div>
+          <div className="flex items-center justify-center gap-2">
+            <span>🎨</span>
+            <span>12 צבעים יפים לבחירה</span>
+          </div>
+          <div className="flex items-center justify-center gap-2">
+            <span>💾</span>
+            <span>שמירת הציור למחשב</span>
           </div>
         </div>
-        
-        <button
-          onClick={() => startGame()}
-          className="bg-gradient-to-r from-blue-500 to-purple-600 text-white text-xl font-bold py-4 px-8 rounded-2xl hover:from-blue-600 hover:to-purple-700 transform hover:scale-105 transition-all duration-200 shadow-lg shadow-blue-200 w-full"
-        >
-          🎨 בואו נתחיל לצייר!
-        </button>
       </div>
-    </div>
+    </GameMenuCard>
   );
 }

--- a/gamesformykids/app/games/memory/components/MemoryStartScreen.tsx
+++ b/gamesformykids/app/games/memory/components/MemoryStartScreen.tsx
@@ -1,37 +1,37 @@
-"use client";
-
-import { useMemoryStore } from "../stores/useMemoryStore";
+'use client';
+import { useMemoryStore } from '../stores/useMemoryStore';
+import GameMenuCard from '@/components/game/shared/GameMenuCard';
 
 export default function MemoryStartScreen() {
   const { initializeGame } = useMemoryStore();
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-pink-100 via-purple-100 to-indigo-200">
-      <div className="text-center p-8 bg-white/80 rounded-3xl shadow-xl max-w-md mx-4">
-        <div className="text-6xl mb-4">🧠</div>
-        <h1 className="text-3xl font-bold text-purple-800 mb-4">משחק הזיכרון</h1>
-        <p className="text-lg text-purple-600 mb-6">
-          מצאו את הזוגות הזהים על הלוח!
-        </p>
+    <GameMenuCard
+      emoji="🧠"
+      title="משחק הזיכרון"
+      description="מצאו את הזוגות הזהים על הלוח!"
+      gradientClass="from-pink-100 via-purple-100 to-indigo-200"
+    >
+      <div className="flex flex-col gap-3">
         <button
           onClick={() => initializeGame('EASY')}
-          className="bg-gradient-to-r from-purple-500 to-pink-500 hover:from-purple-600 hover:to-pink-600 text-white font-bold py-3 px-8 rounded-full text-xl transition-all duration-300 transform hover:scale-105 shadow-lg mb-4 block w-full"
+          className="w-full bg-gradient-to-r from-purple-500 to-pink-500 hover:from-purple-600 hover:to-pink-600 text-white font-bold py-3 px-8 rounded-full text-xl transition-all duration-300 transform hover:scale-105 shadow-lg"
         >
           🎮 התחל משחק קל
         </button>
         <button
           onClick={() => initializeGame('MEDIUM')}
-          className="bg-gradient-to-r from-blue-500 to-purple-500 hover:from-blue-600 hover:to-purple-600 text-white font-bold py-3 px-8 rounded-full text-xl transition-all duration-300 transform hover:scale-105 shadow-lg mb-4 block w-full"
+          className="w-full bg-gradient-to-r from-blue-500 to-purple-500 hover:from-blue-600 hover:to-purple-600 text-white font-bold py-3 px-8 rounded-full text-xl transition-all duration-300 transform hover:scale-105 shadow-lg"
         >
           🌟 התחל משחק בינוני
         </button>
         <button
           onClick={() => initializeGame('HARD')}
-          className="bg-gradient-to-r from-red-500 to-orange-500 hover:from-red-600 hover:to-orange-600 text-white font-bold py-3 px-8 rounded-full text-xl transition-all duration-300 transform hover:scale-105 shadow-lg block w-full"
+          className="w-full bg-gradient-to-r from-red-500 to-orange-500 hover:from-red-600 hover:to-orange-600 text-white font-bold py-3 px-8 rounded-full text-xl transition-all duration-300 transform hover:scale-105 shadow-lg"
         >
           🔥 התחל משחק קשה
         </button>
       </div>
-    </div>
+    </GameMenuCard>
   );
 }


### PR DESCRIPTION
## Summary
- `BubbleStartScreen`, `BuildingStartScreen`, `DrawingStartScreen`, `MemoryStartScreen` all reimplemented their full-screen card shell from scratch
- All 4 now delegate layout to `GameMenuCard` — removes ~107 lines of duplicated structure
- `BubbleStartScreen` keeps its prop-based `startGame` (parent hook has extra logic)
- `BuildingStartScreen` and `DrawingStartScreen` pass feature grids as `children`
- `MemoryStartScreen` passes 3 difficulty buttons as `children` (no `onStart`, per `GameMenuCard` design)

## Test plan
- [ ] Visit `/games/bubbles` — start screen shows, game launches on click
- [ ] Visit `/games/building` — feature grid + start button render, game launches
- [ ] Visit `/games/drawing` — feature list + start button render, game launches
- [ ] Visit `/games/memory` — 3 difficulty buttons render, each starts the correct difficulty
- [ ] `npx tsc --noEmit` → 0 errors
- [ ] ESLint clean

Closes #532

🤖 Generated with [Claude Code](https://claude.com/claude-code)