### PR TITLE
architecture: replace startNextLevel canvas-state field with module-level ref

### DIFF
--- a/gamesformykids/app/games/brick-breaker/useBrickBreakerGame.ts
+++ b/gamesformykids/app/games/brick-breaker/useBrickBreakerGame.ts
@@ -31,6 +31,13 @@ import type { PhaseWonDead as Phase } from '@/lib/types';
 interface Brick { alive: boolean; row: number; }
 type BrickParticle = { x: number; y: number; vx: number; vy: number; life: number; color: string };
 
+/**
+ * Bridge ref: populated by useBrickBreakerGame on mount, read by the draw callback.
+ * Using a plain object rather than React.useRef because the draw function is defined
+ * outside the component render cycle.
+ */
+const _nextLevelRef: { current: ((level: number) => void) | null } = { current: null };
+
 function makeBricks(): Brick[] {
   return Array.from({ length: ROWS * COLS }, (_, i) => ({ alive: true, row: Math.floor(i / COLS) }));
 }
@@ -52,8 +59,6 @@ const _useBrickBreaker = createCanvasArcadeHook({
     bricks: makeBricks(), score: 0, lives: 3, level: 1, frame: 0,
     startTime: 0,
     particles: [] as BrickParticle[],
-    /** Wired by useBrickBreakerGame via useEffect — stored here so draw can call it without a module-level ref. */
-    startNextLevel: undefined as ((level: number) => void) | undefined,
   }),
   onPointerX: (s, x) => { s.padX = Math.max(0, Math.min(W - PAD_W, x - PAD_W / 2)); },
   draw: (ctx, s, _dt, saveRef) => {    s.frame++;
@@ -101,7 +106,7 @@ const _useBrickBreaker = createCanvasArcadeHook({
             saveRef.current({ score: s.score, level: s.level, durationSeconds: elapsed });
             useBrickBreakerStore.getState().setWon(s.score, s.lives, s.level);
           }
-          else { s.startNextLevel?.(nextLevel); }
+          else { _nextLevelRef.current?.(nextLevel); }
         }
       }
       s.particles = s.particles.filter(p => { p.x += p.vx; p.y += p.vy; p.vy += 0.15; p.life -= 0.04; return p.life > 0; });
@@ -155,11 +160,12 @@ export function useBrickBreakerGame() {
     useBrickBreakerStore.getState().startLevel({ score: s.score, lives: s.lives, level });
   }, [st]);
 
-  // Wire level-progression callback into st.current so the draw loop can call it
-  // without a module-level ref. React owns the lifecycle; st is always up-to-date.
+  // Wire startGame into the module-level ref so the draw loop can trigger level
+  // progression. Clean up on unmount so a stale callback is never called.
   useEffect(() => {
-    st.current.startNextLevel = startGame;
-  }, [st, startGame]);
+    _nextLevelRef.current = startGame;
+    return () => { _nextLevelRef.current = null; };
+  }, [startGame]);
 
   const handleClick = useCallback(() => {
     const s = st.current;


### PR DESCRIPTION
## Summary
Follow-up to #633 / #641. While those PRs moved the level-progression callback from a \let\ variable into \st.current\, storing a callback inside the canvas game-state object still mixes concerns. This PR removes \startNextLevel\ from \initialState\ entirely and replaces it with a typed module-level ref object that acts as a bridge between the React hook lifecycle and the draw callback.

## Approach
- \_nextLevelRef: { current: ((level: number) => void) | null }\ is a plain module-level object (not \React.useRef\) because the draw function is defined outside any component render cycle.
- \useBrickBreakerGame\ populates it on mount via \useEffect\ and **clears it on unmount** to prevent stale-callback bugs.
- The draw callback calls \_nextLevelRef.current?.(nextLevel)\ — same call-site, zero coupling to game state.

## Changes
- \pp/games/brick-breaker/useBrickBreakerGame.ts\: added \_nextLevelRef\, removed \startNextLevel\ from \initialState\, updated draw and \useEffect\

## Testing
- [x] \
px tsc --noEmit\ passes

Closes #651

🤖 Generated with [Claude Code](https://claude.com/claude-code)