### PR TITLE
perf(image): use remotePatterns for flagcdn.com instead of unoptimized

### DIFF
--- a/gamesformykids/components/shared/cards/GeographyGameCard.tsx
+++ b/gamesformykids/components/shared/cards/GeographyGameCard.tsx
@@ -24,7 +24,6 @@ export default function GeographyGameCard({ item, onClick, isSelected }: GameIte
           height={53}
           className="w-full h-auto object-cover rounded-xl"
           loading="lazy"
-          unoptimized
         />
       </div>
       <span className="text-sm md:text-base font-bold text-gray-800 text-center leading-tight">

--- a/gamesformykids/components/shared/feedback/GeographyChallengeBox.tsx
+++ b/gamesformykids/components/shared/feedback/GeographyChallengeBox.tsx
@@ -34,7 +34,6 @@ export default function GeographyChallengeBox() {
             alt="דגל"
             fill
             className="object-cover"
-            unoptimized
           />
         </div>
         <p className="text-xl font-bold text-blue-700 text-center">{questionText}</p>

--- a/gamesformykids/next.config.ts
+++ b/gamesformykids/next.config.ts
@@ -10,6 +10,13 @@ const nextConfig: NextConfig = {
   },
   images: {
     formats: ['image/avif', 'image/webp'],
+    remotePatterns: [
+      {
+        protocol: 'https',
+        hostname: 'flagcdn.com',
+        pathname: '/**',
+      },
+    ],
   },
   async headers() {
     return [


### PR DESCRIPTION
## Summary

Adds `flagcdn.com` to `next.config.ts` `images.remotePatterns` so Next.js can optimise external flag images. Removes the `unoptimized` prop from `GeographyGameCard.tsx` and `GeographyChallengeBox.tsx` — with the domain allowlisted, Next.js now serves WebP/AVIF variants and caches optimised flag images at the CDN edge automatically.

The correct fix was always to add the domain, not skip optimisation. `FlagsGameCard.tsx` already had `unoptimized` removed in a prior refactor.

## Changes
- `next.config.ts` — added `remotePatterns` entry for `https://flagcdn.com/**`
- `components/shared/cards/GeographyGameCard.tsx` — removed `unoptimized`
- `components/shared/feedback/GeographyChallengeBox.tsx` — removed `unoptimized`

## Testing
- [x] `npx tsc --noEmit` passes

Closes #698

🤖 Generated with [Claude Code](https://claude.com/claude-code)