### PR TITLE
refactor: add secondaryAction to GameMenuCard + migrate MathStartScreen

### DIFF
--- a/gamesformykids/app/games/math/components/MathStartScreen.tsx
+++ b/gamesformykids/app/games/math/components/MathStartScreen.tsx
@@ -1,4 +1,5 @@
-"use client";
+'use client';
+import GameMenuCard from '@/components/game/shared/GameMenuCard';
 
 interface MathStartScreenProps {
   startGame: () => Promise<void>;
@@ -7,40 +8,22 @@ interface MathStartScreenProps {
 
 export default function MathStartScreen({ startGame, speakQuestion }: MathStartScreenProps) {
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-yellow-100 via-orange-100 to-red-100">
-      <div className="text-center p-8 bg-white/80 rounded-3xl shadow-xl max-w-md mx-4">
-        <div className="text-6xl mb-4">🧮</div>
-        <h1 className="text-3xl font-bold text-orange-800 mb-4">משחק המתמטיקה</h1>
-        <p className="text-lg text-orange-600 mb-6">
-          פתרו תרגילים במתמטיקה ובחרו את התשובה הנכונה!
-        </p>
-        
-        <div className="mb-6">
-          <h3 className="text-lg font-semibold text-orange-700 mb-3">דוגמאות:</h3>
-          <div className="space-y-2">
-            <div className="text-2xl">3 + 2 = ? 🍎</div>
-            <div className="text-2xl">5 - 1 = ? 🎈</div>
-            <div className="text-2xl">2 + 3 = ? 🌟</div>
-            <div className="text-2xl">4 - 2 = ? 🐶</div>
-          </div>
-        </div>
-        
-        <div className="space-y-3">
-          <button
-            onClick={startGame}
-            className="bg-gradient-to-r from-orange-500 to-red-500 hover:from-orange-600 hover:to-red-600 text-white font-bold py-3 px-8 rounded-full text-xl transition-all duration-300 transform hover:scale-105 shadow-lg w-full"
-          >
-            🚀 התחל משחק
-          </button>
-          
-          <button
-            onClick={speakQuestion}
-            className="bg-gradient-to-r from-blue-500 to-cyan-500 hover:from-blue-600 hover:to-cyan-600 text-white font-bold py-2 px-6 rounded-full text-lg transition-all duration-300 transform hover:scale-105 shadow-lg w-full"
-          >
-            🔊 שמע הוראות
-          </button>
-        </div>
+    <GameMenuCard
+      emoji="🧮"
+      title="משחק המתמטיקה"
+      description="פתרו תרגילים במתמטיקה ובחרו את התשובה הנכונה!"
+      gradientClass="from-yellow-100 via-orange-100 to-red-100"
+      buttonClass="from-orange-500 to-red-500"
+      startLabel="🚀 התחל משחק"
+      onStart={startGame}
+      secondaryAction={{ label: '🔊 שמע הוראות', onClick: speakQuestion }}
+    >
+      <div className="space-y-2 text-center">
+        <div className="text-2xl">3 + 2 = ? 🍎</div>
+        <div className="text-2xl">5 - 1 = ? 🎈</div>
+        <div className="text-2xl">2 + 3 = ? 🌟</div>
+        <div className="text-2xl">4 - 2 = ? 🐶</div>
       </div>
-    </div>
+    </GameMenuCard>
   );
 }

--- a/gamesformykids/components/game/shared/GameMenuCard.tsx
+++ b/gamesformykids/components/game/shared/GameMenuCard.tsx
@@ -18,6 +18,8 @@ interface Props {
   hint?: string | undefined;
   /** Optional best score to display */
   best?: number;
+  /** Optional secondary action button rendered below the start button */
+  secondaryAction?: { label: string; onClick: () => void };
   /** Optional extra content rendered below the description (e.g. level/category grid) */
   children?: ReactNode;
 }
@@ -39,6 +41,7 @@ export default function GameMenuCard({
   animateEmoji = false,
   hint,
   best,
+  secondaryAction,
   children,
 }: Props) {
   const router = useRouter();
@@ -65,6 +68,14 @@ export default function GameMenuCard({
             className={`w-full py-4 rounded-2xl bg-gradient-to-r ${buttonClass ?? ''} text-white font-black text-xl hover:opacity-90 active:scale-95 transition-all`}
           >
             {startLabel ?? `${emoji} התחל!`}
+          </button>
+        )}
+        {secondaryAction && (
+          <button
+            onClick={secondaryAction.onClick}
+            className="w-full mt-3 py-3 rounded-2xl border-2 border-gray-200 text-gray-600 font-semibold text-base hover:bg-gray-50 active:scale-95 transition-all"
+          >
+            {secondaryAction.label}
           </button>
         )}
       </div>


### PR DESCRIPTION
## Summary
- Added `secondaryAction?: { label: string; onClick: () => void }` to `GameMenuCard` — renders a outlined secondary button below the primary start button
- `MathStartScreen` migrated from hand-rolled shell to `GameMenuCard` with children (math examples) + `secondaryAction` (speak instructions)
- Pattern is now available for any future start screen needing a secondary action

## Test plan
- [ ] `/games/math` — start screen shows emoji examples + "התחל משחק" + "שמע הוראות" secondary button
- [ ] Secondary button styled as outlined (not filled gradient) to visually distinguish from primary
- [ ] All existing `GameMenuCard` usages unaffected (prop is optional)
- [ ] `npx tsc --noEmit` → 0 errors
- [ ] ESLint clean

Closes #536

🤖 Generated with [Claude Code](https://claude.com/claude-code)