### PR TITLE
fix: remove duplicate useDrawingCanvas() call from DrawingGameClient

### DIFF
--- a/gamesformykids/app/games/drawing/components/DrawingGameClient.tsx
+++ b/gamesformykids/app/games/drawing/components/DrawingGameClient.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import styles from '../drawing.module.css';
-import { useDrawingCanvas } from '../hooks/useDrawingCanvas';
 import { useDrawingStore } from '../store/drawingStore';
 import DrawingStartScreen from './DrawingStartScreen';
 import DrawingHeader from './DrawingHeader';
@@ -11,9 +10,6 @@ import DrawingCanvas from './DrawingCanvas';
 import DrawingActions from './DrawingActions';
 
 export default function DrawingGameClient() {
-  // רישום canvas ops לסטור
-  useDrawingCanvas();
-
   const { isGameStarted } = useDrawingStore();
 
   if (!isGameStarted) {


### PR DESCRIPTION
## Summary
\DrawingGameClient\ called \useDrawingCanvas()\ and discarded the result. \DrawingCanvas\ — which is rendered inside \DrawingGameClient\ — already calls the same hook and correctly uses \canvasRef\, \startDrawing\, \stopDrawing\, and \draw\. The top-level call ran the hook twice per render cycle (two canvas contexts, two event registrations).

## Changes
- \pp/games/drawing/components/DrawingGameClient.tsx\: removed the \useDrawingCanvas()\ call and its import

## Testing
- [x] \
px tsc --noEmit\ passes
- [x] \DrawingCanvas\ still owns the single \useDrawingCanvas\ call

Closes #643

🤖 Generated with [Claude Code](https://claude.com/claude-code)