### PR TITLE
feat: refactor GeographyStartScreen to use GenericStartScreen + add back navigation

### DIFF
--- a/gamesformykids/components/game/quiz/screens/GeographyStartScreen.tsx
+++ b/gamesformykids/components/game/quiz/screens/GeographyStartScreen.tsx
@@ -1,15 +1,34 @@
 'use client';
 
+import { useRouter } from 'next/navigation';
 import Image from 'next/image';
+import GenericStartScreen from '@/components/shared/screens/GenericStartScreen';
 import { COUNTRIES, getFlagUrl } from '@/lib/quiz/data/geography';
 import type { QuestionMode, Country } from '@/lib/quiz/data/geography';
-import StartScreenHeader from '@/components/shared/headers/StartScreenHeader';
-import SimpleGameInstructions from '@/components/shared/feedback/SimpleGameInstructions';
+import { ROUTES } from '@/lib/constants/routes';
 
-const INSTRUCTIONS: Record<QuestionMode, string[]> = {
-  capital:   ['ראה את הדגל ושם המדינה', 'בחר את הבירה הנכונה מבין 4 אפשרויות', 'צבור נקודות ועלה ברמות!'],
-  flag:      ['ראה את הדגל הגדול על המסך', 'בחר את שם המדינה הנכונה מבין 4 אפשרויות', 'צבור נקודות ועלה ברמות!'],
-  continent: ['ראה את הדגל ושם המדינה', 'בחר את היבשת הנכונה מבין 4 אפשרויות', 'צבור נקודות ועלה ברמות!'],
+const STEPS: Record<QuestionMode, Array<{ icon: string; title: string; description: string }>> = {
+  capital: [
+    { icon: '🏳️', title: 'ראה את הדגל',  description: 'ראה את הדגל ושם המדינה' },
+    { icon: '🏙️', title: 'בחר בירה',     description: 'בחר את הבירה הנכונה מבין 4 אפשרויות' },
+    { icon: '⭐',  title: 'צבור נקודות', description: 'צבור נקודות ועלה ברמות!' },
+  ],
+  flag: [
+    { icon: '🏳️', title: 'ראה את הדגל',  description: 'ראה את הדגל הגדול על המסך' },
+    { icon: '🌍', title: 'זהה מדינה',    description: 'בחר את שם המדינה הנכונה מבין 4 אפשרויות' },
+    { icon: '⭐',  title: 'צבור נקודות', description: 'צבור נקודות ועלה ברמות!' },
+  ],
+  continent: [
+    { icon: '🏳️', title: 'ראה את הדגל',  description: 'ראה את הדגל ושם המדינה' },
+    { icon: '🌍', title: 'בחר יבשת',     description: 'בחר את היבשת הנכונה מבין 4 אפשרויות' },
+    { icon: '⭐',  title: 'צבור נקודות', description: 'צבור נקודות ועלה ברמות!' },
+  ],
+};
+
+const ITEMS_TITLE: Record<QuestionMode, string> = {
+  capital:   '🏛️ מדינות ובירותיהן:',
+  flag:      '🚩 דגלי המדינות:',
+  continent: '🌍 מדינות ויבשותיהן:',
 };
 
 function countryLabel(c: Country, mode: QuestionMode): string {
@@ -27,55 +46,48 @@ interface Props {
 }
 
 export default function GeographyStartScreen({ mode, title, subtitle, emoji, onStart }: Props) {
+  const router = useRouter();
+
   return (
-    <div className="min-h-screen bg-gradient-to-br from-teal-500 to-cyan-700 p-4" dir="rtl">
-      <div className="max-w-4xl mx-auto text-center">
-        <StartScreenHeader
-          title={`${emoji} ${title}`}
-          subTitle={subtitle}
-          textColorHeader="text-white"
-          textColorSubHeader="text-teal-100"
-        />
-
-        <SimpleGameInstructions
-          title="איך משחקים?"
-          instructions={INSTRUCTIONS[mode]}
-          showSteps
-          variant="detailed"
-        />
-
-        <div className="mb-10">
-          <button
-            onClick={onStart}
-            className="px-12 py-4 bg-white text-teal-700 text-2xl font-bold rounded-2xl shadow-2xl hover:shadow-3xl transform hover:scale-105 transition-all duration-300 border-4 border-teal-200"
+    <div className="relative">
+      <button
+        onClick={() => router.push(ROUTES.GAMES)}
+        className="absolute top-4 right-4 z-10 flex items-center gap-1 px-4 py-2 bg-white/20 backdrop-blur-sm text-white rounded-lg hover:bg-white/30 active:scale-95 transition-all font-bold text-sm shadow-md"
+      >
+        → חזרה
+      </button>
+      <GenericStartScreen<Country>
+        title={`${emoji} ${title}`}
+        subTitle={subtitle}
+        textColorHeader="text-white"
+        textColorSubHeader="text-teal-100"
+        backgroundStyle="linear-gradient(135deg, #0d9488 0%, #0891b2 100%)"
+        buttonFromColor="from-teal-600"
+        buttonToColor="to-cyan-700"
+        customOnStart={onStart}
+        gameSteps={STEPS[mode]}
+        items={COUNTRIES}
+        itemsTitle={ITEMS_TITLE[mode]}
+        itemsGridClass="grid grid-cols-3 sm:grid-cols-4 md:grid-cols-6 gap-3 max-w-4xl mx-auto"
+        renderItem={(country) => (
+          <div
+            key={country.id}
+            className="bg-white/20 backdrop-blur-sm rounded-xl p-2 flex flex-col items-center gap-1"
           >
-            {emoji} בואו נתחיל לשחק!
-          </button>
-        </div>
-
-        <div>
-          <h3 className="text-2xl font-bold text-white mb-5">המדינות במשחק:</h3>
-          <div className="grid grid-cols-3 sm:grid-cols-4 md:grid-cols-6 gap-3">
-            {COUNTRIES.map(country => (
-              <div
-                key={country.id}
-                className="bg-white/20 backdrop-blur-sm rounded-xl p-2 flex flex-col items-center gap-1"
-              >
-                <Image
-                  src={getFlagUrl(country.iso2, 80)}
-                  alt={country.name}
-                  width={60}
-                  height={40}
-                  className="rounded shadow-md object-cover"
-                />
-                <span className="text-white text-xs font-semibold leading-tight text-center">
-                  {countryLabel(country, mode)}
-                </span>
-              </div>
-            ))}
+            <Image
+              src={getFlagUrl(country.iso2, 80)}
+              alt={country.name}
+              width={60}
+              height={40}
+              className="rounded shadow-md object-cover"
+            />
+            <span className="text-white text-xs font-semibold leading-tight text-center">
+              {countryLabel(country, mode)}
+            </span>
           </div>
-        </div>
-      </div>
+        )}
+        showAudioCheck={false}
+      />
     </div>
   );
 }


### PR DESCRIPTION
## Summary

- Uses existing `GenericStartScreen<Country>` (the same component `AutoStartScreen` uses) instead of a bespoke layout
- Adds `→ חזרה` back navigation button (top-right, frosted glass) that routes to `/games`
- Flag cards grid with mode-specific labels (capitals: `ישראל — ירושלים`, flags: `ישראל`, continents: `ישראל — אסיה`)

## Test plan
- [ ] `/games/geography-capitals` — start screen shows back button + flag grid with `name — capital` labels
- [ ] `/games/geography-flags` — start screen shows back button + flag grid with country names
- [ ] `/games/geography-continents` — start screen shows back button + flag grid with `name — continent` labels
- [ ] Back button navigates to `/games`

Closes #562

🤖 Generated with [Claude Code](https://claude.com/claude-code)