### PR TITLE
architecture: add metadata export to home page (app/page.tsx) for SEO

### DIFF
--- a/gamesformykids/app/page.tsx
+++ b/gamesformykids/app/page.tsx
@@ -1,4 +1,17 @@
+import type { Metadata } from 'next';
 import HomePageClient from './HomePageClient';
+
+export const metadata: Metadata = {
+  title: 'משחקים לילדים 2-5 | GamesForMyKids',
+  description: 'אוסף משחקים חינוכיים ומהנים לילדים בגיל 2–5 שנים — צבעים, מספרים, עברית ועוד',
+  openGraph: {
+    title: 'משחקים לילדים 2–5',
+    description: 'אוסף משחקים חינוכיים ומהנים לילדים בגיל 2–5 שנים',
+    type: 'website',
+    locale: 'he_IL',
+  },
+  keywords: 'משחקים לילדים, חינוכי, זיכרון, צבעים, עברית, מספרים, גיל 2-5, פעוטות',
+};
 
 // הוספת מידע מובנה נוסף לדף הבית
 const homePageStructuredData = {


### PR DESCRIPTION
## Summary
Adds an `export const metadata` to `app/page.tsx`. The home page was missing explicit `<title>` and Open Graph tags — Next.js was falling back to the root layout's generic metadata in Google search results and social sharing previews. Only a JSON-LD `<script>` block existed, which doesn't set the HTML `<title>` or Open Graph tags.

## Changes
- `app/page.tsx`: added `export const metadata: Metadata` with `title`, `description`, `openGraph`, and `keywords` fields

## Testing
- [x] `npx tsc --noEmit` passes

Closes #670

🤖 Generated with [Claude Code](https://claude.com/claude-code)