### PR TITLE
fix(image): remove unoptimized from PuzzleCard static /images/*.png

### DIFF
--- a/gamesformykids/app/games/puzzles/simple/PuzzleCard.tsx
+++ b/gamesformykids/app/games/puzzles/simple/PuzzleCard.tsx
@@ -31,7 +31,6 @@ export default function PuzzleCard({ puzzle }: { puzzle: SimplePuzzle }) {
             width={200}
             height={200}
             className="w-full h-32 object-cover transition-transform duration-300 hover:scale-110"
-            unoptimized
           />
           <div className="absolute inset-0 bg-gradient-to-t from-black/20 to-transparent opacity-0 hover:opacity-100 transition-opacity duration-300" />
         </div>


### PR DESCRIPTION
## Summary

Removes the `unoptimized` prop from `PuzzleCard.tsx`. This component displays static public-folder images (`/images/*.png`), not canvas data-URLs, so bypassing Next.js image optimisation was incorrect. With PR #683's global image optimisation config in place, Next.js will now serve WebP/AVIF variants and apply CDN caching for puzzle thumbnails automatically.

The other three puzzle components (`FloatingDragPiece`, `GridCell`, `PuzzlePieceItem`) correctly keep `unoptimized` because they render base64 canvas data-URLs that cannot be processed by the image optimiser.

## Changes
- `app/games/puzzles/simple/PuzzleCard.tsx` — removed `unoptimized` from the `<Image>` component

## Testing
- [x] `npx tsc --noEmit` passes

Closes #697

🤖 Generated with [Claude Code](https://claude.com/claude-code)