### PR TITLE
fix(seo): remove hardcoded canonical from HeadLinks.tsx

### DIFF
--- a/gamesformykids/components/layout/HeadLinks.tsx
+++ b/gamesformykids/components/layout/HeadLinks.tsx
@@ -26,7 +26,6 @@ export default function HeadLinks() {
       <meta name="apple-mobile-web-app-capable" content="yes" />
       <meta name="apple-mobile-web-app-status-bar-style" content="default" />
       <meta name="apple-mobile-web-app-title" content="משחקים לילדים" />
-      <link rel="canonical" href="https://games-for-my-kids.vercel.app" />
     </>
   );
 }


### PR DESCRIPTION
## Summary

HeadLinks.tsx:29 output a hardcoded canonical pointing to the homepage on every page of the site. This conflicted with per-page canonicals set by generateGameMetadata via the Next.js Metadata API, resulting in two competing canonical tags in every game page's HTML. Google's response to conflicting canonicals is unpredictable and may suppress game pages from search rankings.

The Metadata API already handles canonicals correctly:
- Root layout: siteMetadata.alternates.canonical = '/'
- Game pages: generateGameMetadata sets /games/${gameType}
- Auth pages: robots: { index: false } (no canonical needed)

## Changes
- components/layout/HeadLinks.tsx — removed hardcoded homepage canonical (line 29)

## Testing
- [x] `npx tsc --noEmit` passes

Closes #702

🤖 Generated with [Claude Code](https://claude.com/claude-code)