### PR TITLE
chore: bump tsconfig target from ES2017 to ES2022 — reduce unnecessary transpilation

### DIFF
--- a/gamesformykids/tsconfig.json
+++ b/gamesformykids/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "ES2017",
+    "target": "ES2022",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,


### PR DESCRIPTION
## Summary
Bumps `tsconfig.json` `target` from `ES2017` to `ES2022`. Every browser that supports React 19 also supports ES2022. The previous `ES2017` target caused TypeScript and Turbopack to down-transpile optional chaining (`?.`), nullish coalescing (`??`), logical assignment operators (`||=`, `&&=`), and `Object.fromEntries` into older ES5-style code — adding unnecessary bytes to the bundle and slowing builds.

## Changes
- `tsconfig.json`: `target: ES2017` → `target: ES2022` — build-output change only, no code changes required

## Testing
- [x] `npx tsc --noEmit` passes — 0 errors

Closes #674

🤖 Generated with [Claude Code](https://claude.com/claude-code)