### PR TITLE
fix: add useGameCompletion to whack-a-mole, reflex, simon, true-false, number-bubbles

### DIFF
--- a/gamesformykids/app/games/number-bubbles/useNumberBubblesGame.ts
+++ b/gamesformykids/app/games/number-bubbles/useNumberBubblesGame.ts
@@ -1,8 +1,34 @@
 'use client';
+import { useEffect, useRef } from 'react';
 import { createShallowHook } from '@/lib/stores/utils/sliceUtils';
 import { useNumberBubblesStore } from './numberBubblesStore';
+import { useGameCompletion } from '@/hooks/shared/progress/useGameCompletion';
 
 export type { Bubble } from './numberBubblesStore';
 export { BUBBLE_COLORS, makeBubbles } from './numberBubblesStore';
 
-export const useNumberBubblesGame = createShallowHook(useNumberBubblesStore);
+const _useStore = createShallowHook(useNumberBubblesStore);
+
+export function useNumberBubblesGame() {
+  const state = _useStore();
+  const { saveGameResultRef } = useGameCompletion('number-bubbles');
+  const startTimeRef = useRef<number>(0);
+
+  // Record start time when a round begins
+  useEffect(() => {
+    if (state.phase === 'playing') {
+      startTimeRef.current = Date.now();
+    }
+  }, [state.phase]);
+
+  // Persist result on each level completion
+  useEffect(() => {
+    if (state.phase === 'results') {
+      const durationSeconds = Math.round(state.elapsed);
+      saveGameResultRef.current({ score: state.level, level: state.level, durationSeconds });
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [state.phase, state.level]);
+
+  return state;
+}

--- a/gamesformykids/app/games/reflex/useReflexGame.ts
+++ b/gamesformykids/app/games/reflex/useReflexGame.ts
@@ -1,7 +1,33 @@
 'use client';
+import { useEffect, useRef } from 'react';
 import { createShallowHook } from '@/lib/stores/utils/sliceUtils';
 import { useReflexStore } from './reflexStore';
+import { useGameCompletion } from '@/hooks/shared/progress/useGameCompletion';
 
 export type { Target } from './reflexStore';
 
-export const useReflexGame = createShallowHook(useReflexStore);
+const _useStore = createShallowHook(useReflexStore);
+
+export function useReflexGame() {
+  const state = _useStore();
+  const { saveGameResultRef } = useGameCompletion('reflex');
+  const startTimeRef = useRef<number>(0);
+
+  // Record start time when game begins
+  useEffect(() => {
+    if (state.phase === 'playing') {
+      startTimeRef.current = Date.now();
+    }
+  }, [state.phase]);
+
+  // Persist result when game ends
+  useEffect(() => {
+    if (state.phase === 'result') {
+      const durationSeconds = Math.round((Date.now() - startTimeRef.current) / 1000);
+      saveGameResultRef.current({ score: state.score, level: 1, durationSeconds });
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [state.phase]);
+
+  return state;
+}

--- a/gamesformykids/app/games/simon/useSimonGame.ts
+++ b/gamesformykids/app/games/simon/useSimonGame.ts
@@ -1,8 +1,9 @@
 'use client';
 
-import { useCallback } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 import { useShallow } from 'zustand/react/shallow';
 import { useSimonStore, showSequence, BUTTONS } from './simonStore';
+import { useGameCompletion } from '@/hooks/shared/progress/useGameCompletion';
 export type { ButtonId } from './simonStore';
 export { BUTTONS };
 
@@ -11,6 +12,25 @@ import type { PhaseSimon as Phase } from '@/lib/types';
 export function useSimonGame() {
   const { phase, activeColor, playerIdx, best, roundScore, sequence, startGame } =
     useSimonStore(useShallow((s) => s));
+
+  const { saveGameResultRef } = useGameCompletion('simon');
+  const startTimeRef = useRef<number>(0);
+
+  // Record start time when game begins (showing = sequence display, which is start of a round)
+  useEffect(() => {
+    if (phase === 'showing' && sequence.length === 1) {
+      startTimeRef.current = Date.now();
+    }
+  }, [phase, sequence.length]);
+
+  // Persist result when game ends
+  useEffect(() => {
+    if (phase === 'dead') {
+      const durationSeconds = Math.round((Date.now() - startTimeRef.current) / 1000);
+      saveGameResultRef.current({ score: roundScore, level: 1, durationSeconds });
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [phase]);
 
   const handleTap = useCallback((id: string) => {
     const { phase: currentPhase, playerIdx: idx, sequence: seq } = useSimonStore.getState();

--- a/gamesformykids/app/games/true-false/useTrueFalseGame.ts
+++ b/gamesformykids/app/games/true-false/useTrueFalseGame.ts
@@ -1,6 +1,8 @@
 'use client';
+import { useEffect, useRef } from 'react';
 import { createShallowHook } from '@/lib/stores/utils/sliceUtils';
 import { useTrueFalseStore } from './trueFalseStore';
+import { useGameCompletion } from '@/hooks/shared/progress/useGameCompletion';
 
 export type { Fact } from './trueFalseStore';
 export { FACTS, TIME_PER_Q } from './trueFalseStore';
@@ -9,5 +11,24 @@ const _useStore = createShallowHook(useTrueFalseStore);
 
 export function useTrueFalseGame() {
   const state = _useStore();
+  const { saveGameResultRef } = useGameCompletion('true-false');
+  const startTimeRef = useRef<number>(0);
+
+  // Record start time when game begins
+  useEffect(() => {
+    if (state.phase === 'playing') {
+      startTimeRef.current = Date.now();
+    }
+  }, [state.phase]);
+
+  // Persist result when game ends
+  useEffect(() => {
+    if (state.phase === 'dead') {
+      const durationSeconds = Math.round((Date.now() - startTimeRef.current) / 1000);
+      saveGameResultRef.current({ score: state.score, level: 1, durationSeconds });
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [state.phase]);
+
   return { ...state, q: state.deck[state.idx] };
 }

--- a/gamesformykids/app/games/whack-a-mole/useWhackAMoleGame.ts
+++ b/gamesformykids/app/games/whack-a-mole/useWhackAMoleGame.ts
@@ -1,6 +1,8 @@
 'use client';
+import { useEffect, useRef } from 'react';
 import { createShallowHook } from '@/lib/stores/utils/sliceUtils';
 import { useWhackAMoleStore, GAME_DURATION } from './whackAMoleStore';
+import { useGameCompletion } from '@/hooks/shared/progress/useGameCompletion';
 
 export type { HoleState } from './whackAMoleStore';
 export { GAME_DURATION } from './whackAMoleStore';
@@ -9,6 +11,25 @@ const _useStore = createShallowHook(useWhackAMoleStore);
 
 export function useWhackAMoleGame() {
   const state = _useStore();
+  const { saveGameResultRef } = useGameCompletion('whack-a-mole');
+  const startTimeRef = useRef<number>(0);
+
+  // Record start time when game begins
+  useEffect(() => {
+    if (state.phase === 'playing') {
+      startTimeRef.current = Date.now();
+    }
+  }, [state.phase]);
+
+  // Persist result when game ends
+  useEffect(() => {
+    if (state.phase === 'result') {
+      const durationSeconds = Math.round((Date.now() - startTimeRef.current) / 1000);
+      saveGameResultRef.current({ score: state.score, level: 1, durationSeconds });
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [state.phase]);
+
   const pct     = (state.timeLeft / GAME_DURATION) * 100;
   const bgColor = state.timeLeft <= 10 ? 'from-red-100 to-rose-200' : 'from-yellow-50 to-amber-100';
   return { ...state, bgColor, pct };


### PR DESCRIPTION
## Summary
Five games had no Supabase score persistence after a round ends. Each game hook now calls \useGameCompletion\ and triggers \saveGameResult\ on the game-over phase transition.

| Game | Game-over phase | Saved fields |
|------|----------------|-------------|
| whack-a-mole | \'result'\ | score, level=1, elapsed |
| reflex | \'result'\ | score, level=1, elapsed |
| simon | \'dead'\ | roundScore, level=1, elapsed |
| true-false | \'dead'\ | score, level=1, elapsed |
| number-bubbles | \'results'\ | level (per round), elapsed |

Each hook tracks \startTime\ in a \useRef\ on the \'playing'\ phase transition and computes \durationSeconds\ at game-over.

## Changes
- \pp/games/whack-a-mole/useWhackAMoleGame.ts\
- \pp/games/reflex/useReflexGame.ts\
- \pp/games/simon/useSimonGame.ts\
- \pp/games/true-false/useTrueFalseGame.ts\
- \pp/games/number-bubbles/useNumberBubblesGame.ts\

## Testing
- [x] \
px tsc --noEmit\ passes

Closes #644

🤖 Generated with [Claude Code](https://claude.com/claude-code)