### PR TITLE
refactor: extract ScoreTimeLivesHUD shared component

### DIFF
--- a/gamesformykids/app/games/catch-fruit/components/CatchFruitHUD.tsx
+++ b/gamesformykids/app/games/catch-fruit/components/CatchFruitHUD.tsx
@@ -1,24 +1,8 @@
 'use client';
-
 import { useCatchFruitGame } from '../useCatchFruitGame';
-import LivesDisplay from '@/components/game/shared/LivesDisplay';
+import ScoreTimeLivesHUD from '@/components/game/shared/ScoreTimeLivesHUD';
 
 export default function CatchFruitHUD() {
   const { score, lives, timeLeft } = useCatchFruitGame();
-  return (
-    <div className="flex gap-5 mb-3 text-white text-center">
-      <div>
-        <p className="text-2xl font-black text-yellow-300">{score}</p>
-        <p className="text-xs text-yellow-500">ניקוד</p>
-      </div>
-      <div>
-        <LivesDisplay lives={lives} />
-        <p className="text-xs text-red-400">חיים</p>
-      </div>
-      <div>
-        <p className="text-2xl font-black text-blue-200">{timeLeft}s</p>
-        <p className="text-xs text-blue-400">זמן</p>
-      </div>
-    </div>
-  );
+  return <ScoreTimeLivesHUD score={score} lives={lives} timeLeft={timeLeft} />;
 }

--- a/gamesformykids/app/games/space-defender/components/SpaceDefenderHUD.tsx
+++ b/gamesformykids/app/games/space-defender/components/SpaceDefenderHUD.tsx
@@ -1,24 +1,8 @@
 'use client';
-
 import { useSpaceDefenderGame } from '../useSpaceDefenderGame';
-import LivesDisplay from '@/components/game/shared/LivesDisplay';
+import ScoreTimeLivesHUD from '@/components/game/shared/ScoreTimeLivesHUD';
 
 export default function SpaceDefenderHUD() {
   const { score, lives, timeLeft } = useSpaceDefenderGame();
-  return (
-    <div className="flex gap-5 mb-2 text-white text-center">
-      <div>
-        <p className="text-2xl font-black text-yellow-300">{score}</p>
-        <p className="text-xs text-yellow-500">ניקוד</p>
-      </div>
-      <div>
-        <LivesDisplay lives={lives} />
-        <p className="text-xs text-red-400">חיים</p>
-      </div>
-      <div>
-        <p className="text-2xl font-black text-blue-200">{timeLeft}s</p>
-        <p className="text-xs text-blue-400">זמן</p>
-      </div>
-    </div>
-  );
+  return <ScoreTimeLivesHUD score={score} lives={lives} timeLeft={timeLeft} mb="mb-2" />;
 }

--- a/gamesformykids/components/game/shared/ScoreTimeLivesHUD.tsx
+++ b/gamesformykids/components/game/shared/ScoreTimeLivesHUD.tsx
@@ -1,0 +1,28 @@
+'use client';
+import LivesDisplay from './LivesDisplay';
+
+interface Props {
+  score: number;
+  lives: number;
+  timeLeft: number;
+  mb?: string;
+}
+
+export default function ScoreTimeLivesHUD({ score, lives, timeLeft, mb = 'mb-3' }: Props) {
+  return (
+    <div className={`flex gap-5 ${mb} text-white text-center`}>
+      <div>
+        <p className="text-2xl font-black text-yellow-300">{score}</p>
+        <p className="text-xs text-yellow-500">ניקוד</p>
+      </div>
+      <div>
+        <LivesDisplay lives={lives} />
+        <p className="text-xs text-red-400">חיים</p>
+      </div>
+      <div>
+        <p className="text-2xl font-black text-blue-200">{timeLeft}s</p>
+        <p className="text-xs text-blue-400">זמן</p>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- `CatchFruitHUD` and `SpaceDefenderHUD` were byte-for-byte identical except for `mb-3` vs `mb-2`
- Created `components/game/shared/ScoreTimeLivesHUD.tsx` with `score`, `lives`, `timeLeft`, `mb` props
- Both HUD files reduced to ~5 lines each

## Test plan
- [ ] `/games/catch-fruit` — HUD shows score, lives hearts, and countdown timer
- [ ] `/games/space-defender` — same HUD, slightly less margin below
- [ ] `npx tsc --noEmit` → 0 errors
- [ ] ESLint clean

Closes #533

🤖 Generated with [Claude Code](https://claude.com/claude-code)