### PR TITLE
types: Replace QuizGameConfig<any> in quizGameConfigs.tsx with a concrete type

### DIFF
--- a/gamesformykids/lib/quiz/configs/types.ts
+++ b/gamesformykids/lib/quiz/configs/types.ts
@@ -18,10 +18,12 @@ export interface QuizGameConfig<Q = unknown> {
   menuScreen?: (onStart: () => void) => ReactNode;
   questions: Q[];
   questionsPerGame: number;
-  getChoices: (q: Q) => string[];
-  isCorrect: (choice: string, q: Q) => boolean;
-  getCorrectLabel: (q: Q) => string;
-  renderQuestion: (q: Q) => ReactNode;
+  // Method-syntax declarations are bivariant in TypeScript, allowing concrete
+  // QuizGameConfig<Q> values to be stored in a QuizGameConfig<unknown> map.
+  getChoices(q: Q): string[];
+  isCorrect(choice: string, q: Q): boolean;
+  getCorrectLabel(q: Q): string;
+  renderQuestion(q: Q): ReactNode;
   correctMsg?: string;
-  wrongMsg?: (q: Q) => string;
+  wrongMsg?(q: Q): string;
 }

--- a/gamesformykids/lib/quiz/quizGameConfigs.tsx
+++ b/gamesformykids/lib/quiz/quizGameConfigs.tsx
@@ -7,8 +7,9 @@ import { fractionsConfig, shapes3dConfig } from './configs/math';
 export type { QuizGameConfig } from './configs/types';
 import type { QuizGameConfig } from './configs/types';
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export const QUIZ_GAME_CONFIGS: Partial<Record<GameType, QuizGameConfig<any>>> = {
+// QuizGameConfig<unknown> is the erased form; individual configs retain their Q via defineConfig.
+// Bivariant method declarations in QuizGameConfig allow heterogeneous storage here.
+export const QUIZ_GAME_CONFIGS: Partial<Record<GameType, QuizGameConfig<unknown>>> = {
   riddles: riddlesConfig,
   capitals: capitalsConfig,
   spelling: spellingConfig,


### PR DESCRIPTION
## Summary

Removes the `any`-typed `QuizGameConfig<any>` map in `quizGameConfigs.tsx` by making the `QuizGameConfig<Q>` interface callbacks **bivariant** through method-declaration syntax (vs. arrow-function property syntax). This allows concrete `QuizGameConfig<Riddle>`, `QuizGameConfig<Capital>`, etc. to be stored in a `QuizGameConfig<unknown>` map without per-entry casts or `any`.

## Why method declarations?

Under `strictFunctionTypes`, arrow-function *properties* (`getChoices: (q: Q) => string[]`) are checked **contravariantly** — meaning `QuizGameConfig<Riddle>` is *not* assignable to `QuizGameConfig<unknown>`. TypeScript intentionally exempts *method declarations* (`getChoices(q: Q): string[]`) from strict variance, enabling the heterogeneous-map pattern the runtime already relies on.

## Changes
- `lib/quiz/configs/types.ts` — 5 callbacks converted from arrow-function properties to method declarations; comment explains the variance rationale
- `lib/quiz/quizGameConfigs.tsx` — map re-typed as `QuizGameConfig<unknown>`, eslint-disable comment removed

## Testing
- [x] `npx tsc --noEmit` passes (0 errors)

Closes #574

🤖 Generated with [Claude Code](https://claude.com/claude-code)