### PR TITLE
architecture: Remove goHome() from puzzleStore — used window.location.href

### DIFF
--- a/gamesformykids/app/games/puzzles/store/slices/gameSlice.ts
+++ b/gamesformykids/app/games/puzzles/store/slices/gameSlice.ts
@@ -4,8 +4,6 @@ import { createPuzzlePieces } from '../../utils/puzzleUtils';
 import type { SimplePuzzle } from '../../constants/simplePuzzlesData';
 import { MENU_RESET } from '../puzzleStoreConstants';
 import type { PuzzleStore } from '../puzzleStore';
-import { ROUTES } from '@/lib/constants/routes';
-
 export interface GameSlice {
   initializeGame: (img: HTMLImageElement, difficulty?: number) => void;
   initializeSimpleGame: (puzzle: SimplePuzzle) => void;
@@ -13,7 +11,6 @@ export interface GameSlice {
   shufflePieces: () => void;
   handleImageUpload: (event: ChangeEvent<HTMLInputElement>) => void;
   handlePreMadeImageSelect: (imageSrc: string) => void;
-  goHome: () => void;
   goToMenu: () => void;
   handlePuzzleSelect: (puzzle: SimplePuzzle) => void;
 }
@@ -89,10 +86,6 @@ export const createGameSlice: StateCreator<PuzzleStore, [], [], GameSlice> = (se
     const img = new Image();
     img.onload = () => get().initializeGame(img);
     img.src = imageSrc;
-  },
-
-  goHome: () => {
-    if (typeof window !== 'undefined') window.location.href = ROUTES.HOME;
   },
 
   goToMenu: () => set(MENU_RESET),


### PR DESCRIPTION
## Summary
Removes the `goHome` action from `app/games/puzzles/store/slices/gameSlice.ts`. The action had zero callers anywhere in the component tree and navigated via `window.location.href = ROUTES.HOME`, which causes a full browser navigation — unmounting the entire React tree, re-executing the JS bundle, and destroying all Zustand state. This contradicts how every other game navigates (via `useRouter().push` or `GameHeader`). Since no component calls `goHome`, the fix is a clean deletion with no component changes. The unused `ROUTES` import is removed at the same time.

## Changes
- `app/games/puzzles/store/slices/gameSlice.ts`: remove `goHome` from `GameSlice` interface, remove implementation, remove unused `ROUTES` import

## Testing
- [x] `npx tsc --noEmit` passes (zero errors)

Closes #585

🤖 Generated with [Claude Code](https://claude.com/claude-code)