### PR TITLE
types: GAME_UI_CONFIGS — replace string keys + as-cast with GameType keys + satisfies

### DIFF
--- a/gamesformykids/hooks/shared/game-state/useGameConfig.ts
+++ b/gamesformykids/hooks/shared/game-state/useGameConfig.ts
@@ -36,7 +36,7 @@ function buildGameConfigValue(
   }
 
   try {
-    const config = GAME_UI_CONFIGS[gameType]
+    const config = GAME_UI_CONFIGS[gameType] ?? null
     const useGameHook = GAME_HOOKS_MAP[gameType as AutoGameType]
     const items = storeItems
     const CardComponent = GameCardMap[gameType] ?? null

--- a/gamesformykids/lib/constants/ui/gameConfigs.activities.ts
+++ b/gamesformykids/lib/constants/ui/gameConfigs.activities.ts
@@ -1,9 +1,10 @@
+import type { GameType } from '@/lib/types/core/base';
 import type { GameUIConfig } from './gameUIConfig.types';
 import { creativeConfigs } from './activitiesConfigData/creative';
 import { fantasyConfigs } from './activitiesConfigData/fantasy';
 import { sportsTechConfigs } from './activitiesConfigData/sportsTech';
 
-export const activitiesConfigs: Partial<Record<string, GameUIConfig>> = {
+export const activitiesConfigs: Partial<Record<GameType, GameUIConfig>> = {
   ...creativeConfigs,
   ...fantasyConfigs,
   ...sportsTechConfigs,

--- a/gamesformykids/lib/constants/ui/gameConfigs.advanced.ts
+++ b/gamesformykids/lib/constants/ui/gameConfigs.advanced.ts
@@ -1,8 +1,9 @@
+import type { GameType } from '@/lib/types/core/base';
 import type { GameUIConfig } from './gameUIConfig.types';
 import { cognitiveLearningConfigs } from './advancedConfigData/cognitiveLearning';
 import { sensoryEmotionalConfigs } from './advancedConfigData/sensoryEmotional';
 
-export const advancedConfigs: Partial<Record<string, GameUIConfig>> = {
+export const advancedConfigs: Partial<Record<GameType, GameUIConfig>> = {
   ...cognitiveLearningConfigs,
   ...sensoryEmotionalConfigs,
 };

--- a/gamesformykids/lib/constants/ui/gameConfigs.educational.ts
+++ b/gamesformykids/lib/constants/ui/gameConfigs.educational.ts
@@ -1,9 +1,10 @@
+import type { GameType } from '@/lib/types/core/base';
 import type { GameUIConfig } from './gameUIConfig.types';
 import { coreLearningConfigs } from './educationalConfigData/coreLearning';
 import { mathLogicConfigs } from './educationalConfigData/mathLogic';
 import { socialEmotionalConfigs } from './educationalConfigData/socialEmotional';
 
-export const educationalConfigs: Partial<Record<string, GameUIConfig>> = {
+export const educationalConfigs: Partial<Record<GameType, GameUIConfig>> = {
   ...coreLearningConfigs,
   ...mathLogicConfigs,
   ...socialEmotionalConfigs,

--- a/gamesformykids/lib/constants/ui/gameConfigs.home-life.ts
+++ b/gamesformykids/lib/constants/ui/gameConfigs.home-life.ts
@@ -1,10 +1,11 @@
+import type { GameType } from '@/lib/types/core/base';
 import type { GameUIConfig } from './gameUIConfig.types';
 import { objectsConfigs } from './homeLifeConfigData/objects';
 import { peopleConfigs } from './homeLifeConfigData/people';
 import { healthSensesConfigs } from './homeLifeConfigData/healthSenses';
 import { timeLearningConfigs } from './homeLifeConfigData/timeLearning';
 
-export const homeLifeConfigs: Partial<Record<string, GameUIConfig>> = {
+export const homeLifeConfigs: Partial<Record<GameType, GameUIConfig>> = {
   ...objectsConfigs,
   ...peopleConfigs,
   ...healthSensesConfigs,

--- a/gamesformykids/lib/constants/ui/gameConfigs.nature.ts
+++ b/gamesformykids/lib/constants/ui/gameConfigs.nature.ts
@@ -1,9 +1,10 @@
+import type { GameType } from '@/lib/types/core/base';
 import type { GameUIConfig } from './gameUIConfig.types';
 import { animalsCreaturesConfigs } from './natureConfigData/animalsCreatures';
 import { foodPlantsConfigs } from './natureConfigData/foodPlants';
 import { environmentConfigs } from './natureConfigData/environment';
 
-export const natureConfigs: Partial<Record<string, GameUIConfig>> = {
+export const natureConfigs: Partial<Record<GameType, GameUIConfig>> = {
   ...animalsCreaturesConfigs,
   ...foodPlantsConfigs,
   ...environmentConfigs,

--- a/gamesformykids/lib/constants/ui/gameConfigs.photo-quiz.ts
+++ b/gamesformykids/lib/constants/ui/gameConfigs.photo-quiz.ts
@@ -1,10 +1,11 @@
+import type { GameType } from '@/lib/types/core/base';
 import type { GameUIConfig } from './gameUIConfig.types';
 import { logosSportsConfigs } from './photoQuizConfigData/logosSports';
 import { natureAnimalsConfigs } from './photoQuizConfigData/natureAnimals';
 import { cultureWorldConfigs } from './photoQuizConfigData/cultureWorld';
 import { geographyConfigs } from './photoQuizConfigData/geography';
 
-export const photoQuizConfigs: Partial<Record<string, GameUIConfig>> = {
+export const photoQuizConfigs: Partial<Record<GameType, GameUIConfig>> = {
   ...logosSportsConfigs,
   ...natureAnimalsConfigs,
   ...cultureWorldConfigs,

--- a/gamesformykids/lib/constants/ui/gameConfigs.ts
+++ b/gamesformykids/lib/constants/ui/gameConfigs.ts
@@ -6,7 +6,7 @@
  * ׳™׳‘׳•׳ ׳׳”׳§׳•׳‘׳¥ ׳”׳–׳” ׳׳׳©׳™׳ ׳׳¢׳‘׳•׳“ ׳׳׳ ׳©׳™׳ ׳•׳™.
  */
 
-import { GameType } from "@/lib/types/core/base";
+import type { GameType } from "@/lib/types/core/base";
 import type { GameUIConfig } from './gameUIConfig.types';
 export type { GameUIConfig } from './gameUIConfig.types';
 
@@ -17,11 +17,11 @@ import { activitiesConfigs }   from './gameConfigs.activities';
 import { advancedConfigs }     from './gameConfigs.advanced';
 import { photoQuizConfigs }    from './gameConfigs.photo-quiz';
 
-export const GAME_UI_CONFIGS: Record<GameType, GameUIConfig> = {
+export const GAME_UI_CONFIGS = {
   ...educationalConfigs,
   ...natureConfigs,
   ...homeLifeConfigs,
   ...activitiesConfigs,
   ...advancedConfigs,
   ...photoQuizConfigs,
-} as Record<GameType, GameUIConfig>;
+} satisfies Partial<Record<GameType, GameUIConfig>>;


### PR DESCRIPTION
## Summary

All 6 game UI config files used `Partial<Record<string, GameUIConfig>>` (string key), and the barrel file used `as Record<GameType, GameUIConfig>` to silence TypeScript. This meant a typo in a game type key (e.g. `'animal'` instead of `'animals'`) would silently compile.

This PR changes all sub-files to use `Partial<Record<GameType, GameUIConfig>>` so any invalid key is a compile-time error. The barrel removes the unsafe `as` cast and replaces it with `satisfies Partial<Record<GameType, GameUIConfig>>` — which validates that all present keys are legitimate `GameType` values without requiring exhaustiveness across the spread of six Partial objects.

## Changes
- `lib/constants/ui/gameConfigs.educational.ts` — string → GameType key type
- `lib/constants/ui/gameConfigs.nature.ts` — string → GameType key type
- `lib/constants/ui/gameConfigs.home-life.ts` — string → GameType key type
- `lib/constants/ui/gameConfigs.activities.ts` — string → GameType key type
- `lib/constants/ui/gameConfigs.advanced.ts` — string → GameType key type
- `lib/constants/ui/gameConfigs.photo-quiz.ts` — string → GameType key type
- `lib/constants/ui/gameConfigs.ts` — `as Record<GameType, GameUIConfig>` → `satisfies Partial<Record<GameType, GameUIConfig>>`
- `hooks/shared/game-state/useGameConfig.ts` — added `?? null` to properly handle `GameUIConfig | undefined` from the Partial lookup

## Testing
- [x] `npx tsc --noEmit` passes

Closes #703

🤖 Generated with [Claude Code](https://claude.com/claude-code)