### PR TITLE
perf: remove images.unoptimized:true — enable Next.js image optimisation globally

### DIFF
--- a/gamesformykids/next.config.ts
+++ b/gamesformykids/next.config.ts
@@ -7,7 +7,7 @@ const nextConfig: NextConfig = {
     reactCompiler: true,
   },
   images: {
-    unoptimized: true,
+    formats: ['image/avif', 'image/webp'],
   },
   async headers() {
     return [


### PR DESCRIPTION
## Summary
Removes `images: { unoptimized: true }` from `next.config.ts` and replaces it with `formats: ['image/avif', 'image/webp']`. The global `unoptimized: true` flag was disabling lazy-loading, WebP/AVIF conversion, responsive sizing, and blur placeholders across every `<Image>` in the project — directly damaging LCP (Core Web Vitals) across 45+ games.

## Changes
- `next.config.ts`: replaced `unoptimized: true` with `formats: ['image/avif', 'image/webp']`

## Testing
- [x] `npx tsc --noEmit` passes

Closes #665

🤖 Generated with [Claude Code](https://claude.com/claude-code)