### PR TITLE
refactor: Move COUNTING_ITEMS inline data in useCountingGame.ts to lib/constants/gameData/

### DIFF
--- a/gamesformykids/app/games/counting/useCountingGame.ts
+++ b/gamesformykids/app/games/counting/useCountingGame.ts
@@ -8,25 +8,8 @@ import { getRandomItem } from "@/lib/utils/game/gameUtils";
 import { COUNTING_GAME_CONSTANTS } from "@/lib/constants";
 import { useCountingChallengeStore } from "@/lib/stores/countingChallengeStore";
 import { useNumericQuizRuntime } from "@/hooks/games/useNumericQuizRuntime";
-
-// ---------------------------------------------------------------------------
-// Items
-// ---------------------------------------------------------------------------
-
-const COUNTING_ITEMS = [
-  { emoji: "🐶", name: "כלב", plural: "כלבים" },
-  { emoji: "🐱", name: "חתול", plural: "חתולים" },
-  { emoji: "🍎", name: "תפוח", plural: "תפוחים" },
-  { emoji: "🌟", name: "כוכב", plural: "כוכבים" },
-  { emoji: "⚽", name: "כדור", plural: "כדורים" },
-  { emoji: "🌸", name: "פרח", plural: "פרחים" },
-  { emoji: "🎈", name: "בלון", plural: "בלונים" },
-  { emoji: "🦋", name: "פרפר", plural: "פרפרים" },
-  { emoji: "🍊", name: "תפוז", plural: "תפוזים" },
-  { emoji: "🧸", name: "דובי", plural: "דובים" },
-  { emoji: "🏀", name: "כדורסל", plural: "כדורי סל" },
-  { emoji: "🎀", name: "סרט", plural: "סרטים" },
-];
+import { useGameTypeStore } from "@/lib/stores/gameTypeStore";
+import { COUNTING_ITEMS as FALLBACK_ITEMS } from "@/lib/constants/gameData/counting";
 
 // ---------------------------------------------------------------------------
 // Pure helpers (defined outside hook — stable references, no closures)
@@ -41,16 +24,16 @@ function getMaxCount(level: number): number {
   );
 }
 
