### PR TITLE
architecture: extract Supabase queries into service layer

### DIFF
--- a/gamesformykids/hooks/shared/progress/useAchievements.ts
+++ b/gamesformykids/hooks/shared/progress/useAchievements.ts
@@ -1,212 +1,149 @@
 'use client';
 
-import { useEffect, useCallback } from 'react'
-import { useAuth } from '@/hooks/shared/auth/useAuth'
-import { supabase } from '@/lib/supabase/client'
-import { useAchievementsStore } from '@/lib/stores/achievementsStore'
+import { useEffect, useCallback } from 'react';
+import { useAuth } from '@/hooks/shared/auth/useAuth';
+import { useAchievementsStore } from '@/lib/stores/achievementsStore';
+import {
+  fetchAchievements,
+  findAchievement,
+  insertAchievement,
+} from '@/lib/supabase/achievements';
 
 export interface Achievement {
-  id: string
-  user_id: string
-  achievement_type: string
-  achievement_name: string
-  description: string | null
-  icon: string | null
-  earned_at: string
-  game_type: string | null
-  metadata: Record<string, unknown>
+  id: string;
+  user_id: string;
+  achievement_type: string;
+  achievement_name: string;
+  description: string | null;
+  icon: string | null;
+  earned_at: string;
+  game_type: string | null;
+  metadata: Record<string, unknown>;
 }
 
 export function useAchievements(gameType?: string) {
-  const { user } = useAuth()
-  const achievements = useAchievementsStore((s) => s.achievements)
-  const loading = useAchievementsStore((s) => s.loading)
-  const error = useAchievementsStore((s) => s.error)
-  const loadedForUserId = useAchievementsStore((s) => s.loadedForUserId)
-  const { setAchievements, prependAchievement, setLoading, setError, setLoadedForUserId } = useAchievementsStore()
+  const { user } = useAuth();
+  const achievements = useAchievementsStore((s) => s.achievements);
+  const loading = useAchievementsStore((s) => s.loading);
+  const error = useAchievementsStore((s) => s.error);
+  const loadedForUserId = useAchievementsStore((s) => s.loadedForUserId);
+  const { setAchievements, prependAchievement, setLoading, setError, setLoadedForUserId } =
+    useAchievementsStore();
 
-  const fetchAchievements = useCallback(async () => {
-    if (!user) return
+  const loadAchievements = useCallback(async () => {
+    if (!user) return;
 
     try {
-      setLoading(true)
-      let query = supabase
-        .from('achievements')
-        .select('*')
-        .eq('user_id', user.id)
-        .order('earned_at', { ascending: false })
-
-      if (gameType) {
-        query = query.eq('game_type', gameType)
-      }
-
-      const { data, error } = await query
-
-      if (error) throw error
-
-      setAchievements(data || [])
-      setLoadedForUserId(user.id)
+      setLoading(true);
+      const data = await fetchAchievements(user.id, gameType);
+      setAchievements(data);
+      setLoadedForUserId(user.id);
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'שגיאה בטעינת ההישגים')
+      setError(err instanceof Error ? err.message : 'שגיאה בטעינת ההישגים');
     } finally {
-      setLoading(false)
+      setLoading(false);
     }
-  }, [user, gameType, setAchievements, setLoading, setError, setLoadedForUserId])
+  }, [user, gameType, setAchievements, setLoading, setError, setLoadedForUserId]);
 
   useEffect(() => {
     if (!user) {
-      setLoading(false)
-      return
+      setLoading(false);
+      return;
     }
-    if (loadedForUserId === user.id) return
-    fetchAchievements()
-  }, [user, gameType, loadedForUserId, fetchAchievements, setLoading])
+    if (loadedForUserId === user.id) return;
+    loadAchievements();
+  }, [user, gameType, loadedForUserId, loadAchievements, setLoading]);
 
