### PR TITLE
fix: add useGameCompletion to arithmetic and multiplication

### DIFF
--- a/gamesformykids/app/games/arithmetic/useArithmeticGame.ts
+++ b/gamesformykids/app/games/arithmetic/useArithmeticGame.ts
@@ -1,5 +1,34 @@
 'use client';
+import { useEffect, useRef } from 'react';
 import { createShallowHook } from '@/lib/stores/utils/sliceUtils';
 import { useArithmeticGameStore } from './arithmeticGameStore';
+import { useGameCompletion } from '@/hooks/shared/progress/useGameCompletion';
 
-export const useArithmeticGame = createShallowHook(useArithmeticGameStore);
+const _useStore = createShallowHook(useArithmeticGameStore);
+
+export function useArithmeticGame() {
+  const state = _useStore();
+  const { saveGameResultRef } = useGameCompletion('arithmetic');
+  const startTimeRef = useRef<number>(0);
+
+  // Record start time when game begins
+  useEffect(() => {
+    if (state.phase === 'playing') {
+      startTimeRef.current = Date.now();
+    }
+  }, [state.phase]);
+
+  // Persist result when game ends
+  useEffect(() => {
+    if (state.phase === 'result') {
+      const durationSeconds = Math.round((Date.now() - startTimeRef.current) / 1000);
+      const level = typeof state.level === 'object' && state.level !== null && 'id' in (state.level as object)
+        ? (state.level as { id: number }).id
+        : 1;
+      saveGameResultRef.current({ score: state.score, level, durationSeconds });
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [state.phase]);
+
+  return state;
+}

--- a/gamesformykids/app/games/multiplication/useMultiplicationGame.ts
+++ b/gamesformykids/app/games/multiplication/useMultiplicationGame.ts
@@ -1,8 +1,30 @@
 'use client';
+import { useEffect, useRef } from 'react';
 import { useMultiplicationGameStore } from './multiplicationGameStore';
 import { LEVELS, QUESTIONS_PER_LEVEL, TIME_PER_QUESTION } from './data/tables';
+import { useGameCompletion } from '@/hooks/shared/progress/useGameCompletion';
 
 export function useMultiplicationGame() {
   const store = useMultiplicationGameStore();
+  const { saveGameResultRef } = useGameCompletion('multiplication');
+  const startTimeRef = useRef<number>(0);
+
+  // Record start time when game begins
+  useEffect(() => {
+    if (store.phase === 'playing') {
+      startTimeRef.current = Date.now();
+    }
+  }, [store.phase]);
+
+  // Persist result when game ends
+  useEffect(() => {
+    if (store.phase === 'result') {
+      const durationSeconds = Math.round((Date.now() - startTimeRef.current) / 1000);
+      const level = typeof store.level === 'number' ? store.level : 1;
+      saveGameResultRef.current({ score: store.score, level, durationSeconds });
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [store.phase]);
+
   return { ...store, totalQuestions: QUESTIONS_PER_LEVEL, levels: LEVELS, timePerQuestion: TIME_PER_QUESTION };
 }


### PR DESCRIPTION
## Summary
Both \rithmetic\ and \multiplication\ games use \createTimedQuizStore\, which transitions to \phase:'result'\ after all questions are answered. Neither hook persisted scores to Supabase. Each game hook now calls \useGameCompletion\ and triggers \saveGameResult\ on the \'result'\ phase.

## Changes
- \pp/games/arithmetic/useArithmeticGame.ts\: converted \createShallowHook\ alias into a full function; added \useGameCompletion('arithmetic')\ with phase-based effect
- \pp/games/multiplication/useMultiplicationGame.ts\: added \useGameCompletion('multiplication')\ with phase-based effect

## Testing
- [x] \
px tsc --noEmit\ passes

Closes #645

🤖 Generated with [Claude Code](https://claude.com/claude-code)