### PR TITLE
fix(soccer): replace isolated hook state with shared Zustand store

### DIFF
--- a/gamesformykids/app/games/soccer/soccerGameStore.ts
+++ b/gamesformykids/app/games/soccer/soccerGameStore.ts
@@ -1,0 +1,29 @@
+'use client';
+
+import { create } from 'zustand';
+import type { SoccerQuestion, SoccerCategory } from './data/soccer';
+
+interface SoccerGameState {
+  questions: SoccerQuestion[];
+  category: SoccerCategory;
+  showGoal: boolean;
+}
+
+interface SoccerGameActions {
+  setQuestions: (qs: SoccerQuestion[], cat: SoccerCategory) => void;
+  setShowGoal: (v: boolean) => void;
+  reset: () => void;
+}
+
+const INITIAL: SoccerGameState = {
+  questions: [],
+  category: 'הכל',
+  showGoal: false,
+};
+
+export const useSoccerGameStore = create<SoccerGameState & SoccerGameActions>((set) => ({
+  ...INITIAL,
+  setQuestions: (questions, category) => set({ questions, category }),
+  setShowGoal:  (showGoal) => set({ showGoal }),
+  reset:        () => set(INITIAL),
+}));

--- a/gamesformykids/lib/quiz/useSoccerGame.ts
+++ b/gamesformykids/lib/quiz/useSoccerGame.ts
@@ -1,31 +1,70 @@
 'use client';
 
-import { useState, useCallback } from 'react';
-import { createCategoryIndexQuizHook } from './createCategoryIndexQuizHook';
-import { SOCCER_QUESTIONS, SOCCER_CATEGORIES } from '@/app/games/soccer/data/soccer';
+import { useCallback } from 'react';
+import { SOCCER_QUESTIONS, SOCCER_CATEGORIES, type SoccerCategory } from '@/app/games/soccer/data/soccer';
 import { QUESTIONS_PER_GAME } from './constants';
-
-const _useSoccerBase = createCategoryIndexQuizHook({
-  questions: SOCCER_QUESTIONS,
-  gameType: 'soccer',
-  questionsPerGame: QUESTIONS_PER_GAME,
-  categories: SOCCER_CATEGORIES,
-  allCategory: 'הכל' as const,
-  getCategoryOf: (q) => q.category,
-});
+import { useQuizGameStore } from '@/lib/stores/quizGameStore';
+import { useGameStore } from '@/lib/stores/gameStore';
+import { useGameProgressStore } from '@/lib/stores/gameProgressStore';
+import { shuffle } from '@/lib/utils';
+import { useSoccerGameStore } from '@/app/games/soccer/soccerGameStore';
 
 export function useSoccerGame() {
-  const base = _useSoccerBase();
-  const [showGoal, setShowGoal] = useState(false);
+  const phase    = useQuizGameStore(s => s.phase);
+  const index    = useQuizGameStore(s => s.index);
+  const selected = useQuizGameStore(s => s.selected);
+  const { startQuiz, selectAnswer: storeSelect, restartQuiz } = useQuizGameStore();
+
+  const { questions, category, showGoal, setQuestions, setShowGoal } = useSoccerGameStore();
+  const current      = questions[index] ?? null;
+  const choices      = current ? current.answers.map((_, i) => String(i)) : [];
+  const correctLabel = current ? String(current.correctIndex) : '';
+
+  const startGame = useCallback((cat: SoccerCategory = 'הכל') => {
+    const pool = cat === 'הכל'
+      ? SOCCER_QUESTIONS
+      : SOCCER_QUESTIONS.filter(q => q.category === cat);
+    const shuffled = shuffle(pool).slice(0, QUESTIONS_PER_GAME);
+    setQuestions(shuffled, cat);
+    startQuiz('soccer', shuffled.length);
+    useGameStore.getState().startGame('soccer');
+    useGameProgressStore.getState().resetProgress();
+    useGameProgressStore.getState().setGameActive(true);
+  }, [startQuiz, setQuestions]);
 
   const selectAnswer = useCallback((idx: number) => {
-    const idxStr = String(idx);
-    if (base.correctLabel === idxStr) {
+    if (selected !== null || !current) return;
+    const correct = idx === current.correctIndex;
+    if (correct) {
       setShowGoal(true);
       setTimeout(() => setShowGoal(false), 1500);
     }
-    base.selectAnswer(idxStr);
-  }, [base]);
+    storeSelect(String(idx), correct);
+    useGameProgressStore.getState().recordAttempt(correct);
+  }, [selected, current, storeSelect, setShowGoal]);
 
-  return { ...base, showGoal, selectAnswer };
+  const restart = useCallback(() => {
+    const pool = category === 'הכל'
+      ? SOCCER_QUESTIONS
+      : SOCCER_QUESTIONS.filter(q => q.category === category);
+    const shuffled = shuffle(pool).slice(0, QUESTIONS_PER_GAME);
+    setQuestions(shuffled, category);
+    restartQuiz();
+    useGameStore.getState().startGame('soccer');
+    useGameProgressStore.getState().resetProgress();
+    useGameProgressStore.getState().setGameActive(true);
+  }, [category, restartQuiz, setQuestions]);
+
+  return {
+    phase,
+    category,
+    categories: SOCCER_CATEGORIES,
+    current,
+    choices,
+    correctLabel,
+    showGoal,
+    startGame,
+    selectAnswer,
+    restart,
+  };
 }


### PR DESCRIPTION
## Problem

The soccer game was completely broken — after clicking a category, the question screen never appeared.

**Root cause:** `useSoccerGame()` was called in multiple separate component subtrees:
- `makeQuizGame` (top-level render)
- `SoccerCategoryGrid` (inside `SoccerMenuScreen`)
- `SoccerQuestion`
- `useSoccerQuestion`
- `useSoccerResult`

Each call created its **own isolated `questions` state** (via `useState` inside `createCategoryIndexQuizHook` → `useQuizSession`). When a user clicked a category, `startGame` fired from `SoccerCategoryGrid`'s instance and populated *its* questions. But `makeQuizGame`'s instance had an empty `questions` array, so `current` was always `null` — causing `question: current ? <SoccerQuestion /> : null` to always render `null`.

## Fix

1. **New file** — `app/games/soccer/soccerGameStore.ts`: a Zustand store holding `questions`, `category`, and `showGoal`. All callers of `useSoccerGame()` now share the same state.
2. **Rewritten** — `lib/quiz/useSoccerGame.ts`: removed `createCategoryIndexQuizHook` dependency; reads/writes directly from `soccerGameStore` + `useQuizGameStore`. No changes to any screen components required.