### PR TITLE
refactor: extract balloon-pop animation loop into useBalloonPopLoop hook

### DIFF
--- a/gamesformykids/app/games/balloon-pop/BalloonPopGame.tsx
+++ b/gamesformykids/app/games/balloon-pop/BalloonPopGame.tsx
@@ -1,7 +1,6 @@
 'use client';
-import { useEffect } from 'react';
 import { useBalloonPopGame } from './useBalloonPopGame';
-import { stopBalloonPopGame } from './balloonPopStore';
+import { useBalloonPopLoop } from './useBalloonPopLoop';
 import BalloonPopMenuScreen from './components/BalloonPopMenuScreen';
 import BalloonResultScreen from './components/BalloonResultScreen';
 import BalloonHUD from './components/BalloonHUD';
@@ -9,8 +8,7 @@ import BalloonGameArea from './components/BalloonGameArea';
 
 export default function BalloonPopGame() {
   const { phase } = useBalloonPopGame();
-
-  useEffect(() => stopBalloonPopGame, []);
+  useBalloonPopLoop();
 
   if (phase === 'menu') return <BalloonPopMenuScreen />;
   if (phase === 'result') return <BalloonResultScreen />;

--- a/gamesformykids/app/games/balloon-pop/balloonPopStore.ts
+++ b/gamesformykids/app/games/balloon-pop/balloonPopStore.ts
@@ -2,13 +2,8 @@
  * ===============================================
  * Balloon Pop Store — Zustand
  * ===============================================
- * מנהל את כל הסטייט של משחק פוצץ בלונים:
- * - phase / score / best / lives / timeLeft / balloons
- * - לוגיקת ה-animation loop וה-spawn timer
- *
- * טיימרים ו-animation refs מנוהלים ברמת המודול
- * (בדומה ל-arithmeticGameStore) כדי למנוע re-render.
- * ממדי המשחק (W/H) מעודכנים דרך setDimensions מ-BalloonGameArea.
+ * Pure state + actions only.
+ * Timer / rAF lifecycle is managed by useBalloonPopLoop.ts.
  */
 
 import { create } from 'zustand';
@@ -27,7 +22,7 @@ export const BALLOON_COLORS: [string, string][] = [
   ['#8B5CF6', '#6D28D9'],
   ['#14B8A6', '#0F766E'],
 ];
-const BOMB_CHANCE = 0.12;
+export const BOMB_CHANCE = 0.12;
 
 // ── Types ──────────────────────────────────────────────────
 export interface Balloon {
@@ -42,39 +37,6 @@ export interface Balloon {
   popAnim: number;
 }
 
-// ── Module-level refs (safe on client — all consumers are 'use client') ──
-let uid = 0;
-let timerRef: ReturnType<typeof setInterval> | null = null;
-let spawnRef: ReturnType<typeof setTimeout> | null = null;
-let animRef = 0;
-let frameCount = 0;
-let W = 350;
-let H = 560;
-
-// Sync refs — avoids stale closures in rAF
-const sync = { phase: 'menu' as Phase, score: 0, lives: 5, balloons: [] as Balloon[] };
-
-function clearTimers() {
-  if (timerRef) { clearInterval(timerRef); timerRef = null; }
-  if (spawnRef) { clearTimeout(spawnRef); spawnRef = null; }
-  cancelAnimationFrame(animRef);
-}
-
-function makeBalloon(): Balloon {
-  const isBomb = Math.random() < BOMB_CHANCE;
-  return {
-    id: uid++,
-    x: 30 + Math.random() * (W - 60),
-    y: H + 40,
-    r: 22 + Math.random() * 18,
-    vy: -(0.8 + Math.random() * 1.2),
-    color: BALLOON_COLORS[Math.floor(Math.random() * BALLOON_COLORS.length)],
-    isBomb,
-    popped: false,
-    popAnim: 0,
-  };
-}
-
 // ── State ──────────────────────────────────────────────────
 export interface BalloonPopState {
   phase: Phase;
@@ -83,13 +45,19 @@ export interface BalloonPopState {
   lives: number;
   timeLeft: number;
   balloons: Balloon[];
+  /** Canvas width — set by BalloonGameArea via setDimensions */
+  W: number;
+  /** Canvas height — set by BalloonGameArea via setDimensions */
+  H: number;
 }
 
 // ── Actions ────────────────────────────────────────────────
 export interface BalloonPopActions {
+  /** Sets initial playing state. Loop lifecycle is handled by useBalloonPopLoop. */
   startGame: () => void;
+  /** Called by the loop hook when time runs out or lives hit 0. */
+  endGame: () => void;
   pop: (id: number) => void;
-  /** BalloonGameArea קורא לזה כשנטען כדי לעדכן ממדים */
   setDimensions: (w: number, h: number) => void;
 }
 
@@ -97,112 +65,51 @@ export interface BalloonPopActions {
 export const useBalloonPopStore = create<BalloonPopState & BalloonPopActions>()(
   devtools(
     persist(
-      (set, get) => {
-      function endGame() {
-        clearTimers();
-        const { score, best } = get();
-        sync.phase = 'result';
-        set({ phase: 'result', best: Math.max(best, score) }, false, 'balloon/endGame');
-      }
-
-      function spawnBalloon() {
-        if (sync.phase !== 'playing') return;
-        const b = makeBalloon();
-        sync.balloons = [...sync.balloons, b];
-        set({ balloons: [...sync.balloons] }, false, 'balloon/spawn');
-        const delay = Math.max(500, 1200 - frameCount * 2);
-        spawnRef = setTimeout(spawnBalloon, delay);
-      }
-
-      function animate() {
-        if (sync.phase !== 'playing') return;
-        frameCount++;
-        let needsUpdate = false;
-        const escaped: number[] = [];
-
-        sync.balloons = sync.balloons.map(b => {
-          if (b.popped) {
-            if (b.popAnim < 1) { needsUpdate = true; return { ...b, popAnim: b.popAnim + 0.1 }; }
-            return b;
-          }
-          const ny = b.y + b.vy;
-          if (ny + b.r < 0 && !b.isBomb) { escaped.push(b.id); needsUpdate = true; }
-          needsUpdate = true;
-          return { ...b, y: ny };
-        }).filter(b => {
-          if (b.popped && b.popAnim >= 1) return false;
-          if (escaped.includes(b.id)) return false;
-          return true;
-        });
-
-        if (escaped.length > 0) {
-          sync.lives = Math.max(0, sync.lives - escaped.length);
-          if (sync.lives <= 0) { set({ balloons: [...sync.balloons], lives: 0 }, false, 'balloon/escaped'); endGame(); return; }
-          set({ lives: sync.lives }, false, 'balloon/lostLife');
-        }
-
-        if (needsUpdate) set({ balloons: [...sync.balloons] }, false, 'balloon/animate');
-        animRef = requestAnimationFrame(animate);
-      }
-
-      return {
+      (set, get) => ({
         phase: 'menu',
         score: 0,
         best: 0,
         lives: 5,
         timeLeft: GAME_DURATION,
         balloons: [],
+        W: 350,
+        H: 560,
 
-        setDimensions: (w, h) => { W = w; H = h; },
+        setDimensions: (W, H) => set({ W, H }, false, 'balloon/setDimensions'),
 
-        startGame: () => {
-          clearTimers();
-          sync.phase = 'playing';
-          sync.score = 0;
-          sync.lives = 5;
-          sync.balloons = [];
-          frameCount = 0;
-
+        startGame: () =>
           set(
             { phase: 'playing', score: 0, lives: 5, timeLeft: GAME_DURATION, balloons: [] },
             false,
             'balloon/startGame',
-          );
+          ),
 
-          let t = GAME_DURATION;
-          timerRef = setInterval(() => {
-            t--;
-            set({ timeLeft: t }, false, 'balloon/tick');
-            if (t <= 0) endGame();
-          }, 1000);
-
-          spawnRef = setTimeout(spawnBalloon, 600);
-          animRef = requestAnimationFrame(animate);
+        endGame: () => {
+          const { score, best } = get();
+          set({ phase: 'result', best: Math.max(best, score) }, false, 'balloon/endGame');
         },
 
         pop: (id) => {
-          if (sync.phase !== 'playing') return;
-          const b = sync.balloons.find(b => b.id === id);
+          const { phase, balloons, lives, score } = get();
+          if (phase !== 'playing') return;
+          const b = balloons.find(b => b.id === id);
           if (!b || b.popped) return;
 
           if (b.isBomb) {
-            sync.lives = Math.max(0, sync.lives - 2);
-            sync.balloons = sync.balloons.map(x => x.id === id ? { ...x, popped: true } : x);
-            set({ balloons: [...sync.balloons], lives: sync.lives }, false, 'balloon/bomb');
-            if (sync.lives <= 0) endGame();
+            const newLives = Math.max(0, lives - 2);
+            const newBalloons = balloons.map(x => x.id === id ? { ...x, popped: true } : x);
+            set({ balloons: newBalloons, lives: newLives }, false, 'balloon/bomb');
+            if (newLives <= 0) get().endGame();
           } else {
-            sync.score += 10;
-            sync.balloons = sync.balloons.map(x => x.id === id ? { ...x, popped: true } : x);
-            set({ balloons: [...sync.balloons], score: sync.score }, false, 'balloon/pop');
+            set({
+              balloons: balloons.map(x => x.id === id ? { ...x, popped: true } : x),
+              score: score + 10,
+            }, false, 'balloon/pop');
           }
         },
-      };
-    },
+      }),
       { name: 'balloon-pop-best', partialize: (s) => ({ best: s.best }) },
     ),
     { name: 'BalloonPopStore' },
   ),
 );
-
-/** קרא לזה ב-useEffect cleanup כדי לנקות טיימרים אם המשתמש עוזב */
-export { clearTimers as stopBalloonPopGame };

--- a/gamesformykids/app/games/balloon-pop/useBalloonPopLoop.ts
+++ b/gamesformykids/app/games/balloon-pop/useBalloonPopLoop.ts
@@ -1,0 +1,150 @@
+'use client';
+
+/**
+ * useBalloonPopLoop — manages the balloon-pop animation lifecycle.
+ *
+ * Extracted from balloonPopStore so that React owns the timer / rAF
+ * cleanup (via useEffect return), preventing double-loop on Strict Mode
+ * double-invoke and ensuring cleanup on component unmount.
+ *
+ * The store's startGame action signals intent (phase → 'playing');
+ * this hook detects that transition and starts:
+ *   - requestAnimationFrame(animate) — moves balloons, detects escapes
+ *   - setInterval countdown — ticks timeLeft every second
+ *   - setTimeout chain — spawns new balloons at increasing pace
+ */
+
+import { useEffect, useRef } from 'react';
+import {
+  useBalloonPopStore,
+  GAME_DURATION,
+  BALLOON_COLORS,
+  BOMB_CHANCE,
+  type Balloon,
+} from './balloonPopStore';
+
+export function useBalloonPopLoop() {
+  const timerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const spawnRef  = useRef<ReturnType<typeof setTimeout>  | null>(null);
+  const animRef   = useRef<number>(0);
+  const frameRef  = useRef<number>(0);
+  const uidRef    = useRef<number>(0);
+
+  // Stale-closure-safe mirror of mutable loop state.
+  // Written by the RAF/timer callbacks; read by the same callbacks.
+  const st = useRef({ phase: 'menu', score: 0, lives: 5, balloons: [] as Balloon[] });
+
+  useEffect(() => {
+    function clearTimers() {
+      if (timerRef.current) { clearInterval(timerRef.current); timerRef.current = null; }
+      if (spawnRef.current)  { clearTimeout(spawnRef.current);  spawnRef.current  = null; }
+      cancelAnimationFrame(animRef.current);
+    }
+
+    function makeBalloon(): Balloon {
+      const { W, H } = useBalloonPopStore.getState();
+      const isBomb = Math.random() < BOMB_CHANCE;
+      return {
+        id: uidRef.current++,
+        x:  30 + Math.random() * (W - 60),
+        y:  H + 40,
+        r:  22 + Math.random() * 18,
+        vy: -(0.8 + Math.random() * 1.2),
+        color: BALLOON_COLORS[Math.floor(Math.random() * BALLOON_COLORS.length)],
+        isBomb,
+        popped:   false,
+        popAnim:  0,
+      };
+    }
+
+    function endGame() {
+      clearTimers();
+      useBalloonPopStore.getState().endGame();
+    }
+
+    function spawnBalloon() {
+      if (st.current.phase !== 'playing') return;
+      const b = makeBalloon();
+      st.current.balloons = [...st.current.balloons, b];
+      useBalloonPopStore.setState({ balloons: [...st.current.balloons] });
+      const delay = Math.max(500, 1200 - frameRef.current * 2);
+      spawnRef.current = setTimeout(spawnBalloon, delay);
+    }
+
+    function animate() {
+      if (st.current.phase !== 'playing') return;
+      frameRef.current++;
+      let needsUpdate = false;
+      const escaped: number[] = [];
+
+      st.current.balloons = st.current.balloons.map(b => {
+        if (b.popped) {
+          if (b.popAnim < 1) { needsUpdate = true; return { ...b, popAnim: b.popAnim + 0.1 }; }
+          return b;
+        }
+        const ny = b.y + b.vy;
+        if (ny + b.r < 0 && !b.isBomb) { escaped.push(b.id); needsUpdate = true; }
+        needsUpdate = true;
+        return { ...b, y: ny };
+      }).filter(b => {
+        if (b.popped && b.popAnim >= 1) return false;
+        if (escaped.includes(b.id)) return false;
+        return true;
+      });
+
+      if (escaped.length > 0) {
+        st.current.lives = Math.max(0, st.current.lives - escaped.length);
+        if (st.current.lives <= 0) {
+          useBalloonPopStore.setState({ balloons: [...st.current.balloons], lives: 0 });
+          endGame();
+          return;
+        }
+        useBalloonPopStore.setState({ lives: st.current.lives });
+      }
+
+      if (needsUpdate) useBalloonPopStore.setState({ balloons: [...st.current.balloons] });
+      animRef.current = requestAnimationFrame(animate);
+    }
+
+    function startLoop() {
+      clearTimers();
+      st.current = { phase: 'playing', score: 0, lives: 5, balloons: [] };
+      frameRef.current = 0;
+
+      let t = GAME_DURATION;
+      timerRef.current = setInterval(() => {
+        t--;
+        useBalloonPopStore.setState({ timeLeft: t });
+        if (t <= 0) endGame();
+      }, 1000);
+
+      spawnRef.current = setTimeout(spawnBalloon, 600);
+      animRef.current  = requestAnimationFrame(animate);
+    }
+
+    // Subscribe to phase changes — start the loop when game starts.
+    const unsubscribe = useBalloonPopStore.subscribe((state, prev) => {
+      if (state.phase === 'playing' && prev.phase !== 'playing') {
+        startLoop();
+      } else if (state.phase !== 'playing') {
+        st.current.phase = state.phase;
+      }
+    });
+
+    // Sync lives/score written by the store's pop action back into st.
+    // This prevents the RAF from using a stale lives value after a pop.
+    const unsubPop = useBalloonPopStore.subscribe((state) => {
+      if (state.phase === 'playing') {
+        st.current.lives  = state.lives;
+        st.current.score  = state.score;
+        st.current.balloons = state.balloons;
+      }
+    });
+
+    return () => {
+      unsubscribe();
+      unsubPop();
+      clearTimers();
+    };
+  }, []);
+}


### PR DESCRIPTION
## Summary
Extracts the `requestAnimationFrame` + `setInterval` + `setTimeout` game loop from module-level closures in `balloonPopStore.ts` into a dedicated `useBalloonPopLoop.ts` React hook. React now owns the cleanup path via `useEffect` return, preventing the Strict Mode double-loop hazard and guaranteeing timer cleanup on component unmount.

Additionally moves `W`/`H` canvas dimensions from module-level mutable variables into the Zustand store as regular state fields (set via `setDimensions`), making them reactive and DevTools-visible.

The store now holds only pure state (`phase`, `score`, `best`, `lives`, `timeLeft`, `balloons`, `W`, `H`) and simple actions (`startGame`, `endGame`, `pop`, `setDimensions`) — no timer handles or animation refs.

## Changes
- `app/games/balloon-pop/balloonPopStore.ts` — removed all module-level mutable vars (`uid`, `timerRef`, `spawnRef`, `animRef`, `frameCount`, `W`, `H`, `sync`); added `W`/`H` to state; simplified `startGame`; added `endGame` action; `pop` now uses `get()` instead of stale refs; removed `stopBalloonPopGame` export
- `app/games/balloon-pop/useBalloonPopLoop.ts` — new hook: manages rAF, countdown timer, and balloon spawn chain via `useRef`; subscribes to phase changes; cleans up on unmount
- `app/games/balloon-pop/BalloonPopGame.tsx` — replaced `useEffect(() => stopBalloonPopGame, [])` with `useBalloonPopLoop()`

## Testing
- [x] `npx tsc --noEmit` passes
- [ ] Manually verified at `http://localhost:3000/games/balloon-pop`

Closes #616

🤖 Generated with [Claude Code](https://claude.com/claude-code)