### PR TITLE
perf: replace no-store Cache-Control with CDN-friendly headers on / and /games/*

### DIFF
--- a/gamesformykids/next.config.ts
+++ b/gamesformykids/next.config.ts
@@ -37,21 +37,13 @@ const nextConfig: NextConfig = {
           },
         ],
       },
-      // Cache busting for HTML pages to avoid caching issues
+      // Static pages — allow CDN to cache; stale-while-revalidate serves cached version while revalidating
       {
         source: '/',
         headers: [
           {
             key: 'Cache-Control',
-            value: 'no-cache, no-store, must-revalidate, proxy-revalidate',
-          },
-          {
-            key: 'Pragma',
-            value: 'no-cache',
-          },
-          {
-            key: 'Expires',
-            value: '0',
+            value: 'public, s-maxage=86400, stale-while-revalidate=3600',
           },
         ],
       },
@@ -60,11 +52,7 @@ const nextConfig: NextConfig = {
         headers: [
           {
             key: 'Cache-Control',
-            value: 'no-cache, no-store, must-revalidate, proxy-revalidate',
-          },
-          {
-            key: 'Pragma',
-            value: 'no-cache',
+            value: 'public, s-maxage=31536000, stale-while-revalidate=86400',
           },
         ],
       },


### PR DESCRIPTION
## Summary
Replaces `Cache-Control: no-cache, no-store, must-revalidate, proxy-revalidate` on `/` and `/games/:path*` with CDN-friendly caching directives. All pages in this project are statically generated at build time (SSG), but the previous headers were instructing every CDN and browser to re-fetch from the origin on every visit — completely wasting the SSG work.

## Changes
- `next.config.ts`:
  - `/`: `public, s-maxage=86400, stale-while-revalidate=3600` (CDN caches for 24h, serves stale while revalidating for 1h)
  - `/games/:path*`: `public, s-maxage=31536000, stale-while-revalidate=86400` (game pages are essentially immutable between deploys)
  - Removed `Pragma: no-cache` and `Expires: 0` headers (legacy, irrelevant for modern CDNs)
  - `/dashboard`, `/profile`, `/settings` are not touched — authenticated routes stay uncached

## Testing
- [x] `npx tsc --noEmit` passes

Closes #666

🤖 Generated with [Claude Code](https://claude.com/claude-code)