### PR TITLE
refactor: create TimerProgressBar + migrate 5 components

### DIFF
--- a/gamesformykids/app/games/balloon-pop/components/BalloonHUD.tsx
+++ b/gamesformykids/app/games/balloon-pop/components/BalloonHUD.tsx
@@ -1,10 +1,11 @@
 'use client';
 import { useBalloonPopGame } from '../useBalloonPopGame';
 import { GAME_DURATION } from '../balloonPopStore';
+import TimerProgressBar from '@/components/game/shared/TimerProgressBar';
 
 export default function BalloonHUD() {
   const { score, lives, timeLeft } = useBalloonPopGame();
-  const pct      = (timeLeft / GAME_DURATION) * 100;
+  const pct = (timeLeft / GAME_DURATION) * 100;
 
   return (
     <div className="flex items-center gap-4 p-4 w-full max-w-sm">
@@ -13,14 +14,7 @@ export default function BalloonHUD() {
         <p className="text-xs text-white/70">ניקוד</p>
       </div>
       <div className="flex-1 space-y-1">
-        <div className="h-3 bg-white/30 rounded-full overflow-hidden">
-          <div
-            className={`h-full rounded-full transition-all duration-1000 ${
-              pct > 50 ? 'bg-green-400' : pct > 25 ? 'bg-yellow-300' : 'bg-red-400'
-            }`}
-            style={{ width: `${pct}%` }}
-          />
-        </div>
+        <TimerProgressBar pct={pct} trackClass="h-3 bg-white/30" />
         <p className="text-center text-xs text-white/80">{timeLeft}s</p>
       </div>
       <div className="text-center">

--- a/gamesformykids/app/games/color-tap/components/ColorTapPlayArea.tsx
+++ b/gamesformykids/app/games/color-tap/components/ColorTapPlayArea.tsx
@@ -1,6 +1,7 @@
 'use client';
 import { useColorTapGame, TIME_PER_Q } from '../useColorTapGame';
 import LivesDisplay from '@/components/game/shared/LivesDisplay';
+import TimerProgressBar from '@/components/game/shared/TimerProgressBar';
 import { useKeyboardControls } from '@/hooks/shared/game-controls/useKeyboardControls';
 import { KeyboardHint } from '@/components/game/shared/KeyboardHint';
 
@@ -43,12 +44,11 @@ export default function ColorTapPlayArea() {
           <div className={`w-16 h-16 rounded-full ${question.target.bg} shadow-lg`} />
           <p className="text-4xl font-black text-gray-700">{question.target.name}</p>
         </div>
-        <div className="bg-gray-100 rounded-full h-2 w-full mx-auto">
-          <div
-            className="bg-gradient-to-r from-pink-400 to-purple-500 h-2 rounded-full transition-all duration-1000"
-            style={{ width: `${(timeLeft / TIME_PER_Q) * 100}%` }}
-          />
-        </div>
+        <TimerProgressBar
+          pct={(timeLeft / TIME_PER_Q) * 100}
+          trackClass="h-2 bg-gray-100 w-full mx-auto"
+          barClass="bg-gradient-to-r from-pink-400 to-purple-500"
+        />
       </div>
 
       <div className="grid grid-cols-2 gap-4 w-full max-w-xs">

--- a/gamesformykids/app/games/emoji-math/components/EmojiMathPlayArea.tsx
+++ b/gamesformykids/app/games/emoji-math/components/EmojiMathPlayArea.tsx
@@ -1,6 +1,7 @@
 'use client';
 import { useEmojiMathGame, TIME_PER_Q } from '../useEmojiMathGame';
 import LivesDisplay from '@/components/game/shared/LivesDisplay';
+import TimerProgressBar from '@/components/game/shared/TimerProgressBar';
 import { useKeyboardControls } from '@/hooks/shared/game-controls/useKeyboardControls';
 import { KeyboardHint } from '@/components/game/shared/KeyboardHint';
 
@@ -61,12 +62,11 @@ export default function EmojiMathPlayArea() {
           {renderEmojis(q.b, q.emojiB)}
         </div>
         <p className="text-center text-4xl font-black text-gray-700">= ?</p>
-        <div className="mt-3 bg-gray-100 rounded-full h-1.5">
-          <div
-            className="bg-gradient-to-r from-yellow-400 to-orange-500 h-1.5 rounded-full transition-all duration-1000"
-            style={{ width: `${(timeLeft / TIME_PER_Q) * 100}%` }}
-          />
-        </div>
+        <TimerProgressBar
+          pct={(timeLeft / TIME_PER_Q) * 100}
+          trackClass="mt-3 h-1.5 bg-gray-100"
+          barClass="bg-gradient-to-r from-yellow-400 to-orange-500"
+        />
       </div>
 
       <div className="grid grid-cols-2 gap-3 w-full max-w-sm">

--- a/gamesformykids/app/games/reflex/components/ReflexPlayScreen.tsx
+++ b/gamesformykids/app/games/reflex/components/ReflexPlayScreen.tsx
@@ -1,7 +1,7 @@
 'use client';
-
 import { useReflexGame } from '../useReflexGame';
 import { GAME_DURATION } from '../data/targets';
+import TimerProgressBar from '@/components/game/shared/TimerProgressBar';
 
 export default function ReflexPlayScreen() {
   const { score, timeLeft, targets, hitTarget } = useReflexGame();
@@ -10,12 +10,7 @@ export default function ReflexPlayScreen() {
   return (
     <div className="min-h-screen bg-gradient-to-br from-slate-800 to-slate-900 select-none" dir="rtl">
       <div className="absolute top-0 left-0 right-0 p-3 flex items-center gap-3 z-10">
-        <div className="flex-1 h-3 bg-white/20 rounded-full overflow-hidden">
-          <div
-            className={`h-full rounded-full transition-all duration-1000 ${timePct > 50 ? 'bg-green-400' : timePct > 25 ? 'bg-yellow-400' : 'bg-red-400'}`}
-            style={{ width: `${timePct}%` }}
-          />
-        </div>
+        <TimerProgressBar pct={timePct} trackClass="flex-1 h-3 bg-white/20" />
         <span className="text-white font-bold shrink-0">⏱️ {timeLeft}</span>
         <span className="text-yellow-300 font-bold shrink-0">⭐ {score}</span>
       </div>

--- a/gamesformykids/app/games/whack-a-mole/components/WhackHUD.tsx
+++ b/gamesformykids/app/games/whack-a-mole/components/WhackHUD.tsx
@@ -1,6 +1,6 @@
 'use client';
-
 import { useWhackAMoleStore, GAME_DURATION } from '../whackAMoleStore';
+import TimerProgressBar from '@/components/game/shared/TimerProgressBar';
 
 export default function WhackHUD() {
   const { score, timeLeft, combo } = useWhackAMoleStore();
@@ -13,12 +13,7 @@ export default function WhackHUD() {
         <p className="text-xs text-amber-500">ניקוד</p>
       </div>
       <div className="flex-1">
-        <div className="h-4 bg-white/50 rounded-full overflow-hidden shadow-inner">
-          <div
-            className={`h-full rounded-full transition-all duration-1000 ${pct > 50 ? 'bg-green-400' : pct > 25 ? 'bg-yellow-400' : 'bg-red-400'}`}
-            style={{ width: `${pct}%` }}
-          />
-        </div>
+        <TimerProgressBar pct={pct} trackClass="h-4 bg-white/50 shadow-inner" />
         <p className="text-center text-xs text-amber-600 mt-0.5">{timeLeft}s</p>
       </div>
       {combo >= 3 && (

--- a/gamesformykids/components/game/shared/TimerProgressBar.tsx
+++ b/gamesformykids/components/game/shared/TimerProgressBar.tsx
@@ -1,0 +1,24 @@
+'use client';
+
+interface Props {
+  /** Percentage full, 0–100 */
+  pct: number;
+  /** Tailwind classes for the track (container), e.g. "h-3 bg-white/30" */
+  trackClass?: string;
+  /** Tailwind classes for the bar fill. Omit to use green→yellow→red thresholds. */
+  barClass?: string;
+}
+
+export default function TimerProgressBar({ pct, trackClass = 'h-3 bg-white/30', barClass }: Props) {
+  const fillClass = barClass ?? (
+    pct > 50 ? 'bg-green-400' : pct > 25 ? 'bg-yellow-400' : 'bg-red-400'
+  );
+  return (
+    <div className={`${trackClass} rounded-full overflow-hidden`}>
+      <div
+        className={`h-full rounded-full transition-all duration-1000 ${fillClass}`}
+        style={{ width: `${pct}%` }}
+      />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Created `components/game/shared/TimerProgressBar.tsx` — a `pct`-driven progress bar that uses green→yellow→red thresholds by default, or a custom `barClass` for static gradients
- Migrated: BalloonHUD, WhackHUD, ReflexPlayScreen, ColorTapPlayArea, EmojiMathPlayArea
- BalloonHUD/WhackHUD/Reflex use threshold colors; ColorTap/EmojiMath pass custom gradient `barClass`
- The inline 4-line `div+div` progress bar is now a single `<TimerProgressBar>` call in all 5 files

## Test plan
- [ ] `/games/balloon-pop` — timer bar goes green→yellow→red as time decreases
- [ ] `/games/whack-a-mole` — same threshold-based bar
- [ ] `/games/reflex` — bar in header; goes green→yellow→red
- [ ] `/games/color-tap` — pink→purple gradient bar per question
- [ ] `/games/emoji-math` — yellow→orange gradient bar per question
- [ ] `npx tsc --noEmit` → 0 errors
- [ ] ESLint clean

Closes #537

🤖 Generated with [Claude Code](https://claude.com/claude-code)