-  async function unlockAchievement(achievement: Omit<Achievement, 'id' | 'user_id' | 'earned_at'>) {
-    if (!user) return null
+  async function unlockAchievement(
+    achievement: Omit<Achievement, 'id' | 'user_id' | 'earned_at'>,
+  ) {
+    if (!user) return null;
 
     try {
-      // Check if achievement already exists
-      const { data: existing } = await supabase
-        .from('achievements')
-        .select('id')
-        .eq('user_id', user.id)
-        .eq('achievement_type', achievement.achievement_type)
-        .eq('game_type', achievement.game_type || '')
-        .single()
+      const existing = await findAchievement(
+        user.id,
+        achievement.achievement_type,
+        achievement.game_type ?? '',
+      );
+      if (existing) return existing;
 
-      if (existing) {
-        // Achievement already unlocked
-        return existing
-      }
-
-      // Unlock new achievement
-      const { data, error } = await supabase
-        .from('achievements')
-        .insert({
-          user_id: user.id,
-          ...achievement,
-          earned_at: new Date().toISOString()
-        })
-        .select()
-        .single()
-
-      if (error) throw error
-
-      // Update store
-      prependAchievement(data)
-      
-      return data
+      const data = await insertAchievement(user.id, achievement);
+      prependAchievement(data);
+      return data;
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'שגיאה בשמירת ההישג')
-      return null
+      setError(err instanceof Error ? err.message : 'שגיאה בשמירת ההישג');
+      return null;
     }
   }
 
-  // Pre-defined achievement checkers
   async function checkScoreAchievements(gameType: string, score: number) {
-    const achievements = []
+    const candidates = [];
 
-    // First score achievement
     if (score > 0) {
-      achievements.push({
+      candidates.push({
         achievement_type: 'first_score',
         achievement_name: 'הניקוד הראשון',
         description: 'קיבלת את הניקוד הראשון שלך!',
         icon: '🎯',
         game_type: gameType,
-        metadata: { score }
-      })
+        metadata: { score },
+      });
     }
 
-    // High score achievements
     if (score >= 100) {
-      achievements.push({
+      candidates.push({
         achievement_type: 'score_100',
         achievement_name: 'מאה נקודות',
         description: 'השגת 100 נקודות במשחק!',
         icon: '💯',
         game_type: gameType,
-        metadata: { score }
-      })
+        metadata: { score },
+      });
     }
 
     if (score >= 500) {
-      achievements.push({
+      candidates.push({
         achievement_type: 'score_500',
         achievement_name: 'חמש מאות נקודות',
         description: 'השגת 500 נקודות במשחק!',
         icon: '⭐',
         game_type: gameType,
-        metadata: { score }
-      })
+        metadata: { score },
+      });
     }
 
-    // Unlock achievements
-    for (const achievement of achievements) {
-      await unlockAchievement(achievement)
+    for (const a of candidates) {
+      await unlockAchievement(a);
     }
   }
 
   async function checkLevelAchievements(gameType: string, level: number) {
-    const achievements = []
+    const candidates = [];
 
     if (level >= 5) {
-      achievements.push({
+      candidates.push({
         achievement_type: 'level_5',
         achievement_name: 'רמה 5',
         description: 'הגעת לרמה 5!',
         icon: '🏆',
         game_type: gameType,
-        metadata: { level }
-      })
+        metadata: { level },
+      });
     }
 
     if (level >= 10) {
-      achievements.push({
+      candidates.push({
         achievement_type: 'level_10',
         achievement_name: 'רמה 10',
         description: 'הגעת לרמה 10! מדהים!',
         icon: '👑',
         game_type: gameType,
-        metadata: { level }
-      })
+        metadata: { level },
+      });
     }
 
-    // Unlock achievements
-    for (const achievement of achievements) {
-      await unlockAchievement(achievement)
-    }
-  }
-
-  async function checkPlayTimeAchievements(gameType: string, totalPlayTimeMinutes: number) {
-    const achievements = []
-
-    if (totalPlayTimeMinutes >= 10) {
-      achievements.push({
-        achievement_type: 'playtime_10min',
-        achievement_name: '10 דקות משחק',
-        description: 'שיחקת 10 דקות!',
-        icon: '⏰',
-        game_type: gameType,
-        metadata: { playtime_minutes: totalPlayTimeMinutes }
-      })
-    }
-
-    if (totalPlayTimeMinutes >= 60) {
-      achievements.push({
-        achievement_type: 'playtime_1hour',
-        achievement_name: 'שעה של משחק',
-        description: 'שיחקת שעה שלמה!',
-        icon: '🎮',
-        game_type: gameType,
-        metadata: { playtime_minutes: totalPlayTimeMinutes }
-      })
-    }
-
-    // Unlock achievements
-    for (const achievement of achievements) {
-      await unlockAchievement(achievement)
+    for (const a of candidates) {
+      await unlockAchievement(a);
     }
   }
 
@@ -214,10 +151,7 @@ export function useAchievements(gameType?: string) {
     achievements,
     loading,
     error,
-    unlockAchievement,
     checkScoreAchievements,
     checkLevelAchievements,
-    checkPlayTimeAchievements,
-    refreshAchievements: fetchAchievements
-  }
+  };
 }

