### PR TITLE
fix(seo): fix generateGameMetadata for arcade/board/quiz games + remove broken OG image fallbacks

### DIFF
--- a/gamesformykids/lib/utils/game/gameMetadata.ts
+++ b/gamesformykids/lib/utils/game/gameMetadata.ts
@@ -12,19 +12,31 @@ export function generateGameMetadata(
 ): Metadata {
   const config = GAME_UI_CONFIGS[gameType as keyof typeof GAME_UI_CONFIGS];
   const urlGameType = gameUrlType || gameType;
-  
+
+  // #708: Arcade/board/quiz games have no GAME_UI_CONFIGS entry — return a
+  // readable fallback instead of "משחק לא נמצא" which Google would index.
   if (!config) {
+    const readableTitle = gameType
+      .split('-')
+      .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+      .join(' ');
     return {
-      title: 'משחק לא נמצא',
-      description: 'המשחק שחיפשת לא נמצא',
+      title: `${readableTitle} | GamesForMyKids`,
+      description: `Play ${readableTitle} — a free educational game for kids on GamesForMyKids`,
+      alternates: { canonical: `/games/${urlGameType}` },
+      robots: { index: true, follow: true },
     };
   }
 
   const defaultKeywords = `${config.title}, משחקים לילדים, חינוכי, גיל 2-5, פעוטות, למידה, ${gameType}`;
   const keywords = config.metadata?.keywords || defaultKeywords;
   const description = config.metadata?.description || config.subTitle;
-  const ogImagePath = config.metadata?.ogImagePath || `/images/games/${gameType}-og.png`;
-  const twitterImagePath = config.metadata?.twitterImagePath || `/images/games/${gameType}-twitter.png`;
+
+  // #710: Only include og:image / twitter:image when an actual path is configured.
+  // The old fallback /images/games/${gameType}-og.png pointed to a directory that
+  // does not exist, causing broken preview images on social shares.
+  const ogImagePath = config.metadata?.ogImagePath;
+  const twitterImagePath = config.metadata?.twitterImagePath;
 
   return {
     title: config.title,
@@ -35,20 +47,15 @@ export function generateGameMetadata(
       description,
       type: 'article',
       url: `${baseUrl}/games/${urlGameType}`,
-      images: [
-        {
-          url: ogImagePath,
-          width: 1200,
-          height: 630,
-          alt: config.title,
-        },
-      ],
+      ...(ogImagePath
+        ? { images: [{ url: ogImagePath, width: 1200, height: 630, alt: config.title }] }
+        : {}),
     },
     twitter: {
-      card: 'summary_large_image',
+      card: 'summary',
       title: config.title,
       description,
-      images: [twitterImagePath],
+      ...(twitterImagePath ? { images: [twitterImagePath] } : {}),
     },
     alternates: {
       canonical: `/games/${urlGameType}`,


### PR DESCRIPTION
﻿## Summary

Two SEO bugs in lib/utils/game/gameMetadata.ts fixed together (arch-review run 6, findings N1 and N3).

**Issue 708 - "Game Not Found" titles for 45+ game routes**
generateGameMetadata returned the Hebrew "Game Not Found" message for any game not in GAME_UI_CONFIGS (chess, snake, tetris, memory, flappy-bird, all quiz games, etc.). These pages render and play correctly, but Google was indexing "Game Not Found" as their title and snippet. Now falls back to a readable title derived from the game slug, with correct alternates.canonical and robots tags.

**Issue 710 - Broken OG/Twitter image fallback paths**
The fallback for og:image and twitter:image pointed to /images/games/${gameType}-og.png which does not exist in /public. This caused 404 image requests and blank previews on social shares. Images are now only included when an actual ogImagePath / twitterImagePath is configured in the game's metadata config.

## Changes
- lib/utils/game/gameMetadata.ts
  - Replaced Hebrew "Game Not Found" fallback with a slug-derived English title + description + canonical + robots
  - Removed broken /images/games/${gameType}-og.png fallback; OG/Twitter images now use conditional spread

## Testing
- [x] `npx tsc --noEmit` passes

Closes #708
Closes #710

Generated with [Claude Code](https://claude.com/claude-code)
