### PR TITLE
fix(tetris): fix board direction (RTL) and React Compiler memoization freeze

### DIFF
--- a/gamesformykids/app/games/tetris/components/GameBoard.tsx
+++ b/gamesformykids/app/games/tetris/components/GameBoard.tsx
@@ -2,14 +2,13 @@ import { GameBoardProps } from '../types';
 
 const GameBoard = ({ displayBoard }: GameBoardProps) => (
   <div className="bg-gradient-to-br from-gray-900/50 to-black/50 backdrop-blur-lg rounded-3xl p-3 lg:p-4 shadow-2xl border border-white/20">
-    <div className="grid grid-cols-10 gap-0.5 lg:gap-1 bg-gradient-to-br from-gray-800/80 to-gray-900/80 p-2 lg:p-3 rounded-2xl border border-gray-600/50">
+    <div dir="ltr" style={{ direction: 'ltr' }} className="grid grid-cols-10 gap-0.5 lg:gap-1 bg-gradient-to-br from-gray-800/80 to-gray-900/80 p-2 lg:p-3 rounded-2xl border border-gray-600/50">
       {displayBoard.map((row, y) =>
-        row.slice().reverse().map((cell, x) => {
-          const actualX = row.length - 1 - x; // הפיכת סדר X
+        row.map((cell, x) => {
           const isEmpty = !cell || cell === 0;
           return (
             <div
-              key={`${y}-${actualX}`}
+              key={`${y}-${x}`}
               className={`w-4 h-4 lg:w-6 lg:h-6 rounded-md border border-gray-600/50 ${isEmpty ? '' : 'transform transition-all duration-150'}`}
               style={{
                 background: isEmpty 

--- a/gamesformykids/app/games/tetris/components/TetrisGame.tsx
+++ b/gamesformykids/app/games/tetris/components/TetrisGame.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useMemo } from 'react';
 import { GenericStartScreen } from '@/components/shared';
 import { useTetrisGame } from '../hooks/useTetrisGame';
 import { useTetrisState } from '../hooks/useTetrisState';
@@ -13,7 +14,16 @@ function TetrisGame(){
   // רישום side-effects (game loop, מקלדת, טעינה)
   useTetrisGame();
 
-  const { isLoading, showStartScreen, startNewGame, getBoardWithCurrentPiece } = useTetrisState();
+  const { isLoading, showStartScreen, startNewGame, getBoardWithCurrentPiece,
+          board, currentPiece, position } = useTetrisState();
+
+  // useMemo with explicit reactive deps so the React Compiler never
+  // memoizes this across position/board changes.
+  const displayBoard = useMemo(
+    () => getBoardWithCurrentPiece(),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [board, currentPiece, position],
+  );
 
   if (isLoading) {
     return <LoadingScreen />;
@@ -49,8 +59,6 @@ function TetrisGame(){
       </div>
     );
   }
-
-  const displayBoard = getBoardWithCurrentPiece();
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-purple-900 via-blue-900 to-indigo-800 relative overflow-hidden">


### PR DESCRIPTION
## 🐛 Bugs Fixed

### Bug 1 — ArrowLeft moved piece RIGHT (RTL direction)

\globals.css\ sets \* { direction: rtl }\ on all elements. This caused the CSS grid to flow right-to-left, so ArrowLeft visually moved the piece right and ArrowRight moved it left.

**Fix:** Added \style={{ direction: 'ltr' }}\ inline on the grid \<div>\ in \GameBoard.tsx\. Inline styles override the \* { direction: rtl }\ CSS rule.

### Bug 2 — Piece frozen on screen (React Compiler memoization)

\getBoardWithCurrentPiece\ is a stable Zustand action reference. React Compiler (enabled via \eactCompiler: true\) auto-memoized \const displayBoard = getBoardWithCurrentPiece()\ forever — the piece fell in state but the DOM never updated.

**Fix:** Wrap in \useMemo\ with explicit reactive deps \[board, currentPiece, position]\ so the compiler re-computes on each move.

## Files Changed

| File | Change |
|------|--------|
| \pp/games/tetris/components/GameBoard.tsx\ | Add \style={{ direction: 'ltr' }}\ on grid container |
| \pp/games/tetris/components/TetrisGame.tsx\ | Wrap \displayBoard\ in \useMemo\ with board/piece/position deps |