-function generateCountingChallenge(level: number): CountingChallenge {
+function generateCountingChallenge(level: number, items: BaseGameItem[]): CountingChallenge {
   const maxCount = getMaxCount(level);
   const count = Math.floor(Math.random() * maxCount) + 1;
-  const item = getRandomItem(COUNTING_ITEMS);
+  const item = getRandomItem(items.length > 0 ? items : FALLBACK_ITEMS);
   return {
-    emojis: item.emoji.repeat(count),
+    emojis: (item.emoji ?? '⭐').repeat(count),
     answer: count,
-    itemName: item.name,
-    itemPlural: item.plural,
-    emoji: item.emoji,
+    itemName: item.hebrew,
+    itemPlural: item.plural ?? item.hebrew,
+    emoji: item.emoji ?? '⭐',
   };
 }
 
@@ -84,6 +67,9 @@ function toOptionItem(n: number): BaseGameItem {
 
 export function useCountingGame() {
   const { speechEnabled } = useGameAudio();
+  const storeItems = useGameTypeStore((s) => s.gameItems) as BaseGameItem[];
+  // Use store items loaded server-side; fall back to the constant if store is empty.
+  const items = storeItems.length > 0 ? storeItems : FALLBACK_ITEMS;
 
   const speakCountingQuestion = async (challenge: CountingChallenge): Promise<void> => {
     if (!speechEnabled) return;
@@ -96,7 +82,7 @@ export function useCountingGame() {
 
   const { gameState, startGame, handleNumberClick, handleItemClick, speakItemName, resetGame } =
     useNumericQuizRuntime<CountingChallenge>({
-      generateChallenge: generateCountingChallenge,
+      generateChallenge: (level) => generateCountingChallenge(level, items),
       generateOptions: generateCountingOptions,
       speakQuestion: speakCountingQuestion,
       toChallengeItem,

--- a/gamesformykids/lib/constants/gameData/counting.ts
+++ b/gamesformykids/lib/constants/gameData/counting.ts
@@ -1,0 +1,22 @@
+import type { BaseGameItem } from '@/lib/types/core/base';
+
+/**
+ * Items used in the counting game — things to count on screen.
+ * Previously defined inline in app/games/counting/useCountingGame.ts;
+ * moved here so they can be loaded server-side via gameItemsLoader
+ * and consumed from the store, consistent with all other card games.
+ */
+export const COUNTING_ITEMS: BaseGameItem[] = [
+  { name: 'dog',        hebrew: 'כלב',     english: 'Dog',        emoji: '🐶', plural: 'כלבים',    color: 'bg-amber-400' },
+  { name: 'cat',        hebrew: 'חתול',    english: 'Cat',        emoji: '🐱', plural: 'חתולים',   color: 'bg-orange-400' },
+  { name: 'apple',      hebrew: 'תפוח',    english: 'Apple',      emoji: '🍎', plural: 'תפוחים',   color: 'bg-red-400' },
+  { name: 'star',       hebrew: 'כוכב',    english: 'Star',       emoji: '🌟', plural: 'כוכבים',   color: 'bg-yellow-400' },
+  { name: 'ball',       hebrew: 'כדור',    english: 'Ball',       emoji: '⚽', plural: 'כדורים',   color: 'bg-green-400' },
+  { name: 'flower',     hebrew: 'פרח',     english: 'Flower',     emoji: '🌸', plural: 'פרחים',    color: 'bg-pink-400' },
+  { name: 'balloon',    hebrew: 'בלון',    english: 'Balloon',    emoji: '🎈', plural: 'בלונים',   color: 'bg-blue-400' },
+  { name: 'butterfly',  hebrew: 'פרפר',    english: 'Butterfly',  emoji: '🦋', plural: 'פרפרים',   color: 'bg-purple-400' },
+  { name: 'orange',     hebrew: 'תפוז',    english: 'Orange',     emoji: '🍊', plural: 'תפוזים',   color: 'bg-orange-500' },
+  { name: 'teddy-bear', hebrew: 'דובי',    english: 'Teddy Bear', emoji: '🧸', plural: 'דובים',    color: 'bg-amber-600' },
+  { name: 'basketball', hebrew: 'כדורסל', english: 'Basketball', emoji: '🏀', plural: 'כדורי סל', color: 'bg-orange-600' },
+  { name: 'ribbon',     hebrew: 'סרט',     english: 'Ribbon',     emoji: '🎀', plural: 'סרטים',    color: 'bg-pink-600' },
+];

--- a/gamesformykids/lib/constants/gameItemsLoader.ts
+++ b/gamesformykids/lib/constants/gameItemsLoader.ts
@@ -69,7 +69,7 @@ export async function loadGameItems(gameType: GameType): Promise<BaseGameItem[]>
     case 'numbers':        return fromBasic('ALL_NUMBERS');
     case 'colored-shapes': return fromBasic('ALL_COLORED_SHAPES');
     case 'advanced-colors':return fromBasic('ADVANCED_COLORS_ITEMS');
-    case 'counting':       return fromBasic('ALL_NUMBERS');
+    case 'counting':       return (await import('./gameData/counting')).COUNTING_ITEMS;
     case 'math':           return fromBasic('ALL_NUMBERS');
     case 'bubbles':        return fromBasic('ALL_COLORS');
     case 'puzzles':        return fromBasic('ALL_SHAPES');

--- a/gamesformykids/lib/constants/gameItemsMap.ts
+++ b/gamesformykids/lib/constants/gameItemsMap.ts
@@ -5,6 +5,7 @@
  */
 
 import { ALL_COLORS, ALL_LETTERS, ALL_SHAPES, ALL_NUMBERS, ALL_COLORED_SHAPES, ADVANCED_COLORS_ITEMS } from "@/lib/constants/gameData/basic";
+import { COUNTING_ITEMS } from "@/lib/constants/gameData/counting";
 import { ALL_ANIMALS, ALL_FRUITS, ALL_VEGETABLES, ALL_SMELLS_TASTES, OCEAN_LIFE_ITEMS, GARDEN_PLANTS_ITEMS } from "@/lib/constants/gameData/nature";
 import { ALL_TRANSPORTS, ALL_VEHICLES, ALL_TOOLS, ALL_SPACE_OBJECTS, ALL_WEATHERS, ADVANCED_WEATHER_ITEMS } from "@/lib/constants/gameData/world";
 import { ALL_HOUSE_ITEMS, ALL_CLOTHING, ALL_INSTRUMENTS, ALL_PROFESSIONS, ALL_EMOTIONS } from "@/lib/constants/gameData/lifestyle";
@@ -87,7 +88,7 @@ export const GAME_ITEMS_MAP: Partial<Record<GameType, BaseGameItem[]>> = {
   professions: ALL_PROFESSIONS, // ✅ עודכן!
   emotions: ALL_EMOTIONS, // ✅ עודכן!
   memory: ALL_ANIMALS, // נשאר בעלי חיים - יש לוגיקה מיוחדת במשחק
-  counting: ALL_NUMBERS, // ✅ עודכן!
+  counting: COUNTING_ITEMS, // ✅ emoji items from gameData/counting.ts
   math: ALL_NUMBERS, // ✅ עודכן!
   bubbles: ALL_COLORS, // ✅ עודכן!
   puzzles: ALL_SHAPES, // ✅ עודכן! (זמני - צריך נתוני פאזלים ייעודיים)


### PR DESCRIPTION
## Summary

Moves the 12-item emoji counting array out of `app/games/counting/useCountingGame.ts` into `lib/constants/gameData/counting.ts`, consistent with the project rule that all game item data lives in `lib/constants/gameData/`. The hook now reads items from `useGameTypeStore` (same pattern as `useNatureSoundsGame`) instead of a module-level constant.

## Changes
- **New** `lib/constants/gameData/counting.ts` — `COUNTING_ITEMS: BaseGameItem[]` (12 emoji objects)
- **`lib/constants/gameItemsLoader.ts`** — `counting` case loads from `gameData/counting` instead of `ALL_NUMBERS`
- **`lib/constants/gameItemsMap.ts`** — `counting` entry updated to `COUNTING_ITEMS` (fixes test coverage)
- **`app/games/counting/useCountingGame.ts`** — reads `useGameTypeStore(s => s.gameItems)`; inline constant removed; `generateCountingChallenge` accepts `items: BaseGameItem[]` parameter; falls back to imported constant if store is empty

## Testing
- [x] `npx tsc --noEmit` passes (0 errors)

Closes #573

🤖 Generated with [Claude Code](https://claude.com/claude-code)