### PR TITLE
refactor: create StoryInterludeCard for between-round result screens

### DIFF
--- a/gamesformykids/components/game/quiz/games/holidays/components/HolidaysResultScreen.tsx
+++ b/gamesformykids/components/game/quiz/games/holidays/components/HolidaysResultScreen.tsx
@@ -1,5 +1,5 @@
 'use client';
-
+import StoryInterludeCard from '@/components/game/shared/StoryInterludeCard';
 import type { Holiday } from '../data/holidays';
 
 interface Props {
@@ -13,21 +13,19 @@ interface Props {
 }
 
 export default function HolidaysResultScreen({ current, score, maxScore, holidayIndex, totalHolidays, nextHolidayInfo, onNext }: Props) {
+  const nextLabel = holidayIndex < totalHolidays - 1 && nextHolidayInfo
+    ? `הבא: ${nextHolidayInfo.name} ${nextHolidayInfo.emoji}`
+    : '🎉 לסיכום!';
+
   return (
-    <div className={`min-h-screen bg-gradient-to-br ${current.bg} p-4 flex items-center`} dir="rtl">
-      <div className="max-w-md mx-auto w-full bg-white rounded-3xl shadow-xl p-8 text-center">
-        <div className="text-6xl mb-3">{current.emoji}</div>
-        <h2 className="text-2xl font-bold text-gray-800 mb-1">סיימת — {current.name}!</h2>
-        <p className="text-gray-500 mb-6">⭐ {score} / {maxScore} נקודות</p>
-        <div className="flex flex-col gap-3">
-          <button onClick={onNext}
-            className={`w-full py-4 rounded-2xl text-white font-bold text-xl bg-gradient-to-l ${current.color} shadow-lg hover:opacity-90 active:scale-95 transition-all`}>
-            {holidayIndex < totalHolidays - 1 && nextHolidayInfo
-              ? `הבא: ${nextHolidayInfo.name} ${nextHolidayInfo.emoji}`
-              : '🎉 לסיכום!'}
-          </button>
-        </div>
-      </div>
-    </div>
+    <StoryInterludeCard
+      gradient={current.bg}
+      emoji={current.emoji}
+      title={`סיימת — ${current.name}!`}
+      scoreLine={`⭐ ${score} / ${maxScore} נקודות`}
+      buttonGradient={current.color}
+      nextLabel={nextLabel}
+      onNext={onNext}
+    />
   );
 }

--- a/gamesformykids/components/game/quiz/games/tzadikim/components/ResultView.tsx
+++ b/gamesformykids/components/game/quiz/games/tzadikim/components/ResultView.tsx
@@ -1,5 +1,5 @@
 'use client';
-
+import StoryInterludeCard from '@/components/game/shared/StoryInterludeCard';
 import { TzaddikStory } from '../data/tzadikim';
 
 interface ResultViewProps {
@@ -11,67 +11,32 @@ interface ResultViewProps {
   onNextStory: () => void;
 }
 
-export default function ResultView({
-  story,
-  storyIndex,
-  totalStories,
-  score,
-  maxScore,
-  onNextStory,
-}: ResultViewProps) {
+export default function ResultView({ story, storyIndex, totalStories, score, maxScore, onNextStory }: ResultViewProps) {
   const isLastStory = storyIndex >= totalStories - 1;
+  const starsLit = score % 3 === 0 && score > 0 ? 3 : score % 3;
 
   return (
-    <div className={`min-h-screen bg-gradient-to-br ${story.bgGradient} p-4 flex items-center`} dir="rtl">
-      <div className="max-w-2xl mx-auto w-full">
-
-        <div className="bg-white rounded-3xl shadow-xl p-8 text-center">
-          {/* אייקון */}
-          <div className={`
-            w-24 h-24 rounded-full mx-auto mb-5 flex items-center justify-center text-5xl
-            bg-gradient-to-br ${story.color}
-          `}>
-            {story.emoji}
-          </div>
-
-          <h2 className="text-2xl font-bold text-gray-800 mb-1">סיימת את הסיפור!</h2>
-          <p className="text-gray-500 mb-6">{story.name}</p>
-
-          {/* לקח */}
-          <div className="bg-amber-50 rounded-2xl p-4 mb-6 text-right">
-            <p className="font-bold text-amber-800 mb-1">💡 הלקח:</p>
-            <p className="text-amber-700">{story.lesson}</p>
-          </div>
-
-          {/* ניקוד */}
-          <div className="flex justify-center gap-2 mb-6">
-            {Array.from({ length: 3 }).map((_, i) => (
-              <span key={i} className={`text-4xl ${i < (score % 3 === 0 && score > 0 ? 3 : score % 3) ? 'opacity-100' : 'opacity-25'}`}>
-                ⭐
-              </span>
-            ))}
-          </div>
-
-          <p className="text-gray-500 mb-8 text-sm">
-            {`סה"כ: ${score} / ${maxScore} נקודות`}
-          </p>
-
-          {/* כפתורים */}
-          <div className="flex flex-col gap-3">
-            <button
-              onClick={onNextStory}
-              className={`
-                w-full py-4 rounded-2xl text-white font-bold text-xl shadow-lg
-                bg-gradient-to-l ${story.color}
-                hover:opacity-90 active:scale-95 transition-all
-              `}
-            >
-              {isLastStory ? '🎉 לסיכום הסופי!' : `הסיפור הבא: סיפור ${storyIndex + 2} ←`}
-            </button>
-
-          </div>
-        </div>
+    <StoryInterludeCard
+      gradient={story.bgGradient}
+      emoji={story.emoji}
+      emojiCircleClass={story.color}
+      title="סיימת את הסיפור!"
+      subtitle={story.name}
+      scoreLine={`סה"כ: ${score} / ${maxScore} נקודות`}
+      buttonGradient={story.color}
+      nextLabel={isLastStory ? '🎉 לסיכום הסופי!' : `הסיפור הבא: סיפור ${storyIndex + 2} ←`}
+      onNext={onNextStory}
+      maxWidth="max-w-2xl"
+    >
+      <div className="bg-amber-50 rounded-2xl p-4 mb-6 text-right">
+        <p className="font-bold text-amber-800 mb-1">💡 הלקח:</p>
+        <p className="text-amber-700">{story.lesson}</p>
       </div>
-    </div>
+      <div className="flex justify-center gap-2 mb-6">
+        {Array.from({ length: 3 }).map((_, i) => (
+          <span key={i} className={`text-4xl ${i < starsLit ? 'opacity-100' : 'opacity-25'}`}>⭐</span>
+        ))}
+      </div>
+    </StoryInterludeCard>
   );
 }

--- a/gamesformykids/components/game/shared/StoryInterludeCard.tsx
+++ b/gamesformykids/components/game/shared/StoryInterludeCard.tsx
@@ -1,0 +1,58 @@
+'use client';
+import { ReactNode } from 'react';
+
+interface Props {
+  /** Full Tailwind gradient classes for the background, e.g. "from-blue-100 to-indigo-200" */
+  gradient: string;
+  emoji: string;
+  /** If set, wraps emoji in a colored circle with bg-gradient-to-br + this class */
+  emojiCircleClass?: string;
+  title: string;
+  subtitle?: string;
+  /** Rendered between subtitle and scoreLine, e.g. lesson box or star rating */
+  children?: ReactNode;
+  scoreLine?: string;
+  /** Full Tailwind gradient classes for the next button */
+  buttonGradient: string;
+  nextLabel: string;
+  onNext: () => void;
+  maxWidth?: string;
+}
+
+export default function StoryInterludeCard({
+  gradient,
+  emoji,
+  emojiCircleClass,
+  title,
+  subtitle,
+  children,
+  scoreLine,
+  buttonGradient,
+  nextLabel,
+  onNext,
+  maxWidth = 'max-w-md',
+}: Props) {
+  return (
+    <div className={`min-h-screen bg-gradient-to-br ${gradient} p-4 flex items-center`} dir="rtl">
+      <div className={`${maxWidth} mx-auto w-full bg-white rounded-3xl shadow-xl p-8 text-center`}>
+        {emojiCircleClass ? (
+          <div className={`w-24 h-24 rounded-full mx-auto mb-5 flex items-center justify-center text-5xl bg-gradient-to-br ${emojiCircleClass}`}>
+            {emoji}
+          </div>
+        ) : (
+          <div className="text-6xl mb-3">{emoji}</div>
+        )}
+        <h2 className="text-2xl font-bold text-gray-800 mb-1">{title}</h2>
+        {subtitle && <p className="text-gray-500 mb-4">{subtitle}</p>}
+        {children}
+        {scoreLine && <p className="text-gray-500 mb-6">{scoreLine}</p>}
+        <button
+          onClick={onNext}
+          className={`w-full py-4 rounded-2xl text-white font-bold text-xl bg-gradient-to-l ${buttonGradient} shadow-lg hover:opacity-90 active:scale-95 transition-all`}
+        >
+          {nextLabel}
+        </button>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Created `components/game/shared/StoryInterludeCard.tsx` — shared shell for between-round interlude screens used in story-based games
- Props: `gradient`, `emoji`, `emojiCircleClass` (optional circle wrapper), `title`, `subtitle`, `scoreLine`, `children` (extra content like lesson box or stars), `buttonGradient`, `nextLabel`, `onNext`, `maxWidth`
- `HolidaysResultScreen` migrated: plain emoji, title, score line, dynamic next label — 34 lines → 25 lines
- `ResultView` (Tzadikim) migrated: emoji in circle, subtitle, lesson box + star rating as children, score line — 77 lines → 37 lines

## Test plan
- [ ] Holidays game — between-holiday screen shows holiday emoji, name, score, correct next-holiday label
- [ ] Holidays game — last holiday shows "🎉 לסיכום!" button
- [ ] Tzadikim game — between-story screen shows emoji in colored circle, story name, lesson, stars, score
- [ ] Tzadikim game — last story shows "🎉 לסיכום הסופי!" button
- [ ] `npx tsc --noEmit` → 0 errors
- [ ] ESLint clean

Closes #539

🤖 Generated with [Claude Code](https://claude.com/claude-code)