### PR TITLE
refactor: extract GameErrorScreen from duplicate error.tsx files

### DIFF
--- a/gamesformykids/app/dashboard/error.tsx
+++ b/gamesformykids/app/dashboard/error.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+import GameErrorScreen from '@/components/ui/GameErrorScreen';
+
 export default function DashboardError({
   reset,
 }: {
@@ -7,18 +9,13 @@ export default function DashboardError({
   reset: () => void;
 }) {
   return (
-    <div className="min-h-screen bg-gradient-to-br from-purple-100 via-pink-100 to-blue-100 flex items-center justify-center p-4">
-      <div className="bg-white rounded-2xl shadow-lg p-8 text-center max-w-sm">
-        <div className="text-5xl mb-4">⚠️</div>
-        <h2 className="text-xl font-bold text-gray-800 mb-2">שגיאה בטעינת הנתונים</h2>
-        <p className="text-gray-500 text-sm mb-6">לא ניתן היה לטעון את לוח ההורים</p>
-        <button
-          onClick={reset}
-          className="bg-purple-600 hover:bg-purple-700 text-white font-bold py-2 px-6 rounded-xl transition-colors"
-        >
-          נסה שוב
-        </button>
-      </div>
-    </div>
+    <GameErrorScreen
+      reset={reset}
+      emoji="⚠️"
+      title="שגיאה בטעינת הנתונים"
+      description="לא ניתן היה לטעון את לוח ההורים"
+      gradientClass="from-purple-100 via-pink-100 to-blue-100"
+      cardClass="bg-white rounded-2xl shadow-lg max-w-sm"
+    />
   );
 }

--- a/gamesformykids/app/error.tsx
+++ b/gamesformykids/app/error.tsx
@@ -1,7 +1,6 @@
 'use client';
 
-import { useEffect } from 'react';
-import Link from 'next/link';
+import GameErrorScreen from '@/components/ui/GameErrorScreen';
 
 interface ErrorProps {
   error: Error & { digest?: string };
@@ -9,31 +8,5 @@ interface ErrorProps {
 }
 
 export default function RootError({ error, reset }: ErrorProps) {
-  useEffect(() => {
-    console.error(error);
-  }, [error]);
-
-  return (
-    <div className="min-h-screen flex flex-col items-center justify-center bg-gradient-to-br from-red-50 via-orange-50 to-yellow-50" dir="rtl">
-      <div className="text-center p-8 bg-white/80 rounded-3xl shadow-xl max-w-md mx-4 space-y-4">
-        <div className="text-7xl">😕</div>
-        <h1 className="text-2xl font-bold text-red-700">אופס! משהו השתבש</h1>
-        <p className="text-gray-600">נסה שוב או חזור לדף הבית</p>
-        <div className="flex gap-3 justify-center">
-          <button
-            onClick={reset}
-            className="px-6 py-3 bg-purple-500 text-white font-bold rounded-2xl hover:bg-purple-600 transition-colors"
-          >
-            נסה שוב
-          </button>
-          <Link
-            href="/"
-            className="px-6 py-3 bg-gray-100 text-gray-700 font-bold rounded-2xl hover:bg-gray-200 transition-colors"
-          >
-            דף הבית
-          </Link>
-        </div>
-      </div>
-    </div>
-  );
+  return <GameErrorScreen error={error} reset={reset} homeHref="/" />;
 }

--- a/gamesformykids/components/ui/GameErrorScreen.tsx
+++ b/gamesformykids/components/ui/GameErrorScreen.tsx
@@ -1,0 +1,58 @@
+'use client';
+
+import { useEffect } from 'react';
+import Link from 'next/link';
+
+interface Props {
+  error?: Error & { digest?: string };
+  reset: () => void;
+  emoji?: string;
+  title?: string;
+  description?: string;
+  gradientClass?: string;
+  cardClass?: string;
+  homeHref?: string;
+  resetLabel?: string;
+}
+
+export default function GameErrorScreen({
+  error,
+  reset,
+  emoji = '😕',
+  title = 'אופס! משהו השתבש',
+  description = 'נסה שוב או חזור לדף הבית',
+  gradientClass = 'from-red-50 via-orange-50 to-yellow-50',
+  cardClass = 'bg-white/80 rounded-3xl shadow-xl max-w-md mx-4',
+  homeHref,
+  resetLabel = 'נסה שוב',
+}: Props) {
+  useEffect(() => {
+    if (error) console.error(error);
+  }, [error]);
+
+  return (
+    <div className={`min-h-screen flex flex-col items-center justify-center bg-gradient-to-br ${gradientClass}`} dir="rtl">
+      <div className={`text-center p-8 ${cardClass} space-y-4`}>
+        <div className="text-7xl">{emoji}</div>
+        <h1 className="text-2xl font-bold text-red-700">{title}</h1>
+        {description && <p className="text-gray-600">{description}</p>}
+        <div className="flex gap-3 justify-center">
+          <button
+            onClick={reset}
+            className="px-6 py-3 bg-purple-500 text-white font-bold rounded-2xl hover:bg-purple-600 transition-colors"
+          >
+            {resetLabel}
+          </button>
+          {homeHref && (
+            <Link
+              href={homeHref}
+              className="px-6 py-3 bg-gray-100 text-gray-700 font-bold rounded-2xl hover:bg-gray-200 transition-colors"
+            >
+              דף הבית
+            </Link>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Creates `components/ui/GameErrorScreen.tsx` — shared error boundary screen
- Handles error logging via `useEffect`, reset button, optional home link
- `app/error.tsx` (root) uses defaults + `homeHref="/"` to show home button
- `app/dashboard/error.tsx` passes custom emoji/title/desc/card styling, no home link
- Both error files shrink from ~25 lines to ~10 lines each

## Test plan
- [ ] `npx tsc --noEmit` passes
- [ ] `npx eslint` clean
- [ ] Visual output matches originals

Closes #513

🤖 Generated with [Claude Code](https://claude.com/claude-code)