### PR TITLE
refactor: create StatCell + StatGrid components for result screen grids

### DIFF
--- a/gamesformykids/app/games/math-race/components/MathRaceResultScreen.tsx
+++ b/gamesformykids/app/games/math-race/components/MathRaceResultScreen.tsx
@@ -1,5 +1,6 @@
 'use client';
 import GameResultCard from '@/components/game/shared/GameResultCard';
+import { StatCell, StatGrid } from '@/components/game/shared/StatGrid';
 import { useMathRaceStore } from '../mathRaceStore';
 
 export default function MathRaceResultScreen() {
@@ -16,24 +17,12 @@ export default function MathRaceResultScreen() {
       restartLabel="🔄 שוב!"
       shareText={`🏁 קיבלתי ${score} נקודות במרוץ מתמטיקה!`}
     >
-      <div className="grid grid-cols-2 gap-3">
-        <div className="bg-blue-50 rounded-2xl p-3">
-          <p className="text-3xl font-black text-blue-600">{score}</p>
-          <p className="text-xs text-blue-400">ניקוד</p>
-        </div>
-        <div className="bg-yellow-50 rounded-2xl p-3">
-          <p className="text-3xl font-black text-yellow-500">{best}</p>
-          <p className="text-xs text-yellow-400">שיא</p>
-        </div>
-        <div className="bg-green-50 rounded-2xl p-3">
-          <p className="text-3xl font-black text-green-600">{correct}/{total}</p>
-          <p className="text-xs text-green-400">נכון/סה&quot;כ</p>
-        </div>
-        <div className="bg-purple-50 rounded-2xl p-3">
-          <p className="text-3xl font-black text-purple-600">{accuracy}%</p>
-          <p className="text-xs text-purple-400">דיוק</p>
-        </div>
-      </div>
+      <StatGrid>
+        <StatCell label="ניקוד" value={score} bgClass="bg-blue-50" textClass="text-blue-600" labelClass="text-blue-400" />
+        <StatCell label="שיא" value={best} bgClass="bg-yellow-50" textClass="text-yellow-500" labelClass="text-yellow-400" />
+        <StatCell label='נכון/סה"כ' value={`${correct}/${total}`} bgClass="bg-green-50" textClass="text-green-600" labelClass="text-green-400" />
+        <StatCell label="דיוק" value={`${accuracy}%`} bgClass="bg-purple-50" textClass="text-purple-600" labelClass="text-purple-400" />
+      </StatGrid>
     </GameResultCard>
   );
 }

--- a/gamesformykids/app/games/number-bubbles/components/NumberBubblesResultScreen.tsx
+++ b/gamesformykids/app/games/number-bubbles/components/NumberBubblesResultScreen.tsx
@@ -1,5 +1,6 @@
 'use client';
 import GameResultCard from '@/components/game/shared/GameResultCard';
+import { StatCell, StatGrid } from '@/components/game/shared/StatGrid';
 import { useNumberBubblesGame } from '../useNumberBubblesGame';
 
 export default function NumberBubblesResultScreen() {
@@ -17,16 +18,10 @@ export default function NumberBubblesResultScreen() {
       shareText={`🎈 הגעתי לרמה ${level} בבועות מספרים!`}
     >
       <p className="text-gray-500 mb-2">סיימת רמה {level} ב-{elapsed} שניות</p>
-      <div className="grid grid-cols-2 gap-4">
-        <div className="bg-sky-50 rounded-2xl p-3">
-          <p className="text-3xl font-black text-sky-600">{level}</p>
-          <p className="text-xs text-sky-400">רמה</p>
-        </div>
-        <div className="bg-green-50 rounded-2xl p-3">
-          <p className="text-3xl font-black text-green-600">{elapsed}s</p>
-          <p className="text-xs text-green-400">זמן</p>
-        </div>
-      </div>
+      <StatGrid>
+        <StatCell label="רמה" value={level} bgClass="bg-sky-50" textClass="text-sky-600" labelClass="text-sky-400" />
+        <StatCell label="זמן" value={`${elapsed}s`} bgClass="bg-green-50" textClass="text-green-600" labelClass="text-green-400" />
+      </StatGrid>
     </GameResultCard>
   );
 }

--- a/gamesformykids/app/games/reflex/components/ReflexResultScreen.tsx
+++ b/gamesformykids/app/games/reflex/components/ReflexResultScreen.tsx
@@ -1,5 +1,6 @@
 'use client';
 import GameResultCard from '@/components/game/shared/GameResultCard';
