### PR TITLE
refactor: migrate balloonPopStore, soccerGameStore, useProfileStore to makeStore/makePersistStore

### DIFF
--- a/gamesformykids/app/games/balloon-pop/balloonPopStore.ts
+++ b/gamesformykids/app/games/balloon-pop/balloonPopStore.ts
@@ -6,8 +6,7 @@
  * Timer / rAF lifecycle is managed by useBalloonPopLoop.ts.
  */
 
-import { create } from 'zustand';
-import { devtools, persist } from 'zustand/middleware';
+import { makePersistStore } from '@/lib/stores/createStore';
 import type { PhaseResult as Phase } from '@/lib/types';
 
 // ── Constants ──────────────────────────────────────────────
@@ -62,54 +61,51 @@ export interface BalloonPopActions {
 }
 
 // ── Store ──────────────────────────────────────────────────
-export const useBalloonPopStore = create<BalloonPopState & BalloonPopActions>()(
-  devtools(
-    persist(
-      (set, get) => ({
-        phase: 'menu',
-        score: 0,
-        best: 0,
-        lives: 5,
-        timeLeft: GAME_DURATION,
-        balloons: [],
-        W: 350,
-        H: 560,
+export const useBalloonPopStore = makePersistStore<BalloonPopState & BalloonPopActions>(
+  'BalloonPopStore',
+  'balloon-pop-best',
+  (set, get) => ({
+    phase: 'menu',
+    score: 0,
+    best: 0,
+    lives: 5,
+    timeLeft: GAME_DURATION,
+    balloons: [],
+    W: 350,
+    H: 560,
 
-        setDimensions: (W, H) => set({ W, H }, false, 'balloon/setDimensions'),
+    setDimensions: (W, H) => set({ W, H }, false, 'balloon/setDimensions'),
 
-        startGame: () =>
-          set(
-            { phase: 'playing', score: 0, lives: 5, timeLeft: GAME_DURATION, balloons: [] },
-            false,
-            'balloon/startGame',
-          ),
+    startGame: () =>
+      set(
+        { phase: 'playing', score: 0, lives: 5, timeLeft: GAME_DURATION, balloons: [] },
+        false,
+        'balloon/startGame',
+      ),
 
-        endGame: () => {
-          const { score, best } = get();
-          set({ phase: 'result', best: Math.max(best, score) }, false, 'balloon/endGame');
-        },
+    endGame: () => {
+      const { score, best } = get();
+      set({ phase: 'result', best: Math.max(best, score) }, false, 'balloon/endGame');
+    },
 
-        pop: (id) => {
-          const { phase, balloons, lives, score } = get();
-          if (phase !== 'playing') return;
-          const b = balloons.find(b => b.id === id);
-          if (!b || b.popped) return;
+    pop: (id) => {
+      const { phase, balloons, lives, score } = get();
+      if (phase !== 'playing') return;
+      const b = balloons.find(b => b.id === id);
+      if (!b || b.popped) return;
 
-          if (b.isBomb) {
-            const newLives = Math.max(0, lives - 2);
-            const newBalloons = balloons.map(x => x.id === id ? { ...x, popped: true } : x);
-            set({ balloons: newBalloons, lives: newLives }, false, 'balloon/bomb');
-            if (newLives <= 0) get().endGame();
-          } else {
-            set({
-              balloons: balloons.map(x => x.id === id ? { ...x, popped: true } : x),
-              score: score + 10,
-            }, false, 'balloon/pop');
-          }
-        },
-      }),
-      { name: 'balloon-pop-best', partialize: (s) => ({ best: s.best }) },
-    ),
-    { name: 'BalloonPopStore' },
-  ),
+      if (b.isBomb) {
+        const newLives = Math.max(0, lives - 2);
+        const newBalloons = balloons.map(x => x.id === id ? { ...x, popped: true } : x);
+        set({ balloons: newBalloons, lives: newLives }, false, 'balloon/bomb');
+        if (newLives <= 0) get().endGame();
+      } else {
+        set({
+          balloons: balloons.map(x => x.id === id ? { ...x, popped: true } : x),
+          score: score + 10,
+        }, false, 'balloon/pop');
+      }
+    },
+  }),
+  { partialize: (s) => ({ best: s.best }) },
 );

--- a/gamesformykids/app/games/soccer/soccerGameStore.ts
+++ b/gamesformykids/app/games/soccer/soccerGameStore.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { create } from 'zustand';
+import { makeStore } from '@/lib/stores/createStore';
 import type { SoccerQuestion, SoccerCategory } from './data/soccer';
 
 interface SoccerGameState {
@@ -21,9 +21,12 @@ const INITIAL: SoccerGameState = {
   showGoal: false,
 };
 
-export const useSoccerGameStore = create<SoccerGameState & SoccerGameActions>((set) => ({
-  ...INITIAL,
-  setQuestions: (questions, category) => set({ questions, category }),
-  setShowGoal:  (showGoal) => set({ showGoal }),
-  reset:        () => set(INITIAL),
-}));
+export const useSoccerGameStore = makeStore<SoccerGameState & SoccerGameActions>(
+  'SoccerGameStore',
+  (set) => ({
+    ...INITIAL,
+    setQuestions: (questions, category) => set({ questions, category }),
+    setShowGoal:  (showGoal) => set({ showGoal }),
+    reset:        () => set(INITIAL),
+  }),
+);

--- a/gamesformykids/app/profile/stores/useProfileStore.ts
+++ b/gamesformykids/app/profile/stores/useProfileStore.ts
@@ -6,8 +6,7 @@
  * קומפוננטות קוראות ישירות לסטור — אין props drilling.
  */
 
-import { create } from 'zustand';
-import { devtools } from 'zustand/middleware';
+import { makeStore } from '@/lib/stores/createStore';
 import { useUserProfileStore } from '@/lib/stores/userProfileStore';
 import { useGameProgressDataStore } from '@/lib/stores/gameProgressDataStore';
 import { useAchievementsStore } from '@/lib/stores/achievementsStore';
@@ -54,9 +53,9 @@ export function useProfileComputedStats() {
 
 // ── Store ─────────────────────────────────────────────────
 
-export const useProfileStore = create<ProfileState & ProfileActions>()(
-  devtools(
-    (set, get) => ({
+export const useProfileStore = makeStore<ProfileState & ProfileActions>(
+  'ProfileStore',
+  (set, get) => ({
       isEditing: false,
       uploadingAvatar: false,
       editingName: '',
@@ -83,7 +82,5 @@ export const useProfileStore = create<ProfileState & ProfileActions>()(
         await updateFn({ full_name: editingName });
         set({ isEditing: false }, false, 'profile/updateDone');
       },
-    }),
-    { name: 'ProfileStore' }
-  )
+  }),
 );


### PR DESCRIPTION
## Summary
Migrates the three stores missed by PR #590 to the project-standard `makeStore`/`makePersistStore` factory from `lib/stores/createStore.ts`. All other app stores already use these factories for consistent DevTools naming and middleware ordering.

## Changes
- `app/games/balloon-pop/balloonPopStore.ts` — replaced `create()(devtools(persist(...)))` with `makePersistStore('BalloonPopStore', 'balloon-pop-best', creator, { partialize })`
- `app/games/soccer/soccerGameStore.ts` — replaced bare `create<T>((set) => ...)` with `makeStore('SoccerGameStore', (set) => ...)`
- `app/profile/stores/useProfileStore.ts` — replaced `create()(devtools(...))` with `makeStore('ProfileStore', (set, get) => ...)`

## Testing
- [x] `npx tsc --noEmit` passes

Closes #615

🤖 Generated with [Claude Code](https://claude.com/claude-code)