### PR TITLE
chore: remove useSpeech dead hook from lib/utils/speech/speaker.ts

### DIFF
--- a/gamesformykids/lib/utils/speech/enhancedSpeechUtils.ts
+++ b/gamesformykids/lib/utils/speech/enhancedSpeechUtils.ts
@@ -17,5 +17,4 @@ export {
   isSpeechEnabled,
   isCurrentlySpeaking,
   initSpeechAndAudio,
-  useSpeech,
 } from "./speaker";

--- a/gamesformykids/lib/utils/speech/speaker.ts
+++ b/gamesformykids/lib/utils/speech/speaker.ts
@@ -186,27 +186,3 @@ export function initSpeechAndAudio(
     setAudioContext(new AudioContextClass());
   }
 }
-
-// Hook לשימוש ב-React
-export function useSpeech() {
-  return {
-    // פונקציות דיבור בסיסיות
-    speak,
-    speakHebrew,
-    speakEnglish,
-
-    // שליטה ובדיקות
-    cancel: cancelSpeech,
-    testSpeech,
-
-    // בדיקות מצב
-    isCurrentlySpeaking: isCurrentlySpeaking(),
-    isEnabled: isSpeechEnabled(),
-
-    // פונקציות עזר
-    findHebrewVoice,
-
-    // אתחול
-    initSpeechAndAudio,
-  };
-}


### PR DESCRIPTION
## Summary
Removes the `useSpeech()` function from `lib/utils/speech/speaker.ts` and its re-export from `enhancedSpeechUtils.ts`. The function was misplaced in the `lib/utils/` layer (React hooks belong in `hooks/`) and had zero consumers — no component, hook, or store ever imported or called it. The existing `useGameAudio.ts` in `hooks/shared/audio/` is the correct speech hook for components.

## Changes
- `lib/utils/speech/speaker.ts` — deleted `useSpeech()` function (lines 191–212)
- `lib/utils/speech/enhancedSpeechUtils.ts` — removed `useSpeech` from re-export list

## Testing
- [x] `npx tsc --noEmit` passes

Closes #619

🤖 Generated with [Claude Code](https://claude.com/claude-code)