### PR TITLE
architecture: migrate login form to <Form> from next/form + useActionState

### DIFF
--- a/gamesformykids/app/login/LoginClient.tsx
+++ b/gamesformykids/app/login/LoginClient.tsx
@@ -39,7 +39,7 @@ export default function LoginClient() {
             setEmail={vm.setEmail}
             setPassword={vm.setPassword}
             setName={vm.setName}
-            onSubmit={vm.handleEmailAuth}
+            action={vm.loginAction}
           />
 
           <AuthToggle isRegistering={vm.isRegistering} onToggle={vm.toggleMode} />

--- a/gamesformykids/app/login/components/EmailAuthForm.tsx
+++ b/gamesformykids/app/login/components/EmailAuthForm.tsx
@@ -1,3 +1,4 @@
+import Form from 'next/form';
 import { LOGIN_LABELS } from '../loginConstants';
 
 interface EmailAuthFormProps {
@@ -10,17 +11,17 @@ interface EmailAuthFormProps {
   setEmail:    (v: string) => void;
   setPassword: (v: string) => void;
   setName:     (v: string) => void;
-  onSubmit:    (e: React.FormEvent) => Promise<void>;
+  action:      (formData: FormData) => void;
 }
 
 export default function EmailAuthForm({
   isRegistering,
   email, password, name, error, isSubmitting,
   setEmail, setPassword, setName,
-  onSubmit,
+  action,
 }: EmailAuthFormProps) {
   return (
-    <form onSubmit={onSubmit} className="space-y-4">
+    <Form action={action} className="space-y-4">
       {isRegistering && (
         <div>
           <label htmlFor="name" className="block text-sm font-medium text-gray-700 mb-1">
@@ -28,6 +29,7 @@ export default function EmailAuthForm({
           </label>
           <input
             id="name"
+            name="name"
             type="text"
             value={name}
             onChange={(e) => setName(e.target.value)}
@@ -43,6 +45,7 @@ export default function EmailAuthForm({
         </label>
         <input
           id="email"
+          name="email"
           type="email"
           required
           value={email}
@@ -58,6 +61,7 @@ export default function EmailAuthForm({
         </label>
         <input
           id="password"
+          name="password"
           type="password"
           required
           value={password}
@@ -85,6 +89,6 @@ export default function EmailAuthForm({
             ? LOGIN_LABELS.createAccount
             : LOGIN_LABELS.signInBtn}
       </button>
-    </form>
+    </Form>
   );
 }

--- a/gamesformykids/app/login/loginConstants.ts
+++ b/gamesformykids/app/login/loginConstants.ts
@@ -43,7 +43,7 @@ export interface LoginPageViewModel {
   setEmail:      (v: string) => void;
   setPassword:   (v: string) => void;
   setName:       (v: string) => void;
-  handleEmailAuth: (e: React.FormEvent) => Promise<void>;
+  loginAction: (formData: FormData) => void;
   toggleMode:      () => void;
   continueAsGuest: () => void;
   signInWithGoogle: () => void;

--- a/gamesformykids/app/login/useLoginPage.ts
+++ b/gamesformykids/app/login/useLoginPage.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useActionState, useState, useEffect } from 'react';
 import { useRouter } from 'next/navigation';
 import { useAuth } from '@/hooks/shared/auth/useAuth';
 import { ROUTES } from '@/lib/constants/routes';
@@ -12,32 +12,32 @@ export function useLoginPage(): { vm: LoginPageViewModel; isLoading: boolean; is
   const [email,         setEmail]         = useState('');
   const [password,      setPassword]      = useState('');
   const [name,          setName]          = useState('');
-  const [error,         setError]         = useState('');
-  const [isSubmitting,  setIsSubmitting]  = useState(false);
 
   useEffect(() => {
     if (user && !loading) router.push(ROUTES.HOME);
   }, [user, loading, router]);
 
-  const handleEmailAuth = async (e: React.FormEvent) => {
-    e.preventDefault();
-    setError('');
-    setIsSubmitting(true);
-    try {
-      const result = isRegistering
-        ? await signUpWithEmail(email, password, name)
-        : await signInWithEmail(email, password);
-      if (result.error) setError(result.error);
-    } catch {
-      setError(LOGIN_LABELS.genericError);
-    } finally {
-      setIsSubmitting(false);
-    }
-  };
+  // useActionState + <Form action={loginAction}> replaces manual isSubmitting + error useState.
+  // FormData values are read from the named inputs; isRegistering read from closure.
+  const [error, loginAction, isPending] = useActionState(
+    async (_prev: string | null, formData: FormData): Promise<string | null> => {
+      const emailVal    = formData.get('email')    as string;
+      const passwordVal = formData.get('password') as string;
+      const nameVal     = (formData.get('name') as string) ?? '';
+      try {
+        const result = isRegistering
+          ? await signUpWithEmail(emailVal, passwordVal, nameVal)
+          : await signInWithEmail(emailVal, passwordVal);
+        return result.error ?? null;
+      } catch {
+        return LOGIN_LABELS.genericError;
+      }
+    },
+    null
+  );
 
   const toggleMode = () => {
     setIsRegistering((prev) => !prev);
-    setError('');
   };
 
   const vm: LoginPageViewModel = {
@@ -45,12 +45,12 @@ export function useLoginPage(): { vm: LoginPageViewModel; isLoading: boolean; is
     email,
     password,
     name,
-    error,
-    isSubmitting,
+    error: error ?? '',
+    isSubmitting: isPending,
     setEmail,
     setPassword,
     setName,
-    handleEmailAuth,
+    loginAction,
     toggleMode,
     continueAsGuest,
     signInWithGoogle,


### PR DESCRIPTION
## Summary
Replaces the manual \<form onSubmit={handleEmailAuth}>\ pattern with Next.js 15's \<Form action={loginAction}>\ component and React 19's \useActionState\. The action reads email/password/name directly from \FormData\ (no \e.preventDefault()\ needed), and \isPending\ from \useActionState\ replaces the manual \isSubmitting\ \useState\.

## Changes
- \pp/login/LoginClient.tsx\ — pass \ction={vm.loginAction}\ instead of \onSubmit={vm.handleEmailAuth}\
- \pp/login/components/EmailAuthForm.tsx\ — swap \<form onSubmit>\ for \<Form action>\ from \
ext/form\; add \
ame\ attributes to all inputs
- \pp/login/useLoginPage.ts\ — rewrite email auth handler with \useActionState\; action reads from \FormData\; drop manual \isSubmitting\/\error\ useState
- \pp/login/loginConstants.ts\ — rename \handleEmailAuth\ → \loginAction\ in \LoginPageViewModel\ interface

## Testing
- [x] \
px tsc --noEmit\ passes
- [ ] Manually verified at \http://localhost:3000/login\

Closes #677

🤖 Generated with [Claude Code](https://claude.com/claude-code)