### PR TITLE
fix: use real flag images from flagcdn.com in geography flag mode

### DIFF
--- a/gamesformykids/components/game/quiz/screens/GeographyQuestion.tsx
+++ b/gamesformykids/components/game/quiz/screens/GeographyQuestion.tsx
@@ -2,7 +2,7 @@
 
 import { QuizQuestionShell } from '@/components/game/quiz';
 import type { GeoQuestion } from '@/lib/quiz/useGeographyGame';
-import { getGeoPrompt, getChoiceLabel } from '@/lib/quiz/data/geography';
+import { getGeoPrompt, getChoiceLabel, getFlagUrl } from '@/lib/quiz/data/geography';
 
 interface Props {
   current: GeoQuestion;
@@ -23,7 +23,8 @@ export default function GeographyQuestion({ current, onSelect }: Props) {
         if (mode === 'flag') {
           return (
             <div className="flex flex-col items-center gap-1 py-1">
-              <span className="text-5xl leading-none">{c.flag}</span>
+              {/* eslint-disable-next-line @next/next/no-img-element */}
+              <img src={getFlagUrl(c.iso2, 80)} alt={c.name} width={60} height={40} className="rounded shadow-sm object-cover" />
               <span className="text-sm font-bold">{c.name}</span>
             </div>
           );
@@ -35,7 +36,8 @@ export default function GeographyQuestion({ current, onSelect }: Props) {
     >
       {mode === 'flag' ? (
         <div className="flex flex-col items-center gap-3 py-2">
-          <span className="text-8xl leading-none">{country.flag}</span>
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img src={getFlagUrl(country.iso2, 160)} alt={country.name} width={160} height={107} className="rounded-lg shadow-md object-cover" />
           <p className="text-lg font-bold text-gray-700">לאיזו מדינה שייך הדגל?</p>
         </div>
       ) : (

--- a/gamesformykids/lib/quiz/data/geography.ts
+++ b/gamesformykids/lib/quiz/data/geography.ts
@@ -6,33 +6,38 @@ export interface Country {
   capital: string;
   continent: Continent;
   flag: string;
+  iso2: string;
+}
+
+export function getFlagUrl(iso2: string, size: 80 | 160 = 80): string {
+  return `https://flagcdn.com/w${size}/${iso2}.png`;
 }
 
 export const COUNTRIES: Country[] = [
-  { id: 'israel',      name: 'ישראל',        capital: 'ירושלים',      continent: 'אסיה',     flag: '🇮🇱' },
-  { id: 'france',      name: 'צרפת',          capital: 'פריז',          continent: 'אירופה',   flag: '🇫🇷' },
-  { id: 'germany',     name: 'גרמניה',        capital: 'ברלין',         continent: 'אירופה',   flag: '🇩🇪' },
-  { id: 'uk',          name: 'בריטניה',       capital: 'לונדון',        continent: 'אירופה',   flag: '🇬🇧' },
-  { id: 'italy',       name: 'איטליה',        capital: 'רומא',          continent: 'אירופה',   flag: '🇮🇹' },
-  { id: 'spain',       name: 'ספרד',          capital: 'מדריד',         continent: 'אירופה',   flag: '🇪🇸' },
-  { id: 'usa',         name: 'ארצות הברית',   capital: 'וושינגטון',     continent: 'אמריקה',   flag: '🇺🇸' },
-  { id: 'brazil',      name: 'ברזיל',         capital: 'ברזיליה',       continent: 'אמריקה',   flag: '🇧🇷' },
-  { id: 'argentina',   name: 'ארגנטינה',      capital: 'בואנוס איירס',  continent: 'אמריקה',   flag: '🇦🇷' },
-  { id: 'canada',      name: 'קנדה',          capital: 'אוטווה',        continent: 'אמריקה',   flag: '🇨🇦' },
-  { id: 'mexico',      name: 'מקסיקו',        capital: 'מקסיקו סיטי',   continent: 'אמריקה',   flag: '🇲🇽' },
-  { id: 'china',       name: 'סין',           capital: 'בייג\'ינג',     continent: 'אסיה',     flag: '🇨🇳' },
-  { id: 'japan',       name: 'יפן',           capital: 'טוקיו',         continent: 'אסיה',     flag: '🇯🇵' },
-  { id: 'india',       name: 'הודו',          capital: 'ניו דלהי',      continent: 'אסיה',     flag: '🇮🇳' },
-  { id: 'russia',      name: 'רוסיה',         capital: 'מוסקבה',        continent: 'אירופה',   flag: '🇷🇺' },
-  { id: 'australia',   name: 'אוסטרליה',      capital: 'קנברה',         continent: 'אוקיאניה', flag: '🇦🇺' },
-  { id: 'egypt',       name: 'מצרים',         capital: 'קהיר',          continent: 'אפריקה',   flag: '🇪🇬' },
-  { id: 'south-africa',name: 'דרום אפריקה',   capital: 'פרטוריה',       continent: 'אפריקה',   flag: '🇿🇦' },
-  { id: 'nigeria',     name: 'ניגריה',        capital: 'אבוג\'ה',       continent: 'אפריקה',   flag: '🇳🇬' },
-  { id: 'turkey',      name: 'טורקיה',        capital: 'אנקרה',         continent: 'אסיה',     flag: '🇹🇷' },
-  { id: 'greece',      name: 'יוון',          capital: 'אתונה',         continent: 'אירופה',   flag: '🇬🇷' },
-  { id: 'portugal',    name: 'פורטוגל',       capital: 'ליסבון',        continent: 'אירופה',   flag: '🇵🇹' },
-  { id: 'netherlands', name: 'הולנד',         capital: 'אמסטרדם',       continent: 'אירופה',   flag: '🇳🇱' },
-  { id: 'sweden',      name: 'שוודיה',        capital: 'שטוקהולם',      continent: 'אירופה',   flag: '🇸🇪' },
+  { id: 'israel',       name: 'ישראל',        capital: 'ירושלים',      continent: 'אסיה',     flag: '🇮🇱', iso2: 'il' },
+  { id: 'france',       name: 'צרפת',          capital: 'פריז',          continent: 'אירופה',   flag: '🇫🇷', iso2: 'fr' },
+  { id: 'germany',      name: 'גרמניה',        capital: 'ברלין',         continent: 'אירופה',   flag: '🇩🇪', iso2: 'de' },
+  { id: 'uk',           name: 'בריטניה',       capital: 'לונדון',        continent: 'אירופה',   flag: '🇬🇧', iso2: 'gb' },
+  { id: 'italy',        name: 'איטליה',        capital: 'רומא',          continent: 'אירופה',   flag: '🇮🇹', iso2: 'it' },
+  { id: 'spain',        name: 'ספרד',          capital: 'מדריד',         continent: 'אירופה',   flag: '🇪🇸', iso2: 'es' },
+  { id: 'usa',          name: 'ארצות הברית',   capital: 'וושינגטון',     continent: 'אמריקה',   flag: '🇺🇸', iso2: 'us' },
+  { id: 'brazil',       name: 'ברזיל',         capital: 'ברזיליה',       continent: 'אמריקה',   flag: '🇧🇷', iso2: 'br' },
+  { id: 'argentina',    name: 'ארגנטינה',      capital: 'בואנוס איירס',  continent: 'אמריקה',   flag: '🇦🇷', iso2: 'ar' },
+  { id: 'canada',       name: 'קנדה',          capital: 'אוטווה',        continent: 'אמריקה',   flag: '🇨🇦', iso2: 'ca' },
+  { id: 'mexico',       name: 'מקסיקו',        capital: 'מקסיקו סיטי',   continent: 'אמריקה',   flag: '🇲🇽', iso2: 'mx' },
+  { id: 'china',        name: 'סין',           capital: 'בייג\'ינג',     continent: 'אסיה',     flag: '🇨🇳', iso2: 'cn' },
+  { id: 'japan',        name: 'יפן',           capital: 'טוקיו',         continent: 'אסיה',     flag: '🇯🇵', iso2: 'jp' },
+  { id: 'india',        name: 'הודו',          capital: 'ניו דלהי',      continent: 'אסיה',     flag: '🇮🇳', iso2: 'in' },
+  { id: 'russia',       name: 'רוסיה',         capital: 'מוסקבה',        continent: 'אירופה',   flag: '🇷🇺', iso2: 'ru' },
+  { id: 'australia',    name: 'אוסטרליה',      capital: 'קנברה',         continent: 'אוקיאניה', flag: '🇦🇺', iso2: 'au' },
+  { id: 'egypt',        name: 'מצרים',         capital: 'קהיר',          continent: 'אפריקה',   flag: '🇪🇬', iso2: 'eg' },
+  { id: 'south-africa', name: 'דרום אפריקה',   capital: 'פרטוריה',       continent: 'אפריקה',   flag: '🇿🇦', iso2: 'za' },
+  { id: 'nigeria',      name: 'ניגריה',        capital: 'אבוג\'ה',       continent: 'אפריקה',   flag: '🇳🇬', iso2: 'ng' },
+  { id: 'turkey',       name: 'טורקיה',        capital: 'אנקרה',         continent: 'אסיה',     flag: '🇹🇷', iso2: 'tr' },
+  { id: 'greece',       name: 'יוון',          capital: 'אתונה',         continent: 'אירופה',   flag: '🇬🇷', iso2: 'gr' },
+  { id: 'portugal',     name: 'פורטוגל',       capital: 'ליסבון',        continent: 'אירופה',   flag: '🇵🇹', iso2: 'pt' },
+  { id: 'netherlands',  name: 'הולנד',         capital: 'אמסטרדם',       continent: 'אירופה',   flag: '🇳🇱', iso2: 'nl' },
+  { id: 'sweden',       name: 'שוודיה',        capital: 'שטוקהולם',      continent: 'אירופה',   flag: '🇸🇪', iso2: 'se' },
 ];
 
 export type QuestionMode = 'capital' | 'flag' | 'continent';


### PR DESCRIPTION
## Summary
- אמוג'י דגלים לא מתרנדרים כתמונות ב-Windows/Chrome — מציג "IL", "US" במקום דגל
- שאלת הדגל: תמונת PNG 160px מ-flagcdn.com עם עיגול פינות וצל
- כפתורי תשובות: תמונת PNG 80px עם שם המדינה מתחת
- הוספת שדה `iso2` לכל מדינה ב-`geography.ts` + פונקציה `getFlagUrl()`

## Test plan
- [ ] פתח גאוגרפיה → מצב "דגלים"
- [ ] ודא שהדגל בשאלה מוצג כתמונה אמיתית (160px)
- [ ] ודא שכל כפתור תשובה מציג תמונת דגל (80px) + שם מדינה
- [ ] ודא שמצבים אחרים (בירות, יבשות) עובדים כרגיל

Closes #556

🤖 Generated with [Claude Code](https://claude.com/claude-code)