### PR TITLE
refactor: migrate 10 canvas arcade games to createCanvasArcadeHook factory

### DIFF
--- a/.claude/issue-tracker-state.json
+++ b/.claude/issue-tracker-state.json
@@ -1,17 +1,23 @@
 {
-  "lastRun": "2026-05-24T14:30:00.000Z",
+  "lastRun": "2026-05-25T12:00:00.000Z",
   "issues": {
     "568": { "title": "refactor: Split useMemoryStore.ts — extract pure helpers and match logic", "hasPR": true, "prNumber": 592, "prState": "merged", "label": "refactor" },
     "569": { "title": "refactor: Split sheshBeshGameStore.ts — separate AI logic, player move execution, and timer utilities", "hasPR": true, "prNumber": 593, "prState": "merged", "label": "refactor" },
     "570": { "title": "refactor: Split useSnakeGame.ts — separate constants, canvas renderer, and input handlers", "hasPR": true, "prNumber": 594, "prState": "open", "label": "refactor" },
     "571": { "title": "refactor: Split blockSlice.ts — extract drag handlers into a dedicated slice", "hasPR": true, "prNumber": 591, "prState": "merged", "label": "refactor" },
-    "572": { "title": "refactor: Extract createCanvasArcadeHook factory — 8 canvas games share the same ref+loop pattern", "hasPR": true, "prNumber": 596, "prState": "open", "label": "refactor" },
+    "572": { "title": "refactor: Extract createCanvasArcadeHook factory — 8 canvas games share the same ref+loop pattern", "hasPR": true, "prNumber": 596, "prState": "merged", "label": "refactor" },
     "578": { "title": "refactor: Migrate soccer game from manual Zustand quiz store to makeQuizGame factory", "hasPR": true, "prNumber": 595, "prState": "merged", "label": "refactor" },
     "586": { "title": "refactor: 7 game stores bypass makeStore/makePersistStore factory and call create+devtools directly", "hasPR": true, "prNumber": 590, "prState": "merged", "label": "refactor" },
-    "587": { "title": "bug: catch-fruit, frogger, pong, space-defender missing useGameCompletion — scores never saved to Supabase", "hasPR": false, "prNumber": null, "prState": null, "label": "bug" }
+    "587": { "title": "bug: catch-fruit, frogger, pong, space-defender missing useGameCompletion — scores never saved to Supabase", "hasPR": true, "prNumber": 610, "prState": "merged", "label": "bug" },
+    "597": { "title": "bug: vehicles game missing from GAMES_REGISTRY — game page broken", "hasPR": true, "prNumber": 609, "prState": "merged", "label": "bug" },
+    "601": { "title": "refactor: Migrate canvas arcade games to createCanvasArcadeHook factory", "hasPR": true, "prNumber": 614, "prState": "open", "label": "refactor" },
+    "602": { "title": "perf: Wrap handler callbacks in useNumericQuizRuntime with useCallback", "hasPR": true, "prNumber": 611, "prState": "merged", "label": "perf" },
+    "603": { "title": "dead-code: Remove unused progressStats from useDashboard", "hasPR": true, "prNumber": 608, "prState": "merged", "label": "dead-code" },
+    "604": { "title": "refactor: Extract building game loop to useBuildingGameLoop hook", "hasPR": true, "prNumber": 612, "prState": "merged", "label": "refactor" },
+    "605": { "title": "bug: Dual-registry quiz games missing GameLogicSync guard", "hasPR": true, "prNumber": 613, "prState": "merged", "label": "bug" }
   },
   "prs": {
-    "596": { "title": "refactor: Extract createCanvasArcadeHook factory — 8 canvas games share the same ref+loop pattern", "state": "OPEN", "linkedIssue": 572 },
+    "596": { "title": "refactor: Extract createCanvasArcadeHook factory — 8 canvas games share the same ref+loop pattern", "state": "MERGED", "linkedIssue": 572 },
     "595": { "title": "refactor: Migrate soccer game from manual Zustand quiz store to makeQuizGame factory", "state": "MERGED", "linkedIssue": 578 },
     "594": { "title": "refactor: Split useSnakeGame.ts — separate constants, canvas renderer, and input handlers", "state": "OPEN", "linkedIssue": 570 },
     "593": { "title": "refactor: Split sheshBeshGameStore.ts — separate AI logic, player move execution, and timer utilities", "state": "MERGED", "linkedIssue": 569 },
@@ -25,6 +31,13 @@
     "581": { "title": "refactor: Move COUNTING_ITEMS inline data in useCountingGame.ts to lib/constants/gameData/", "state": "MERGED", "linkedIssue": 573 },
     "580": { "title": "types: Replace QuizGameConfig<any> in quizGameConfigs.tsx with a concrete type", "state": "MERGED", "linkedIssue": 574 },
     "579": { "title": "types: Replace Record<string, any> DataModule type in gameItemsLoader.ts", "state": "MERGED", "linkedIssue": 575 },
-    "567": { "title": "fix: use text-only cards for geography-capitals and geography-continents", "state": "MERGED", "linkedIssue": 566 }
+    "567": { "title": "fix: use text-only cards for geography-capitals and geography-continents", "state": "MERGED", "linkedIssue": 566 },
+    "608": { "title": "dead-code: Remove unused progressStats from useDashboard", "state": "MERGED", "linkedIssue": 603 },
+    "609": { "title": "bug: vehicles game missing from GAMES_REGISTRY — game page broken", "state": "MERGED", "linkedIssue": 597 },
+    "610": { "title": "bug: add useGameCompletion to catch-fruit, frogger, pong, space-defender", "state": "MERGED", "linkedIssue": 587 },
+    "611": { "title": "perf: Wrap handler callbacks in useNumericQuizRuntime with useCallback", "state": "MERGED", "linkedIssue": 602 },
+    "612": { "title": "refactor: Extract building game loop to useBuildingGameLoop hook", "state": "MERGED", "linkedIssue": 604 },
+    "613": { "title": "bug: Dual-registry quiz games missing GameLogicSync guard", "state": "MERGED", "linkedIssue": 605 },
+    "614": { "title": "refactor: migrate 10 canvas arcade games to createCanvasArcadeHook factory", "state": "OPEN", "linkedIssue": 601 }
   }
 }

--- a/gamesformykids/app/games/brick-breaker/useBrickBreakerGame.ts
+++ b/gamesformykids/app/games/brick-breaker/useBrickBreakerGame.ts
@@ -1,10 +1,9 @@
 'use client';
 
-import { useEffect, useRef, useCallback } from 'react';
+import { useEffect, useCallback } from 'react';
 import { useShallow } from 'zustand/react/shallow';
 import { useBrickBreakerStore } from './brickBreakerStore';
-import { useCanvasLoop } from '@/hooks/canvas';
-import { useGameCompletion } from '@/hooks/shared/progress';
+import { createCanvasArcadeHook } from '@/hooks/canvas';
 
 export const W = 360;
 export const H = 560;
@@ -41,64 +40,24 @@ function brickRect(i: number) {
   return { x, y, w: BRICK_W - BRICK_PAD, h: BRICK_H };
 }
 
