### PR TITLE
architecture: store _brickStartNextLevel in st.current instead of module-level ref

### DIFF
--- a/gamesformykids/app/games/brick-breaker/useBrickBreakerGame.ts
+++ b/gamesformykids/app/games/brick-breaker/useBrickBreakerGame.ts
@@ -40,10 +40,6 @@ function brickRect(i: number) {
   return { x, y, w: BRICK_W - BRICK_PAD, h: BRICK_H };
 }
 
-// Module-level ref so the draw config can trigger level progression
-// (brick-breaker advances levels from inside the canvas loop).
-let _brickStartNextLevel: (level: number) => void = () => {};
-
 const _useBrickBreaker = createCanvasArcadeHook({
   gameType: 'brick-breaker',
   width: W,
@@ -55,6 +51,8 @@ const _useBrickBreaker = createCanvasArcadeHook({
     bricks: makeBricks(), score: 0, lives: 3, level: 1, frame: 0,
     startTime: 0,
     particles: [] as { x: number; y: number; vx: number; vy: number; life: number; color: string }[],
+    /** Wired by useBrickBreakerGame via useEffect — stored here so draw can call it without a module-level ref. */
+    startNextLevel: undefined as ((level: number) => void) | undefined,
   }),
   onPointerX: (s, x) => { s.padX = Math.max(0, Math.min(W - PAD_W, x - PAD_W / 2)); },
   draw: (ctx, s, _dt, saveRef) => {    s.frame++;
@@ -102,7 +100,7 @@ const _useBrickBreaker = createCanvasArcadeHook({
             saveRef.current({ score: s.score, level: s.level, durationSeconds: elapsed });
             useBrickBreakerStore.getState().setWon(s.score, s.lives, s.level);
           }
-          else { _brickStartNextLevel(nextLevel); }
+          else { s.startNextLevel?.(nextLevel); }
         }
       }
       s.particles = s.particles.filter(p => { p.x += p.vx; p.y += p.vy; p.vy += 0.15; p.life -= 0.04; return p.life > 0; });
@@ -155,8 +153,12 @@ export function useBrickBreakerGame() {
     s.level = level; s.particles = [];
     useBrickBreakerStore.getState().startLevel({ score: s.score, lives: s.lives, level });
   }, [st]);
-  // Wire level-progression callback so draw config can call it
-  _brickStartNextLevel = startGame;
+
+  // Wire level-progression callback into st.current so the draw loop can call it
+  // without a module-level ref. React owns the lifecycle; st is always up-to-date.
+  useEffect(() => {
+    st.current.startNextLevel = startGame;
+  }, [st, startGame]);
 
   const handleClick = useCallback(() => {
     const s = st.current;


### PR DESCRIPTION
## Summary
Fixes the `_brickStartNextLevel` module-level ref in `useBrickBreakerGame`. The draw callback (running inside the rAF loop) needed to call `startGame` when all bricks were cleared, but because the `createCanvasArcadeHook` draw config is fixed at creation time, it couldn't close over hook-local callbacks. The previous solution used a module-level `let _brickStartNextLevel` that was reassigned on every render — breaking isolation if two instances ever mounted simultaneously. The fix stores the callback in `st.current` (the mutable game-state ref that the draw callback already reads from), which is per-instance and React-lifecycle-aware.

## Changes
- Add `startNextLevel?: (level: number) => void` to `initialState` in the `createCanvasArcadeHook` call
- Replace `_brickStartNextLevel(nextLevel)` in the draw callback with `s.startNextLevel?.(nextLevel)`
- Replace the bare `_brickStartNextLevel = startGame` assignment with a `useEffect` that writes `st.current.startNextLevel = startGame`
- Remove the module-level `let _brickStartNextLevel` variable

## Testing
- [x] `npx tsc --noEmit` passes

Closes #633

🤖 Generated with [Claude Code](https://claude.com/claude-code)