### PR TITLE
fix: add st to useCallback/useEffect deps in canvas arcade game hooks

### DIFF
--- a/gamesformykids/app/games/brick-breaker/useBrickBreakerGame.ts
+++ b/gamesformykids/app/games/brick-breaker/useBrickBreakerGame.ts
@@ -154,7 +154,7 @@ export function useBrickBreakerGame() {
     s.lives = level === 1 ? 3 : s.lives;
     s.level = level; s.particles = [];
     useBrickBreakerStore.getState().startLevel({ score: s.score, lives: s.lives, level });
-  }, []);
+  }, [st]);
   // Wire level-progression callback so draw config can call it
   _brickStartNextLevel = startGame;
 
@@ -162,7 +162,7 @@ export function useBrickBreakerGame() {
     const s = st.current;
     if (s.phase === 'playing' && !s.launched) { s.launched = true; }
     else if (s.phase === 'menu') { startGame(1); }
-  }, [startGame]);
+  }, [st, startGame]);
 
   const handleTouchStart = useCallback((e: React.TouchEvent<HTMLCanvasElement>) => {
     e.preventDefault();
@@ -170,8 +170,8 @@ export function useBrickBreakerGame() {
     handlers.onTouchMove(e);
   }, [handleClick, handlers]);
 
-  const nudgeLeft = useCallback(() => { st.current.padX = Math.max(0, st.current.padX - 40); }, []);
-  const nudgeRight = useCallback(() => { st.current.padX = Math.min(W - PAD_W, st.current.padX + 40); }, []);
+  const nudgeLeft = useCallback(() => { st.current.padX = Math.max(0, st.current.padX - 40); }, [st]);
+  const nudgeRight = useCallback(() => { st.current.padX = Math.min(W - PAD_W, st.current.padX + 40); }, [st]);
 
 
   useEffect(() => {
@@ -194,7 +194,7 @@ export function useBrickBreakerGame() {
     window.addEventListener('keydown', kd);
     window.addEventListener('keyup', ku);
     return () => { clearInterval(interval); window.removeEventListener('keydown', kd); window.removeEventListener('keyup', ku); };
-  }, [handleClick]);
+  }, [handleClick, st]);
 
   const { phase, score, best, lives, level } = useBrickBreakerStore(useShallow(s => ({ phase: s.phase, score: s.score, best: s.best, lives: s.lives, level: s.level })));
 

--- a/gamesformykids/app/games/catch-fruit/useCatchFruitGame.ts
+++ b/gamesformykids/app/games/catch-fruit/useCatchFruitGame.ts
@@ -121,7 +121,7 @@ export function useCatchFruitGame() {
     s.items = [];
     s.score = 0; s.lives = 3; s.timeLeft = GAME_DURATION; s.frame = 0; s.nextItem = 40; s.startTime = Date.now();
     useCatchFruitStore.getState().startGame();
-  }, []);
+  }, [st]);
 
   const handleMouseUp = useCallback(() => {
     pointerDown.current = false;
@@ -137,7 +137,7 @@ export function useCatchFruitGame() {
     const scaleX = W / rect.width;
     const mx = (e.clientX - rect.left) * scaleX;
     st.current.basketX = Math.max(0, Math.min(W - BASKET_W, mx - BASKET_W / 2));
-  }, [canvasRef]);
+  }, [canvasRef, st]);
 
   const handleMouseDown = useCallback((e: React.MouseEvent<HTMLCanvasElement>) => {
     pointerDown.current = true;
@@ -147,7 +147,7 @@ export function useCatchFruitGame() {
     const scaleX = W / rect.width;
     const mx = (e.clientX - rect.left) * scaleX;
     st.current.basketX = Math.max(0, Math.min(W - BASKET_W, mx - BASKET_W / 2));
-  }, [canvasRef]);
+  }, [canvasRef, st]);
 
   const handleTouchMove = useCallback((e: React.TouchEvent<HTMLCanvasElement>) => {
     e.preventDefault();
@@ -157,7 +157,7 @@ export function useCatchFruitGame() {
     const scaleX = W / rect.width;
     const mx = (e.touches[0].clientX - rect.left) * scaleX;
     st.current.basketX = Math.max(0, Math.min(W - BASKET_W, mx - BASKET_W / 2));
-  }, [canvasRef]);
+  }, [canvasRef, st]);
 
   const handleTouchStart = useCallback((e: React.TouchEvent<HTMLCanvasElement>) => {
     e.preventDefault();
@@ -168,7 +168,7 @@ export function useCatchFruitGame() {
     const mx = (e.touches[0].clientX - rect.left) * scaleX;
     st.current.basketX = Math.max(0, Math.min(W - BASKET_W, mx - BASKET_W / 2));
     if (st.current.phase !== 'playing') startGame();
-  }, [canvasRef, startGame]);
+  }, [canvasRef, st, startGame]);
 
   const { phase, best, score, lives, timeLeft } = useCatchFruitStore(useShallow(s => ({ phase: s.phase, best: s.best, score: s.score, lives: s.lives, timeLeft: s.timeLeft })));
 

