### PR TITLE
refactor: Split blockSlice.ts — extract drag handlers into blockDragSlice

### DIFF
--- a/gamesformykids/app/games/building/store/blockDragSlice.ts
+++ b/gamesformykids/app/games/building/store/blockDragSlice.ts
@@ -1,0 +1,97 @@
+import type { StateCreator } from 'zustand';
+import type { BuildingStore } from './buildingStore';
+import type { Block, DragState } from '../types';
+import { calcDragPosition } from './blockDragUtils';
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+export type BlockDragSlice = {
+  dragState: DragState;
+  handleMouseDown: (e: React.MouseEvent, block: Block) => void;
+  handleTouchStart: (e: React.TouchEvent, block: Block) => void;
+  handleMouseMove: (e: React.MouseEvent) => void;
+  handleTouchMove: (e: React.TouchEvent) => void;
+  handleMouseUp: () => void;
+  handleTouchEnd: () => void;
+};
+
+// ── Slice ─────────────────────────────────────────────────────────────────────
+
+export const createBlockDragSlice: StateCreator<BuildingStore, [], [], BlockDragSlice> = (set, get) => ({
+  dragState: {
+    isDragging: false,
+    dragOffset: { x: 0, y: 0 },
+    draggedBlock: null,
+  },
+
+  handleMouseDown: (e, block) => {
+    e.preventDefault();
+    const { canvasEl, blocks } = get();
+    const rect = canvasEl?.getBoundingClientRect();
+    if (!rect) return;
+    set({
+      dragState: {
+        isDragging: true,
+        dragOffset: { x: e.clientX - rect.left - block.x, y: e.clientY - rect.top - block.y },
+        draggedBlock: block,
+      },
+      blocks: [...blocks.filter((b) => b.id !== block.id), block],
+    });
+  },
+
+  handleTouchStart: (e, block) => {
+    e.preventDefault();
+    const { canvasEl, blocks } = get();
+    const rect = canvasEl?.getBoundingClientRect();
+    if (!rect) return;
+    const touch = e.touches[0];
+    set({
+      dragState: {
+        isDragging: true,
+        dragOffset: {
+          x: touch.clientX - rect.left - block.x,
+          y: touch.clientY - rect.top - block.y,
+        },
+        draggedBlock: block,
+      },
+      blocks: [...blocks.filter((b) => b.id !== block.id), block],
+    });
+  },
+
+  handleMouseMove: (e) => {
+    const { dragState, canvasEl, showGrid } = get();
+    if (!dragState.isDragging || !dragState.draggedBlock) return;
+    const rect = canvasEl?.getBoundingClientRect();
+    if (!rect) return;
+    const pos = calcDragPosition(e.clientX, e.clientY, rect, dragState.dragOffset, showGrid);
+    set((s) => ({
+      blocks: s.blocks.map((b) =>
+        b.id === dragState.draggedBlock!.id ? { ...b, ...pos } : b,
+      ),
+    }));
+  },
+
+  handleTouchMove: (e) => {
+    const { dragState, canvasEl, showGrid } = get();
+    if (!dragState.isDragging || !dragState.draggedBlock) return;
+    const rect = canvasEl?.getBoundingClientRect();
+    if (!rect) return;
+    const touch = e.touches[0];
+    const pos = calcDragPosition(touch.clientX, touch.clientY, rect, dragState.dragOffset, showGrid);
+    set((s) => ({
+      blocks: s.blocks.map((b) =>
+        b.id === dragState.draggedBlock!.id ? { ...b, ...pos } : b,
+      ),
+    }));
+  },
+
+  handleMouseUp: () => {
+    const { dragState, blocks } = get();
+    if (dragState.isDragging && dragState.draggedBlock) {
+      get().addToHistory(blocks);
+    }
+    set({ dragState: { isDragging: false, dragOffset: { x: 0, y: 0 }, draggedBlock: null } });
+  },
+
+  handleTouchEnd: () => get().handleMouseUp(),
+});

--- a/gamesformykids/app/games/building/store/blockDragUtils.ts
+++ b/gamesformykids/app/games/building/store/blockDragUtils.ts
@@ -1,0 +1,23 @@
+import { CANVAS_CONFIG } from '../constants';
+
+/**
+ * Pure helper — no Zustand dependency.
+ * Converts raw pointer coordinates into clamped (and optionally grid-snapped)
+ * block position coordinates relative to the canvas element.
+ */
+export function calcDragPosition(
+  clientX: number,
+  clientY: number,
+  rect: DOMRect,
+  dragOffset: { x: number; y: number },
+  showGrid: boolean,
+): { x: number; y: number } {
+  const rawX = clientX - rect.left - dragOffset.x;
+  const rawY = clientY - rect.top - dragOffset.y;
+  const clampX = Math.max(0, Math.min(rawX, rect.width - CANVAS_CONFIG.BLOCK_SIZE));
+  const clampY = Math.max(0, Math.min(rawY, rect.height - CANVAS_CONFIG.BLOCK_SIZE));
+  return {
+    x: showGrid ? Math.round(clampX / CANVAS_CONFIG.GRID_SIZE) * CANVAS_CONFIG.GRID_SIZE : clampX,
+    y: showGrid ? Math.round(clampY / CANVAS_CONFIG.GRID_SIZE) * CANVAS_CONFIG.GRID_SIZE : clampY,
+  };
+}

