### PR TITLE
types: Remove permissive [key: string]: unknown from AnyGameHookFn

### DIFF
--- a/gamesformykids/hooks/shared/game-state/gameHooksMap.ts
+++ b/gamesformykids/hooks/shared/game-state/gameHooksMap.ts
@@ -23,7 +23,6 @@ type AnyGameHookFn = () => {
   showNextHint?: () => void;
   currentAccuracy?: number;
   progressStats?: unknown;
-  [key: string]: unknown;
 };
 
 // טיפוס עבור משחקים שתומכים ב-AutoGamePage בלבד


### PR DESCRIPTION
## Summary
Removes the `[key: string]: unknown` index signature from `AnyGameHookFn` in `gameHooksMap.ts`. The index signature was added defensively but is never used — all consumers (`GameLogicSync.tsx` and `useAutoGame.ts`) destructure only the explicitly-named properties already declared in the type. Keeping it was masking potential return-value typos.

## Changes
- `hooks/shared/game-state/gameHooksMap.ts`: delete the one-line index signature from `AnyGameHookFn`

## Testing
- [x] `npx tsc --noEmit` passes (zero errors)

Closes #576

🤖 Generated with [Claude Code](https://claude.com/claude-code)