### PR TITLE
architecture: replace useMemo+eslint-disable with 'use no memo' in TetrisGame

### DIFF
--- a/gamesformykids/app/games/tetris/components/TetrisGame.tsx
+++ b/gamesformykids/app/games/tetris/components/TetrisGame.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import { useMemo } from 'react';
 import { GenericStartScreen } from '@/components/shared';
 import { useTetrisGame } from '../hooks/useTetrisGame';
 import { useTetrisState } from '../hooks/useTetrisState';
@@ -11,19 +10,15 @@ import AnimatedBackground from './AnimatedBackground';
 import LoadingScreen from '@/components/layout/LoadingScreen';
 
 function TetrisGame(){
+  'use no memo'; // opt-out of React Compiler — known memoization freeze on displayBoard
+
   // רישום side-effects (game loop, מקלדת, טעינה)
   useTetrisGame();
 
-  const { isLoading, showStartScreen, startNewGame, getBoardWithCurrentPiece,
-          board, currentPiece, position } = useTetrisState();
+  const { isLoading, showStartScreen, startNewGame, getBoardWithCurrentPiece } = useTetrisState();
 
-  // useMemo with explicit reactive deps so the React Compiler never
-  // memoizes this across position/board changes.
-  const displayBoard = useMemo(
-    () => getBoardWithCurrentPiece(),
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [board, currentPiece, position],
-  );
+  // Computed directly — React Compiler is opted out via 'use no memo' above
+  const displayBoard = getBoardWithCurrentPiece();
 
   if (isLoading) {
     return <LoadingScreen />;


### PR DESCRIPTION
## Summary
Replaces the `useMemo` + `eslint-disable-next-line react-hooks/exhaustive-deps` workaround in `TetrisGame.tsx` with the correct React Compiler escape hatch: `'use no memo'` directive. The manual `useMemo` with suppressed lint could interact unpredictably with the compiler across future upgrades, and the incomplete deps were silently hidden.

## Approach
Adding `'use no memo'` as the first statement in `TetrisGame` opts the entire function out of React Compiler memoization. This makes the workaround explicit, searchable, and safe to remove when the upstream compiler bug is fixed. `displayBoard` is now computed directly (no `useMemo`) which is correct since the compiler won't touch this function.

## Changes
- `app/games/tetris/components/TetrisGame.tsx`:
  - Added `'use no memo'` directive
  - Removed `useMemo` import and the manual memo wrapper
  - Removed unused `board, currentPiece, position` destructuring from `useTetrisState()`
  - `displayBoard` is now a direct call to `getBoardWithCurrentPiece()`

## Testing
- [x] `npx tsc --noEmit` passes — 0 errors

Closes #668

🤖 Generated with [Claude Code](https://claude.com/claude-code)