--- a/gamesformykids/app/games/building/store/blockSlice.ts
+++ b/gamesformykids/app/games/building/store/blockSlice.ts
@@ -1,7 +1,6 @@
 import type { StateCreator } from 'zustand';
 import type { BuildingStore } from './buildingStore';
-import type { Block, DragState, ShapeType } from '../types';
-import { CANVAS_CONFIG } from '../constants';
+import type { Block, ShapeType } from '../types';
 import {
   generateBlockId,
   getRandomPosition,
@@ -12,11 +11,12 @@ import {
   playSound,
 } from '../utils';
 
-export type BlockSlice = {
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+export type BlockGameSlice = {
   isPlaying: boolean;
   blocks: Block[];
   selectedBlock: Block | null;
-  dragState: DragState;
   canvasEl: HTMLDivElement | null;
   startGame: () => void;
   createBlock: (shape: ShapeType) => void;
@@ -29,40 +29,14 @@ export type BlockSlice = {
   magicShuffle: () => void;
   saveCreation: () => void;
   setCanvasElement: (el: HTMLDivElement | null) => void;
-  handleMouseDown: (e: React.MouseEvent, block: Block) => void;
-  handleTouchStart: (e: React.TouchEvent, block: Block) => void;
-  handleMouseMove: (e: React.MouseEvent) => void;
-  handleTouchMove: (e: React.TouchEvent) => void;
-  handleMouseUp: () => void;
-  handleTouchEnd: () => void;
 };
 
-function calcDragPosition(
-  clientX: number,
-  clientY: number,
-  rect: DOMRect,
-  dragOffset: { x: number; y: number },
-  showGrid: boolean,
-) {
-  const rawX = clientX - rect.left - dragOffset.x;
-  const rawY = clientY - rect.top - dragOffset.y;
-  const clampX = Math.max(0, Math.min(rawX, rect.width - CANVAS_CONFIG.BLOCK_SIZE));
-  const clampY = Math.max(0, Math.min(rawY, rect.height - CANVAS_CONFIG.BLOCK_SIZE));
-  return {
-    x: showGrid ? Math.round(clampX / CANVAS_CONFIG.GRID_SIZE) * CANVAS_CONFIG.GRID_SIZE : clampX,
-    y: showGrid ? Math.round(clampY / CANVAS_CONFIG.GRID_SIZE) * CANVAS_CONFIG.GRID_SIZE : clampY,
-  };
-}
+// ── Slice ─────────────────────────────────────────────────────────────────────
 
-export const createBlockSlice: StateCreator<BuildingStore, [], [], BlockSlice> = (set, get) => ({
+export const createBlockSlice: StateCreator<BuildingStore, [], [], BlockGameSlice> = (set, get) => ({
   isPlaying: false,
   blocks: [],
   selectedBlock: null,
-  dragState: {
-    isDragging: false,
-    dragOffset: { x: 0, y: 0 },
-    draggedBlock: null,
-  },
   canvasEl: null,
 
   startGame: () => set({ isPlaying: true }),
@@ -152,75 +126,4 @@ export const createBlockSlice: StateCreator<BuildingStore, [], [], BlockSlice> =
   },
 
   setCanvasElement: (el) => set({ canvasEl: el }),
-
-  handleMouseDown: (e, block) => {
-    e.preventDefault();
-    const { canvasEl, blocks } = get();
-    const rect = canvasEl?.getBoundingClientRect();
-    if (!rect) return;
-    set({
-      dragState: {
-        isDragging: true,
-        dragOffset: { x: e.clientX - rect.left - block.x, y: e.clientY - rect.top - block.y },
-        draggedBlock: block,
-      },
-      blocks: [...blocks.filter((b) => b.id !== block.id), block],
-    });
-  },
-
-  handleTouchStart: (e, block) => {
-    e.preventDefault();
-    const { canvasEl, blocks } = get();
-    const rect = canvasEl?.getBoundingClientRect();
-    if (!rect) return;
-    const touch = e.touches[0];
-    set({
-      dragState: {
-        isDragging: true,
-        dragOffset: {
-          x: touch.clientX - rect.left - block.x,
-          y: touch.clientY - rect.top - block.y,
-        },
-        draggedBlock: block,
-      },
-      blocks: [...blocks.filter((b) => b.id !== block.id), block],
-    });
-  },
-
-  handleMouseMove: (e) => {
-    const { dragState, canvasEl, showGrid } = get();
-    if (!dragState.isDragging || !dragState.draggedBlock) return;
-    const rect = canvasEl?.getBoundingClientRect();
-    if (!rect) return;
-    const pos = calcDragPosition(e.clientX, e.clientY, rect, dragState.dragOffset, showGrid);
-    set((s) => ({
-      blocks: s.blocks.map((b) =>
-        b.id === dragState.draggedBlock!.id ? { ...b, ...pos } : b,
-      ),
-    }));
-  },
-
-  handleTouchMove: (e) => {
-    const { dragState, canvasEl, showGrid } = get();
-    if (!dragState.isDragging || !dragState.draggedBlock) return;
-    const rect = canvasEl?.getBoundingClientRect();
-    if (!rect) return;
-    const touch = e.touches[0];
-    const pos = calcDragPosition(touch.clientX, touch.clientY, rect, dragState.dragOffset, showGrid);
-    set((s) => ({
-      blocks: s.blocks.map((b) =>
-        b.id === dragState.draggedBlock!.id ? { ...b, ...pos } : b,
-      ),
-    }));
-  },
-
-  handleMouseUp: () => {
-    const { dragState, blocks } = get();
-    if (dragState.isDragging && dragState.draggedBlock) {
-      get().addToHistory(blocks);
-    }
-    set({ dragState: { isDragging: false, dragOffset: { x: 0, y: 0 }, draggedBlock: null } });
-  },
-
-  handleTouchEnd: () => get().handleMouseUp(),
 });

--- a/gamesformykids/app/games/building/store/buildingStore.ts
+++ b/gamesformykids/app/games/building/store/buildingStore.ts
@@ -1,6 +1,7 @@
 import { COLORS, SHAPES } from '../constants';
 import { makeStore } from '@/lib/stores/createStore';
-import { createBlockSlice, type BlockSlice } from './blockSlice';
+import { createBlockSlice, type BlockGameSlice } from './blockSlice';
+import { createBlockDragSlice, type BlockDragSlice } from './blockDragSlice';
 import { createHistorySlice, type HistorySlice } from './historySlice';
 import { createParticleSlice, type ParticleSlice } from './particleSlice';
 import { createAchievementSlice, type AchievementSlice } from './achievementSlice';
@@ -8,15 +9,16 @@ import { createSettingsSlice, type SettingsSlice } from './settingsSlice';
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
-export type BuildingStore = BlockSlice & HistorySlice & ParticleSlice & AchievementSlice & SettingsSlice;
+export type BuildingStore = BlockGameSlice & BlockDragSlice & HistorySlice & ParticleSlice & AchievementSlice & SettingsSlice;
 
-// Re-export for consumers that import BuildingState / BuildingActions by name
-export type { BlockSlice as BuildingState, BlockSlice as BuildingActions };
+// Re-export aliases for backward-compat consumers
+export type { BlockGameSlice as BuildingState, BlockGameSlice as BuildingActions, BlockGameSlice as BlockSlice };
 
 // ─── Store ────────────────────────────────────────────────────────────────────
 
 export const useBuildingStore = makeStore<BuildingStore>('BuildingStore', (...a) => ({
   ...createBlockSlice(...a),
+  ...createBlockDragSlice(...a),
   ...createHistorySlice(...a),
   ...createParticleSlice(...a),
   ...createAchievementSlice(...a),


### PR DESCRIPTION
## Summary
Extracts the self-contained pointer-event state machine from `blockSlice.ts` into two new files, separating drag logic from game scoring/history logic. Game actions (`startGame`, `createBlock`, `handleRotate`, etc.) stay in `blockSlice.ts`; drag state and pointer handlers move to the new `blockDragSlice.ts`. The pure `calcDragPosition` helper is extracted to `blockDragUtils.ts` with no Zustand dependency.

## Changes
- `store/blockDragUtils.ts` *(new)*: pure `calcDragPosition` helper — zero Zustand dependency, fully unit-testable
- `store/blockDragSlice.ts` *(new)*: `StateCreator` with `dragState` + 6 pointer-event handlers (mouse/touch down/move/up)
- `store/blockSlice.ts`: renamed type `BlockSlice` → `BlockGameSlice`; removed `dragState` and all drag handlers; removed `calcDragPosition`
- `store/buildingStore.ts`: composes both slices; exports `BlockSlice` alias for backward compat

## Testing
- [x] `npx tsc --noEmit` passes (zero errors)

Closes #571

🤖 Generated with [Claude Code](https://claude.com/claude-code)