### PR TITLE
fix: enlarge flag emojis in geography flag-mode question

### DIFF
--- a/gamesformykids/components/game/quiz/screens/GeographyQuestion.tsx
+++ b/gamesformykids/components/game/quiz/screens/GeographyQuestion.tsx
@@ -18,11 +18,29 @@ export default function GeographyQuestion({ current, onSelect }: Props) {
       correctLabel={country.id}
       onSelect={onSelect}
       cols={2}
-      renderChoice={(id) => getChoiceLabel(choices.find(c => c.id === id)!, mode)}
+      renderChoice={(id) => {
+        const c = choices.find(ch => ch.id === id)!;
+        if (mode === 'flag') {
+          return (
+            <div className="flex flex-col items-center gap-1 py-1">
+              <span className="text-5xl leading-none">{c.flag}</span>
+              <span className="text-sm font-bold">{c.name}</span>
+            </div>
+          );
+        }
+        return getChoiceLabel(c, mode);
+      }}
       correctMsg={`✅ נכון! ${country.flag} ${country.name} — ${country.capital}`}
       wrongMsg={`💙 ${country.flag} ${country.name} — ${country.capital}, ${country.continent}`}
     >
-      <p className="text-xl font-bold text-gray-800">{getGeoPrompt(country, mode)}</p>
+      {mode === 'flag' ? (
+        <div className="flex flex-col items-center gap-3 py-2">
+          <span className="text-8xl leading-none">{country.flag}</span>
+          <p className="text-lg font-bold text-gray-700">לאיזו מדינה שייך הדגל?</p>
+        </div>
+      ) : (
+        <p className="text-xl font-bold text-gray-800">{getGeoPrompt(country, mode)}</p>
+      )}
     </QuizQuestionShell>
   );
 }


### PR DESCRIPTION
## Summary
- הדגלים בשאלת הדגלים בגאוגרפיה היו זעירים (inline `text-xl`/`text-base`) — כמעט בלתי נראים לילדים
- שאלה: הדגל הנכון מוצג עכשיו ב-`text-8xl` כאלמנט ויזואלי מרכזי
- כפתורי תשובות: כל דגל מוצג ב-`text-5xl` מעל שם המדינה

## Test plan
- [ ] פתח משחק גאוגרפיה → בחר מצב "דגלים"
- [ ] ודא שהדגל בשאלה גדול ובולט
- [ ] ודא שכפתורי התשובה מציגים דגל גדול + שם מדינה קטן מתחתיו
- [ ] ודא ששאר המצבים (בירות, יבשות) נראים כרגיל ללא שינוי

Closes #554

🤖 Generated with [Claude Code](https://claude.com/claude-code)