--- a/gamesformykids/app/games/dino-runner/useDinoRunnerGame.ts
+++ b/gamesformykids/app/games/dino-runner/useDinoRunnerGame.ts
@@ -156,7 +156,7 @@ export function useDinoRunnerGame() {
       s.phase = 'menu';
       useDinoRunnerStore.getState().resetToMenu();
     }
-  }, []);
+  }, [st]);
 
 
   useEffect(() => {

--- a/gamesformykids/app/games/flappy-bird/useFlappyBirdGame.ts
+++ b/gamesformykids/app/games/flappy-bird/useFlappyBirdGame.ts
@@ -194,7 +194,7 @@ export function useFlappyBirdGame() {
     s.startTime = Date.now();
     useFlappyBirdStore.getState().setPhase('playing');
     useFlappyBirdStore.getState().setScore(0);
-  }, []);
+  }, [st]);
 
   const flap = useCallback(() => {
     const s = st.current;
@@ -206,7 +206,7 @@ export function useFlappyBirdGame() {
       s.phase = 'menu';
       useFlappyBirdStore.getState().setPhase('menu');
     }
-  }, [resetGame]);
+  }, [st, resetGame]);
 
 
   const handleInput = useCallback((e?: React.MouseEvent | React.TouchEvent) => {

--- a/gamesformykids/app/games/frogger/useFroggerGame.ts
+++ b/gamesformykids/app/games/frogger/useFroggerGame.ts
@@ -118,7 +118,7 @@ export function useFroggerGame() {
     s.lives = 3; s.score = 0; s.level = 1; s.frame = 0; s.dead = false; s.deadTimer = 0;
     s.lanes = makeLanes(); s.startTime = Date.now();
     useFroggerStore.getState().startPlaying();
-  }, []);
+  }, [st]);
 
   const moveFrog = useCallback((dc: number, dr: number) => {
     const s = st.current;
@@ -128,7 +128,7 @@ export function useFroggerGame() {
     if (dr < 0) s.score += 2;
     s.fCol = nc; s.fRow = nr;
     if (nr === 0) { s.score += 30; s.level++; s.fCol = 4; s.fRow = 8; useFroggerStore.getState().setScore(s.score); }
-  }, []);
+  }, [st]);
 
   const touchRef = useRef<{ x: number; y: number } | null>(null);
 

--- a/gamesformykids/app/games/jumper/useJumperGame.ts
+++ b/gamesformykids/app/games/jumper/useJumperGame.ts
@@ -161,16 +161,16 @@ export function useJumperGame() {
     s.nextPlatY = H - 60 - INIT_PLATS * (PLAT_GAP * 0.75);
     s.startTime = Date.now();
     useJumperStore.getState().startPlaying();
-  }, []);
+  }, [st]);
 
   const handleCanvasClick = useCallback(() => {
     if (st.current.phase === 'menu') startGame();
-  }, [startGame]);
+  }, [st, startGame]);
 
-  const pressLeft = useCallback(() => { st.current.leftDown = true; }, []);
-  const releaseLeft = useCallback(() => { st.current.leftDown = false; }, []);
-  const pressRight = useCallback(() => { st.current.rightDown = true; }, []);
-  const releaseRight = useCallback(() => { st.current.rightDown = false; }, []);
+  const pressLeft = useCallback(() => { st.current.leftDown = true; }, [st]);
+  const releaseLeft = useCallback(() => { st.current.leftDown = false; }, [st]);
+  const pressRight = useCallback(() => { st.current.rightDown = true; }, [st]);
+  const releaseRight = useCallback(() => { st.current.rightDown = false; }, [st]);
 
 
   useEffect(() => {
@@ -185,7 +185,7 @@ export function useJumperGame() {
     window.addEventListener('keydown', kd);
     window.addEventListener('keyup', ku);
     return () => { window.removeEventListener('keydown', kd); window.removeEventListener('keyup', ku); };
-  }, []);
+  }, [st]);
 
   const handleTouchMove = useCallback((e: React.TouchEvent<HTMLCanvasElement>) => {
     e.preventDefault();
@@ -195,12 +195,12 @@ export function useJumperGame() {
     if (s.phase !== 'playing') return;
     if (tx < W / 2) { s.leftDown = true; s.rightDown = false; }
     else             { s.rightDown = true; s.leftDown = false; }
-  }, []);
+  }, [st]);
 
   const handleTouchEnd = useCallback(() => {
     st.current.leftDown = false;
     st.current.rightDown = false;
-  }, []);
+  }, [st]);
 
   const { phase, score, best } = useJumperStore(useShallow(s => ({ phase: s.phase, score: s.score, best: s.best })));
 

