### PR TITLE
chore: add engines field to package.json — declare Node.js 20+ requirement

### DIFF
--- a/gamesformykids/package.json
+++ b/gamesformykids/package.json
@@ -2,6 +2,7 @@
   "name": "gamesformykids",
   "version": "0.1.0",
   "private": true,
+  "engines": { "node": ">=20.0.0" },
   "scripts": {
     "dev": "next dev --turbopack",
     "build": "next build",


### PR DESCRIPTION
## Summary
Adds an explicit `engines` field to `package.json` declaring the minimum Node.js version. The project runs Node.js 22 in CI, and Next.js 16 will drop Node.js 18 support. Without this declaration, contributors running Node.js 18 (EOL) would encounter silent failures with no clear error message.

## Changes
- `package.json`: added `engines: { node: >=20.0.0 }`

## Testing
- [x] `npx tsc --noEmit` passes
- The CI workflow already uses `node-version: 22` — this makes the requirement explicit in the manifest

Closes #675

🤖 Generated with [Claude Code](https://claude.com/claude-code)