+import { StatCell, StatGrid } from '@/components/game/shared/StatGrid';
 import { useReflexStore } from '../reflexStore';
 
 export default function ReflexResultScreen() {
@@ -16,20 +17,11 @@ export default function ReflexResultScreen() {
       animateEmoji
       shareText={`⚡ קיבלתי ${score} לחיצות ברפלקס!`}
     >
-      <div className="grid grid-cols-3 gap-3">
-        <div className="bg-yellow-50 rounded-2xl p-4">
-          <p className="text-3xl font-black text-yellow-600">{score}</p>
-          <p className="text-xs text-yellow-500">לחיצות</p>
-        </div>
-        <div className="bg-red-50 rounded-2xl p-4">
-          <p className="text-3xl font-black text-red-500">{missed}</p>
-          <p className="text-xs text-red-400">פספוסים</p>
-        </div>
-        <div className="bg-blue-50 rounded-2xl p-4">
-          <p className="text-3xl font-black text-blue-600">{accuracy}%</p>
-          <p className="text-xs text-blue-400">דיוק</p>
-        </div>
-      </div>
+      <StatGrid cols={3}>
+        <StatCell label="לחיצות" value={score} bgClass="bg-yellow-50" textClass="text-yellow-600" labelClass="text-yellow-500" />
+        <StatCell label="פספוסים" value={missed} bgClass="bg-red-50" textClass="text-red-500" labelClass="text-red-400" />
+        <StatCell label="דיוק" value={`${accuracy}%`} bgClass="bg-blue-50" textClass="text-blue-600" labelClass="text-blue-400" />
+      </StatGrid>
     </GameResultCard>
   );
 }

--- a/gamesformykids/app/games/word-scramble/components/WordScrambleResultScreen.tsx
+++ b/gamesformykids/app/games/word-scramble/components/WordScrambleResultScreen.tsx
@@ -1,5 +1,6 @@
 'use client';
 import GameResultCard from '@/components/game/shared/GameResultCard';
+import { StatCell, StatGrid } from '@/components/game/shared/StatGrid';
 import { useWordScrambleStore } from '../wordScrambleStore';
 
 export default function WordScrambleResultScreen() {
@@ -16,16 +17,10 @@ export default function WordScrambleResultScreen() {
       restartLabel="🔄 שחק שוב"
       shareText={`📝 קיבלתי ${score} נקודות בחילופי מילים!`}
     >
-      <div className="grid grid-cols-2 gap-4">
-        <div className="bg-green-50 rounded-2xl p-3">
-          <p className="text-3xl font-black text-green-600">{score}</p>
-          <p className="text-xs text-green-400">ניקוד</p>
-        </div>
-        <div className="bg-red-50 rounded-2xl p-3">
-          <p className="text-3xl font-black text-red-500">{3 - lives}</p>
-          <p className="text-xs text-red-400">טעויות</p>
-        </div>
-      </div>
+      <StatGrid>
+        <StatCell label="ניקוד" value={score} bgClass="bg-green-50" textClass="text-green-600" labelClass="text-green-400" />
+        <StatCell label="טעויות" value={3 - lives} bgClass="bg-red-50" textClass="text-red-500" labelClass="text-red-400" />
+      </StatGrid>
     </GameResultCard>
   );
 }

--- a/gamesformykids/components/game/shared/StatGrid.tsx
+++ b/gamesformykids/components/game/shared/StatGrid.tsx
@@ -1,0 +1,38 @@
+'use client';
+import { ReactNode } from 'react';
+
+interface StatCellProps {
+  label: string;
+  value: string | number;
+  bgClass?: string;
+  textClass?: string;
+  labelClass?: string;
+}
+
+export function StatCell({
+  label,
+  value,
+  bgClass = 'bg-gray-50',
+  textClass = 'text-gray-700',
+  labelClass = 'text-gray-400',
+}: StatCellProps) {
+  return (
+    <div className={`${bgClass} rounded-2xl p-3`}>
+      <p className={`text-3xl font-black ${textClass}`}>{value}</p>
+      <p className={`text-xs ${labelClass}`}>{label}</p>
+    </div>
+  );
+}
+
+interface StatGridProps {
+  cols?: 2 | 3;
+  children: ReactNode;
+}
+
+export function StatGrid({ cols = 2, children }: StatGridProps) {
+  return (
+    <div className={`grid ${cols === 3 ? 'grid-cols-3' : 'grid-cols-2'} gap-3`}>
+      {children}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Created `components/game/shared/StatGrid.tsx` exporting `StatCell` and `StatGrid`
- `StatCell`: renders `bg-X-50 rounded-2xl p-3` stat cell with value + label; accepts color classes as props
- `StatGrid`: wraps cells in `grid grid-cols-{2|3} gap-3`
- Migrated: MathRaceResultScreen (4 cells, 2 cols), ReflexResultScreen (3 cells, 3 cols), WordScrambleResultScreen (2 cells), NumberBubblesResultScreen (2 cells + subtitle)
- SimonGameOverScreen and BalloonResultScreen were already handled by issue #535 via `ScoreBestResultCard`

## Test plan
- [ ] `/games/math-race` — result shows 4-cell grid: score, best, correct/total, accuracy %
- [ ] `/games/reflex` — result shows 3-cell grid: clicks, misses, accuracy %
- [ ] `/games/word-scramble` — result shows 2-cell grid: score, errors
- [ ] `/games/number-bubbles` — result shows subtitle + 2-cell grid: level, time
- [ ] `npx tsc --noEmit` → 0 errors
- [ ] ESLint clean

Closes #538

🤖 Generated with [Claude Code](https://claude.com/claude-code)