--- a/gamesformykids/app/games/meteor-dodge/useMeteorDodgeGame.ts
+++ b/gamesformykids/app/games/meteor-dodge/useMeteorDodgeGame.ts
@@ -126,11 +126,11 @@ export function useMeteorDodgeGame() {
     s.score = 0; s.frame = 0; s.nextMeteor = 50; s.nextStar = 120; s.invincible = 0;
     s.startTime = Date.now();
     useMeteorDodgeStore.getState().startPlaying();
-  }, []);
+  }, [st]);
 
   const handleCanvasClick = useCallback(() => {
     if (st.current.phase === 'menu') startGame();
-  }, [startGame]);
+  }, [st, startGame]);
 
   const handleTouchStart = useCallback((e: React.TouchEvent<HTMLCanvasElement>) => {
     e.preventDefault();
@@ -157,12 +157,12 @@ export function useMeteorDodgeGame() {
   const nudgeLeft = useCallback(() => {
     const s = st.current;
     s.playerX = Math.max(PLAYER_R, s.playerX - 45);
-  }, []);
+  }, [st]);
 
   const nudgeRight = useCallback(() => {
     const s = st.current;
     s.playerX = Math.min(W - PLAYER_R, s.playerX + 45);
-  }, []);
+  }, [st]);
 
   const { phase, score, best } = useMeteorDodgeStore(useShallow(s => ({ phase: s.phase, score: s.score, best: s.best })));
 

--- a/gamesformykids/app/games/pong/usePongGame.ts
+++ b/gamesformykids/app/games/pong/usePongGame.ts
@@ -105,11 +105,11 @@ export function usePongGame() {
     s.ballVX = Math.sin(angle) * spd; s.ballVY = (Math.random() < 0.5 ? 1 : -1) * Math.cos(angle) * spd;
     s.playerScore = 0; s.aiScore = 0; s.frame = 0; s.particles = []; s.startTime = Date.now();
     usePongStore.getState().startGame();
-  }, []);
+  }, [st]);
 
   const handleCanvasClick = useCallback(() => {
     if (st.current.phase === 'menu') startGame();
-  }, [startGame]);
+  }, [st, startGame]);
 
   const handleTouchStart = useCallback((e: React.TouchEvent<HTMLCanvasElement>) => {
     e.preventDefault();
@@ -137,7 +137,7 @@ export function usePongGame() {
     window.addEventListener('keydown', kd);
     window.addEventListener('keyup', ku);
     return () => { clearInterval(interval); window.removeEventListener('keydown', kd); window.removeEventListener('keyup', ku); };
-  }, []);
+  }, [st]);
 
   const { phase, playerScore, aiScore } = usePongStore(useShallow(s => ({ phase: s.phase, playerScore: s.playerScore, aiScore: s.aiScore })));
 

