### PR TITLE
refactor: Extract useGeographyCapitalsGame and useGeographyContinentsGame from gameHooksMap.ts

### DIFF
--- a/gamesformykids/hooks/games/useGeographyCapitalsGame.ts
+++ b/gamesformykids/hooks/games/useGeographyCapitalsGame.ts
@@ -1,0 +1,24 @@
+'use client';
+
+import { useGameTypeStore } from '@/lib/stores/gameTypeStore';
+import { useBaseGame } from '@/hooks/shared/game-state/useBaseGame';
+import type { BaseGameItem } from '@/lib/types/core/base';
+
+/**
+ * Hook for the geography-capitals game.
+ * Reads items from the store (loaded server-side) and builds a pronunciation map
+ * that speaks the country name (item.plural) instead of the capital answer (item.hebrew).
+ */
+export function useGeographyCapitalsGame(): ReturnType<typeof useBaseGame> {
+  const items = useGameTypeStore((s) => s.gameItems) as BaseGameItem[];
+  const pronunciations = (items ?? []).reduce<Record<string, string>>((acc, item) => {
+    acc[item.name] = item.plural ?? item.hebrew;
+    return acc;
+  }, {});
+  return useBaseGame({
+    gameType: 'geography-capitals',
+    items: items ?? [],
+    pronunciations,
+    gameConstants: { BASE_COUNT: 4, INCREMENT: 0, LEVEL_THRESHOLD: 99 },
+  });
+}

--- a/gamesformykids/hooks/games/useGeographyContinentsGame.ts
+++ b/gamesformykids/hooks/games/useGeographyContinentsGame.ts
@@ -1,0 +1,25 @@
+'use client';
+
+import { useGameTypeStore } from '@/lib/stores/gameTypeStore';
+import { useBaseGame } from '@/hooks/shared/game-state/useBaseGame';
+import type { BaseGameItem } from '@/lib/types/core/base';
+
+/**
+ * Hook for the geography-continents game.
+ * Same as useGeographyCapitalsGame but adds uniqueByField: 'color' so that the
+ * 4 wrong-answer options always come from different continents (color field = continent).
+ */
+export function useGeographyContinentsGame(): ReturnType<typeof useBaseGame> {
+  const items = useGameTypeStore((s) => s.gameItems) as BaseGameItem[];
+  const pronunciations = (items ?? []).reduce<Record<string, string>>((acc, item) => {
+    acc[item.name] = item.plural ?? item.hebrew;
+    return acc;
+  }, {});
+  return useBaseGame({
+    gameType: 'geography-continents',
+    items: items ?? [],
+    pronunciations,
+    gameConstants: { BASE_COUNT: 4, INCREMENT: 0, LEVEL_THRESHOLD: 99 },
+    uniqueByField: 'color',
+  });
+}

--- a/gamesformykids/hooks/shared/game-state/gameHooksMap.ts
+++ b/gamesformykids/hooks/shared/game-state/gameHooksMap.ts
@@ -9,7 +9,8 @@ import { useGameTypeStore } from "@/lib/stores/gameTypeStore";
 import { useMathGame } from "@/app/games/math/hooks/useMathGame";
 import { useCountingGame } from "@/app/games/counting/useCountingGame";
 import { useNatureSoundsGame } from "@/app/games/nature-sounds/useNatureSoundsGame";
-import { useBaseGame } from "@/hooks/shared/game-state/useBaseGame";
+import { useGeographyCapitalsGame } from "@/hooks/games/useGeographyCapitalsGame";
+import { useGeographyContinentsGame } from "@/hooks/games/useGeographyContinentsGame";
 import type { BaseGameItem } from "@/lib/types/core/base";
 
 type AnyGameHookFn = () => {
@@ -23,37 +24,6 @@ type AnyGameHookFn = () => {
   currentAccuracy?: number;
   progressStats?: unknown;
   [key: string]: unknown;
-};
-
-// geography-capitals: speak country name (plural), not capital name (hebrew = answer)
-const useGeographyCapitalsGame = (): ReturnType<typeof useBaseGame> => {
-  const items = useGameTypeStore((s) => s.gameItems) as BaseGameItem[];
-  const pronunciations = (items ?? []).reduce<Record<string, string>>((acc, item) => {
-    acc[item.name] = item.plural ?? item.hebrew;
-    return acc;
-  }, {});
-  return useBaseGame({
-    gameType: 'geography-capitals',
-    items: items ?? [],
-    pronunciations,
-    gameConstants: { BASE_COUNT: 4, INCREMENT: 0, LEVEL_THRESHOLD: 99 },
-  });
-};
-
-// geography-continents: speak country name (plural); unique-by-continent option generation
-const useGeographyContinentsGame = (): ReturnType<typeof useBaseGame> => {
-  const items = useGameTypeStore((s) => s.gameItems) as BaseGameItem[];
-  const pronunciations = (items ?? []).reduce<Record<string, string>>((acc, item) => {
-    acc[item.name] = item.plural ?? item.hebrew;
-    return acc;
-  }, {});
-  return useBaseGame({
-    gameType: 'geography-continents',
-    items: items ?? [],
-    pronunciations,
-    gameConstants: { BASE_COUNT: 4, INCREMENT: 0, LEVEL_THRESHOLD: 99 },
-    uniqueByField: 'color',
-  });
 };
 
 // טיפוס עבור משחקים שתומכים ב-AutoGamePage בלבד


### PR DESCRIPTION
## Summary

Removes the two inline hook lambdas (`useGeographyCapitalsGame`, `useGeographyContinentsGame`) that were defined inside `gameHooksMap.ts`'s module scope and moves them to dedicated files under `hooks/games/`, consistent with every other named hook in the project.

**Why this matters:** Defining hooks as `const fn = (): ReturnType<typeof useBaseGame> => { ... }` inside a module-level map initializer is a React Rules-of-Hooks anti-pattern risk (hooks must only be called from React functions/hooks, not from closures created at module evaluation time). It also violates the one-hook-per-file convention used everywhere else.

## Changes
- **New** `hooks/games/useGeographyCapitalsGame.ts` — reads store items, builds pronunciation map, calls `useBaseGame` with `geography-capitals`
- **New** `hooks/games/useGeographyContinentsGame.ts` — same pattern + `uniqueByField: 'color'` for continent-unique options
- **`hooks/shared/game-state/gameHooksMap.ts`** — two inline lambdas removed; named imports added (same pattern as `useNatureSoundsGame`)

## Testing
- [x] `npx tsc --noEmit` passes (0 errors)

Closes #577

🤖 Generated with [Claude Code](https://claude.com/claude-code)