### PR TITLE
chore: remove useAddNotification dead selector from uiStore

### DIFF
--- a/gamesformykids/lib/stores/index.ts
+++ b/gamesformykids/lib/stores/index.ts
@@ -19,7 +19,6 @@ export type { GameStats } from './gameStore';
 export {
   useUIStore,
   useNotifications,
-  useAddNotification,
 } from './uiStore';
 export type { Notification, NotificationType } from './uiStore';
 

--- a/gamesformykids/lib/stores/uiStore.ts
+++ b/gamesformykids/lib/stores/uiStore.ts
@@ -115,5 +115,3 @@ export const useUIStore = makeStore<UIState & UIActions>('UIStore', (set, get) =
 /** שמישה ישירות בתוך קומפוננט הצגת Toasts */
 export const useNotifications = () => useUIStore((s) => s.notifications);
 
-/** helper hooks נוחים */
-export const useAddNotification = () => useUIStore((s) => s.addNotification);


### PR DESCRIPTION
## Summary
Removes the useAddNotification convenience selector that was never consumed anywhere. All notification calls in the codebase use the imperative useUIStore.getState().addNotification(...) pattern directly — the hook-based selector was dead code.

## Changes
- \lib/stores/uiStore.ts\: deleted the \useAddNotification\ export
- \lib/stores/index.ts\: removed \useAddNotification\ from the barrel re-export

## Testing
- [x] \
px tsc --noEmit\ passes
- [x] Grep confirms zero callers of \useAddNotification\ outside these two files

Closes #646

🤖 Generated with [Claude Code](https://claude.com/claude-code)