### PR TITLE
chore: remove sidebar slice from uiStore

### DIFF
--- a/gamesformykids/__tests__/stores/uiStore.test.ts
+++ b/gamesformykids/__tests__/stores/uiStore.test.ts
@@ -4,7 +4,6 @@ import { useUIStore } from '@/lib/stores/uiStore';
 beforeEach(() => {
   useUIStore.setState({
     notifications: [],
-    sidebarOpen: false,
     showProgressModal: false,
     isUserMenuOpen: false,
   });
@@ -73,20 +72,6 @@ describe('uiStore', () => {
       useUIStore.getState().addNotification('b');
       useUIStore.getState().clearAllNotifications();
       expect(useUIStore.getState().notifications).toHaveLength(0);
-    });
-  });
-
-  describe('sidebar', () => {
-    it('setSidebarOpen sets the value', () => {
-      useUIStore.getState().setSidebarOpen(true);
-      expect(useUIStore.getState().sidebarOpen).toBe(true);
-    });
-
-    it('toggleSidebar flips the value', () => {
-      useUIStore.getState().toggleSidebar();
-      expect(useUIStore.getState().sidebarOpen).toBe(true);
-      useUIStore.getState().toggleSidebar();
-      expect(useUIStore.getState().sidebarOpen).toBe(false);
     });
   });
 

--- a/gamesformykids/lib/stores/uiStore.ts
+++ b/gamesformykids/lib/stores/uiStore.ts
@@ -31,8 +31,6 @@ export interface Notification {
 
 export interface UIState {
   notifications: Notification[];
-  /** האם ה-sidebar/drawer פתוח (שמישה עתידית) */
-  sidebarOpen: boolean;
   /** האם מודל ההתקדמות פתוח */
   showProgressModal: boolean;
   /** האם תפריט המשתמש פתוח */
@@ -47,8 +45,6 @@ export interface UIActions {
   ) => string; // מחזיר את ה-id למי שרוצה לבטל ידנית
   removeNotification: (id: string) => void;
   clearAllNotifications: () => void;
-  setSidebarOpen: (open: boolean) => void;
-  toggleSidebar: () => void;
   setShowProgressModal: (show: boolean) => void;
   openUserMenu: () => void;
   closeUserMenu: () => void;
@@ -61,7 +57,6 @@ const genId = () => `notif_${Date.now()}_${++_counter}`;
 // ── Store ──────────────────────────────────────────────────
 export const useUIStore = makeStore<UIState & UIActions>('UIStore', (set, get) => ({
       notifications: [],
-      sidebarOpen: false,
       showProgressModal: false,
       isUserMenuOpen: false,
 
@@ -95,12 +90,6 @@ export const useUIStore = makeStore<UIState & UIActions>('UIStore', (set, get) =
 
       clearAllNotifications: () =>
         set({ notifications: [] }, false, 'ui/clearAll'),
-
-      setSidebarOpen: (open) =>
-        set({ sidebarOpen: open }, false, 'ui/setSidebarOpen'),
-
-      toggleSidebar: () =>
-        set((s) => ({ sidebarOpen: !s.sidebarOpen }), false, 'ui/toggleSidebar'),
 
       setShowProgressModal: (show) =>
         set({ showProgressModal: show }, false, 'ui/setShowProgressModal'),


### PR DESCRIPTION
## Summary
Removes the sidebar slice (sidebarOpen, setSidebarOpen, 	oggleSidebar) from uiStore.ts. The sidebar feature was never built — no component or hook reads or sets sidebarOpen. The field was annotated *'future use'* but has been dead since the store was created.

## Changes
- \lib/stores/uiStore.ts\: removed \sidebarOpen\ from \UIState\, \setSidebarOpen\/\	oggleSidebar\ from \UIActions\, and their implementations
- \__tests__/stores/uiStore.test.ts\: removed \sidebarOpen: false\ from \eforeEach\ reset and deleted the \sidebar\ describe block

## Testing
- [x] \
px tsc --noEmit\ passes
- [x] Grep confirms zero external callers of \sidebarOpen\, \setSidebarOpen\, or \	oggleSidebar\

Closes #649

🤖 Generated with [Claude Code](https://claude.com/claude-code)