### PR TITLE
dead-code: remove progressStats — wired through architecture but never rendered

### DIFF
--- a/gamesformykids/hooks/shared/game-state/gameHooksMap.ts
+++ b/gamesformykids/hooks/shared/game-state/gameHooksMap.ts
@@ -22,7 +22,6 @@ type AnyGameHookFn = () => {
   hasMoreHints?: boolean;
   showNextHint?: () => void;
   currentAccuracy?: number;
-  progressStats?: unknown;
 };
 
 // טיפוס עבור משחקים שתומכים ב-AutoGamePage בלבד

--- a/gamesformykids/hooks/shared/game-state/useAutoGame.ts
+++ b/gamesformykids/hooks/shared/game-state/useAutoGame.ts
@@ -41,7 +41,7 @@ export function useAutoGame(): GameLogicState {
 
   // Actions from the hook result (freshest closures)
   const { startGame, handleItemClick, resetGame, speakItemName,
-          hints, hasMoreHints, showNextHint, currentAccuracy, progressStats } = gameHookResult;
+          hints, hasMoreHints, showNextHint, currentAccuracy } = gameHookResult;
 
   // UI state from Zustand
   const showProgressModal    = useUIStore((s) => s.showProgressModal);
@@ -88,7 +88,6 @@ export function useAutoGame(): GameLogicState {
     }),
     hasMoreHints,
     showNextHint,
-    progressStats: progressStats ? (progressStats as unknown as Record<string, unknown>) : undefined,
 
     // UI State
     showProgressModal,

--- a/gamesformykids/hooks/shared/game-state/useBaseGame.ts
+++ b/gamesformykids/hooks/shared/game-state/useBaseGame.ts
@@ -221,7 +221,6 @@ export function useBaseGame<T extends BaseGameItem = BaseGameItem>(config: UseBa
     hasMoreHints: hintsHooks.hasMoreHints || false,
     showNextHint: hintsHooks.showNextHint || (() => {}),
     currentAccuracy: progressHooks.getCurrentAccuracy() || 0,
-    progressStats: progressHooks.progressStats || null,
     performanceHooks, // לשימוש בקומפוננטים
   };
 }

--- a/gamesformykids/lib/types/hooks/gameStateTypes/logicState.ts
+++ b/gamesformykids/lib/types/hooks/gameStateTypes/logicState.ts
@@ -32,5 +32,4 @@ export interface GameLogicState extends
   GameConfiguration {
   readonly gameState: GameState | null;
   readonly isGameActive: boolean;
-  readonly progressStats?: Record<string, unknown> | undefined;
 }


### PR DESCRIPTION
## Summary
Removes the progressStats field that was threaded through four layers of the game system but never consumed by any component. A grep for progressStats across components/ returns zero matches. The s unknown as Record<string, unknown> cast in useAutoGame.ts is also eliminated.

## Changes
- \hooks/shared/game-state/gameHooksMap.ts\ — removed \progressStats?: unknown\ from \AnyGameHookFn\
- \hooks/shared/game-state/useAutoGame.ts\ — removed from destructuring and return object; removed the \s unknown as\ cast
- \hooks/shared/game-state/useBaseGame.ts\ — removed \progressStats: progressHooks.progressStats || null\ from return
- \lib/types/hooks/gameStateTypes/logicState.ts\ — removed \eadonly progressStats?: Record<string, unknown>\ from \GameLogicState\

## Testing
- [x] \
px tsc --noEmit\ passes

Closes #603

🤖 Generated with [Claude Code](https://claude.com/claude-code)