-export function useBrickBreakerGame() {
-  const { saveGameResultRef } = useGameCompletion('brick-breaker');
+// Module-level ref so the draw config can trigger level progression
+// (brick-breaker advances levels from inside the canvas loop).
+let _brickStartNextLevel: (level: number) => void = () => {};
 
-  const st = useRef({
+const _useBrickBreaker = createCanvasArcadeHook({
+  gameType: 'brick-breaker',
+  width: W,
+  height: H,
+  initialState: () => ({
     phase: 'menu' as Phase,
     padX: W / 2 - PAD_W / 2,
     ballX: W / 2, ballY: PAD_Y - BALL_R - 2, ballVX: 3, ballVY: -4, launched: false,
     bricks: makeBricks(), score: 0, lives: 3, level: 1, frame: 0,
     startTime: 0,
     particles: [] as { x: number; y: number; vx: number; vy: number; life: number; color: string }[],
-  });
-  const startGame = useCallback((level = 1) => {
-    const s = st.current;
-    s.phase = 'playing';
-    s.padX = W / 2 - PAD_W / 2; s.ballX = W / 2; s.ballY = PAD_Y - BALL_R - 2;
-    const spd = 3.5 + (level - 1) * 0.5;
-    s.ballVX = spd; s.ballVY = -(spd + 0.5); s.launched = false;
-    s.bricks = makeBricks();
-    if (level === 1) s.startTime = Date.now();
-    s.score = level === 1 ? 0 : s.score;
-    s.lives = level === 1 ? 3 : s.lives;
-    s.level = level; s.particles = [];
-    useBrickBreakerStore.getState().startLevel({ score: s.score, lives: s.lives, level });
-  }, []);
-
-  const handleClick = useCallback(() => {
-    const s = st.current;
-    if (s.phase === 'playing' && !s.launched) { s.launched = true; }
-    else if (s.phase === 'menu') { startGame(1); }
-  }, [startGame]);
-
-  const movePaddle = useCallback((clientX: number, rect: DOMRect) => {
-    const scaleX = W / rect.width;
-    const mx = (clientX - rect.left) * scaleX;
-    st.current.padX = Math.max(0, Math.min(W - PAD_W, mx - PAD_W / 2));
-  }, []);
-
-  const handleMouseMove = useCallback((e: React.MouseEvent<HTMLCanvasElement>) => {
-    movePaddle(e.clientX, e.currentTarget.getBoundingClientRect());
-  }, [movePaddle]);
-
-  const handleTouchMove = useCallback((e: React.TouchEvent<HTMLCanvasElement>) => {
-    e.preventDefault();
-    movePaddle(e.touches[0].clientX, e.currentTarget.getBoundingClientRect());
-  }, [movePaddle]);
-
-  const handleTouchStart = useCallback((e: React.TouchEvent<HTMLCanvasElement>) => {
-    e.preventDefault();
-    handleClick();
-    movePaddle(e.touches[0].clientX, e.currentTarget.getBoundingClientRect());
-  }, [handleClick, movePaddle]);
-
-  const nudgeLeft = useCallback(() => { st.current.padX = Math.max(0, st.current.padX - 40); }, []);
-  const nudgeRight = useCallback(() => { st.current.padX = Math.min(W - PAD_W, st.current.padX + 40); }, []);
-
-  const canvasRef = useCanvasLoop((ctx) => {
-    const s = st.current;
-    s.frame++;
+  }),
+  onPointerX: (s, x) => { s.padX = Math.max(0, Math.min(W - PAD_W, x - PAD_W / 2)); },
+  draw: (ctx, s, _dt, saveRef) => {    s.frame++;
 
     if (s.phase === 'playing') {
       if (!s.launched) { s.ballX = s.padX + PAD_W / 2; s.ballY = PAD_Y - BALL_R - 2; }
@@ -118,7 +77,7 @@ export function useBrickBreakerGame() {
           if (s.lives <= 0) {
             s.lives = 0; s.phase = 'dead';
             const elapsed = Math.round((Date.now() - s.startTime) / 1000);
-            saveGameResultRef.current({ score: s.score, level: s.level, durationSeconds: elapsed });
+            saveRef.current({ score: s.score, level: s.level, durationSeconds: elapsed });
             useBrickBreakerStore.getState().setGameOver(s.score, s.level);
           } else { useBrickBreakerStore.getState().setLives(s.lives); }
         }
@@ -140,10 +99,10 @@ export function useBrickBreakerGame() {
           if (nextLevel > 5) {
             s.phase = 'won';
             const elapsed = Math.round((Date.now() - s.startTime) / 1000);
-            saveGameResultRef.current({ score: s.score, level: s.level, durationSeconds: elapsed });
+            saveRef.current({ score: s.score, level: s.level, durationSeconds: elapsed });
             useBrickBreakerStore.getState().setWon(s.score, s.lives, s.level);
           }
-          else { startGame(nextLevel); }
+          else { _brickStartNextLevel(nextLevel); }
         }
       }
       s.particles = s.particles.filter(p => { p.x += p.vx; p.y += p.vy; p.vy += 0.15; p.life -= 0.04; return p.life > 0; });
@@ -176,7 +135,44 @@ export function useBrickBreakerGame() {
     ctx.fillStyle = padGrad; ctx.beginPath(); ctx.roundRect(s.padX, PAD_Y, PAD_W, PAD_H, 6); ctx.fill();
 
     if (s.phase === 'playing' && !s.launched) { ctx.fillStyle = 'rgba(255,255,255,0.7)'; ctx.font = '14px Arial'; ctx.textAlign = 'center'; ctx.fillText('הקש להשיק! 🏏', W / 2, PAD_Y - 20); }
-  });
+  },
+});
+
+export function useBrickBreakerGame() {
+  const { st, canvasRef, handlers } = _useBrickBreaker();
+
+
+  const startGame = useCallback((level = 1) => {
+    const s = st.current;
+    s.phase = 'playing';
+    s.padX = W / 2 - PAD_W / 2; s.ballX = W / 2; s.ballY = PAD_Y - BALL_R - 2;
+    const spd = 3.5 + (level - 1) * 0.5;
+    s.ballVX = spd; s.ballVY = -(spd + 0.5); s.launched = false;
+    s.bricks = makeBricks();
+    if (level === 1) s.startTime = Date.now();
+    s.score = level === 1 ? 0 : s.score;
+    s.lives = level === 1 ? 3 : s.lives;
+    s.level = level; s.particles = [];
+    useBrickBreakerStore.getState().startLevel({ score: s.score, lives: s.lives, level });
+  }, []);
+  // Wire level-progression callback so draw config can call it
+  _brickStartNextLevel = startGame;
+
+  const handleClick = useCallback(() => {
+    const s = st.current;
+    if (s.phase === 'playing' && !s.launched) { s.launched = true; }
+    else if (s.phase === 'menu') { startGame(1); }
+  }, [startGame]);
+
+  const handleTouchStart = useCallback((e: React.TouchEvent<HTMLCanvasElement>) => {
+    e.preventDefault();
+    handleClick();
+    handlers.onTouchMove(e);
+  }, [handleClick, handlers]);
+
+  const nudgeLeft = useCallback(() => { st.current.padX = Math.max(0, st.current.padX - 40); }, []);
+  const nudgeRight = useCallback(() => { st.current.padX = Math.min(W - PAD_W, st.current.padX + 40); }, []);
+
 
   useEffect(() => {
     let left = false, right = false;
@@ -202,5 +198,5 @@ export function useBrickBreakerGame() {
 
   const { phase, score, best, lives, level } = useBrickBreakerStore(useShallow(s => ({ phase: s.phase, score: s.score, best: s.best, lives: s.lives, level: s.level })));
 
-  return { canvasRef, startGame, handleMouseMove, handleTouchMove, handleTouchStart, handleClick, nudgeLeft, nudgeRight, phase, score, best, lives, level };
+  return { canvasRef, startGame, handleMouseMove: handlers.onMouseMove, handleTouchMove: handlers.onTouchMove, handleTouchStart, handleClick, nudgeLeft, nudgeRight, phase, score, best, lives, level };
 }

--- a/gamesformykids/app/games/catch-fruit/useCatchFruitGame.ts
+++ b/gamesformykids/app/games/catch-fruit/useCatchFruitGame.ts
@@ -3,8 +3,7 @@
 import { useRef, useCallback } from 'react';
 import { useShallow } from 'zustand/react/shallow';
 import { useCatchFruitStore, GAME_DURATION } from './catchFruitStore';
-import { useCanvasLoop } from '@/hooks/canvas';
-import { useGameCompletion } from '@/hooks/shared/progress';
+import { createCanvasArcadeHook } from '@/hooks/canvas';
 
 export const W = 360;
 export const H = 520;
@@ -19,42 +18,25 @@ const GOOD_FRUITS = ['🍎', '🍊', '🍋', '🍇', '🍓', '🍑', '🥝', '�
 const BAD_ITEMS = ['💣', '☠️', '🪨'];
 let idCounter = 0;
 
-export function useCatchFruitGame() {
-  const { saveGameResultRef } = useGameCompletion('catch-fruit');
-  const st = useRef({
+const _useCatchFruit = createCanvasArcadeHook({
+  gameType: 'catch-fruit',
+  width: W,
+  height: H,
+  initialState: () => ({
     phase: 'menu' as Phase,
     basketX: W / 2 - BASKET_W / 2,
     items: [] as FallingItem[],
     score: 0, lives: 3, timeLeft: GAME_DURATION, frame: 0, nextItem: 40, startTime: 0,
     bgStars: Array.from({ length: 8 }, () => ({ x: Math.random() * W, y: Math.random() * H * 0.7, r: 2 + Math.random() * 3 })),
-  });
-  const dragging = useRef(false);
-  const pointerDown = useRef(false);
-
-  const startGame = useCallback(() => {
-    const s = st.current;
-    s.phase = 'playing';
-    s.basketX = W / 2 - BASKET_W / 2;
-    s.items = [];
-    s.score = 0; s.lives = 3; s.timeLeft = GAME_DURATION; s.frame = 0; s.nextItem = 40; s.startTime = Date.now();
-    useCatchFruitStore.getState().startGame();
-  }, []);
-
-  const handleMouseUp = useCallback(() => {
-    pointerDown.current = false;
-    dragging.current = false;
-  }, []);
-
-  const canvasRef = useCanvasLoop((ctx, dt) => {
-    const s = st.current;
-
+  }),
+  draw: (ctx, s, dt, saveRef) => {
     if (s.phase === 'playing') {
       s.frame++;
       s.timeLeft -= dt / 1000;
       if (s.timeLeft <= 0) {
         s.timeLeft = 0;
         s.phase = 'result';
-        saveGameResultRef.current({ score: s.score, level: 1, durationSeconds: Math.round((Date.now() - s.startTime) / 1000) });
+        saveRef.current({ score: s.score, level: 1, durationSeconds: Math.round((Date.now() - s.startTime) / 1000) });
         useCatchFruitStore.getState().setGameResult(s.score, s.lives, 0);
       }
       s.nextItem--;
@@ -70,7 +52,7 @@ export function useCatchFruitGame() {
         if (item.y + FRUIT_R >= BASKET_Y && item.y - FRUIT_R <= BASKET_Y + BASKET_H && item.x + FRUIT_R > bx && item.x - FRUIT_R < bx + BASKET_W) {
           if (item.isBad) {
             s.lives--;
-            if (s.lives <= 0) { s.lives = 0; s.phase = 'result'; saveGameResultRef.current({ score: s.score, level: 1, durationSeconds: Math.round((Date.now() - s.startTime) / 1000) }); useCatchFruitStore.getState().setGameResult(s.score, 0, Math.ceil(s.timeLeft)); }
+            if (s.lives <= 0) { s.lives = 0; s.phase = 'result'; saveRef.current({ score: s.score, level: 1, durationSeconds: Math.round((Date.now() - s.startTime) / 1000) }); useCatchFruitStore.getState().setGameResult(s.score, 0, Math.ceil(s.timeLeft)); }
             else { useCatchFruitStore.getState().setLives(s.lives); }
           } else { s.score += 10; useCatchFruitStore.getState().setScore(s.score); }
           return false;
@@ -78,7 +60,7 @@ export function useCatchFruitGame() {
         if (item.y - FRUIT_R > H) return false;
         return true;
       });
-      if (s.frame % 20 === 0 && st.current.phase === 'playing') useCatchFruitStore.getState().setTimeLeft(Math.ceil(s.timeLeft));
+      if (s.frame % 20 === 0 && s.phase === 'playing') useCatchFruitStore.getState().setTimeLeft(Math.ceil(s.timeLeft));
     }
 
     const grad = ctx.createLinearGradient(0, 0, 0, H);
@@ -94,7 +76,7 @@ export function useCatchFruitGame() {
       ctx.fill();
     }
 
-    const curr = st.current;
+    const curr = s;
     ctx.font = `${FRUIT_R * 1.8}px serif`;
     ctx.textAlign = 'center';
     ctx.textBaseline = 'middle';
@@ -122,7 +104,30 @@ export function useCatchFruitGame() {
     ctx.beginPath();
     ctx.arc(bxD + BASKET_W / 2, BASKET_Y - 2, BASKET_W / 3, Math.PI, Math.PI * 2);
     ctx.stroke();
-  });
+  },
+});
+
+export function useCatchFruitGame() {
+  const { st, canvasRef } = _useCatchFruit();
+
+
+  const dragging = useRef(false);
+  const pointerDown = useRef(false);
+
+  const startGame = useCallback(() => {
+    const s = st.current;
+    s.phase = 'playing';
+    s.basketX = W / 2 - BASKET_W / 2;
+    s.items = [];
+    s.score = 0; s.lives = 3; s.timeLeft = GAME_DURATION; s.frame = 0; s.nextItem = 40; s.startTime = Date.now();
+    useCatchFruitStore.getState().startGame();
+  }, []);
+
+  const handleMouseUp = useCallback(() => {
+    pointerDown.current = false;
+    dragging.current = false;
+  }, []);
+
 
   const handleMouseMove = useCallback((e: React.MouseEvent<HTMLCanvasElement>) => {
     if (!pointerDown.current) return;

--- a/gamesformykids/app/games/dino-runner/useDinoRunnerGame.ts
+++ b/gamesformykids/app/games/dino-runner/useDinoRunnerGame.ts
@@ -1,10 +1,9 @@
 'use client';
 
-import { useEffect, useRef, useCallback } from 'react';
+import { useEffect, useCallback } from 'react';
 import { useShallow } from 'zustand/react/shallow';
 import { useDinoRunnerStore } from './dinoRunnerStore';
-import { useCanvasLoop } from '@/hooks/canvas';
-import { useGameCompletion } from '@/hooks/shared/progress';
+import { createCanvasArcadeHook } from '@/hooks/canvas';
 
 export const W = 400;
 export const H = 220;
@@ -21,10 +20,11 @@ interface Obstacle { x: number; w: number; h: number; emoji: string; }
 
 const OBSTACLE_EMOJIS = ['🌵', '🪨', '🌴', '🌿', '🍄'];
 
-export function useDinoRunnerGame() {
-  const { saveGameResultRef } = useGameCompletion('dino-runner');
-
-  const st = useRef({
+const _useDinoRunner = createCanvasArcadeHook({
+  gameType: 'dino-runner',
+  width: W,
+  height: H,
+  initialState: () => ({
     phase: 'menu' as Phase,
     dinoY: GROUND_Y - DINO_H,
     dinoVY: 0,
@@ -36,33 +36,8 @@ export function useDinoRunnerGame() {
     speed: BASE_SPEED,
     nextObstacle: 80,
     startTime: 0,
-  });
-  const jump = useCallback(() => {
-    const s = st.current;
-    if (s.phase === 'playing' && s.onGround) {
-      s.dinoVY = JUMP_V;
-      s.onGround = false;
-    } else if (s.phase === 'menu') {
-      s.phase = 'playing';
-      s.dinoY = GROUND_Y - DINO_H;
-      s.dinoVY = JUMP_V;
-      s.onGround = false;
-      s.obstacles = [];
-      s.score = 0;
-      s.frame = 0;
-      s.speed = BASE_SPEED;
-      s.nextObstacle = 80;
-      s.startTime = Date.now();
-      useDinoRunnerStore.getState().startGame();
-    } else if (s.phase === 'dead') {
-      s.phase = 'menu';
-      useDinoRunnerStore.getState().resetToMenu();
-    }
-  }, []);
-
-  const canvasRef = useCanvasLoop((ctx) => {
-    const s = st.current;
-
+  }),
+  draw: (ctx, s, _dt, saveRef) => {
     if (s.phase === 'playing') {
       s.frame++;
       s.score = Math.floor(s.frame / 6);
@@ -107,7 +82,7 @@ export function useDinoRunnerGame() {
         ) {
           s.phase = 'dead';
           const elapsed = Math.round((Date.now() - s.startTime) / 1000);
-          saveGameResultRef.current({ score: s.score, level: 1, durationSeconds: elapsed });
+          saveRef.current({ score: s.score, level: 1, durationSeconds: elapsed });
           useDinoRunnerStore.getState().setGameOver(s.score);
         }
       }
@@ -117,7 +92,7 @@ export function useDinoRunnerGame() {
     ctx.fillRect(0, 0, W, H);
 
     ctx.fillStyle = 'rgba(200,230,255,0.6)';
-    for (const c of st.current.clouds) {
+    for (const c of s.clouds) {
       ctx.beginPath();
       ctx.ellipse(c.x, c.y, 30, 16, 0, 0, Math.PI * 2);
       ctx.fill();
@@ -134,8 +109,8 @@ export function useDinoRunnerGame() {
     ctx.fillStyle = '#b45309';
     ctx.fillRect(0, GROUND_Y, W, 3);
 
-    if (st.current.phase !== 'menu') {
-      const s2 = st.current;
+    if (s.phase !== 'menu') {
+      const s2 = s;
       ctx.font = `${DINO_W}px serif`;
       ctx.textAlign = 'center';
       ctx.textBaseline = 'bottom';
@@ -152,8 +127,37 @@ export function useDinoRunnerGame() {
     ctx.font = 'bold 18px Arial';
     ctx.textAlign = 'right';
     ctx.textBaseline = 'top';
-    ctx.fillText(`${st.current.score}`, W - 12, 10);
-  });
+    ctx.fillText(`${s.score}`, W - 12, 10);
+  },
+});
+
+export function useDinoRunnerGame() {
+  const { st, canvasRef } = _useDinoRunner();
+
+
+  const jump = useCallback(() => {
+    const s = st.current;
+    if (s.phase === 'playing' && s.onGround) {
+      s.dinoVY = JUMP_V;
+      s.onGround = false;
+    } else if (s.phase === 'menu') {
+      s.phase = 'playing';
+      s.dinoY = GROUND_Y - DINO_H;
+      s.dinoVY = JUMP_V;
+      s.onGround = false;
+      s.obstacles = [];
+      s.score = 0;
+      s.frame = 0;
+      s.speed = BASE_SPEED;
+      s.nextObstacle = 80;
+      s.startTime = Date.now();
+      useDinoRunnerStore.getState().startGame();
+    } else if (s.phase === 'dead') {
+      s.phase = 'menu';
+      useDinoRunnerStore.getState().resetToMenu();
+    }
+  }, []);
+
 
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {

--- a/gamesformykids/app/games/flappy-bird/useFlappyBirdGame.ts
+++ b/gamesformykids/app/games/flappy-bird/useFlappyBirdGame.ts
@@ -1,10 +1,9 @@
 'use client';
 
-import { useRef, useCallback } from 'react';
+import { useCallback } from 'react';
 import { useShallow } from 'zustand/react/shallow';
 import { useFlappyBirdStore } from './flappyBirdStore';
-import { useCanvasLoop } from '@/hooks/canvas';
-import { useGameCompletion } from '@/hooks/shared/progress';
+import { createCanvasArcadeHook } from '@/hooks/canvas';
 
 export const W = 360;
 export const H = 560;
@@ -36,10 +35,11 @@ function drawRoundRect(ctx: CanvasRenderingContext2D, x: number, y: number, w: n
   ctx.closePath();
 }
 
-export function useFlappyBirdGame() {
-  const { saveGameResultRef } = useGameCompletion('flappy-bird');
-
-  const s = useRef({
+const _useFlappyBird = createCanvasArcadeHook({
+  gameType: 'flappy-bird',
+  width: W,
+  height: H,
+  initialState: () => ({
     phase: 'menu' as Phase,
     birdY: H / 2,
     birdVY: 0,
@@ -48,34 +48,9 @@ export function useFlappyBirdGame() {
     frame: 0,
     bgOffset: 0,
     startTime: 0,
-  });
-  const resetGame = useCallback(() => {
-    const st = s.current;
-    st.phase = 'playing';
-    st.birdY = H / 2;
-    st.birdVY = FLAP_STRENGTH;
-    st.pipes = [];
-    st.score = 0;
-    st.frame = 0;
-    st.startTime = Date.now();
-    useFlappyBirdStore.getState().setPhase('playing');
-    useFlappyBirdStore.getState().setScore(0);
-  }, []);
-
-  const flap = useCallback(() => {
-    const st = s.current;
-    if (st.phase === 'playing') {
-      st.birdVY = FLAP_STRENGTH;
-    } else if (st.phase === 'menu') {
-      resetGame();
-    } else if (st.phase === 'dead') {
-      st.phase = 'menu';
-      useFlappyBirdStore.getState().setPhase('menu');
-    }
-  }, [resetGame]);
-
-  const canvasRef = useCanvasLoop((ctx) => {
-    const st = s.current;
+  }),
+  draw: (ctx, s, _dt, saveRef) => {
+    const st = s;
     if (st.phase === 'playing') {
       st.frame++;
       st.birdVY += GRAVITY;
@@ -99,7 +74,7 @@ export function useFlappyBirdGame() {
       if (st.birdY + BIRD_R >= H - GROUND_H || st.birdY - BIRD_R <= 0) {
         if (st.phase === 'playing') {
           const elapsed = Math.round((Date.now() - st.startTime) / 1000);
-          saveGameResultRef.current({ score: st.score, level: 1, durationSeconds: elapsed });
+          saveRef.current({ score: st.score, level: 1, durationSeconds: elapsed });
           st.phase = 'dead';
           useFlappyBirdStore.getState().endGame(st.score);
         }
@@ -113,7 +88,7 @@ export function useFlappyBirdGame() {
         if (bR > p.x && bL < p.x + PIPE_W) {
           if ((bT < p.gapY || bB > p.gapY + PIPE_GAP) && st.phase === 'playing') {
             const elapsed = Math.round((Date.now() - st.startTime) / 1000);
-            saveGameResultRef.current({ score: st.score, level: 1, durationSeconds: elapsed });
+            saveRef.current({ score: st.score, level: 1, durationSeconds: elapsed });
             st.phase = 'dead';
             useFlappyBirdStore.getState().endGame(st.score);
           }
@@ -201,7 +176,38 @@ export function useFlappyBirdGame() {
     ctx.strokeText(String(st.score), W / 2, 52);
     ctx.fillStyle = 'white';
     ctx.fillText(String(st.score), W / 2, 52);
-  });
+  },
+});
+
+export function useFlappyBirdGame() {
+  const { st, canvasRef } = _useFlappyBird();
+
+
+  const resetGame = useCallback(() => {
+    const s = st.current;
+    s.phase = 'playing';
+    s.birdY = H / 2;
+    s.birdVY = FLAP_STRENGTH;
+    s.pipes = [];
+    s.score = 0;
+    s.frame = 0;
+    s.startTime = Date.now();
+    useFlappyBirdStore.getState().setPhase('playing');
+    useFlappyBirdStore.getState().setScore(0);
+  }, []);
+
+  const flap = useCallback(() => {
+    const s = st.current;
+    if (s.phase === 'playing') {
+      s.birdVY = FLAP_STRENGTH;
+    } else if (s.phase === 'menu') {
+      resetGame();
+    } else if (s.phase === 'dead') {
+      s.phase = 'menu';
+      useFlappyBirdStore.getState().setPhase('menu');
+    }
+  }, [resetGame]);
+
 
   const handleInput = useCallback((e?: React.MouseEvent | React.TouchEvent) => {
     e?.preventDefault();

--- a/gamesformykids/app/games/frogger/useFroggerGame.ts
+++ b/gamesformykids/app/games/frogger/useFroggerGame.ts
@@ -3,8 +3,7 @@
 import { useEffect, useRef, useCallback } from 'react';
 import { useShallow } from 'zustand/react/shallow';
 import { useFroggerStore } from './froggerStore';
-import { useCanvasLoop } from '@/hooks/canvas';
-import { useGameCompletion } from '@/hooks/shared/progress';
+import { createCanvasArcadeHook } from '@/hooks/canvas';
 
 const CELL = 40;
 const COLS = 9;
@@ -34,15 +33,85 @@ function makeLanes() {
   }));
 }
 
-export function useFroggerGame() {
-  const { saveGameResultRef } = useGameCompletion('frogger');
-  const st = useRef({
+const _useFrogger = createCanvasArcadeHook({
+  gameType: 'frogger',
+  width: W,
+  height: H,
+  initialState: () => ({
     phase: 'menu' as Phase,
     fCol: 4, fRow: 8,
     lives: 3, score: 0, best: 0, level: 1,
     frame: 0, dead: false, deadTimer: 0, startTime: 0,
     lanes: makeLanes(),
-  });
+  }),
+  draw: (ctx, s, _dt, saveRef) => {    s.frame++;
+
+    if (s.phase === 'playing') {
+      const mul = 1 + (s.level - 1) * 0.18;
+      if (s.dead) {
+        s.deadTimer--;
+        if (s.deadTimer <= 0) s.dead = false;
+      } else {
+        for (const lane of s.lanes) {
+          for (const car of lane.cars) {
+            car.x += lane.speed * mul;
+            if (lane.speed > 0 && car.x > W + 5) car.x -= W + CAR_W * 3.5;
+            if (lane.speed < 0 && car.x + CAR_W < -5) car.x += W + CAR_W * 3.5;
+          }
+        }
+        const fx = s.fCol * CELL + CELL / 2, fy = s.fRow * CELL + CELL / 2;
+        for (const lane of s.lanes) {
+          if (Math.abs(fy - (lane.row * CELL + CELL / 2)) > CELL * 0.45) continue;
+          for (const car of lane.cars) {
+            const cx = car.x + CAR_W / 2;
+            if (Math.abs(fx - cx) < CAR_W / 2 - 4) {
+              s.lives--; s.dead = true; s.deadTimer = 55; s.fCol = 4; s.fRow = 8;
+              if (s.lives <= 0) { s.phase = 'dead'; saveRef.current({ score: s.score, level: s.level, durationSeconds: Math.round((Date.now() - s.startTime) / 1000) }); useFroggerStore.getState().endGame(s.score); }
+            }
+          }
+        }
+      }
+    }
+
+    for (let row = 0; row < ROWS; row++) {
+      if (row === 0) ctx.fillStyle = '#14532d';
+      else if (row === 4) ctx.fillStyle = '#4b5563';
+      else if (row === 8) ctx.fillStyle = '#166534';
+      else ctx.fillStyle = '#374151';
+      ctx.fillRect(0, row * CELL, W, CELL);
+      if ((row >= 1 && row <= 3) || (row >= 5 && row <= 7)) {
+        ctx.fillStyle = 'rgba(255,220,0,0.2)';
+        for (let c = 0; c < COLS; c++) ctx.fillRect(c * CELL + CELL / 2 - 2, row * CELL + CELL / 2 - 7, 4, 14);
+      }
+    }
+
+    ctx.font = `${CELL * 0.65}px serif`; ctx.textAlign = 'center'; ctx.textBaseline = 'middle';
+    for (let c = 1; c < COLS; c += 2) ctx.fillText('🏁', c * CELL + CELL / 2, CELL / 2);
+
+    const s2 = s;
+    for (const lane of s2.lanes) {
+      for (const car of lane.cars) {
+        ctx.fillStyle = car.color; ctx.beginPath(); ctx.roundRect(car.x, lane.row * CELL + 5, CAR_W, CELL - 10, 5); ctx.fill();
+        ctx.font = `${CELL * 0.65}px serif`; ctx.textAlign = 'center'; ctx.textBaseline = 'middle';
+        ctx.fillText(car.emoji, car.x + CAR_W / 2, lane.row * CELL + CELL / 2);
+      }
+    }
+
+    const blink = s2.dead && s2.frame % 6 < 3;
+    if (!blink) {
+      ctx.font = `${CELL * 0.75}px serif`; ctx.textAlign = 'center'; ctx.textBaseline = 'middle';
+      ctx.fillText('🐸', s2.fCol * CELL + CELL / 2, s2.fRow * CELL + CELL / 2);
+    }
+
+    ctx.font = 'bold 15px Arial'; ctx.fillStyle = 'rgba(255,255,255,0.8)'; ctx.textAlign = 'right'; ctx.textBaseline = 'top';
+    ctx.fillText(`${s2.score}`, W - 6, 4);
+  },
+});
+
+export function useFroggerGame() {
+  const { st, canvasRef } = _useFrogger();
+
+
   const startGame = useCallback(() => {
     const s = st.current;
     s.phase = 'playing'; s.fCol = 4; s.fRow = 8;
@@ -78,70 +147,6 @@ export function useFroggerGame() {
     else moveFrog(0, dy > 0 ? 1 : -1);
   }, [moveFrog]);
 
-  const canvasRef = useCanvasLoop((ctx) => {
-    const s = st.current;
-    s.frame++;
-
-    if (s.phase === 'playing') {
-      const mul = 1 + (s.level - 1) * 0.18;
-      if (s.dead) {
-        s.deadTimer--;
-        if (s.deadTimer <= 0) s.dead = false;
-      } else {
-        for (const lane of s.lanes) {
-          for (const car of lane.cars) {
-            car.x += lane.speed * mul;
-            if (lane.speed > 0 && car.x > W + 5) car.x -= W + CAR_W * 3.5;
-            if (lane.speed < 0 && car.x + CAR_W < -5) car.x += W + CAR_W * 3.5;
-          }
-        }
-        const fx = s.fCol * CELL + CELL / 2, fy = s.fRow * CELL + CELL / 2;
-        for (const lane of s.lanes) {
-          if (Math.abs(fy - (lane.row * CELL + CELL / 2)) > CELL * 0.45) continue;
-          for (const car of lane.cars) {
-            const cx = car.x + CAR_W / 2;
-            if (Math.abs(fx - cx) < CAR_W / 2 - 4) {
-              s.lives--; s.dead = true; s.deadTimer = 55; s.fCol = 4; s.fRow = 8;
-              if (s.lives <= 0) { s.phase = 'dead'; saveGameResultRef.current({ score: s.score, level: s.level, durationSeconds: Math.round((Date.now() - s.startTime) / 1000) }); useFroggerStore.getState().endGame(s.score); }
-            }
-          }
-        }
-      }
-    }
-
-    for (let row = 0; row < ROWS; row++) {
-      if (row === 0) ctx.fillStyle = '#14532d';
-      else if (row === 4) ctx.fillStyle = '#4b5563';
-      else if (row === 8) ctx.fillStyle = '#166534';
-      else ctx.fillStyle = '#374151';
-      ctx.fillRect(0, row * CELL, W, CELL);
-      if ((row >= 1 && row <= 3) || (row >= 5 && row <= 7)) {
-        ctx.fillStyle = 'rgba(255,220,0,0.2)';
-        for (let c = 0; c < COLS; c++) ctx.fillRect(c * CELL + CELL / 2 - 2, row * CELL + CELL / 2 - 7, 4, 14);
-      }
-    }
-
-    ctx.font = `${CELL * 0.65}px serif`; ctx.textAlign = 'center'; ctx.textBaseline = 'middle';
-    for (let c = 1; c < COLS; c += 2) ctx.fillText('🏁', c * CELL + CELL / 2, CELL / 2);
-
-    const s2 = st.current;
-    for (const lane of s2.lanes) {
-      for (const car of lane.cars) {
-        ctx.fillStyle = car.color; ctx.beginPath(); ctx.roundRect(car.x, lane.row * CELL + 5, CAR_W, CELL - 10, 5); ctx.fill();
-        ctx.font = `${CELL * 0.65}px serif`; ctx.textAlign = 'center'; ctx.textBaseline = 'middle';
-        ctx.fillText(car.emoji, car.x + CAR_W / 2, lane.row * CELL + CELL / 2);
-      }
-    }
-
-    const blink = s2.dead && s2.frame % 6 < 3;
-    if (!blink) {
-      ctx.font = `${CELL * 0.75}px serif`; ctx.textAlign = 'center'; ctx.textBaseline = 'middle';
-      ctx.fillText('🐸', s2.fCol * CELL + CELL / 2, s2.fRow * CELL + CELL / 2);
-    }
-
-    ctx.font = 'bold 15px Arial'; ctx.fillStyle = 'rgba(255,255,255,0.8)'; ctx.textAlign = 'right'; ctx.textBaseline = 'top';
-    ctx.fillText(`${s2.score}`, W - 6, 4);
-  });
 
   useEffect(() => {
     const kd = (e: KeyboardEvent) => {

--- a/gamesformykids/app/games/jumper/useJumperGame.ts
+++ b/gamesformykids/app/games/jumper/useJumperGame.ts
@@ -1,10 +1,9 @@
 'use client';
 
-import { useEffect, useRef, useCallback } from 'react';
+import { useEffect, useCallback } from 'react';
 import { useShallow } from 'zustand/react/shallow';
 import { useJumperStore } from './jumperStore';
-import { useCanvasLoop } from '@/hooks/canvas';
-import { useGameCompletion } from '@/hooks/shared/progress';
+import { createCanvasArcadeHook } from '@/hooks/canvas';
 
 export const W = 300;
 export const H = 500;
@@ -32,10 +31,11 @@ function generateInitial(): Array<Platform & { id: number }> {
   return plats;
 }
 
-export function useJumperGame() {
-  const { saveGameResultRef } = useGameCompletion('jumper');
-
-  const st = useRef({
+const _useJumper = createCanvasArcadeHook({
+  gameType: 'jumper',
+  width: W,
+  height: H,
+  initialState: () => ({
     phase: 'menu' as Phase,
     px: W / 2, py: H - 100,
     pvx: 0, pvy: 0,
@@ -47,32 +47,8 @@ export function useJumperGame() {
     leftDown: false, rightDown: false,
     nextPlatY: H - 60 - INIT_PLATS * (PLAT_GAP * 0.75),
     startTime: 0,
-  });
-  const startGame = useCallback(() => {
-    const s = st.current;
-    s.phase = 'playing';
-    s.px = W / 2; s.py = H - 100;
-    s.pvx = 0; s.pvy = JUMP_VY;
-    s.camY = 0; s.maxCamY = 0;
-    s.score = 0; s.frame = 0;
-    s.platforms = generateInitial();
-    s.nextPlatY = H - 60 - INIT_PLATS * (PLAT_GAP * 0.75);
-    s.startTime = Date.now();
-    useJumperStore.getState().startPlaying();
-  }, []);
-
-  const handleCanvasClick = useCallback(() => {
-    if (st.current.phase === 'menu') startGame();
-  }, [startGame]);
-
-  const pressLeft = useCallback(() => { st.current.leftDown = true; }, []);
-  const releaseLeft = useCallback(() => { st.current.leftDown = false; }, []);
-  const pressRight = useCallback(() => { st.current.rightDown = true; }, []);
-  const releaseRight = useCallback(() => { st.current.rightDown = false; }, []);
-
-  const canvasRef = useCanvasLoop((ctx) => {
-    const s = st.current;
-    s.frame++;
+  }),
+  draw: (ctx, s, _dt, saveRef) => {    s.frame++;
 
     if (s.phase === 'playing') {
       const HSPEED = 4.5;
@@ -124,7 +100,7 @@ export function useJumperGame() {
       if (s.py > H + 60) {
         s.phase = 'dead';
         const elapsed = Math.round((Date.now() - s.startTime) / 1000);
-        saveGameResultRef.current({ score: s.score, level: 1, durationSeconds: elapsed });
+        saveRef.current({ score: s.score, level: 1, durationSeconds: elapsed });
         useJumperStore.getState().endGame(s.score);
       }
     }
@@ -137,14 +113,14 @@ export function useJumperGame() {
 
     ctx.fillStyle = 'rgba(255,255,255,0.6)';
     for (let i = 0; i < 30; i++) {
-      const sx = ((i * 97 + st.current.camY * 0.05) % W + W) % W;
+      const sx = ((i * 97 + s.camY * 0.05) % W + W) % W;
       const sy = ((i * 137) % H);
       ctx.beginPath();
       ctx.arc(sx, sy, 0.8, 0, Math.PI * 2);
       ctx.fill();
     }
 
-    const s2 = st.current;
+    const s2 = s;
     for (const p of s2.platforms) {
       const drawY = p.y + s2.camY;
       if (drawY > H + 10 || drawY < -PLAT_H - 5) continue;
@@ -167,7 +143,35 @@ export function useJumperGame() {
     ctx.fillStyle = 'rgba(255,255,255,0.85)';
     ctx.textAlign = 'left';
     ctx.fillText(`${s2.score}m`, 10, 30);
-  });
+  },
+});
+
+export function useJumperGame() {
+  const { st, canvasRef } = _useJumper();
+
+
+  const startGame = useCallback(() => {
+    const s = st.current;
+    s.phase = 'playing';
+    s.px = W / 2; s.py = H - 100;
+    s.pvx = 0; s.pvy = JUMP_VY;
+    s.camY = 0; s.maxCamY = 0;
+    s.score = 0; s.frame = 0;
+    s.platforms = generateInitial();
+    s.nextPlatY = H - 60 - INIT_PLATS * (PLAT_GAP * 0.75);
+    s.startTime = Date.now();
+    useJumperStore.getState().startPlaying();
+  }, []);
+
+  const handleCanvasClick = useCallback(() => {
+    if (st.current.phase === 'menu') startGame();
+  }, [startGame]);
+
+  const pressLeft = useCallback(() => { st.current.leftDown = true; }, []);
+  const releaseLeft = useCallback(() => { st.current.leftDown = false; }, []);
+  const pressRight = useCallback(() => { st.current.rightDown = true; }, []);
+  const releaseRight = useCallback(() => { st.current.rightDown = false; }, []);
+
 
   useEffect(() => {
     const kd = (e: KeyboardEvent) => {

--- a/gamesformykids/app/games/meteor-dodge/useMeteorDodgeGame.ts
+++ b/gamesformykids/app/games/meteor-dodge/useMeteorDodgeGame.ts
@@ -1,10 +1,9 @@
 'use client';
 
-import { useEffect, useRef, useCallback } from 'react';
+import { useEffect, useCallback } from 'react';
 import { useShallow } from 'zustand/react/shallow';
 import { useMeteorDodgeStore } from './meteorDodgeStore';
-import { useCanvasLoop } from '@/hooks/canvas';
-import { useGameCompletion } from '@/hooks/shared/progress';
+import { createCanvasArcadeHook } from '@/hooks/canvas';
 
 export const W = 360;
 export const H = 560;
@@ -19,51 +18,20 @@ interface StarPick { id: number; x: number; y: number; vy: number; emoji: string
 
 let uid = 0;
 
-export function useMeteorDodgeGame() {
-  const { saveGameResultRef } = useGameCompletion('meteor-dodge');
-
-  const st = useRef({
+const _useMeteorDodge = createCanvasArcadeHook({
+  gameType: 'meteor-dodge',
+  width: W,
+  height: H,
+  initialState: () => ({
     phase: 'menu' as Phase,
     playerX: W / 2,
     meteors: [] as Meteor[], stars: [] as StarPick[],
     score: 0, best: 0, frame: 0, nextMeteor: 50, nextStar: 120,
     bgStars: Array.from({ length: 50 }, () => ({ x: Math.random() * W, y: Math.random() * H, r: 0.5 + Math.random() * 1.5, twinkle: Math.random() * Math.PI * 2 })),
     invincible: 0, startTime: 0,
-  });
-  const startGame = useCallback(() => {
-    const s = st.current;
-    s.phase = 'playing'; s.playerX = W / 2; s.meteors = []; s.stars = [];
-    s.score = 0; s.frame = 0; s.nextMeteor = 50; s.nextStar = 120; s.invincible = 0;
-    s.startTime = Date.now();
-    useMeteorDodgeStore.getState().startPlaying();
-  }, []);
-
-  const handleMouseMove = useCallback((e: React.MouseEvent<HTMLCanvasElement>) => {
-    if (st.current.phase !== 'playing') return;
-    const rect = e.currentTarget.getBoundingClientRect();
-    st.current.playerX = Math.max(PLAYER_R, Math.min(W - PLAYER_R, (e.clientX - rect.left) * (W / rect.width)));
-  }, []);
-
-  const handleTouchMove = useCallback((e: React.TouchEvent<HTMLCanvasElement>) => {
-    e.preventDefault();
-    if (st.current.phase !== 'playing') return;
-    const rect = e.currentTarget.getBoundingClientRect();
-    st.current.playerX = Math.max(PLAYER_R, Math.min(W - PLAYER_R, (e.touches[0].clientX - rect.left) * (W / rect.width)));
-  }, []);
-
-  const handleCanvasClick = useCallback(() => {
-    if (st.current.phase === 'menu') startGame();
-  }, [startGame]);
-
-  const handleTouchStart = useCallback((e: React.TouchEvent<HTMLCanvasElement>) => {
-    e.preventDefault();
-    if (st.current.phase === 'menu') startGame();
-    handleTouchMove(e);
-  }, [startGame, handleTouchMove]);
-
-  const canvasRef = useCanvasLoop((ctx) => {
-    const s = st.current;
-
+  }),
+  onPointerX: (s, x) => { s.playerX = Math.max(PLAYER_R, Math.min(W - PLAYER_R, x)); },
+  draw: (ctx, s, _dt, saveRef) => {
     if (s.phase === 'playing') {
       s.frame++;
       s.score = Math.floor(s.frame / 4);
@@ -98,7 +66,7 @@ export function useMeteorDodgeGame() {
           const dx = m.x - s.playerX, dy = m.y - PLAYER_Y;
           if (Math.sqrt(dx * dx + dy * dy) < PLAYER_R + m.r - 8) {
             const elapsed = Math.round((Date.now() - s.startTime) / 1000);
-            saveGameResultRef.current({ score: s.score, level: 1, durationSeconds: elapsed });
+            saveRef.current({ score: s.score, level: 1, durationSeconds: elapsed });
             s.phase = 'dead'; useMeteorDodgeStore.getState().endGame(s.score); break;
           }
         }
@@ -108,7 +76,7 @@ export function useMeteorDodgeGame() {
     }
 
     ctx.fillStyle = '#030712'; ctx.fillRect(0, 0, W, H);
-    const curr = st.current;
+    const curr = s;
     for (const star of curr.bgStars) {
       const alpha = 0.3 + Math.sin(curr.frame * 0.02 + star.twinkle) * 0.3;
       ctx.beginPath(); ctx.arc(star.x, star.y, star.r, 0, Math.PI * 2);
@@ -144,7 +112,32 @@ export function useMeteorDodgeGame() {
 
     ctx.font = 'bold 20px Arial'; ctx.fillStyle = 'rgba(255,255,255,0.8)'; ctx.textAlign = 'right';
     ctx.fillText(`${curr.score}`, W - 12, 28);
-  });
+  },
+});
+
+export function useMeteorDodgeGame() {
+  const { st, canvasRef, handlers } = _useMeteorDodge();
+
+
+
+  const startGame = useCallback(() => {
+    const s = st.current;
+    s.phase = 'playing'; s.playerX = W / 2; s.meteors = []; s.stars = [];
+    s.score = 0; s.frame = 0; s.nextMeteor = 50; s.nextStar = 120; s.invincible = 0;
+    s.startTime = Date.now();
+    useMeteorDodgeStore.getState().startPlaying();
+  }, []);
+
+  const handleCanvasClick = useCallback(() => {
+    if (st.current.phase === 'menu') startGame();
+  }, [startGame]);
+
+  const handleTouchStart = useCallback((e: React.TouchEvent<HTMLCanvasElement>) => {
+    e.preventDefault();
+    if (st.current.phase === 'menu') startGame();
+    handlers.onTouchMove(e);
+  }, [startGame, handlers, st]);
+
 
   useEffect(() => {
     let left = false, right = false;
@@ -159,7 +152,7 @@ export function useMeteorDodgeGame() {
     window.addEventListener('keydown', kd);
     window.addEventListener('keyup', ku);
     return () => { clearInterval(interval); window.removeEventListener('keydown', kd); window.removeEventListener('keyup', ku); };
-  }, []);
+  }, [st]);
 
   const nudgeLeft = useCallback(() => {
     const s = st.current;
@@ -173,5 +166,5 @@ export function useMeteorDodgeGame() {
 
   const { phase, score, best } = useMeteorDodgeStore(useShallow(s => ({ phase: s.phase, score: s.score, best: s.best })));
 
-  return { canvasRef, startGame, handleMouseMove, handleTouchMove, handleCanvasClick, handleTouchStart, nudgeLeft, nudgeRight, phase, score, best };
+  return { canvasRef, startGame, handleMouseMove: handlers.onMouseMove, handleTouchMove: handlers.onTouchMove, handleCanvasClick, handleTouchStart, nudgeLeft, nudgeRight, phase, score, best };
 }

--- a/gamesformykids/app/games/pong/usePongGame.ts
+++ b/gamesformykids/app/games/pong/usePongGame.ts
@@ -1,10 +1,10 @@
 'use client';
 
-import { useEffect, useRef, useCallback } from 'react';
+import { useEffect, useCallback } from 'react';
 import { useShallow } from 'zustand/react/shallow';
 import { usePongStore } from './pongStore';
-import { useCanvasLoop } from '@/hooks/canvas';
-import { useGameCompletion } from '@/hooks/shared/progress';
+import { createCanvasArcadeHook } from '@/hooks/canvas';
+import type { PhaseResult as Phase } from '@/lib/types';
 
 export const W = 360;
 export const H = 560;
@@ -13,67 +13,29 @@ const PAD_H = 12;
 const BALL_R = 8;
 const AI_SPEED = 3.5;
 
-import type { PhaseResult as Phase } from '@/lib/types';
-
-export function usePongGame() {
-  const { saveGameResultRef } = useGameCompletion('pong');
-  const st = useRef({
+const _usePong = createCanvasArcadeHook({
+  gameType: 'pong',
+  width: W,
+  height: H,
+  initialState: () => ({
     phase: 'menu' as Phase,
     playerX: W / 2 - PAD_W / 2, aiX: W / 2 - PAD_W / 2,
     ballX: W / 2, ballY: H / 2, ballVX: 3, ballVY: 4,
     playerScore: 0, aiScore: 0, frame: 0, startTime: 0,
     particles: [] as { x: number; y: number; vx: number; vy: number; life: number }[],
-  });
-  function serveBall(direction: 1 | -1) {
-    const s = st.current;
-    const spd = 4 + Math.min(s.playerScore + s.aiScore, 8) * 0.2;
-    const angle = (Math.random() - 0.5) * 1.0;
-    s.ballX = W / 2; s.ballY = H / 2;
-    s.ballVX = Math.sin(angle) * spd; s.ballVY = direction * Math.cos(angle) * spd;
-  }
-
-  const startGame = useCallback(() => {
-    const s = st.current;
-    s.phase = 'playing';
-    s.playerX = W / 2 - PAD_W / 2; s.aiX = W / 2 - PAD_W / 2;
-    s.ballX = W / 2; s.ballY = H / 2;
-    const angle = (Math.random() - 0.5) * 1.2, spd = 4;
-    s.ballVX = Math.sin(angle) * spd; s.ballVY = (Math.random() < 0.5 ? 1 : -1) * Math.cos(angle) * spd;
-    s.playerScore = 0; s.aiScore = 0; s.frame = 0; s.particles = []; s.startTime = Date.now();
-    usePongStore.getState().startGame();
-  }, []);
-
-  const handleCanvasClick = useCallback(() => {
-    if (st.current.phase === 'menu') startGame();
-  }, [startGame]);
-
-  const handleMouseMove = useCallback((e: React.MouseEvent<HTMLCanvasElement>) => {
-    if (st.current.phase !== 'playing') return;
-    const rect = e.currentTarget.getBoundingClientRect();
-    const mx = (e.clientX - rect.left) * (W / rect.width);
-    st.current.playerX = Math.max(0, Math.min(W - PAD_W, mx - PAD_W / 2));
-  }, []);
-
-  const handleTouchMove = useCallback((e: React.TouchEvent<HTMLCanvasElement>) => {
-    e.preventDefault();
-    if (st.current.phase !== 'playing') return;
-    const rect = e.currentTarget.getBoundingClientRect();
-    const mx = (e.touches[0].clientX - rect.left) * (W / rect.width);
-    st.current.playerX = Math.max(0, Math.min(W - PAD_W, mx - PAD_W / 2));
-  }, []);
-
-  const handleTouchStart = useCallback((e: React.TouchEvent<HTMLCanvasElement>) => {
-    e.preventDefault();
-    if (st.current.phase === 'menu') startGame();
-    handleTouchMove(e);
-  }, [startGame, handleTouchMove]);
-
-  const canvasRef = useCanvasLoop((ctx) => {
-    const s = st.current;
-    s.frame++;
+  }),
+  onPointerX: (s, x) => { s.playerX = Math.max(0, Math.min(W - PAD_W, x - PAD_W / 2)); },
+  draw: (ctx, s, _dt, saveRef) => {    s.frame++;
 
     function addParticles(x: number, y: number) {
       for (let i = 0; i < 8; i++) s.particles.push({ x, y, vx: (Math.random() - 0.5) * 6, vy: (Math.random() - 0.5) * 6, life: 1 });
+    }
+
+    function serveBall(direction: 1 | -1) {
+      const spd = 4 + Math.min(s.playerScore + s.aiScore, 8) * 0.2;
+      const angle = (Math.random() - 0.5) * 1.0;
+      s.ballX = W / 2; s.ballY = H / 2;
+      s.ballVX = Math.sin(angle) * spd; s.ballVY = direction * Math.cos(angle) * spd;
     }
 
     if (s.phase === 'playing') {
@@ -100,8 +62,8 @@ export function usePongGame() {
         addParticles(s.ballX, aiPad_Y + PAD_H);
       }
 
-      if (s.ballY + BALL_R > H) { s.aiScore++; const aiWon = usePongStore.getState().aiScores(s.aiScore); if (aiWon) { s.phase = 'result'; saveGameResultRef.current({ score: s.playerScore, level: 1, durationSeconds: Math.round((Date.now() - s.startTime) / 1000) }); } else serveBall(-1); }
-      if (s.ballY - BALL_R < 0) { s.playerScore++; const playerWon = usePongStore.getState().playerScores(s.playerScore); if (playerWon) { s.phase = 'result'; saveGameResultRef.current({ score: s.playerScore, level: 1, durationSeconds: Math.round((Date.now() - s.startTime) / 1000) }); } else serveBall(1); }
+      if (s.ballY + BALL_R > H) { s.aiScore++; const aiWon = usePongStore.getState().aiScores(s.aiScore); if (aiWon) { s.phase = 'result'; saveRef.current({ score: s.playerScore, level: 1, durationSeconds: Math.round((Date.now() - s.startTime) / 1000) }); } else serveBall(-1); }
+      if (s.ballY - BALL_R < 0) { s.playerScore++; const playerWon = usePongStore.getState().playerScores(s.playerScore); if (playerWon) { s.phase = 'result'; saveRef.current({ score: s.playerScore, level: 1, durationSeconds: Math.round((Date.now() - s.startTime) / 1000) }); } else serveBall(1); }
 
       s.particles = s.particles.filter(p => { p.x += p.vx; p.y += p.vy; p.vy += 0.08; p.life -= 0.05; return p.life > 0; });
     }
@@ -127,7 +89,34 @@ export function usePongGame() {
     glow.addColorStop(0, 'rgba(255,255,255,0.5)'); glow.addColorStop(1, 'rgba(255,255,255,0)');
     ctx.fillStyle = glow; ctx.beginPath(); ctx.arc(s.ballX, s.ballY, BALL_R * 3, 0, Math.PI * 2); ctx.fill();
     ctx.fillStyle = 'white'; ctx.beginPath(); ctx.arc(s.ballX, s.ballY, BALL_R, 0, Math.PI * 2); ctx.fill();
-  });
+  },
+});
+
+export function usePongGame() {
+  const { st, canvasRef, handlers } = _usePong();
+
+
+  const startGame = useCallback(() => {
+    const s = st.current;
+    s.phase = 'playing';
+    s.playerX = W / 2 - PAD_W / 2; s.aiX = W / 2 - PAD_W / 2;
+    s.ballX = W / 2; s.ballY = H / 2;
+    const angle = (Math.random() - 0.5) * 1.2, spd = 4;
+    s.ballVX = Math.sin(angle) * spd; s.ballVY = (Math.random() < 0.5 ? 1 : -1) * Math.cos(angle) * spd;
+    s.playerScore = 0; s.aiScore = 0; s.frame = 0; s.particles = []; s.startTime = Date.now();
+    usePongStore.getState().startGame();
+  }, []);
+
+  const handleCanvasClick = useCallback(() => {
+    if (st.current.phase === 'menu') startGame();
+  }, [startGame]);
+
+  const handleTouchStart = useCallback((e: React.TouchEvent<HTMLCanvasElement>) => {
+    e.preventDefault();
+    if (st.current.phase === 'menu') startGame();
+    handlers.onTouchMove(e);
+  }, [startGame, handlers, st]);
+
 
   useEffect(() => {
     let left = false, right = false;
@@ -153,7 +142,7 @@ export function usePongGame() {
   const { phase, playerScore, aiScore } = usePongStore(useShallow(s => ({ phase: s.phase, playerScore: s.playerScore, aiScore: s.aiScore })));
 
   return {
-    canvasRef, startGame, handleMouseMove, handleTouchMove, handleTouchStart, handleCanvasClick,
+    canvasRef, startGame, handleMouseMove: handlers.onMouseMove, handleTouchMove: handlers.onTouchMove, handleTouchStart, handleCanvasClick,
     nudgeLeft:  () => { const s = st.current; s.playerX = Math.max(0, s.playerX - 45); },
     nudgeRight: () => { const s = st.current; s.playerX = Math.min(W - PAD_W, s.playerX + 45); },
     phase, playerScore, aiScore,

--- a/gamesformykids/app/games/space-defender/useSpaceDefenderGame.ts
+++ b/gamesformykids/app/games/space-defender/useSpaceDefenderGame.ts
@@ -1,10 +1,9 @@
 'use client';
 
-import { useEffect, useRef, useCallback } from 'react';
+import { useEffect, useCallback } from 'react';
 import { useShallow } from 'zustand/react/shallow';
 import { useSpaceDefenderStore, GAME_DURATION } from './spaceDefenderStore';
-import { useCanvasLoop } from '@/hooks/canvas';
-import { useGameCompletion } from '@/hooks/shared/progress';
+import { createCanvasArcadeHook } from '@/hooks/canvas';
 
 export const W = 360;
 export const H = 560;
@@ -19,9 +18,11 @@ interface Asteroid { id: number; x: number; y: number; speed: number; r: number;
 
 let uid = 0;
 
-export function useSpaceDefenderGame() {
-  const { saveGameResultRef } = useGameCompletion('space-defender');
-  const st = useRef({
+const _useSpaceDefender = createCanvasArcadeHook({
+  gameType: 'space-defender',
+  width: W,
+  height: H,
+  initialState: () => ({
     phase: 'menu' as Phase,
     shipX: W / 2,
     bullets: [] as Bullet[],
@@ -29,34 +30,15 @@ export function useSpaceDefenderGame() {
     score: 0, lives: 3, timeLeft: GAME_DURATION, frame: 0, nextAsteroid: 60, startTime: 0,
     stars: Array.from({ length: 40 }, () => ({ x: Math.random() * W, y: Math.random() * H, r: 0.5 + Math.random() * 2, twinkle: Math.random() * Math.PI * 2 })),
     lastShot: 0,
-  });
-  const shoot = useCallback(() => {
-    const s = st.current;
-    if (s.phase !== 'playing') return;
-    const now = s.frame;
-    if (now - s.lastShot < 12) return;
-    s.lastShot = now;
-    s.bullets.push({ id: uid++, x: s.shipX, y: H - 80 });
-  }, []);
-
-  const startGame = useCallback(() => {
-    const s = st.current;
-    s.phase = 'playing';
-    s.shipX = W / 2; s.bullets = []; s.asteroids = [];
-    s.score = 0; s.lives = 3; s.timeLeft = GAME_DURATION; s.frame = 0; s.nextAsteroid = 60; s.lastShot = 0; s.startTime = Date.now();
-    useSpaceDefenderStore.getState().startGame();
-  }, []);
-
-  const canvasRef = useCanvasLoop((ctx, dt) => {
-    const s = st.current;
-
+  }),
+  draw: (ctx, s, dt, saveRef) => {
     if (s.phase === 'playing') {
       s.frame++;
       s.timeLeft -= dt / 1000;
       if (s.timeLeft <= 0) {
         s.timeLeft = 0;
         s.phase = 'result';
-        saveGameResultRef.current({ score: s.score, level: 1, durationSeconds: Math.round((Date.now() - s.startTime) / 1000) });
+        saveRef.current({ score: s.score, level: 1, durationSeconds: Math.round((Date.now() - s.startTime) / 1000) });
         useSpaceDefenderStore.getState().setGameResult(s.score, s.lives, 0);
       }
       s.nextAsteroid--;
@@ -81,11 +63,11 @@ export function useSpaceDefenderGame() {
 
       const shipY = H - 80;
       s.asteroids = s.asteroids.filter(a => {
-        if (a.y + a.r > H) { s.lives--; if (s.lives <= 0) { s.lives = 0; s.phase = 'result'; saveGameResultRef.current({ score: s.score, level: 1, durationSeconds: Math.round((Date.now() - s.startTime) / 1000) }); useSpaceDefenderStore.getState().setGameResult(s.score, 0, Math.ceil(s.timeLeft)); } else { useSpaceDefenderStore.getState().setLives(s.lives); } return false; }
-        if (Math.abs(a.x - s.shipX) < SHIP_W / 2 + a.r && Math.abs(a.y - shipY) < SHIP_H / 2 + a.r) { s.lives--; if (s.lives <= 0) { s.lives = 0; s.phase = 'result'; saveGameResultRef.current({ score: s.score, level: 1, durationSeconds: Math.round((Date.now() - s.startTime) / 1000) }); useSpaceDefenderStore.getState().setGameResult(s.score, 0, Math.ceil(s.timeLeft)); } else { useSpaceDefenderStore.getState().setLives(s.lives); } return false; }
+        if (a.y + a.r > H) { s.lives--; if (s.lives <= 0) { s.lives = 0; s.phase = 'result'; saveRef.current({ score: s.score, level: 1, durationSeconds: Math.round((Date.now() - s.startTime) / 1000) }); useSpaceDefenderStore.getState().setGameResult(s.score, 0, Math.ceil(s.timeLeft)); } else { useSpaceDefenderStore.getState().setLives(s.lives); } return false; }
+        if (Math.abs(a.x - s.shipX) < SHIP_W / 2 + a.r && Math.abs(a.y - shipY) < SHIP_H / 2 + a.r) { s.lives--; if (s.lives <= 0) { s.lives = 0; s.phase = 'result'; saveRef.current({ score: s.score, level: 1, durationSeconds: Math.round((Date.now() - s.startTime) / 1000) }); useSpaceDefenderStore.getState().setGameResult(s.score, 0, Math.ceil(s.timeLeft)); } else { useSpaceDefenderStore.getState().setLives(s.lives); } return false; }
         return true;
       });
-      if (s.frame % 20 === 0 && st.current.phase === 'playing') useSpaceDefenderStore.getState().setTimeLeft(Math.ceil(s.timeLeft));
+      if (s.frame % 20 === 0 && s.phase === 'playing') useSpaceDefenderStore.getState().setTimeLeft(Math.ceil(s.timeLeft));
     }
 
     ctx.fillStyle = '#050514';
@@ -97,7 +79,7 @@ export function useSpaceDefenderGame() {
       ctx.fillStyle = `rgba(255,255,220,${alpha})`; ctx.fill();
     }
 
-    const curr = st.current;
+    const curr = s;
     for (const b of curr.bullets) {
       const grad = ctx.createLinearGradient(b.x, b.y - 14, b.x, b.y + 4);
       grad.addColorStop(0, '#FFD700'); grad.addColorStop(1, 'rgba(255,215,0,0)');
@@ -131,7 +113,30 @@ export function useSpaceDefenderGame() {
 
     ctx.fillStyle = 'rgba(30,100,50,0.3)'; ctx.fillRect(0, H - 18, W, 18);
     ctx.fillStyle = 'rgba(50,150,80,0.5)'; ctx.fillRect(0, H - 10, W, 10);
-  });
+  },
+});
+
+export function useSpaceDefenderGame() {
+  const { st, canvasRef } = _useSpaceDefender();
+
+
+  const shoot = useCallback(() => {
+    const s = st.current;
+    if (s.phase !== 'playing') return;
+    const now = s.frame;
+    if (now - s.lastShot < 12) return;
+    s.lastShot = now;
+    s.bullets.push({ id: uid++, x: s.shipX, y: H - 80 });
+  }, []);
+
+  const startGame = useCallback(() => {
+    const s = st.current;
+    s.phase = 'playing';
+    s.shipX = W / 2; s.bullets = []; s.asteroids = [];
+    s.score = 0; s.lives = 3; s.timeLeft = GAME_DURATION; s.frame = 0; s.nextAsteroid = 60; s.lastShot = 0; s.startTime = Date.now();
+    useSpaceDefenderStore.getState().startGame();
+  }, []);
+
 
   const handleMouseMove = useCallback((e: React.MouseEvent<HTMLCanvasElement>) => {
     const canvas = canvasRef.current;

--- a/gamesformykids/app/games/stack/useStackGame.ts
+++ b/gamesformykids/app/games/stack/useStackGame.ts
@@ -1,10 +1,9 @@
 'use client';
 
-import { useEffect, useRef, useCallback } from 'react';
+import { useEffect, useCallback } from 'react';
 import { useShallow } from 'zustand/react/shallow';
 import { useStackStore } from './stackStore';
-import { useCanvasLoop } from '@/hooks/canvas';
-import { useGameCompletion } from '@/hooks/shared/progress';
+import { createCanvasArcadeHook } from '@/hooks/canvas';
 
 export const W = 300;
 export const H = 480;
@@ -17,10 +16,11 @@ const TARGET_TOP = 90;
 import type { PhaseDead as Phase } from '@/lib/types';
 interface Block { x: number; y: number; w: number; color: string; }
 
-export function useStackGame() {
-  const { saveGameResultRef } = useGameCompletion('stack');
-
-  const st = useRef({
+const _useStack = createCanvasArcadeHook({
+  gameType: 'stack',
+  width: W,
+  height: H,
+  initialState: () => ({
     phase: 'menu' as Phase,
     blocks: [] as Block[],
     curX: 0, curW: INIT_W,
@@ -31,57 +31,8 @@ export function useStackGame() {
     colorIdx: 0,
     frame: 0,
     startTime: 0,
-  });
-  const startGame = useCallback(() => {
-    const s = st.current;
-    s.phase = 'playing';
-    s.score = 0; s.frame = 0; s.camOffset = 0;
-    s.curW = INIT_W; s.curX = (W - INIT_W) / 2;
-    s.curDir = 1; s.curSpeed = 2.5; s.colorIdx = 0;
-    s.blocks = [{ x: (W - INIT_W) / 2, y: FLOOR_Y, w: INIT_W, color: '#6b7280' }];
-    s.startTime = Date.now();
-    useStackStore.getState().startPlaying();
-  }, []);
-
-  const drop = useCallback(() => {
-    const s = st.current;
-    if (s.phase !== 'playing') return;
-
-    const top = s.blocks[s.blocks.length - 1];
-    const sliderWorldY = top.y - BH;
-    const left = Math.max(s.curX, top.x);
-    const right = Math.min(s.curX + s.curW, top.x + top.w);
-    const overlap = right - left;
-
-    if (overlap <= 2) {
-      s.phase = 'dead';
-      const elapsed = Math.round((Date.now() - s.startTime) / 1000);
-      saveGameResultRef.current({ score: s.score, level: 1, durationSeconds: elapsed });
-      useStackStore.getState().endGame(s.score);
-      return;
-    }
-
-    s.colorIdx = (s.colorIdx + 1) % COLORS.length;
-    s.blocks.push({ x: left, y: sliderWorldY, w: overlap, color: COLORS[s.colorIdx] });
-    s.score++;
-    s.curW = overlap;
-    s.curDir = (Math.random() < 0.5 ? 1 : -1) as 1 | -1;
-    s.curX = s.curDir > 0 ? -s.curW - 10 : W + 10;
-    s.curSpeed = Math.min(7, 2.5 + s.score * 0.09);
-
-    const topWorldY = sliderWorldY;
-    s.camOffset = Math.max(0, TARGET_TOP - topWorldY);
-    useStackStore.getState().setScore(s.score);
-  }, [saveGameResultRef]);
-
-  const handleCanvasClick = useCallback(() => {
-    if (st.current.phase === 'playing') drop();
-    else if (st.current.phase === 'menu') startGame();
-  }, [drop, startGame]);
-
-  const canvasRef = useCanvasLoop((ctx) => {
-    const s = st.current;
-    s.frame++;
+  }),
+  draw: (ctx, s, _dt, _saveRef) => {    s.frame++;
 
     if (s.phase === 'playing') {
       s.curX += s.curDir * s.curSpeed;
@@ -129,7 +80,60 @@ export function useStackGame() {
     ctx.font = '13px Arial';
     ctx.fillStyle = 'rgba(255,255,255,0.35)';
     ctx.fillText('TAP to drop!', W / 2, 74);
-  });
+  },
+});
+
+export function useStackGame() {
+  const { st, canvasRef, saveGameResultRef } = _useStack();
+
+
+  const startGame = useCallback(() => {
+    const s = st.current;
+    s.phase = 'playing';
+    s.score = 0; s.frame = 0; s.camOffset = 0;
+    s.curW = INIT_W; s.curX = (W - INIT_W) / 2;
+    s.curDir = 1; s.curSpeed = 2.5; s.colorIdx = 0;
+    s.blocks = [{ x: (W - INIT_W) / 2, y: FLOOR_Y, w: INIT_W, color: '#6b7280' }];
+    s.startTime = Date.now();
+    useStackStore.getState().startPlaying();
+  }, []);
+
+  const drop = useCallback(() => {
+    const s = st.current;
+    if (s.phase !== 'playing') return;
+
+    const top = s.blocks[s.blocks.length - 1];
+    const sliderWorldY = top.y - BH;
+    const left = Math.max(s.curX, top.x);
+    const right = Math.min(s.curX + s.curW, top.x + top.w);
+    const overlap = right - left;
+
+    if (overlap <= 2) {
+      s.phase = 'dead';
+      const elapsed = Math.round((Date.now() - s.startTime) / 1000);
+      saveGameResultRef.current({ score: s.score, level: 1, durationSeconds: elapsed });
+      useStackStore.getState().endGame(s.score);
+      return;
+    }
+
+    s.colorIdx = (s.colorIdx + 1) % COLORS.length;
+    s.blocks.push({ x: left, y: sliderWorldY, w: overlap, color: COLORS[s.colorIdx] });
+    s.score++;
+    s.curW = overlap;
+    s.curDir = (Math.random() < 0.5 ? 1 : -1) as 1 | -1;
+    s.curX = s.curDir > 0 ? -s.curW - 10 : W + 10;
+    s.curSpeed = Math.min(7, 2.5 + s.score * 0.09);
+
+    const topWorldY = sliderWorldY;
+    s.camOffset = Math.max(0, TARGET_TOP - topWorldY);
+    useStackStore.getState().setScore(s.score);
+  }, [saveGameResultRef]);
+
+  const handleCanvasClick = useCallback(() => {
+    if (st.current.phase === 'playing') drop();
+    else if (st.current.phase === 'menu') startGame();
+  }, [drop, startGame]);
+
 
   useEffect(() => {
     const kd = (e: KeyboardEvent) => {

--- a/gamesformykids/hooks/canvas/createCanvasArcadeHook.ts
+++ b/gamesformykids/hooks/canvas/createCanvasArcadeHook.ts
@@ -61,8 +61,9 @@ export interface CanvasArcadeConfig<S extends { phase: string }> {
    * @param ctx  2D canvas context
    * @param state  mutable game state (mutate directly — no setState)
    * @param dt   milliseconds since the previous frame
+   * @param saveRef  ref from useGameCompletion — call `.current({score,level,durationSeconds})` on game-over
    */
-  draw: (ctx: CanvasRenderingContext2D, state: S, dt: number) => void;
+  draw: (ctx: CanvasRenderingContext2D, state: S, dt: number, saveRef: ReturnType<typeof useGameCompletion>['saveGameResultRef']) => void;
   /**
    * Optional pointer-X handler — called on mouse/touch move while playing.
    * Receives the x position in *game* coordinates (already scaled + biased).
@@ -98,7 +99,7 @@ export function createCanvasArcadeHook<S extends { phase: string }>(
     // `tick` is a stable arrow so the ref-based tickRef inside useCanvasLoop
     // picks up changes to `config.draw` on every render without re-running the effect.
     const canvasRef = useCanvasLoop((ctx, dt) => {
-      config.draw(ctx, st.current, dt);
+      config.draw(ctx, st.current, dt, saveGameResultRef);
     });
 
     // ── Pointer handlers ───────────────────────────────────────────────────────

--- a/gamesformykids/scripts/fix-canvas-migration.py
+++ b/gamesformykids/scripts/fix-canvas-migration.py
@@ -1,0 +1,281 @@
+"""
+fix-canvas-migration.py
+Fixes the output of migrate-canvas-arcade.py:
+  1. Move factory call to FIRST statement of each wrapper function
+  2. Add serveBall into pong's draw callback
+  3. Restore useRef import in catch-fruit and frogger (still used for local refs)
+  4. Fix flappy-bird's s.current collision
+Run from: gamesformykids/ directory.
+"""
+
+import re
+import pathlib
+
+BASE = pathlib.Path(".")
+
+
+def move_factory_call_first(content: str, func_name: str, factory_call_pattern: str) -> str:
+    """
+    Find `const { ... } = _useXxx();` anywhere in the function body,
+    remove it, then insert it as the VERY FIRST statement after the function
+    opening brace.
+    """
+    # Find and capture the factory call line(s)
+    m = re.search(factory_call_pattern, content)
+    if not m:
+        print(f"  WARNING: factory call not found for {func_name}")
+        return content
+
+    factory_line = m.group(0)
+    # Remove from current position
+    content = content[:m.start()] + content[m.end():]
+
+    # Find the function opening brace
+    func_m = re.search(r"\nexport function " + func_name + r"\(\)", content)
+    if not func_m:
+        print(f"  WARNING: function {func_name} not found")
+        return content
+
+    open_brace = content.index("{", func_m.end())
+    # Insert factory call right after '{'
+    content = content[: open_brace + 1] + "\n" + factory_line + content[open_brace + 1 :]
+    return content
+
+
+def fix_pong():
+    path = BASE / "app/games/pong/usePongGame.ts"
+    content = path.read_text(encoding="utf-8")
+
+    # 1. Move factory call to first line of function
+    content = move_factory_call_first(
+        content,
+        "usePongGame",
+        r"  const \{ st, canvasRef, handlers \} = _usePong\(\);\n",
+    )
+
+    # 2. Add serveBall inside draw callback (before `if (s.phase === 'playing')`)
+    serve_ball_fn = (
+        "\n    function serveBall(direction: 1 | -1) {\n"
+        "      const spd = 4 + Math.min(s.playerScore + s.aiScore, 8) * 0.2;\n"
+        "      const angle = (Math.random() - 0.5) * 1.0;\n"
+        "      s.ballX = W / 2; s.ballY = H / 2;\n"
+        "      s.ballVX = Math.sin(angle) * spd; s.ballVY = direction * Math.cos(angle) * spd;\n"
+        "    }\n"
+    )
+    content = content.replace(
+        "\n    if (s.phase === 'playing') {\n      s.ballX +=",
+        serve_ball_fn + "\n    if (s.phase === 'playing') {\n      s.ballX +=",
+    )
+
+    # 3. Move the import type to the top imports section
+    content = content.replace(
+        "import { createCanvasArcadeHook } from '@/hooks/canvas';\n\nexport const W",
+        "import { createCanvasArcadeHook } from '@/hooks/canvas';\nimport type { PhaseResult as Phase } from '@/lib/types';\n\nexport const W",
+    )
+    content = content.replace(
+        "\nimport type { PhaseResult as Phase } from '@/lib/types';\n\nconst _usePong",
+        "\nconst _usePong",
+    )
+
+    path.write_text(content, encoding="utf-8")
+    print("✓ Fixed pong")
+
+
+def fix_meteor_dodge():
+    path = BASE / "app/games/meteor-dodge/useMeteorDodgeGame.ts"
+    content = path.read_text(encoding="utf-8")
+
+    content = move_factory_call_first(
+        content,
+        "useMeteorDodgeGame",
+        r"  const \{ st, canvasRef, handlers \} = _useMeteorDodge\(\);\n",
+    )
+
+    path.write_text(content, encoding="utf-8")
+    print("✓ Fixed meteor-dodge")
+
+
+def fix_flappy_bird():
+    """
+    Special: original used `s = useRef(...)` (not `st`).
+    In resetGame and flap: `const st = s.current` must become `const s = st.current`
+    and all `st.xxx` inside those callbacks → `s.xxx`.
+    Also: move factory call to first line.
+    """
+    path = BASE / "app/games/flappy-bird/useFlappyBirdGame.ts"
+    content = path.read_text(encoding="utf-8")
+
+    # Move factory call first
+    content = move_factory_call_first(
+        content,
+        "useFlappyBirdGame",
+        r"  const \{ st, canvasRef \} = _useFlappyBird\(\);\n",
+    )
+
+    # Fix resetGame callback: `const st = s.current;` → `const s = st.current;`
+    # and `st.xxx` → `s.xxx` within resetGame
+    def fix_callback(match):
+        body = match.group(0)
+        # Replace `const st = s.current;` → `const s = st.current;`
+        # BUT s.current here refers to the OLD ref `s`; after migration `st` is the factory ref
+        body = body.replace("const st = s.current;", "const s = st.current;")
+        # Replace `st.xxx` with `s.xxx` (state property access, not the ref)
+        # Use negative lookbehind to avoid replacing `_st.xxx` or similar
+        body = re.sub(r"\bst\.(?!current\b)", "s.", body)
+        return body
+
+    # Fix the resetGame callback
+    content = re.sub(
+        r"  const resetGame = useCallback\(\(\) => \{.*?\}, \[\]\);",
+        fix_callback,
+        content,
+        flags=re.DOTALL,
+    )
+
+    # Fix the flap callback
+    content = re.sub(
+        r"  const flap = useCallback\(\(\) => \{.*?\}, \[resetGame\]\);",
+        fix_callback,
+        content,
+        flags=re.DOTALL,
+    )
+
+    # Fix handleInput callback if it also uses s.current
+    content = re.sub(
+        r"  const handleInput = useCallback\([^)]+\) => \{.*?\}, \[[^\]]*\]\);",
+        fix_callback,
+        content,
+        flags=re.DOTALL,
+    )
+
+    # Remove the leftover `s.current → st.current` replacement artifacts
+    # (the global replacement from the original script may have broken things)
+    # Specifically: if `const st = st.current;` still appears, fix it
+    content = content.replace("const st = st.current;", "const s = st.current;")
+
+    path.write_text(content, encoding="utf-8")
+    print("✓ Fixed flappy-bird")
+
+
+def fix_dino_runner():
+    path = BASE / "app/games/dino-runner/useDinoRunnerGame.ts"
+    content = path.read_text(encoding="utf-8")
+
+    content = move_factory_call_first(
+        content,
+        "useDinoRunnerGame",
+        r"  const \{ st, canvasRef \} = _useDinoRunner\(\);\n",
+    )
+
+    path.write_text(content, encoding="utf-8")
+    print("✓ Fixed dino-runner")
+
+
+def fix_frogger():
+    path = BASE / "app/games/frogger/useFroggerGame.ts"
+    content = path.read_text(encoding="utf-8")
+
+    # Restore useRef import (frogger uses it for touchRef)
+    content = content.replace(
+        "import { useEffect, useCallback } from 'react';",
+        "import { useEffect, useRef, useCallback } from 'react';",
+    )
+
+    content = move_factory_call_first(
+        content,
+        "useFroggerGame",
+        r"  const \{ st, canvasRef \} = _useFrogger\(\);\n",
+    )
+
+    path.write_text(content, encoding="utf-8")
+    print("✓ Fixed frogger")
+
+
+def fix_stack():
+    path = BASE / "app/games/stack/useStackGame.ts"
+    content = path.read_text(encoding="utf-8")
+
+    content = move_factory_call_first(
+        content,
+        "useStackGame",
+        r"  const \{ st, canvasRef, saveGameResultRef \} = _useStack\(\);\n",
+    )
+
+    path.write_text(content, encoding="utf-8")
+    print("✓ Fixed stack")
+
+
+def fix_jumper():
+    path = BASE / "app/games/jumper/useJumperGame.ts"
+    content = path.read_text(encoding="utf-8")
+
+    content = move_factory_call_first(
+        content,
+        "useJumperGame",
+        r"  const \{ st, canvasRef \} = _useJumper\(\);\n",
+    )
+
+    path.write_text(content, encoding="utf-8")
+    print("✓ Fixed jumper")
+
+
+def fix_catch_fruit():
+    path = BASE / "app/games/catch-fruit/useCatchFruitGame.ts"
+    content = path.read_text(encoding="utf-8")
+
+    # Restore useRef import (still used for dragging / pointerDown)
+    content = content.replace(
+        "import { useCallback } from 'react';",
+        "import { useRef, useCallback } from 'react';",
+    )
+
+    content = move_factory_call_first(
+        content,
+        "useCatchFruitGame",
+        r"  const \{ st, canvasRef \} = _useCatchFruit\(\);\n",
+    )
+
+    path.write_text(content, encoding="utf-8")
+    print("✓ Fixed catch-fruit")
+
+
+def fix_space_defender():
+    path = BASE / "app/games/space-defender/useSpaceDefenderGame.ts"
+    content = path.read_text(encoding="utf-8")
+
+    content = move_factory_call_first(
+        content,
+        "useSpaceDefenderGame",
+        r"  const \{ st, canvasRef \} = _useSpaceDefender\(\);\n",
+    )
+
+    path.write_text(content, encoding="utf-8")
+    print("✓ Fixed space-defender")
+
+
+def fix_brick_breaker():
+    path = BASE / "app/games/brick-breaker/useBrickBreakerGame.ts"
+    content = path.read_text(encoding="utf-8")
+
+    content = move_factory_call_first(
+        content,
+        "useBrickBreakerGame",
+        r"  const \{ st, canvasRef, handlers \} = _useBrickBreaker\(\);\n",
+    )
+
+    path.write_text(content, encoding="utf-8")
+    print("✓ Fixed brick-breaker")
+
+
+if __name__ == "__main__":
+    fix_pong()
+    fix_meteor_dodge()
+    fix_flappy_bird()
+    fix_dino_runner()
+    fix_frogger()
+    fix_stack()
+    fix_jumper()
+    fix_catch_fruit()
+    fix_space_defender()
+    fix_brick_breaker()
+    print("\nAll fixes applied.")

--- a/gamesformykids/scripts/migrate-canvas-arcade.py
+++ b/gamesformykids/scripts/migrate-canvas-arcade.py
@@ -1,0 +1,988 @@
+"""
+migrate-canvas-arcade.py
+Migrates 10 canvas arcade games to use the createCanvasArcadeHook factory.
+Run from: gamesformykids/ directory.
+"""
+
+import re
+import pathlib
+
+
+def find_matching_close(text: str, open_pos: int) -> int:
+    """
+    Given `open_pos` pointing at an opening '{' in `text`,
+    return the index of the matching closing '}'.
+    Handles nested braces and ignores braces inside strings/template literals.
+    """
+    depth = 0
+    i = open_pos
+    in_str: bool = False
+    str_char: str = ""
+    escaped: bool = False
+    in_template: int = 0  # nesting depth of template literals
+
+    while i < len(text):
+        c = text[i]
+        if escaped:
+            escaped = False
+        elif c == "\\" and in_str:
+            escaped = True
+        elif in_str:
+            if c == str_char:
+                in_str = False
+        elif c == "`":
+            in_template += 1
+        elif in_template and c == "`":
+            in_template -= 1
+        elif c in ('"', "'"):
+            in_str = True
+            str_char = c
+        elif c == "{":
+            depth += 1
+        elif c == "}":
+            depth -= 1
+            if depth == 0:
+                return i
+        i += 1
+    return -1
+
+
+def extract_canvas_loop_body(content: str):
+    """
+    Find `const canvasRef = useCanvasLoop((ctx...)  => { ... });`
+    and return (callback_body_str, canvas_call_start, canvas_call_end_exclusive).
+    callback_body_str does NOT include the outer braces.
+    """
+    m = re.search(
+        r"  const canvasRef = useCanvasLoop\(\(ctx(?:, dt)?\) => \{",
+        content,
+    )
+    if not m:
+        return None, -1, -1
+
+    brace_open = m.end() - 1  # position of the opening '{'
+    brace_close = find_matching_close(content, brace_open)
+    if brace_close == -1:
+        return None, -1, -1
+
+    # After the closing '}' comes ');'  followed by optional whitespace / newline
+    call_end = brace_close + 1
+    while call_end < len(content) and content[call_end] in (" ", "\t"):
+        call_end += 1
+    if content[call_end : call_end + 2] == ");":
+        call_end += 2
+
+    body = content[brace_open + 1 : brace_close]
+    return body, m.start(), call_end
+
+
+def extract_use_ref_block(content: str):
+    """
+    Find `  const st = useRef({...});` (may span multiple lines) and return
+    (block_str, start, end_exclusive).
+    """
+    m = re.search(r"  const (?:st|s) = useRef\(\{", content)
+    if not m:
+        return None, -1, -1
+
+    brace_open = m.end() - 1
+    brace_close = find_matching_close(content, brace_open)
+    if brace_close == -1:
+        return None, -1, -1
+
+    # Skip trailing  '  });'  or  '  })  as MutableRefObject<...>);'
+    end = brace_close + 1
+    while end < len(content) and content[end] in (" ", "\t"):
+        end += 1
+    # might be   '  as XXX'
+    if content[end:].startswith(" as "):
+        paren_end = content.find(");", end)
+        if paren_end != -1:
+            end = paren_end + 2
+    elif content[end : end + 2] == ");":
+        end += 2
+
+    block = content[m.start() : end]
+    return block, m.start(), end
+
+
+# ─── Shared helpers ────────────────────────────────────────────────────────────
+
+def fix_draw_body(body: str, state_var: str = "s") -> str:
+    """
+    Transform a raw useCanvasLoop callback body for use in factory draw config:
+    1.  Remove `const s = st.current;`  (or `const st = s.current;` etc.)
+    2.  Change `const curr = st.current;` → `const curr = s;`
+    3.  Change `saveGameResultRef.current` → `saveRef.current`
+    4.  Keep everything else (including emoji) verbatim.
+    """
+    # Remove the first `const X = Y.current;\n` line (state alias at top of loop)
+    body = re.sub(r"^\n?    const (?:s|st|curr2?) = (?:s|st)\.current;\n", "", body, count=1)
+
+    # Also handle `const curr = st.current;` anywhere (rename to use `s`)
+    body = body.replace("const curr = st.current;", "const curr = s;")
+    body = body.replace("const curr = s.current;", "const curr = s;")
+
+    # Rename saveGameResultRef → saveRef
+    body = body.replace("saveGameResultRef.current", "saveRef.current")
+
+    return body
+
+
+# ─── Per-game migrations ───────────────────────────────────────────────────────
+
+BASE = pathlib.Path(".")
+
+
+def migrate_pong():
+    path = BASE / "app/games/pong/usePongGame.ts"
+    content = path.read_text(encoding="utf-8")
+
+    # --- imports ---
+    content = re.sub(
+        r"import \{ useEffect, useRef, useCallback \} from 'react';",
+        "import { useEffect, useCallback } from 'react';",
+        content,
+    )
+    content = content.replace(
+        "import { useCanvasLoop } from '@/hooks/canvas';",
+        "import { createCanvasArcadeHook } from '@/hooks/canvas';",
+    )
+    content = content.replace(
+        "import { useGameCompletion } from '@/hooks/shared/progress';\n", ""
+    )
+
+    # --- extract loop body ---
+    body, loop_start, loop_end = extract_canvas_loop_body(content)
+    assert body is not None, "Could not find useCanvasLoop in pong"
+
+    draw_body = fix_draw_body(body)
+
+    # Move serveBall inside draw (it was a module-level helper in the function);
+    # the original function has `function serveBall` BEFORE useCanvasLoop, so
+    # it's already captured inside loop body indirectly — actually it's OUTSIDE
+    # the loop in the original source.  We leave it as a nested helper inside draw.
+
+    # --- build factory config ---
+    factory = (
+        "\nconst _usePong = createCanvasArcadeHook({\n"
+        "  gameType: 'pong',\n"
+        "  width: W,\n"
+        "  height: H,\n"
+        "  initialState: () => ({\n"
+        "    phase: 'menu' as Phase,\n"
+        "    playerX: W / 2 - PAD_W / 2, aiX: W / 2 - PAD_W / 2,\n"
+        "    ballX: W / 2, ballY: H / 2, ballVX: 3, ballVY: 4,\n"
+        "    playerScore: 0, aiScore: 0, frame: 0, startTime: 0,\n"
+        "    particles: [] as { x: number; y: number; vx: number; vy: number; life: number }[],\n"
+        "  }),\n"
+        "  onPointerX: (s, x) => { s.playerX = Math.max(0, Math.min(W - PAD_W, x - PAD_W / 2)); },\n"
+        f"  draw: (ctx, s, _dt, saveRef) => {{{draw_body}}},\n"
+        "});\n"
+    )
+
+    # --- strip the serveBall declaration from inside the function (it moves into draw) ---
+    # serveBall in original is inside the hook, before useCanvasLoop
+    content = re.sub(
+        r"  function serveBall\(direction: 1 \| -1\) \{[^}]+\}\n\n",
+        "",
+        content,
+    )
+
+    # --- strip saveGameResultRef line ---
+    content = re.sub(
+        r"  const \{ saveGameResultRef \} = useGameCompletion\('[^']+'\);\n",
+        "",
+        content,
+    )
+
+    # --- strip st useRef block ---
+    _, ref_start, ref_end = extract_use_ref_block(content)
+    content = content[:ref_start] + content[ref_end:]
+
+    # --- re-find loop (positions shifted) ---
+    body2, loop_start2, loop_end2 = extract_canvas_loop_body(content)
+    assert body2 is not None
+
+    # --- insert factory before function, replace loop with factory call ---
+    func_m = re.search(r"\nexport function usePongGame\(\)", content)
+    assert func_m
+
+    # Replace the canvas loop with the factory hook call
+    replacement_call = "  const { st, canvasRef, handlers } = _usePong();"
+    content = content[:loop_start2] + replacement_call + content[loop_end2:]
+
+    # Insert factory before the function
+    content = content[:func_m.start()] + factory + content[func_m.start():]
+
+    # --- fix startGame (remove startTime from st.current since st.current is now used) ---
+    # startGame now needs to set startTime on st.current
+    # Already correct since it uses s = st.current
+
+    # --- fix return statement: map handlers ---
+    content = content.replace(
+        "    canvasRef, startGame, handleMouseMove, handleTouchMove, handleTouchStart, handleCanvasClick,",
+        "    canvasRef, startGame, handleMouseMove: handlers.onMouseMove, handleTouchMove: handlers.onTouchMove, handleTouchStart, handleCanvasClick,",
+    )
+
+    # Remove handleMouseMove and handleTouchMove declarations (replaced by factory)
+    content = re.sub(
+        r"  const handleMouseMove = useCallback\(\(e: React\.MouseEvent<HTMLCanvasElement>\) => \{[^}]+\}, \[\]\);\n\n",
+        "",
+        content,
+    )
+    content = re.sub(
+        r"  const handleTouchMove = useCallback\(\(e: React\.TouchEvent<HTMLCanvasElement>\) => \{[^}]+\}, \[\]\);\n\n",
+        "",
+        content,
+    )
+
+    # Replace handleTouchStart to use handlers.onTouchMove
+    content = content.replace(
+        "    handleTouchMove(e);",
+        "    handlers.onTouchMove(e);",
+    )
+
+    # handleTouchStart now needs `handlers` and `st` in its deps
+    content = content.replace(
+        "  }, [startGame, handleTouchMove]);",
+        "  }, [startGame, handlers, st]);",
+    )
+
+    # Fix nudgeLeft/nudgeRight: they reference st
+    content = content.replace(
+        "    nudgeLeft:  () => { const s = st.current; s.playerX = Math.max(0, s.playerX - 45); },",
+        "    nudgeLeft:  () => { const s = st.current; s.playerX = Math.max(0, s.playerX - 45); },",
+    )
+
+    path.write_text(content, encoding="utf-8")
+    print(f"✓ Migrated pong")
+
+
+def migrate_meteor_dodge():
+    path = BASE / "app/games/meteor-dodge/useMeteorDodgeGame.ts"
+    content = path.read_text(encoding="utf-8")
+
+    # imports
+    content = re.sub(
+        r"import \{ useEffect, useRef, useCallback \} from 'react';",
+        "import { useEffect, useCallback } from 'react';",
+        content,
+    )
+    content = content.replace(
+        "import { useCanvasLoop } from '@/hooks/canvas';",
+        "import { createCanvasArcadeHook } from '@/hooks/canvas';",
+    )
+    content = content.replace(
+        "import { useGameCompletion } from '@/hooks/shared/progress';\n", ""
+    )
+
+    # strip saveGameResultRef line
+    content = re.sub(
+        r"  const \{ saveGameResultRef \} = useGameCompletion\('[^']+'\);\n",
+        "",
+        content,
+    )
+
+    # strip useRef block
+    _, ref_start, ref_end = extract_use_ref_block(content)
+    content = content[:ref_start] + content[ref_end:]
+
+    # extract loop body
+    body, loop_start, loop_end = extract_canvas_loop_body(content)
+    assert body is not None, "Could not find useCanvasLoop in meteor-dodge"
+    draw_body = fix_draw_body(body)
+
+    initial_state = (
+        "  initialState: () => ({\n"
+        "    phase: 'menu' as Phase,\n"
+        "    playerX: W / 2,\n"
+        "    meteors: [] as Meteor[], stars: [] as StarPick[],\n"
+        "    score: 0, best: 0, frame: 0, nextMeteor: 50, nextStar: 120,\n"
+        "    bgStars: Array.from({ length: 50 }, () => ({ x: Math.random() * W, y: Math.random() * H, r: 0.5 + Math.random() * 1.5, twinkle: Math.random() * Math.PI * 2 })),\n"
+        "    invincible: 0, startTime: 0,\n"
+        "  }),\n"
+    )
+
+    factory = (
+        "\nconst _useMeteorDodge = createCanvasArcadeHook({\n"
+        "  gameType: 'meteor-dodge',\n"
+        "  width: W,\n"
+        "  height: H,\n"
+        + initial_state
+        + "  onPointerX: (s, x) => { s.playerX = Math.max(PLAYER_R, Math.min(W - PLAYER_R, x)); },\n"
+        f"  draw: (ctx, s, _dt, saveRef) => {{{draw_body}}},\n"
+        "});\n"
+    )
+
+    func_m = re.search(r"\nexport function useMeteorDodgeGame\(\)", content)
+    assert func_m
+
+    replacement_call = "  const { st, canvasRef, handlers } = _useMeteorDodge();"
+    content = content[:loop_start] + replacement_call + content[loop_end:]
+
+    content = content[:func_m.start()] + factory + content[func_m.start():]
+
+    # Remove handleMouseMove / handleTouchMove (replaced by handlers)
+    content = re.sub(
+        r"  const handleMouseMove = useCallback\(\(e: React\.MouseEvent<HTMLCanvasElement>\) => \{[^}]+\}, \[\]\);\n\n",
+        "",
+        content,
+    )
+    content = re.sub(
+        r"  const handleTouchMove = useCallback\(\(e: React\.TouchEvent<HTMLCanvasElement>\) => \{[^}]+\}, \[\]\);\n\n",
+        "",
+        content,
+    )
+
+    # handleTouchStart now uses handlers.onTouchMove
+    content = content.replace(
+        "    handleTouchMove(e);",
+        "    handlers.onTouchMove(e);",
+    )
+    content = re.sub(
+        r"  \}, \[startGame, handleTouchMove\]\);",
+        "  }, [startGame, handlers, st]);",
+        content,
+    )
+
+    # fix deps in keyboard useEffect (closes over st ref)
+    content = re.sub(
+        r"  \}, \[\]\);\n\n  const nudgeLeft",
+        "  }, [st]);\n\n  const nudgeLeft",
+        content,
+    )
+
+    # fix return
+    content = content.replace(
+        "return { canvasRef, startGame, handleMouseMove, handleTouchMove, handleCanvasClick, handleTouchStart,",
+        "return { canvasRef, startGame, handleMouseMove: handlers.onMouseMove, handleTouchMove: handlers.onTouchMove, handleCanvasClick, handleTouchStart,",
+    )
+
+    path.write_text(content, encoding="utf-8")
+    print("✓ Migrated meteor-dodge")
+
+
+def migrate_flappy_bird():
+    path = BASE / "app/games/flappy-bird/useFlappyBirdGame.ts"
+    content = path.read_text(encoding="utf-8")
+
+    # imports
+    content = re.sub(
+        r"import \{ useRef, useCallback \} from 'react';",
+        "import { useCallback } from 'react';",
+        content,
+    )
+    content = content.replace(
+        "import { useCanvasLoop } from '@/hooks/canvas';",
+        "import { createCanvasArcadeHook } from '@/hooks/canvas';",
+    )
+    content = content.replace(
+        "import { useGameCompletion } from '@/hooks/shared/progress';\n", ""
+    )
+
+    # strip saveGameResultRef line
+    content = re.sub(
+        r"  const \{ saveGameResultRef \} = useGameCompletion\('[^']+'\);\n\n?",
+        "",
+        content,
+    )
+
+    # The ref in flappy-bird is `const s = useRef(...)` with `st = s.current` in the loop
+    # Strip the `const s = useRef({...});` block
+    _, ref_start, ref_end = extract_use_ref_block(content)
+    content = content[:ref_start] + content[ref_end:]
+
+    # extract loop body
+    body, loop_start, loop_end = extract_canvas_loop_body(content)
+    assert body is not None, "Could not find useCanvasLoop in flappy-bird"
+
+    # In flappy-bird the loop uses `const st = s.current;` — fix to `const st = s;`
+    draw_body = body.replace("const st = s.current;", "const st = s;")
+    draw_body = draw_body.replace("saveGameResultRef.current", "saveRef.current")
+
+    factory = (
+        "\nconst _useFlappyBird = createCanvasArcadeHook({\n"
+        "  gameType: 'flappy-bird',\n"
+        "  width: W,\n"
+        "  height: H,\n"
+        "  initialState: () => ({\n"
+        "    phase: 'menu' as Phase,\n"
+        "    birdY: H / 2,\n"
+        "    birdVY: 0,\n"
+        "    pipes: [] as Pipe[],\n"
+        "    score: 0,\n"
+        "    frame: 0,\n"
+        "    bgOffset: 0,\n"
+        "    startTime: 0,\n"
+        "  }),\n"
+        f"  draw: (ctx, s, _dt, saveRef) => {{{draw_body}}},\n"
+        "});\n"
+    )
+
+    func_m = re.search(r"\nexport function useFlappyBirdGame\(\)", content)
+    assert func_m
+
+    replacement_call = "  const { st, canvasRef } = _useFlappyBird();"
+    content = content[:loop_start] + replacement_call + content[loop_end:]
+    content = content[:func_m.start()] + factory + content[func_m.start():]
+
+    # The flappy-bird wrapper uses `const s = useRef(...)` as ref name.
+    # After factory migration, `s` is removed. All references to `s.current` in
+    # the hook (resetGame, flap) should become `st.current`.
+    content = re.sub(r"\b(?<!\.)s\.current\b", "st.current", content)
+
+    # fix return
+    content = content.replace(
+        "  return { canvasRef, flap, handleInput, phase, best, score };",
+        "  return { canvasRef, flap, handleInput, phase, best, score };",
+    )
+
+    path.write_text(content, encoding="utf-8")
+    print("✓ Migrated flappy-bird")
+
+
+def migrate_dino_runner():
+    path = BASE / "app/games/dino-runner/useDinoRunnerGame.ts"
+    content = path.read_text(encoding="utf-8")
+
+    # imports
+    content = re.sub(
+        r"import \{ useEffect, useRef, useCallback \} from 'react';",
+        "import { useEffect, useCallback } from 'react';",
+        content,
+    )
+    content = content.replace(
+        "import { useCanvasLoop } from '@/hooks/canvas';",
+        "import { createCanvasArcadeHook } from '@/hooks/canvas';",
+    )
+    content = content.replace(
+        "import { useGameCompletion } from '@/hooks/shared/progress';\n", ""
+    )
+
+    # strip saveGameResultRef line
+    content = re.sub(
+        r"  const \{ saveGameResultRef \} = useGameCompletion\('[^']+'\);\n\n?",
+        "",
+        content,
+    )
+
+    # strip useRef block
+    _, ref_start, ref_end = extract_use_ref_block(content)
+    content = content[:ref_start] + content[ref_end:]
+
+    # extract loop body
+    body, loop_start, loop_end = extract_canvas_loop_body(content)
+    assert body is not None, "Could not find useCanvasLoop in dino-runner"
+    draw_body = fix_draw_body(body)
+
+    factory = (
+        "\nconst _useDinoRunner = createCanvasArcadeHook({\n"
+        "  gameType: 'dino-runner',\n"
+        "  width: W,\n"
+        "  height: H,\n"
+        "  initialState: () => ({\n"
+        "    phase: 'menu' as Phase,\n"
+        "    dinoY: GROUND_Y - DINO_H,\n"
+        "    dinoVY: 0,\n"
+        "    onGround: true,\n"
+        "    obstacles: [] as Obstacle[],\n"
+        "    clouds: [{ x: 100, y: 40 }, { x: 280, y: 25 }, { x: 360, y: 55 }] as Cloud[],\n"
+        "    score: 0,\n"
+        "    frame: 0,\n"
+        "    speed: BASE_SPEED,\n"
+        "    nextObstacle: 80,\n"
+        "    startTime: 0,\n"
+        "  }),\n"
+        f"  draw: (ctx, s, _dt, saveRef) => {{{draw_body}}},\n"
+        "});\n"
+    )
+
+    func_m = re.search(r"\nexport function useDinoRunnerGame\(\)", content)
+    assert func_m
+
+    replacement_call = "  const { st, canvasRef } = _useDinoRunner();"
+    content = content[:loop_start] + replacement_call + content[loop_end:]
+    content = content[:func_m.start()] + factory + content[func_m.start():]
+
+    path.write_text(content, encoding="utf-8")
+    print("✓ Migrated dino-runner")
+
+
+def migrate_frogger():
+    path = BASE / "app/games/frogger/useFroggerGame.ts"
+    content = path.read_text(encoding="utf-8")
+
+    # imports
+    content = re.sub(
+        r"import \{ useEffect, useRef, useCallback \} from 'react';",
+        "import { useEffect, useCallback } from 'react';",
+        content,
+    )
+    content = content.replace(
+        "import { useCanvasLoop } from '@/hooks/canvas';",
+        "import { createCanvasArcadeHook } from '@/hooks/canvas';",
+    )
+    content = content.replace(
+        "import { useGameCompletion } from '@/hooks/shared/progress';\n", ""
+    )
+
+    # strip saveGameResultRef line
+    content = re.sub(
+        r"  const \{ saveGameResultRef \} = useGameCompletion\('[^']+'\);\n",
+        "",
+        content,
+    )
+
+    # strip useRef block
+    _, ref_start, ref_end = extract_use_ref_block(content)
+    content = content[:ref_start] + content[ref_end:]
+
+    # extract loop body
+    body, loop_start, loop_end = extract_canvas_loop_body(content)
+    assert body is not None, "Could not find useCanvasLoop in frogger"
+    draw_body = fix_draw_body(body)
+
+    factory = (
+        "\nconst _useFrogger = createCanvasArcadeHook({\n"
+        "  gameType: 'frogger',\n"
+        "  width: W,\n"
+        "  height: H,\n"
+        "  initialState: () => ({\n"
+        "    phase: 'menu' as Phase,\n"
+        "    fCol: 4, fRow: 8,\n"
+        "    lives: 3, score: 0, best: 0, level: 1,\n"
+        "    frame: 0, dead: false, deadTimer: 0, startTime: 0,\n"
+        "    lanes: makeLanes(),\n"
+        "  }),\n"
+        f"  draw: (ctx, s, _dt, saveRef) => {{{draw_body}}},\n"
+        "});\n"
+    )
+
+    func_m = re.search(r"\nexport function useFroggerGame\(\)", content)
+    assert func_m
+
+    replacement_call = "  const { st, canvasRef } = _useFrogger();"
+    content = content[:loop_start] + replacement_call + content[loop_end:]
+    content = content[:func_m.start()] + factory + content[func_m.start():]
+
+    path.write_text(content, encoding="utf-8")
+    print("✓ Migrated frogger")
+
+
+def migrate_stack():
+    path = BASE / "app/games/stack/useStackGame.ts"
+    content = path.read_text(encoding="utf-8")
+
+    # imports
+    content = re.sub(
+        r"import \{ useEffect, useRef, useCallback \} from 'react';",
+        "import { useEffect, useCallback } from 'react';",
+        content,
+    )
+    content = content.replace(
+        "import { useCanvasLoop } from '@/hooks/canvas';",
+        "import { createCanvasArcadeHook } from '@/hooks/canvas';",
+    )
+    content = content.replace(
+        "import { useGameCompletion } from '@/hooks/shared/progress';\n", ""
+    )
+
+    # strip saveGameResultRef line (stack uses it in drop(), not draw — so we keep it
+    # accessible via factory return)
+    content = re.sub(
+        r"  const \{ saveGameResultRef \} = useGameCompletion\('[^']+'\);\n\n?",
+        "",
+        content,
+    )
+
+    # strip useRef block
+    _, ref_start, ref_end = extract_use_ref_block(content)
+    content = content[:ref_start] + content[ref_end:]
+
+    # extract loop body (stack's draw does NOT use saveRef)
+    body, loop_start, loop_end = extract_canvas_loop_body(content)
+    assert body is not None, "Could not find useCanvasLoop in stack"
+    draw_body = fix_draw_body(body)
+
+    factory = (
+        "\nconst _useStack = createCanvasArcadeHook({\n"
+        "  gameType: 'stack',\n"
+        "  width: W,\n"
+        "  height: H,\n"
+        "  initialState: () => ({\n"
+        "    phase: 'menu' as Phase,\n"
+        "    blocks: [] as Block[],\n"
+        "    curX: 0, curW: INIT_W,\n"
+        "    curDir: 1 as 1 | -1,\n"
+        "    curSpeed: 2.5,\n"
+        "    camOffset: 0,\n"
+        "    score: 0, best: 0,\n"
+        "    colorIdx: 0,\n"
+        "    frame: 0,\n"
+        "    startTime: 0,\n"
+        "  }),\n"
+        f"  draw: (ctx, s, _dt, _saveRef) => {{{draw_body}}},\n"
+        "});\n"
+    )
+
+    func_m = re.search(r"\nexport function useStackGame\(\)", content)
+    assert func_m
+
+    # The `drop` callback uses saveGameResultRef — it comes from factory return
+    replacement_call = "  const { st, canvasRef, saveGameResultRef } = _useStack();"
+    content = content[:loop_start] + replacement_call + content[loop_end:]
+    content = content[:func_m.start()] + factory + content[func_m.start():]
+
+    path.write_text(content, encoding="utf-8")
+    print("✓ Migrated stack")
+
+
+def migrate_jumper():
+    path = BASE / "app/games/jumper/useJumperGame.ts"
+    content = path.read_text(encoding="utf-8")
+
+    # imports
+    content = re.sub(
+        r"import \{ useEffect, useRef, useCallback \} from 'react';",
+        "import { useEffect, useCallback } from 'react';",
+        content,
+    )
+    content = content.replace(
+        "import { useCanvasLoop } from '@/hooks/canvas';",
+        "import { createCanvasArcadeHook } from '@/hooks/canvas';",
+    )
+    content = content.replace(
+        "import { useGameCompletion } from '@/hooks/shared/progress';\n", ""
+    )
+
+    # strip saveGameResultRef line
+    content = re.sub(
+        r"  const \{ saveGameResultRef \} = useGameCompletion\('[^']+'\);\n\n?",
+        "",
+        content,
+    )
+
+    # strip useRef block
+    _, ref_start, ref_end = extract_use_ref_block(content)
+    content = content[:ref_start] + content[ref_end:]
+
+    # extract loop body
+    body, loop_start, loop_end = extract_canvas_loop_body(content)
+    assert body is not None, "Could not find useCanvasLoop in jumper"
+    draw_body = fix_draw_body(body)
+
+    factory = (
+        "\nconst _useJumper = createCanvasArcadeHook({\n"
+        "  gameType: 'jumper',\n"
+        "  width: W,\n"
+        "  height: H,\n"
+        "  initialState: () => ({\n"
+        "    phase: 'menu' as Phase,\n"
+        "    px: W / 2, py: H - 100,\n"
+        "    pvx: 0, pvy: 0,\n"
+        "    camY: 0,\n"
+        "    maxCamY: 0,\n"
+        "    platforms: generateInitial() as Array<Platform & { id: number }>,\n"
+        "    score: 0, best: 0,\n"
+        "    frame: 0,\n"
+        "    leftDown: false, rightDown: false,\n"
+        "    nextPlatY: H - 60 - INIT_PLATS * (PLAT_GAP * 0.75),\n"
+        "    startTime: 0,\n"
+        "  }),\n"
+        f"  draw: (ctx, s, _dt, saveRef) => {{{draw_body}}},\n"
+        "});\n"
+    )
+
+    func_m = re.search(r"\nexport function useJumperGame\(\)", content)
+    assert func_m
+
+    replacement_call = "  const { st, canvasRef } = _useJumper();"
+    content = content[:loop_start] + replacement_call + content[loop_end:]
+    content = content[:func_m.start()] + factory + content[func_m.start():]
+
+    path.write_text(content, encoding="utf-8")
+    print("✓ Migrated jumper")
+
+
+def migrate_catch_fruit():
+    """
+    catch-fruit has mouse-down drag semantics, so we don't use onPointerX.
+    We still use the factory for useGameCompletion + useRef + useCanvasLoop.
+    The custom pointer handlers remain in the wrapper hook.
+    """
+    path = BASE / "app/games/catch-fruit/useCatchFruitGame.ts"
+    content = path.read_text(encoding="utf-8")
+
+    # imports
+    content = re.sub(
+        r"import \{ useRef, useCallback \} from 'react';",
+        "import { useCallback } from 'react';",
+        content,
+    )
+    content = content.replace(
+        "import { useCanvasLoop } from '@/hooks/canvas';",
+        "import { createCanvasArcadeHook } from '@/hooks/canvas';",
+    )
+    content = content.replace(
+        "import { useGameCompletion } from '@/hooks/shared/progress';\n", ""
+    )
+
+    # strip saveGameResultRef line
+    content = re.sub(
+        r"  const \{ saveGameResultRef \} = useGameCompletion\('[^']+'\);\n",
+        "",
+        content,
+    )
+
+    # strip useRef block (multi-line)
+    _, ref_start, ref_end = extract_use_ref_block(content)
+    content = content[:ref_start] + content[ref_end:]
+
+    # extract loop body
+    body, loop_start, loop_end = extract_canvas_loop_body(content)
+    assert body is not None, "Could not find useCanvasLoop in catch-fruit"
+    draw_body = fix_draw_body(body)
+
+    factory = (
+        "\nconst _useCatchFruit = createCanvasArcadeHook({\n"
+        "  gameType: 'catch-fruit',\n"
+        "  width: W,\n"
+        "  height: H,\n"
+        "  initialState: () => ({\n"
+        "    phase: 'menu' as Phase,\n"
+        "    basketX: W / 2 - BASKET_W / 2,\n"
+        "    items: [] as FallingItem[],\n"
+        "    score: 0, lives: 3, timeLeft: GAME_DURATION, frame: 0, nextItem: 40, startTime: 0,\n"
+        "    bgStars: Array.from({ length: 8 }, () => ({ x: Math.random() * W, y: Math.random() * H * 0.7, r: 2 + Math.random() * 3 })),\n"
+        "  }),\n"
+        f"  draw: (ctx, s, dt, saveRef) => {{{draw_body}}},\n"
+        "});\n"
+    )
+
+    func_m = re.search(r"\nexport function useCatchFruitGame\(\)", content)
+    assert func_m
+
+    # The wrapper keeps the custom pointer handlers; st comes from factory
+    replacement_call = "  const { st, canvasRef } = _useCatchFruit();"
+    content = content[:loop_start] + replacement_call + content[loop_end:]
+    content = content[:func_m.start()] + factory + content[func_m.start():]
+
+    # pointer handlers reference canvasRef — but now canvasRef is from factory return.
+    # They use `canvasRef.current` to get the bounding rect. This still works since
+    # canvasRef is in scope via _useCatchFruit().
+    # The handleMouseMove / handleTouchMove still need [canvasRef] in deps.
+    # canvasRef type is React.RefObject<HTMLCanvasElement | null> — same as before.
+
+    path.write_text(content, encoding="utf-8")
+    print("✓ Migrated catch-fruit")
+
+
+def migrate_space_defender():
+    """
+    space-defender: touch = move AND shoot. We keep custom pointer handlers.
+    Factory handles useGameCompletion + useRef + useCanvasLoop.
+    """
+    path = BASE / "app/games/space-defender/useSpaceDefenderGame.ts"
+    content = path.read_text(encoding="utf-8")
+
+    # imports
+    content = re.sub(
+        r"import \{ useEffect, useRef, useCallback \} from 'react';",
+        "import { useEffect, useCallback } from 'react';",
+        content,
+    )
+    content = content.replace(
+        "import { useCanvasLoop } from '@/hooks/canvas';",
+        "import { createCanvasArcadeHook } from '@/hooks/canvas';",
+    )
+    content = content.replace(
+        "import { useGameCompletion } from '@/hooks/shared/progress';\n", ""
+    )
+
+    # strip saveGameResultRef line
+    content = re.sub(
+        r"  const \{ saveGameResultRef \} = useGameCompletion\('[^']+'\);\n",
+        "",
+        content,
+    )
+
+    # strip useRef block
+    _, ref_start, ref_end = extract_use_ref_block(content)
+    content = content[:ref_start] + content[ref_end:]
+
+    # extract loop body
+    body, loop_start, loop_end = extract_canvas_loop_body(content)
+    assert body is not None, "Could not find useCanvasLoop in space-defender"
+    draw_body = fix_draw_body(body)
+
+    factory = (
+        "\nconst _useSpaceDefender = createCanvasArcadeHook({\n"
+        "  gameType: 'space-defender',\n"
+        "  width: W,\n"
+        "  height: H,\n"
+        "  initialState: () => ({\n"
+        "    phase: 'menu' as Phase,\n"
+        "    shipX: W / 2,\n"
+        "    bullets: [] as Bullet[],\n"
+        "    asteroids: [] as Asteroid[],\n"
+        "    score: 0, lives: 3, timeLeft: GAME_DURATION, frame: 0, nextAsteroid: 60, startTime: 0,\n"
+        "    stars: Array.from({ length: 40 }, () => ({ x: Math.random() * W, y: Math.random() * H, r: 0.5 + Math.random() * 2, twinkle: Math.random() * Math.PI * 2 })),\n"
+        "    lastShot: 0,\n"
+        "  }),\n"
+        f"  draw: (ctx, s, dt, saveRef) => {{{draw_body}}},\n"
+        "});\n"
+    )
+
+    func_m = re.search(r"\nexport function useSpaceDefenderGame\(\)", content)
+    assert func_m
+
+    replacement_call = "  const { st, canvasRef } = _useSpaceDefender();"
+    content = content[:loop_start] + replacement_call + content[loop_end:]
+    content = content[:func_m.start()] + factory + content[func_m.start():]
+
+    path.write_text(content, encoding="utf-8")
+    print("✓ Migrated space-defender")
+
+
+def migrate_brick_breaker():
+    """
+    brick-breaker: canvas loop calls startGame(nextLevel) for level progression.
+    Solution: module-level mutable ref `_brickStartNextLevel` that the wrapper sets
+    each render, allowing the draw config to trigger level changes.
+    """
+    path = BASE / "app/games/brick-breaker/useBrickBreakerGame.ts"
+    content = path.read_text(encoding="utf-8")
+
+    # imports
+    content = re.sub(
+        r"import \{ useEffect, useRef, useCallback \} from 'react';",
+        "import { useEffect, useCallback } from 'react';",
+        content,
+    )
+    content = content.replace(
+        "import { useCanvasLoop } from '@/hooks/canvas';",
+        "import { createCanvasArcadeHook } from '@/hooks/canvas';",
+    )
+    content = content.replace(
+        "import { useGameCompletion } from '@/hooks/shared/progress';\n", ""
+    )
+
+    # strip saveGameResultRef line
+    content = re.sub(
+        r"  const \{ saveGameResultRef \} = useGameCompletion\('[^']+'\);\n\n?",
+        "",
+        content,
+    )
+
+    # strip useRef block
+    _, ref_start, ref_end = extract_use_ref_block(content)
+    content = content[:ref_start] + content[ref_end:]
+
+    # extract loop body
+    body, loop_start, loop_end = extract_canvas_loop_body(content)
+    assert body is not None, "Could not find useCanvasLoop in brick-breaker"
+    draw_body = fix_draw_body(body)
+
+    # Replace `startGame(nextLevel)` inside draw with `_brickStartNextLevel(nextLevel)`
+    draw_body = draw_body.replace(
+        "          else { startGame(nextLevel); }",
+        "          else { _brickStartNextLevel(nextLevel); }",
+    )
+
+    factory = (
+        "\n// Module-level ref so the draw config can trigger level progression\n"
+        "// (brick-breaker advances levels from inside the canvas loop).\n"
+        "let _brickStartNextLevel: (level: number) => void = () => {};\n"
+        "\nconst _useBrickBreaker = createCanvasArcadeHook({\n"
+        "  gameType: 'brick-breaker',\n"
+        "  width: W,\n"
+        "  height: H,\n"
+        "  initialState: () => ({\n"
+        "    phase: 'menu' as Phase,\n"
+        "    padX: W / 2 - PAD_W / 2,\n"
+        "    ballX: W / 2, ballY: PAD_Y - BALL_R - 2, ballVX: 3, ballVY: -4, launched: false,\n"
+        "    bricks: makeBricks(), score: 0, lives: 3, level: 1, frame: 0,\n"
+        "    startTime: 0,\n"
+        "    particles: [] as { x: number; y: number; vx: number; vy: number; life: number; color: string }[],\n"
+        "  }),\n"
+        "  onPointerX: (s, x) => { s.padX = Math.max(0, Math.min(W - PAD_W, x - PAD_W / 2)); },\n"
+        f"  draw: (ctx, s, _dt, saveRef) => {{{draw_body}}},\n"
+        "});\n"
+    )
+
+    func_m = re.search(r"\nexport function useBrickBreakerGame\(\)", content)
+    assert func_m
+
+    replacement_call = "  const { st, canvasRef, handlers } = _useBrickBreaker();"
+    content = content[:loop_start] + replacement_call + content[loop_end:]
+    content = content[:func_m.start()] + factory + content[func_m.start():]
+
+    # Wire _brickStartNextLevel in the wrapper hook (after startGame is defined)
+    # Find the startGame useCallback and insert the wire after it
+    content = content.replace(
+        "  }, []);\n\n  const handleClick",
+        "  }, []);\n  // Wire level-progression callback so draw config can call it\n  _brickStartNextLevel = startGame;\n\n  const handleClick",
+    )
+
+    # Remove movePaddle (replaced by factory onPointerX) but keep handleTouchStart/handleMouseMove
+    # Actually keep the existing handlers since they use movePaddle which does the same as onPointerX
+    # The factory's handlers.onMouseMove / handlers.onTouchMove are equivalent to movePaddle
+    # BUT handleTouchStart calls handleClick() too, so we keep it.
+    # Let's just replace handleMouseMove and handleTouchMove with the factory ones
+    # in the return object, and keep handleTouchStart custom.
+
+    # Remove movePaddle since it's replaced by onPointerX
+    content = re.sub(
+        r"  const movePaddle = useCallback\([^)]+\) => \{[^}]+\}, \[[^\]]*\]\);\n\n",
+        "",
+        content,
+    )
+
+    # handleMouseMove now delegates to factory
+    content = re.sub(
+        r"  const handleMouseMove = useCallback\(\(e: React\.MouseEvent<HTMLCanvasElement>\) => \{[^}]+\}, \[[^\]]*\]\);\n\n",
+        "",
+        content,
+    )
+    # handleTouchMove now delegates to factory (keep handleTouchStart which calls handleClick)
+    content = re.sub(
+        r"  const handleTouchMove = useCallback\(\(e: React\.TouchEvent<HTMLCanvasElement>\) => \{[^}]+\}, \[[^\]]*\]\);\n\n",
+        "",
+        content,
+    )
+
+    # handleTouchStart uses movePaddle — replace with handlers.onTouchMove
+    content = content.replace(
+        "    movePaddle(e.touches[0].clientX, e.currentTarget.getBoundingClientRect());",
+        "    handlers.onTouchMove(e);",
+    )
+    # handleTouchStart deps
+    content = re.sub(
+        r"  \}, \[handleClick, movePaddle\]\);",
+        "  }, [handleClick, handlers]);",
+        content,
+    )
+
+    # fix return
+    content = content.replace(
+        "  return { canvasRef, startGame, handleMouseMove, handleTouchMove, handleTouchStart, handleClick, nudgeLeft, nudgeRight, phase, score, best, lives, level };",
+        "  return { canvasRef, startGame, handleMouseMove: handlers.onMouseMove, handleTouchMove: handlers.onTouchMove, handleTouchStart, handleClick, nudgeLeft, nudgeRight, phase, score, best, lives, level };",
+    )
+
+    path.write_text(content, encoding="utf-8")
+    print("✓ Migrated brick-breaker")
+
+
+if __name__ == "__main__":
+    migrate_pong()
+    migrate_meteor_dodge()
+    migrate_flappy_bird()
+    migrate_dino_runner()
+    migrate_frogger()
+    migrate_stack()
+    migrate_jumper()
+    migrate_catch_fruit()
+    migrate_space_defender()
+    migrate_brick_breaker()
+    print("\nAll migrations complete.")


### PR DESCRIPTION
Closes #601

## Changes

### Factory extension
- createCanvasArcadeHook draw signature extended to accept saveRef as 4th parameter so games can save results from inside the canvas loop

### Migrated games (full factory pattern)
- **meteor-dodge** — uses onPointerX for mouse/touch X tracking
- **pong** — uses onPointerX; serveBall helper moved into draw config
- **brick-breaker** — uses onPointerX; module-level _brickStartNextLevel callback bridges level progression from draw config to wrapper hook
- **flappy-bird** — tap/jump only, no pointer X; callbacks updated for renamed ref
- **dino-runner** — tap/jump only, no pointer X
- **frogger** — keyboard/touch directional input, no pointer X
- **stack** — tap to drop, saveGameResultRef exposed from factory return
- **jumper** — keyboard + button controls, no pointer X

### Migrated games (custom pointer handlers)
- **catch-fruit** — basket moves only while mouse button held (drag semantics); custom handlers kept in wrapper
- **space-defender** — touch simultaneously moves ship and fires (touch=move+shoot); custom handlers kept in wrapper

### Excluded
- **snake** — uses useSnakeDraw + setTimeout architecture, incompatible with factory

### Migration artifacts
- scripts/migrate-canvas-arcade.py — automated structural transformation script
- scripts/fix-canvas-migration.py — post-processing fixes (factory call hoisting, draw-body ref cleanup)