### PR TITLE
types: migrate forwardRef to ref-as-prop in button.tsx and card.tsx (React 19)

### DIFF
--- a/gamesformykids/components/ui/button.tsx
+++ b/gamesformykids/components/ui/button.tsx
@@ -1,40 +1,39 @@
-import { ButtonHTMLAttributes, forwardRef } from "react"
+import { ButtonHTMLAttributes } from "react"
 
 export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   variant?: "default" | "destructive" | "outline" | "secondary" | "ghost" | "link"
   size?: "default" | "sm" | "lg" | "icon"
   asChild?: boolean
+  ref?: React.Ref<HTMLButtonElement>
 }
 
-const Button = forwardRef<HTMLButtonElement, ButtonProps>(
-  ({ className = "", variant = "default", size = "default", ...props }, ref) => {
-    const baseClasses = "inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50"
-    
-    const variantClasses = {
-      default: "bg-blue-600 text-white hover:bg-blue-700",
-      destructive: "bg-red-600 text-white hover:bg-red-700",
-      outline: "border border-gray-300 bg-white hover:bg-gray-100 hover:text-gray-900",
-      secondary: "bg-gray-200 text-gray-900 hover:bg-gray-300",
-      ghost: "hover:bg-gray-100 hover:text-gray-900",
-      link: "text-blue-600 underline-offset-4 hover:underline",
-    }
-    
-    const sizeClasses = {
-      default: "h-10 px-4 py-2",
-      sm: "h-9 rounded-md px-3",
-      lg: "h-11 rounded-md px-8",
-      icon: "h-10 w-10",
-    }
-    
-    return (
-      <button
-        className={`${baseClasses} ${variantClasses[variant]} ${sizeClasses[size]} ${className}`}
-        ref={ref}
-        {...props}
-      />
-    )
+function Button({ className = "", variant = "default", size = "default", ref, ...props }: ButtonProps) {
+  const baseClasses = "inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50"
+
+  const variantClasses = {
+    default: "bg-blue-600 text-white hover:bg-blue-700",
+    destructive: "bg-red-600 text-white hover:bg-red-700",
+    outline: "border border-gray-300 bg-white hover:bg-gray-100 hover:text-gray-900",
+    secondary: "bg-gray-200 text-gray-900 hover:bg-gray-300",
+    ghost: "hover:bg-gray-100 hover:text-gray-900",
+    link: "text-blue-600 underline-offset-4 hover:underline",
   }
-)
+
+  const sizeClasses = {
+    default: "h-10 px-4 py-2",
+    sm: "h-9 rounded-md px-3",
+    lg: "h-11 rounded-md px-8",
+    icon: "h-10 w-10",
+  }
+
+  return (
+    <button
+      className={`${baseClasses} ${variantClasses[variant]} ${sizeClasses[size]} ${className}`}
+      ref={ref}
+      {...props}
+    />
+  )
+}
 Button.displayName = "Button"
 
 export { Button }

--- a/gamesformykids/components/ui/card.tsx
+++ b/gamesformykids/components/ui/card.tsx
@@ -1,54 +1,45 @@
-import { forwardRef, HTMLAttributes } from "react"
+import { HTMLAttributes } from "react"
 
-
-const Card = forwardRef<HTMLDivElement, HTMLAttributes<HTMLDivElement>>(
-  ({ className = "", ...props }, ref) => (
+function Card({ className = "", ref, ...props }: HTMLAttributes<HTMLDivElement> & { ref?: React.Ref<HTMLDivElement> }) {
+  return (
     <div
       ref={ref}
       className={`rounded-lg border bg-white text-gray-900 shadow-sm ${className}`}
       {...props}
     />
   )
-)
+}
 Card.displayName = "Card"
 
-const CardHeader = forwardRef<HTMLDivElement, HTMLAttributes<HTMLDivElement>>(
-  ({ className = "", ...props }, ref) => (
-    <div ref={ref} className={`flex flex-col space-y-1.5 p-6 ${className}`} {...props} />
-  )
-)
+function CardHeader({ className = "", ref, ...props }: HTMLAttributes<HTMLDivElement> & { ref?: React.Ref<HTMLDivElement> }) {
+  return <div ref={ref} className={`flex flex-col space-y-1.5 p-6 ${className}`} {...props} />
+}
 CardHeader.displayName = "CardHeader"
 
-const CardTitle = forwardRef<HTMLHeadingElement,  HTMLAttributes<HTMLHeadingElement>>(
-  ({ className = "", ...props }, ref) => (
+function CardTitle({ className = "", ref, ...props }: HTMLAttributes<HTMLHeadingElement> & { ref?: React.Ref<HTMLHeadingElement> }) {
+  return (
     <h3
       ref={ref}
       className={`text-2xl font-semibold leading-none tracking-tight ${className}`}
       {...props}
     />
   )
-)
+}
 CardTitle.displayName = "CardTitle"
 
-const CardDescription = forwardRef<HTMLParagraphElement,HTMLAttributes<HTMLParagraphElement>>(
-  ({ className = "", ...props }, ref) => (
-    <p ref={ref} className={`text-sm text-gray-600 ${className}`} {...props} />
-  )
-)
+function CardDescription({ className = "", ref, ...props }: HTMLAttributes<HTMLParagraphElement> & { ref?: React.Ref<HTMLParagraphElement> }) {
+  return <p ref={ref} className={`text-sm text-gray-600 ${className}`} {...props} />
+}
 CardDescription.displayName = "CardDescription"
 
-const CardContent = forwardRef<HTMLDivElement, HTMLAttributes<HTMLDivElement>>(
-  ({ className = "", ...props }, ref) => (
-    <div ref={ref} className={`p-6 pt-0 ${className}`} {...props} />
-  )
-)
+function CardContent({ className = "", ref, ...props }: HTMLAttributes<HTMLDivElement> & { ref?: React.Ref<HTMLDivElement> }) {
+  return <div ref={ref} className={`p-6 pt-0 ${className}`} {...props} />
+}
 CardContent.displayName = "CardContent"
 
-const CardFooter = forwardRef<HTMLDivElement, HTMLAttributes<HTMLDivElement>>(
-  ({ className = "", ...props }, ref) => (
-    <div ref={ref} className={`flex items-center p-6 pt-0 ${className}`} {...props} />
-  )
-)
+function CardFooter({ className = "", ref, ...props }: HTMLAttributes<HTMLDivElement> & { ref?: React.Ref<HTMLDivElement> }) {
+  return <div ref={ref} className={`flex items-center p-6 pt-0 ${className}`} {...props} />
+}
 CardFooter.displayName = "CardFooter"
 
 export { Card, CardHeader, CardFooter, CardTitle, CardDescription, CardContent }


### PR DESCRIPTION
## Summary
Migrates `components/ui/button.tsx` and `components/ui/card.tsx` from the deprecated `forwardRef` pattern to React 19's `ref` as a plain prop. These are the project's most widely-used UI primitives — keeping deprecated APIs accumulates warnings and blocks future React upgrades.

## Approach
React 19 allows `ref` to be passed as a plain prop — no `forwardRef` wrapper needed. The `ref` field is added to the props interface and destructured alongside `className` and other props. No runtime changes.

## Changes
- `components/ui/button.tsx`: converted `forwardRef<HTMLButtonElement, ButtonProps>` to a plain function; added `ref?: React.Ref<HTMLButtonElement>` to `ButtonProps`
- `components/ui/card.tsx`: converted all 6 sub-components (`Card`, `CardHeader`, `CardTitle`, `CardDescription`, `CardContent`, `CardFooter`) from `forwardRef` to plain functions with inline ref prop types; removed `forwardRef` import

## Testing
- [x] `npx tsc --noEmit` passes — 0 errors

Closes #669

🤖 Generated with [Claude Code](https://claude.com/claude-code)