### PR TITLE
chore: HeadLinks cleanup — remove dead meta tags + migrate viewport to Viewport object

### DIFF
--- a/gamesformykids/components/layout/HeadLinks.tsx
+++ b/gamesformykids/components/layout/HeadLinks.tsx
@@ -3,22 +3,13 @@ import { BUILD_INFO } from '@/lib/build-info';
 export default function HeadLinks() {
   return (
     <>
-      {/* Critical font preloading */}
-      <link rel="preconnect" href="https://fonts.googleapis.com" crossOrigin="" />
-      <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="" />
-
       {/* Preload critical resources */}
       <link rel="preconnect" href="https://www.googletagmanager.com" />
       <link rel="preconnect" href="https://www.google-analytics.com" />
-      <link rel="dns-prefetch" href="//fonts.googleapis.com" />
-      <link rel="dns-prefetch" href="//fonts.gstatic.com" />
 
       {/* Cache busting */}
       <meta name="build-version" content={BUILD_INFO.version} />
       <meta name="build-timestamp" content={BUILD_INFO.timestamp.toString()} />
-      <meta name="cache-control" content="no-cache, no-store, must-revalidate" />
-      <meta name="pragma" content="no-cache" />
-      <meta name="expires" content="0" />
 
       <link rel="manifest" href="/manifest.json" />
       <meta name="theme-color" content="#8b5cf6" />

--- a/gamesformykids/lib/constants/siteMetadata.ts
+++ b/gamesformykids/lib/constants/siteMetadata.ts
@@ -1,4 +1,4 @@
-import type { Metadata } from 'next';
+import type { Metadata, Viewport } from 'next';
 
 export const siteMetadata: Metadata = {
   title: '🎮 משחקים לילדים 2-5 - למידה מהנה וחינוכית',
@@ -39,7 +39,12 @@ export const siteMetadata: Metadata = {
   },
 };
 
-export const siteViewport = 'width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no';
+export const siteViewport: Viewport = {
+  width: 'device-width',
+  initialScale: 1,
+  maximumScale: 1,
+  userScalable: false,
+};
 
 export const structuredData = {
   "@context": "https://schema.org",


### PR DESCRIPTION
## Summary

Three cleanup items in two files (arch-review run 5 findings N3, N4, N5):

**N3 — Obsolete HTTP cache-control meta tags (HeadLinks.tsx:19–21)**
`<meta name=cache-control>`, `<meta name=pragma>`, and `<meta name=expires>` do nothing in modern browsers. HTTP caching is controlled by response headers. The `Cache-Control` headers in `next.config.ts` (`s-maxage`, `stale-while-revalidate`) are authoritative. These meta tags were misleading dead code.

**N4 — Unnecessary Google Fonts preconnect hints (HeadLinks.tsx:7–8, 13–14)**
`next/font/google` downloads and self-hosts the Inter font at build time. The browser never makes a runtime request to `fonts.googleapis.com`. The `<link rel=preconnect>` and `<link rel=dns-prefetch>` hints added an unnecessary TCP handshake on every page load.

**N5 — Deprecated string viewport (siteMetadata.ts:42)**
The string form `'width=device-width, initial-scale=1, ...'` is `@deprecated` in Next.js types (a Next.js 13 pattern). Migrated to the `Viewport` object type from `next`. `layout.tsx` required no changes — `export const viewport = siteViewport` is now correctly typed as `Viewport`.

## Changes
- `components/layout/HeadLinks.tsx` — removed 6 lines: cache-control/pragma/expires meta tags + Google Fonts preconnect/dns-prefetch hints
- `lib/constants/siteMetadata.ts` — added `Viewport` import; changed `siteViewport` from string literal to `Viewport` object

## Testing
- [x] `npx tsc --noEmit` passes

Closes #704

🤖 Generated with [Claude Code](https://claude.com/claude-code)