### PR TITLE
refactor: Migrate 7 game stores to makeStore factory

### DIFF
--- a/gamesformykids/app/games/chess/store/useChessStore.ts
+++ b/gamesformykids/app/games/chess/store/useChessStore.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { create } from 'zustand';
+import { makeStore } from '@/lib/stores/createStore';
 import { makeInitialBoard, applyMove, isInCheck, pieceColor, INIT_CASTLING, INIT } from '../logic/chessBoardUtils';
 import { getAllValidMoves, getValidMoves } from '../logic/chessMoveGen';
 import { bestComputerMove } from '../logic/chessAI';
@@ -98,7 +98,7 @@ function scheduleComputerMove() {
   }, 600);
 }
 
-export const useChessStore = create<ChessStore>((set, get) => ({
+export const useChessStore = makeStore<ChessStore>('ChessStore', (set, get) => ({
   ...INIT,
 
   startGame: () => {

--- a/gamesformykids/app/games/coloring/store/coloringStore.ts
+++ b/gamesformykids/app/games/coloring/store/coloringStore.ts
@@ -3,8 +3,7 @@
  * מנהל את כל מצב משחק הצביעה: תמונה נוכחית, צבע נבחר, מילויים.
  * לחיצה על אזור → מצבע מיד בצבע הנבחר.
  */
-import { create } from 'zustand';
-import { devtools } from 'zustand/middleware';
+import { makeStore } from '@/lib/stores/createStore';
 import { PALETTE_COLORS, IMAGES, type ImageId } from '../constants';
 
 export type { ImageId };
@@ -44,9 +43,9 @@ interface ColoringActions {
   fillGroup: (memberIds: string[], colorableIds: string[]) => void;  clearImage: () => void;
 }
 
-export const useColoringStore = create<ColoringState & ColoringActions>()(
-  devtools(
-    (set, get) => ({
+export const useColoringStore = makeStore<ColoringState & ColoringActions>(
+  'ColoringStore',
+  (set, get) => ({
       currentImage: 'cat',
       selectedColor: PALETTE_COLORS[0].hex,
       allFills: EMPTY_FILLS,
@@ -104,7 +103,5 @@ export const useColoringStore = create<ColoringState & ColoringActions>()(
           'clearImage',
         );
       },
-    }),
-    { name: 'ColoringStore' },
-  ),
+  }),
 );

--- a/gamesformykids/app/games/drawing/store/drawingStore.ts
+++ b/gamesformykids/app/games/drawing/store/drawingStore.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { create } from 'zustand';
+import { makeStore } from '@/lib/stores/createStore';
 
 interface DrawingStore {
   // Tool state
@@ -36,7 +36,7 @@ interface DrawingStore {
   stopGame: (defaultTimeLimit?: number) => void;
 }
 
-export const useDrawingStore = create<DrawingStore>((set) => ({
+export const useDrawingStore = makeStore<DrawingStore>('DrawingStore', (set) => ({
   // Tool state
   currentColor: '#000000',
   brushSize: 5,

--- a/gamesformykids/app/games/hebrew-letters/store/hebrewLettersStore.ts
+++ b/gamesformykids/app/games/hebrew-letters/store/hebrewLettersStore.ts
@@ -1,5 +1,4 @@
-﻿import { create } from 'zustand';
-import { devtools } from 'zustand/middleware';
+﻿import { makeStore } from '@/lib/stores/createStore';
 import { TOTAL_HEBREW_LETTERS } from '../constants/hebrewLetters';
 import { PRACTICE_STEPS, STEP_MESSAGES } from '../constants/hebrewLettersConstants';
 import type { PracticeState } from '../types/hebrew-letters';
@@ -17,17 +16,15 @@ export type { HebrewLettersState, HebrewLettersStore };
 export type { HebrewLettersStoreActions } from './types';
 
 // ── Store ──────────────────────────────────────────────────
-export const useHebrewLettersStore = create<HebrewLettersStore>()(
-  devtools(
-    (...a) => ({
-      ...createLetterSlice(...a),
-      ...createAudioSlice(...a),
-      ...createDrawingSlice(...a),
-      ...createPracticeSlice(...a),
-      ...createStatsSlice(...a),
-    }),
-    { name: 'hebrewLettersStore' },
-  ),
+export const useHebrewLettersStore = makeStore<HebrewLettersStore>(
+  'hebrewLettersStore',
+  (...a) => ({
+    ...createLetterSlice(...a),
+    ...createAudioSlice(...a),
+    ...createDrawingSlice(...a),
+    ...createPracticeSlice(...a),
+    ...createStatsSlice(...a),
+  }),
 );
 
 // ── Pure utility functions ─────────────────────────────────

--- a/gamesformykids/app/games/puzzles/store/puzzleStore.ts
+++ b/gamesformykids/app/games/puzzles/store/puzzleStore.ts
@@ -1,4 +1,4 @@
-﻿import { create } from 'zustand';
+﻿import { makeStore } from '@/lib/stores/createStore';
 import type { PuzzleState } from '../types/puzzle';
 import { initialTouchState } from './puzzleStoreConstants';
 import { type FeedbackSlice, createFeedbackSlice } from './slices/feedbackSlice';
@@ -9,7 +9,7 @@ import { type ControlsSlice, createControlsSlice } from './slices/controlsSlice'
 
 export type PuzzleStore = PuzzleState & FeedbackSlice & GameSlice & DropSlice & DragSlice & ControlsSlice;
 
-export const usePuzzleStore = create<PuzzleStore>()((...a) => ({
+export const usePuzzleStore = makeStore<PuzzleStore>('PuzzleStore', (...a) => ({
   // --- Base PuzzleState ---
   gameStarted: false,
   isCompleted: false,

--- a/gamesformykids/app/games/taki/takiGameStore.ts
+++ b/gamesformykids/app/games/taki/takiGameStore.ts
@@ -1,4 +1,4 @@
-﻿import { create } from 'zustand';
+﻿import { makeStore } from '@/lib/stores/createStore';
 import type { TakiGameState, TakiCard, CardColor } from './takiTypes';
 import { INITIAL_STATE } from './takiTypes';
 import { buildDeck } from './takiDeck';
@@ -21,7 +21,7 @@ interface TakiGameActions {
   computerTurn: () => void;
 }
 
-export const useTakiStore = create<TakiGameState & TakiGameActions>()((set, get) => ({
+export const useTakiStore = makeStore<TakiGameState & TakiGameActions>('TakiStore', (set, get) => ({
   ...INITIAL_STATE,
 
   startGame: () => {

--- a/gamesformykids/components/game/quiz/games/transport/store/transportStore.ts
+++ b/gamesformykids/components/game/quiz/games/transport/store/transportStore.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { create } from 'zustand';
+import { makeStore } from '@/lib/stores/createStore';
 import type { PhaseQuiz as Phase } from '@/lib/types';
 import { shuffle } from '@/lib/utils';
 import {
@@ -34,7 +34,7 @@ interface TransportStore {
   goToMenu: () => void;
 }
 
-export const useTransportStore = create<TransportStore>((set, get) => ({
+export const useTransportStore = makeStore<TransportStore>('TransportStore', (set, get) => ({
   // Base quiz state
   phase: 'menu',
   questions: [],


### PR DESCRIPTION
## Summary
Migrates 7 game stores that were calling `create+devtools` directly to the project-standard `makeStore` factory from `lib/stores/createStore.ts`. This ensures consistent DevTools naming and means any future changes to the factory pattern (global middleware, logging) automatically apply to all stores. No logic was changed — only the wrapping pattern.

## Changes
- `app/games/chess/store/useChessStore.ts` → `makeStore('ChessStore', ...)`
- `app/games/coloring/store/coloringStore.ts` → `makeStore('ColoringStore', ...)`
- `app/games/drawing/store/drawingStore.ts` → `makeStore('DrawingStore', ...)`
- `app/games/hebrew-letters/store/hebrewLettersStore.ts` → `makeStore('hebrewLettersStore', ...)`
- `app/games/puzzles/store/puzzleStore.ts` → `makeStore('PuzzleStore', ...)`
- `app/games/taki/takiGameStore.ts` → `makeStore('TakiStore', ...)`
- `components/game/quiz/games/transport/store/transportStore.ts` → `makeStore('TransportStore', ...)`

## Testing
- [x] `npx tsc --noEmit` passes (zero errors)

Closes #586

🤖 Generated with [Claude Code](https://claude.com/claude-code)