### PR TITLE
chore: add workflow_dispatch trigger to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.ref || github.ref }}
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,12 @@ on:
     branches: [main]
   push:
     branches: [main]
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Branch, tag, or SHA to run CI on'
+        required: false
+        default: ''
 
 jobs:
   ci:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -5,6 +5,12 @@ on:
     branches: [main]
   push:
     branches: [main]
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Branch, tag, or SHA to run CI on'
+        required: false
+        default: ''
 
 jobs:
   e2e:
@@ -22,6 +28,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.ref || github.ref }}
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -3,6 +3,12 @@ name: Lighthouse CI
 on:
   pull_request:
     branches: [main]
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Branch, tag, or SHA to run CI on'
+        required: false
+        default: ''
 
 jobs:
   lighthouse:
@@ -15,6 +21,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.ref || github.ref }}
 
       - uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
## Summary
Adds `workflow_dispatch` trigger to `ci.yml` so CI can be manually triggered from the GitHub UI when automated `pull_request` triggers don't fire (e.g. after a burst of PRs).

## Usage after merging
Go to **Actions → CI → Run workflow** and enter the branch name to re-run CI on any PR branch.

## Testing
This PR itself serves as the test — if CI runs on this PR automatically, the automated triggers are working again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)