--- a/gamesformykids/hooks/shared/progress/useGameCompletion.ts
+++ b/gamesformykids/hooks/shared/progress/useGameCompletion.ts
@@ -2,9 +2,9 @@
 
 import { useCallback, useRef, useEffect } from 'react';
 import type { GameType } from '@/lib/types';
-import { supabase } from '@/lib/supabase/client';
 import { useAuth } from '@/hooks/shared/auth/useAuth';
 import { useGameProgressDataStore } from '@/lib/stores/gameProgressDataStore';
+import { upsertGameProgress } from '@/lib/supabase/gameProgress';
 import { useAchievements } from './useAchievements';
 
 export interface GameResult {
@@ -17,40 +17,42 @@ export function useGameCompletion(gameType: GameType) {
   const { user } = useAuth();
   const { checkScoreAchievements, checkLevelAchievements } = useAchievements();
 
-  const saveGameResult = useCallback(async ({ score, level, durationSeconds }: GameResult) => {
-    if (!user) return;
+  const saveGameResult = useCallback(
+    async ({ score, level, durationSeconds }: GameResult) => {
+      if (!user) return;
 
-    const gt = gameType as string;
-    const progress = useGameProgressDataStore.getState().progress;
-    const cur = progress.find((p) => p.game_type === gt);
+      const gt = gameType as string;
+      const progress = useGameProgressDataStore.getState().progress;
+      const cur = progress.find((p) => p.game_type === gt);
 
-    const { data, error } = await supabase
-      .from('game_progress')
-      .upsert({
-        user_id: user.id,
-        game_type: gt,
-        score,
-        last_score: score,
-        best_score: Math.max(cur?.best_score ?? 0, score),
-        level,
-        completed_levels: Math.max(cur?.completed_levels ?? 0, level - 1),
-        total_play_time: (cur?.total_play_time ?? 0) + durationSeconds,
-        last_played_at: new Date().toISOString(),
-        updated_at: new Date().toISOString(),
-      })
-      .select()
-      .single();
+      try {
+        const data = await upsertGameProgress(user.id, {
+          game_type: gt,
+          score,
+          last_score: score,
+          best_score: Math.max(cur?.best_score ?? 0, score),
+          level,
+          completed_levels: Math.max(cur?.completed_levels ?? 0, level - 1),
+          total_play_time: (cur?.total_play_time ?? 0) + durationSeconds,
+          last_played_at: new Date().toISOString(),
+          updated_at: new Date().toISOString(),
+        });
 
-    if (!error && data) {
-      useGameProgressDataStore.getState().upsertProgressItem(data);
-    }
+        useGameProgressDataStore.getState().upsertProgressItem(data);
+      } catch {
+        // progress save failure is non-fatal — continue to achievements
+      }
 
-    checkScoreAchievements(gt, score);
-    checkLevelAchievements(gt, level);
-  }, [gameType, user, checkScoreAchievements, checkLevelAchievements]);
+      checkScoreAchievements(gt, score);
+      checkLevelAchievements(gt, level);
+    },
+    [gameType, user, checkScoreAchievements, checkLevelAchievements],
+  );
 
   const saveGameResultRef = useRef(saveGameResult);
-  useEffect(() => { saveGameResultRef.current = saveGameResult; }, [saveGameResult]);
+  useEffect(() => {
+    saveGameResultRef.current = saveGameResult;
+  }, [saveGameResult]);
 
   return { saveGameResult, saveGameResultRef };
 }

--- a/gamesformykids/lib/supabase/achievements.ts
+++ b/gamesformykids/lib/supabase/achievements.ts
@@ -1,0 +1,68 @@
+/**
+ * ===============================================
+ * Supabase Service — Achievements
+ * ===============================================
+ * All raw `supabase.from('achievements')` calls live here.
+ * Hooks import these functions instead of calling supabase directly.
+ */
+
+import { supabase } from './client';
+import type { Achievement } from '@/hooks/shared/progress/useAchievements';
+
+type NewAchievement = Omit<Achievement, 'id' | 'user_id' | 'earned_at'>;
+
+/** Fetch all achievements for a user, optionally filtered by game type. */
+export async function fetchAchievements(
+  userId: string,
+  gameType?: string,
+): Promise<Achievement[]> {
+  let query = supabase
+    .from('achievements')
+    .select('*')
+    .eq('user_id', userId)
+    .order('earned_at', { ascending: false });
+
+  if (gameType) {
+    query = query.eq('game_type', gameType);
+  }
+
+  const { data, error } = await query;
+  if (error) throw error;
+  return (data ?? []) as Achievement[];
+}
+
+/** Returns an existing achievement row if the user already has it, or null. */
+export async function findAchievement(
+  userId: string,
+  achievementType: string,
+  gameType: string,
+): Promise<{ id: string } | null> {
+  const { data } = await supabase
+    .from('achievements')
+    .select('id')
+    .eq('user_id', userId)
+    .eq('achievement_type', achievementType)
+    .eq('game_type', gameType)
+    .single();
+
+  return data ?? null;
+}
+
+/** Insert a new achievement row and return it. */
+export async function insertAchievement(
+  userId: string,
+  achievement: NewAchievement,
+): Promise<Achievement> {
+  const { data, error } = await supabase
+    .from('achievements')
+    .insert({
+      user_id: userId,
+      ...achievement,
+      earned_at: new Date().toISOString(),
+    })
+    .select()
+    .single();
+
+  if (error) throw error;
+  return data as Achievement;
+}

--- a/gamesformykids/lib/supabase/gameProgress.ts
+++ b/gamesformykids/lib/supabase/gameProgress.ts
@@ -1,0 +1,25 @@
+/**
+ * ===============================================
+ * Supabase Service — Game Progress
+ * ===============================================
+ * All raw `supabase.from('game_progress')` calls live here.
+ * Hooks import these functions instead of calling supabase directly.
+ */
+
+import { supabase } from './client';
+import type { GameProgress } from '@/hooks/shared/progress/useGameProgress';
+
+/** Upsert a game progress row and return the saved record. */
+export async function upsertGameProgress(
+  userId: string,
+  data: Omit<GameProgress, 'id' | 'user_id' | 'created_at'>,
+): Promise<GameProgress> {
+  const { data: row, error } = await supabase
+    .from('game_progress')
+    .upsert({ user_id: userId, ...data })
+    .select()
+    .single();
+
+  if (error) throw error;
+  return row as GameProgress;
+}


### PR DESCRIPTION
## Summary
Moves all raw `supabase.from()` calls out of hooks into a thin service layer under `lib/supabase/`. Both `useAchievements` and `useGameCompletion` now call named functions instead of inline queries, making the data-access logic easier to test, mock, and reuse.

## Changes
- `lib/supabase/achievements.ts` (new) — `fetchAchievements(userId, gameType?)`, `findAchievement(userId, type, gameType)`, `insertAchievement(userId, achievement)`
- `lib/supabase/gameProgress.ts` (new) — `upsertGameProgress(userId, data)` using the existing `GameProgress` type from `useGameProgress.ts`
- `hooks/shared/progress/useAchievements.ts` — replaced 3 inline Supabase queries with service calls; also removed dead code (`checkPlayTimeAchievements`, `unlockAchievement`, `refreshAchievements`) from the public return
- `hooks/shared/progress/useGameCompletion.ts` — replaced inline upsert with `upsertGameProgress`; wrapped in try/catch so progress failure is non-fatal

## Testing
- [x] `npx tsc --noEmit` passes

Closes #617

🤖 Generated with [Claude Code](https://claude.com/claude-code)