--- a/gamesformykids/app/games/space-defender/useSpaceDefenderGame.ts
+++ b/gamesformykids/app/games/space-defender/useSpaceDefenderGame.ts
@@ -127,7 +127,7 @@ export function useSpaceDefenderGame() {
     if (now - s.lastShot < 12) return;
     s.lastShot = now;
     s.bullets.push({ id: uid++, x: s.shipX, y: H - 80 });
-  }, []);
+  }, [st]);
 
   const startGame = useCallback(() => {
     const s = st.current;
@@ -135,7 +135,7 @@ export function useSpaceDefenderGame() {
     s.shipX = W / 2; s.bullets = []; s.asteroids = [];
     s.score = 0; s.lives = 3; s.timeLeft = GAME_DURATION; s.frame = 0; s.nextAsteroid = 60; s.lastShot = 0; s.startTime = Date.now();
     useSpaceDefenderStore.getState().startGame();
-  }, []);
+  }, [st]);
 
 
   const handleMouseMove = useCallback((e: React.MouseEvent<HTMLCanvasElement>) => {
@@ -144,13 +144,13 @@ export function useSpaceDefenderGame() {
     const rect = canvas.getBoundingClientRect();
     const scaleX = W / rect.width;
     st.current.shipX = Math.max(SHIP_W / 2, Math.min(W - SHIP_W / 2, (e.clientX - rect.left) * scaleX));
-  }, [canvasRef]);
+  }, [st, canvasRef]);
 
   const handleCanvasClick = useCallback(() => {
     const s = st.current;
     if (s.phase === 'playing') { shoot(); return; }
     if (s.phase === 'menu') startGame();
-  }, [shoot, startGame]);
+  }, [st, shoot, startGame]);
 
   const handleTouchMove = useCallback((e: React.TouchEvent<HTMLCanvasElement>) => {
     e.preventDefault();
@@ -160,12 +160,12 @@ export function useSpaceDefenderGame() {
     const scaleX = W / rect.width;
     st.current.shipX = Math.max(SHIP_W / 2, Math.min(W - SHIP_W / 2, (e.touches[0].clientX - rect.left) * scaleX));
     shoot();
-  }, [canvasRef, shoot]);
+  }, [st, canvasRef, shoot]);
 
   const handleTouchStart = useCallback((e: React.TouchEvent<HTMLCanvasElement>) => {
     e.preventDefault();
     if (st.current.phase !== 'playing') startGame();
-  }, [startGame]);
+  }, [st, startGame]);
 
   useEffect(() => {
     let leftDown = false, rightDown = false;
@@ -187,7 +187,7 @@ export function useSpaceDefenderGame() {
     window.addEventListener('keydown', kd);
     window.addEventListener('keyup', ku);
     return () => { window.removeEventListener('keydown', kd); window.removeEventListener('keyup', ku); clearInterval(moveInterval); };
-  }, [shoot]);
+  }, [st, shoot]);
 
   const { phase, best, score, lives, timeLeft } = useSpaceDefenderStore(useShallow(s => ({ phase: s.phase, best: s.best, score: s.score, lives: s.lives, timeLeft: s.timeLeft })));
 

--- a/gamesformykids/app/games/stack/useStackGame.ts
+++ b/gamesformykids/app/games/stack/useStackGame.ts
@@ -96,7 +96,7 @@ export function useStackGame() {
     s.blocks = [{ x: (W - INIT_W) / 2, y: FLOOR_Y, w: INIT_W, color: '#6b7280' }];
     s.startTime = Date.now();
     useStackStore.getState().startPlaying();
-  }, []);
+  }, [st]);
 
   const drop = useCallback(() => {
     const s = st.current;
@@ -127,12 +127,12 @@ export function useStackGame() {
     const topWorldY = sliderWorldY;
     s.camOffset = Math.max(0, TARGET_TOP - topWorldY);
     useStackStore.getState().setScore(s.score);
-  }, [saveGameResultRef]);
+  }, [st, saveGameResultRef]);
 
   const handleCanvasClick = useCallback(() => {
     if (st.current.phase === 'playing') drop();
     else if (st.current.phase === 'menu') startGame();
-  }, [drop, startGame]);
+  }, [st, drop, startGame]);
 
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
All 5 open PRs (#620–#624) were failing `Typecheck, Lint & Test` because `eslint --max-warnings=0` was detecting 41 `react-hooks/exhaustive-deps` warnings about a missing `st` dependency across 10 canvas arcade game hooks.

`st` is a `MutableRefObject<S>` returned by `createCanvasArcadeHook`. Because it comes from a custom hook (not a direct `useRef` call), ESLint cannot tell it is stable and correctly warns that it is missing from dependency arrays. The factory's own usage example already shows `[st]` in the `useCallback` deps — the game hooks were simply inconsistent with that guidance.

Adding `st` to the dependency arrays is correct: the ref identity never changes, so no unnecessary re-renders occur.

## Affected files (10)
- `app/games/brick-breaker/useBrickBreakerGame.ts`
- `app/games/catch-fruit/useCatchFruitGame.ts`
- `app/games/dino-runner/useDinoRunnerGame.ts`
- `app/games/flappy-bird/useFlappyBirdGame.ts`
- `app/games/frogger/useFroggerGame.ts`
- `app/games/jumper/useJumperGame.ts`
- `app/games/meteor-dodge/useMeteorDodgeGame.ts`
- `app/games/pong/usePongGame.ts`
- `app/games/space-defender/useSpaceDefenderGame.ts`
- `app/games/stack/useStackGame.ts`

## Testing
- [x] `npx eslint . --max-warnings=0` — 0 warnings
- [x] `npx tsc --noEmit` — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)