### PR TITLE
refactor: migrate Simon + BalloonPop result screens to ScoreBestResultCard

### DIFF
--- a/gamesformykids/app/games/balloon-pop/components/BalloonResultScreen.tsx
+++ b/gamesformykids/app/games/balloon-pop/components/BalloonResultScreen.tsx
@@ -1,29 +1,22 @@
 'use client';
+import { createScoreBestResultScreen } from '@/components/game/shared/createScoreBestResultScreen';
 import { useBalloonPopGame } from '../useBalloonPopGame';
-import GameResultCard from '@/components/game/shared/GameResultCard';
 
-export default function BalloonResultScreen() {
-  const { score, best, lives, startGame } = useBalloonPopGame();
-  return (
-    <GameResultCard
-      emoji={lives <= 0 ? '💔' : '🎉'}
-      title={lives <= 0 ? 'נגמרו החיים!' : 'הזמן נגמר!'}
-      gradientClass="from-sky-200 to-blue-400"
-      buttonClass="from-pink-500 to-rose-500"
-      onRestart={startGame}
-      restartLabel="🔄 שוב!"
-      shareText={`🎈 קיבלתי ${score} נקודות בפוצץ בלונים!`}
-    >
-      <div className="grid grid-cols-2 gap-3">
-        <div className="bg-pink-50 rounded-2xl p-4">
-          <p className="text-4xl font-black text-pink-500">{score}</p>
-          <p className="text-xs text-pink-400">ניקוד</p>
-        </div>
-        <div className="bg-yellow-50 rounded-2xl p-4">
-          <p className="text-4xl font-black text-yellow-500">{best}</p>
-          <p className="text-xs text-yellow-400">שיא</p>
-        </div>
-      </div>
-    </GameResultCard>
-  );
-}
+export default createScoreBestResultScreen(
+  {
+    emoji: '🎉',
+    title: 'הזמן נגמר!',
+    gradientClass: 'from-sky-200 to-blue-400',
+    buttonClass: 'from-pink-500 to-rose-500',
+    scoreBgClass: 'bg-pink-50',
+    scoreTextClass: 'text-pink-500',
+    scoreLabelClass: 'text-pink-400',
+    restartLabel: '🔄 שוב!',
+    shareTextFn: (score) => `🎈 קיבלתי ${score} נקודות בפוצץ בלונים!`,
+  },
+  useBalloonPopGame,
+  (state) => ({
+    emoji: state.lives <= 0 ? '💔' : '🎉',
+    title: state.lives <= 0 ? 'נגמרו החיים!' : 'הזמן נגמר!',
+  }),
+);

--- a/gamesformykids/app/games/simon/components/SimonGameOverScreen.tsx
+++ b/gamesformykids/app/games/simon/components/SimonGameOverScreen.tsx
@@ -1,32 +1,21 @@
 'use client';
-
-import GameResultCard from '@/components/game/shared/GameResultCard';
+import ScoreBestResultCard from '@/components/game/shared/ScoreBestResultCard';
 import { useSimonStore } from '../simonStore';
 
 export default function SimonGameOverScreen() {
   const { roundScore, best, startGame } = useSimonStore();
-
   return (
-    <GameResultCard
+    <ScoreBestResultCard
       emoji="😵"
       title="טעית!"
       gradientClass="from-gray-800 to-gray-900"
       buttonClass="from-gray-600 to-gray-800"
+      score={roundScore}
+      best={best}
+      scoreLabel="סיבובים"
       onRestart={startGame}
       restartLabel="🔄 שוב!"
       shareText={`🎮 הגעתי לרצף ${roundScore} צבעים בסימון!`}
-    >
-      <p className="text-gray-400 text-sm mb-4">הגעת לרצף של {roundScore} צבעים</p>
-      <div className="grid grid-cols-2 gap-4">
-        <div className="bg-gray-50 rounded-2xl p-3">
-          <p className="text-3xl font-black text-gray-700">{roundScore}</p>
-          <p className="text-xs text-gray-400">סיבובים</p>
-        </div>
-        <div className="bg-yellow-50 rounded-2xl p-3">
-          <p className="text-3xl font-black text-yellow-500">{best}</p>
-          <p className="text-xs text-yellow-400">שיא</p>
-        </div>
-      </div>
-    </GameResultCard>
+    />
   );
 }

--- a/gamesformykids/components/game/shared/createScoreBestResultScreen.tsx
+++ b/gamesformykids/components/game/shared/createScoreBestResultScreen.tsx
@@ -14,15 +14,19 @@ export interface ScoreBestResultScreenConfig {
   shareTextFn: (score: number) => string;
 }
 
-export function createScoreBestResultScreen(
+export function createScoreBestResultScreen<S extends { score: number; best: number; startGame: () => void }>(
   config: ScoreBestResultScreenConfig,
-  useGameHook: () => { score: number; best: number; startGame: () => void },
+  useGameHook: () => S,
+  getConfig?: (state: S) => Partial<Pick<ScoreBestResultScreenConfig, 'emoji' | 'title'>>,
 ) {
   function ScoreBestResultScreen() {
-    const { score, best, startGame } = useGameHook();
+    const state = useGameHook();
+    const { score, best, startGame } = state;
+    const dynamic = getConfig ? getConfig(state) : {};
     return (
       <ScoreBestResultCard
         {...config}
+        {...dynamic}
         score={score}
         best={best}
         onRestart={startGame}


### PR DESCRIPTION
## Summary
- Extended `createScoreBestResultScreen` with optional `getConfig` arg for dynamic emoji/title based on state
- `BalloonResultScreen` now uses the factory — emoji/title switch based on `lives <= 0`
- `SimonGameOverScreen` now uses `ScoreBestResultCard` directly with `scoreLabel="סיבובים"` (field is `roundScore` not `score`, so factory doesn't apply)
- Both gain score count-up animation from `ScoreBestResultCard`; manual grid JSX removed

## Test plan
- [ ] `/games/balloon-pop` — result shows 💔 + "נגמרו החיים!" when lives run out, 🎉 + "הזמן נגמר!" when time expires
- [ ] `/games/simon` — game-over shows round count with "סיבובים" label and personal best
- [ ] Score animates up on result screen for both games
- [ ] `npx tsc --noEmit` → 0 errors
- [ ] ESLint clean

Closes #535

🤖 Generated with [Claude Code](https://claude.com/claude-code)