### PR TITLE
refactor: login form uses manual isSubmitting state — migrate to useActionState (React 19)

### DIFF
--- a/gamesformykids/app/login/useLoginPage.ts
+++ b/gamesformykids/app/login/useLoginPage.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useActionState, useState, useEffect } from 'react';
 import { useRouter } from 'next/navigation';
 import { useAuth } from '@/hooks/shared/auth/useAuth';
 import { ROUTES } from '@/lib/constants/routes';
@@ -12,32 +12,37 @@ export function useLoginPage(): { vm: LoginPageViewModel; isLoading: boolean; is
   const [email,         setEmail]         = useState('');
   const [password,      setPassword]      = useState('');
   const [name,          setName]          = useState('');
-  const [error,         setError]         = useState('');
-  const [isSubmitting,  setIsSubmitting]  = useState(false);
 
   useEffect(() => {
     if (user && !loading) router.push(ROUTES.HOME);
   }, [user, loading, router]);
 
+  // useActionState replaces manual isSubmitting + error useState.
+  // The action reads from closure (controlled inputs) — no FormData needed.
+  // Payload 'reset' clears the error when toggling between login/register.
+  const [error, loginAction, isPending] = useActionState(
+    async (_prev: string | null, payload: 'reset' | undefined): Promise<string | null> => {
+      if (payload === 'reset') return null;
+      try {
+        const result = isRegistering
+          ? await signUpWithEmail(email, password, name)
+          : await signInWithEmail(email, password);
+        return result.error ?? null;
+      } catch {
+        return LOGIN_LABELS.genericError;
+      }
+    },
+    null
+  );
+
   const handleEmailAuth = async (e: React.FormEvent) => {
     e.preventDefault();
-    setError('');
-    setIsSubmitting(true);
-    try {
-      const result = isRegistering
-        ? await signUpWithEmail(email, password, name)
-        : await signInWithEmail(email, password);
-      if (result.error) setError(result.error);
-    } catch {
-      setError(LOGIN_LABELS.genericError);
-    } finally {
-      setIsSubmitting(false);
-    }
+    loginAction(undefined);
   };
 
   const toggleMode = () => {
     setIsRegistering((prev) => !prev);
-    setError('');
+    loginAction('reset');
   };
 
   const vm: LoginPageViewModel = {
@@ -45,8 +50,8 @@ export function useLoginPage(): { vm: LoginPageViewModel; isLoading: boolean; is
     email,
     password,
     name,
-    error,
-    isSubmitting,
+    error: error ?? '',
+    isSubmitting: isPending,
     setEmail,
     setPassword,
     setName,


### PR DESCRIPTION
@
## Summary
Replaces the manual `isSubmitting` boolean state and `try/finally` boilerplate in `useLoginPage.ts` with a single `useActionState` call. `isPending` replaces `isSubmitting` and the action return value (`string | null`) replaces `setError`, eliminating the risk of a state leak if the action throws.

## Changes
- `app/login/useLoginPage.ts`:
  - Removed `useState` for `error` and `isSubmitting` (2 state slots eliminated)
  - Added `useActionState(action, null)` — `isPending` maps to `isSubmitting`, returned string maps to `error`
  - Action reads from closure (controlled inputs) with payload `reset | undefined`: `undefined` triggers auth, `reset` clears the error state when toggling between login/register
  - `handleEmailAuth` calls `loginAction(undefined)`, `toggleMode` calls `loginAction(reset)`
  - `EmailAuthForm.tsx` interface is **unchanged** — `isSubmitting` and `error` field names preserved in `LoginPageViewModel`

## Testing
- [x] `npx tsc --noEmit` passes — 0 errors

Closes #672

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@