### PR TITLE
architecture: add instrumentation.ts with onRequestError for complete Sentry coverage

### DIFF
--- a/gamesformykids/instrumentation.ts
+++ b/gamesformykids/instrumentation.ts
@@ -1,0 +1,28 @@
+/**
+ * Next.js instrumentation file — loaded once per server process startup.
+ *
+ * `register()` initialises Sentry for the correct runtime so error reports
+ * include server-component stack traces and request context.
+ *
+ * `onRequestError()` feeds unhandled request errors directly to Sentry with
+ * the route type and path — richer than the Webpack wrapper alone.
+ *
+ * @see https://nextjs.org/docs/app/building-your-application/optimizing/instrumentation
+ */
+export async function register() {
+  if (process.env.NEXT_RUNTIME === 'nodejs') {
+    await import('./sentry.server.config');
+  }
+  if (process.env.NEXT_RUNTIME === 'edge') {
+    await import('./sentry.edge.config');
+  }
+}
+
+export async function onRequestError(
+  err: unknown,
+  request: { path: string; method: string; headers: Record<string, string | string[] | undefined> },
+  context: { routerKind: string; routePath: string; routeType: string },
+) {
+  const { captureRequestError } = await import('@sentry/nextjs');
+  await captureRequestError(err, request, context);
+}


### PR DESCRIPTION
## Summary
Creates `instrumentation.ts` in the app root. Previously `@sentry/nextjs` was only configured via `withSentryConfig` in `next.config.ts` — the Webpack wrapper alone cannot capture server-component stack traces, request URLs, or route context. The `onRequestError` hook (stable in Next.js 15+) feeds unhandled request errors directly to Sentry with full context.

## Changes
- **NEW** `instrumentation.ts`:
  - `register()` — initialises Sentry for `nodejs` and `edge` runtimes on process startup, importing the existing `sentry.server.config.ts` and `sentry.edge.config.ts`
  - `onRequestError()` — captures request errors via `captureRequestError` with the correct request/context shape expected by `@sentry/nextjs`

## Testing
- [x] `npx tsc --noEmit` passes — 0 errors (parameter types match `@sentry/nextjs`'s `RequestInfo` and `ErrorContext`)

Closes #671

🤖 Generated with [Claude Code](https://claude.com/claude-code)