### PR TITLE
dead-code: Remove exported playAnimalSound and playCustomSound from audioUtils

### DIFF
--- a/gamesformykids/lib/utils/game/audioUtils.ts
+++ b/gamesformykids/lib/utils/game/audioUtils.ts
@@ -34,9 +34,9 @@ export function playSuccessSound(audioContext: AudioContext | null): void {
 }
 
 /**
- * פונקציה גנרית ליצירת צליל מותאם אישית
+ * פונקציה גנרית ליצירת צליל מותאם אישית (internal helper — not exported)
  */
-export function playCustomSound(
+function playCustomSound(
   audioContext: AudioContext | null,
   frequencies: number[],
   type: OscillatorType = 'sine',
@@ -63,18 +63,6 @@ export function playCustomSound(
     osc.start(t);
     osc.stop(t + durationMs / 1000);
   });
-}
-
-/**
- * פונקציה להשמעת צליל של חיה
- */
-export function playAnimalSound(
-  audioContext: AudioContext | null,
-  emoji: string,
-  frequencies: Record<string, number[]>,
-): void {
-  const animalFreqs = frequencies[emoji] || frequencies['default'];
-  playCustomSound(audioContext, animalFreqs);
 }
 
 /**

--- a/gamesformykids/lib/utils/game/gameUtils.ts
+++ b/gamesformykids/lib/utils/game/gameUtils.ts
@@ -7,7 +7,7 @@ import { shuffleArray } from './cardUtils';
 import { speakPositiveFeedback, speakNegativeFeedback, speakStartMessage } from './feedbackUtils';
 
 // ── Re-exports from domain files (backward compat) ──────────────────────────
-export { playSuccessSound, playCustomSound, playAnimalSound, playMemorySuccessSound } from './audioUtils';
+export { playSuccessSound, playMemorySuccessSound } from './audioUtils';
 export { shuffleArray, shuffle, createShuffledMemoryCards } from './cardUtils';
 export {
   getRandomFeedbackMessage,


### PR DESCRIPTION
## Summary
Removes two dead exported functions from `lib/utils/game/audioUtils.ts` that had zero consumers anywhere in the codebase. `playAnimalSound` is deleted entirely. `playCustomSound` is kept as a module-private helper because `playMemorySuccessSound` (which is actively used) depends on it internally — only the `export` keyword is removed. The backward-compat re-export in `gameUtils.ts` is updated to drop both names.

## Changes
- `lib/utils/game/audioUtils.ts`: remove `export` from `playCustomSound`; delete `playAnimalSound`
- `lib/utils/game/gameUtils.ts`: drop `playCustomSound` and `playAnimalSound` from the re-export line

## Testing
- [x] `npx tsc --noEmit` passes (zero errors)

Closes #584

🤖 Generated with [Claude Code](https://claude.com/claude-code)