### PR TITLE
refactor: migrate result overlays to CanvasGameOverOverlay

### DIFF
--- a/gamesformykids/app/games/catch-fruit/components/CatchFruitResultOverlay.tsx
+++ b/gamesformykids/app/games/catch-fruit/components/CatchFruitResultOverlay.tsx
@@ -1,6 +1,6 @@
 'use client';
-
 import { useCatchFruitGame } from '../useCatchFruitGame';
+import CanvasGameOverOverlay from '@/components/game/shared/CanvasGameOverOverlay';
 
 interface Props {
   onRestart: () => void;
@@ -9,27 +9,17 @@ interface Props {
 export default function CatchFruitResultOverlay({ onRestart }: Props) {
   const { score, best, lives } = useCatchFruitGame();
   return (
-    <div className="absolute inset-0 flex items-center justify-center rounded-3xl bg-black/50">
-      <div className="bg-white rounded-3xl p-7 text-center shadow-2xl w-72">
-        <div className="text-5xl mb-2">{lives === 0 ? '💔' : '🎉'}</div>
-        <h2 className="text-2xl font-black text-gray-800 mb-3">{lives === 0 ? 'נגמרו החיים!' : 'הזמן נגמר!'}</h2>
-        <div className="grid grid-cols-2 gap-3 mb-5">
-          <div className="bg-purple-50 rounded-2xl p-3">
-            <p className="text-3xl font-black text-purple-600">{score}</p>
-            <p className="text-xs text-purple-400">ניקוד</p>
-          </div>
-          <div className="bg-yellow-50 rounded-2xl p-3">
-            <p className="text-3xl font-black text-yellow-500">{best}</p>
-            <p className="text-xs text-yellow-400">שיא</p>
-          </div>
-        </div>
-        <button
-          onClick={onRestart}
-          className="w-full py-4 rounded-2xl bg-gradient-to-l from-purple-500 to-indigo-600 text-white font-black text-xl shadow-lg hover:opacity-90 active:scale-95 transition-all"
-        >
-          🔄 שוב!
-        </button>
-      </div>
-    </div>
+    <CanvasGameOverOverlay
+      emoji={lives === 0 ? '💔' : '🎉'}
+      title={lives === 0 ? 'נגמרו החיים!' : 'הזמן נגמר!'}
+      score={score}
+      best={best}
+      scoreBgClass="bg-purple-50"
+      scoreTextClass="text-purple-600"
+      scoreLabelClass="text-purple-400"
+      buttonClass="bg-gradient-to-l from-purple-500 to-indigo-600"
+      backdropClass="bg-black/50"
+      onRestart={onRestart}
+    />
   );
 }

--- a/gamesformykids/app/games/space-defender/components/SpaceDefenderResultOverlay.tsx
+++ b/gamesformykids/app/games/space-defender/components/SpaceDefenderResultOverlay.tsx
@@ -1,6 +1,6 @@
 'use client';
-
 import { useSpaceDefenderGame } from '../useSpaceDefenderGame';
+import CanvasGameOverOverlay from '@/components/game/shared/CanvasGameOverOverlay';
 
 interface Props {
   onRestart: () => void;
@@ -10,27 +10,16 @@ export default function SpaceDefenderResultOverlay({ onRestart }: Props) {
   const { lives, score, best } = useSpaceDefenderGame();
   const outOfLives = lives === 0;
   return (
-    <div className="absolute inset-0 flex items-center justify-center rounded-3xl bg-black/60">
-      <div className="bg-white rounded-3xl p-7 text-center shadow-2xl w-72">
-        <div className="text-5xl mb-2">{outOfLives ? '💥' : '🎉'}</div>
-        <h2 className="text-2xl font-black text-gray-800 mb-3">{outOfLives ? 'נגמרו החיים!' : 'הזמן נגמר!'}</h2>
-        <div className="grid grid-cols-2 gap-3 mb-5">
-          <div className="bg-indigo-50 rounded-2xl p-3">
-            <p className="text-3xl font-black text-indigo-600">{score}</p>
-            <p className="text-xs text-indigo-400">ניקוד</p>
-          </div>
-          <div className="bg-yellow-50 rounded-2xl p-3">
-            <p className="text-3xl font-black text-yellow-500">{best}</p>
-            <p className="text-xs text-yellow-400">שיא</p>
-          </div>
-        </div>
-        <button
-          onClick={onRestart}
-          className="w-full py-4 rounded-2xl bg-gradient-to-l from-indigo-500 to-blue-600 text-white font-black text-xl shadow-lg hover:opacity-90 active:scale-95 transition-all"
-        >
-          🔄 שוב!
-        </button>
-      </div>
-    </div>
+    <CanvasGameOverOverlay
+      emoji={outOfLives ? '💥' : '🎉'}
+      title={outOfLives ? 'נגמרו החיים!' : 'הזמן נגמר!'}
+      score={score}
+      best={best}
+      scoreBgClass="bg-indigo-50"
+      scoreTextClass="text-indigo-600"
+      scoreLabelClass="text-indigo-400"
+      buttonClass="bg-gradient-to-l from-indigo-500 to-blue-600"
+      onRestart={onRestart}
+    />
   );
 }


### PR DESCRIPTION
## Summary
- `SpaceDefenderResultOverlay` and `CatchFruitResultOverlay` had identical structure — only colors, emoji, and backdrop opacity differed
- Both now delegate to `CanvasGameOverOverlay` (created in #530)
- Each file reduced from ~35 lines to ~20 lines

## Test plan
- [ ] `/games/space-defender` — game-over overlay shows score/best with indigo theme
- [ ] `/games/catch-fruit` — game-over overlay shows score/best with purple theme
- [ ] Both emoji/title change correctly based on `lives === 0` vs timeout
- [ ] `npx tsc --noEmit` → 0 errors
- [ ] ESLint clean

Closes #534

🤖 Generated with [Claude Code](https://claude.com/claude-code)