### PR TITLE
fix(seo): sitemap — use SUPPORTED_GAMES for all game routes + remove lastModified

### DIFF
--- a/gamesformykids/app/sitemap.ts
+++ b/gamesformykids/app/sitemap.ts
@@ -1,25 +1,27 @@
 import { MetadataRoute } from 'next'
-import { GAME_UI_CONFIGS } from '@/lib/constants/ui/gameConfigs'
+import { SUPPORTED_GAMES } from '@/app/games/[gameType]/gamePageConstants'
 import { hebrewLetters } from '@/app/games/hebrew-letters/constants/hebrewLetters'
 
 export default function sitemap(): MetadataRoute.Sitemap {
   const baseUrl = 'https://games-for-my-kids.vercel.app'
-  
+
   // דף הבית
   const routes: MetadataRoute.Sitemap = [
     {
       url: baseUrl,
-      lastModified: new Date(),
+      // #711: No lastModified — avoid stamping every URL with the deploy timestamp.
+      // Google's crawler determines freshness more accurately than a static date.
       changeFrequency: 'weekly',
       priority: 1.0,
     },
   ]
 
-  // דפי משחקים כלליים
-  Object.keys(GAME_UI_CONFIGS).forEach((gameType) => {
+  // #709: Use SUPPORTED_GAMES (the authoritative list of all ~127 game routes)
+  // instead of Object.keys(GAME_UI_CONFIGS) which only covered ~65 card games.
+  // This adds the missing arcade, board, quiz, and custom game URLs to sitemap.xml.
+  SUPPORTED_GAMES.forEach((gameType) => {
     routes.push({
       url: `${baseUrl}/games/${gameType}`,
-      lastModified: new Date(),
       changeFrequency: 'monthly',
       priority: 0.8,
     })
@@ -29,7 +31,6 @@ export default function sitemap(): MetadataRoute.Sitemap {
   hebrewLetters.forEach((letter) => {
     routes.push({
       url: `${baseUrl}/games/hebrew-letters/${letter.name}`,
-      lastModified: new Date(),
       changeFrequency: 'monthly',
       priority: 0.6,
     })
@@ -38,7 +39,6 @@ export default function sitemap(): MetadataRoute.Sitemap {
   // דף אותיות עבריות כללי
   routes.push({
     url: `${baseUrl}/games/hebrew-letters`,
-    lastModified: new Date(),
     changeFrequency: 'monthly',
     priority: 0.7,
   })
@@ -46,7 +46,6 @@ export default function sitemap(): MetadataRoute.Sitemap {
   // דפי קטגוריות סטטיות
   routes.push({
     url: `${baseUrl}/games/educational`,
-    lastModified: new Date(),
     changeFrequency: 'monthly',
     priority: 0.7,
   })


### PR DESCRIPTION
﻿## Summary

Two sitemap bugs in app/sitemap.ts fixed together (arch-review run 6, findings N2 and N4).

**Issue 709 - Missing ~62 game URLs from sitemap**
app/sitemap.ts used Object.keys(GAME_UI_CONFIGS) to build the game URL list. GAME_UI_CONFIGS only covers card-style games (~65 types). All arcade, board, quiz, and custom games (chess, snake, tetris, memory, checkers, flappy-bird, pong, shesh-besh, taki, riddles, capitals, spelling, etc.) were absent from sitemap.xml — even though they are statically generated routes that appear in SUPPORTED_GAMES. Replaced with SUPPORTED_GAMES, the single authoritative list of all supported game routes (~127 entries).

**Issue 711 - lastModified stamps all URLs with the deploy timestamp**
Every route entry used lastModified: new Date(), which stamps all 100+ URLs with the current timestamp on every deploy — even backend config changes unrelated to any game content. Google uses lastModified for re-crawl scheduling; when all pages are always "modified today" the field loses its signal value. Removed lastModified from all entries and let Googlebot determine freshness on its own.

## Changes
- app/sitemap.ts
  - Replaced Object.keys(GAME_UI_CONFIGS) import with SUPPORTED_GAMES from gamePageConstants.ts
  - Removed GAME_UI_CONFIGS import (no longer needed)
  - Removed lastModified: new Date() from all route entries

## Testing
- [x] `npx tsc --noEmit` passes

Closes #709
Closes #711

Generated with [Claude Code](https://claude.com/claude-code)
