### PR TITLE
fix: home page openGraph missing siteName and url

### DIFF
--- a/gamesformykids/app/page.tsx
+++ b/gamesformykids/app/page.tsx
@@ -9,6 +9,8 @@ export const metadata: Metadata = {
     description: 'אוסף משחקים חינוכיים ומהנים לילדים בגיל 2–5 שנים',
     type: 'website',
     locale: 'he_IL',
+    siteName: 'GamesForMyKids',
+    url: 'https://games-for-my-kids.vercel.app',
   },
   keywords: 'משחקים לילדים, חינוכי, זיכרון, צבעים, עברית, מספרים, גיל 2-5, פעוטות',
 };


### PR DESCRIPTION
## Summary

Next.js shallow-merges `openGraph` — a page-level `openGraph` object replaces the root layout's `openGraph` entirely, silently dropping any fields not repeated at the page level. `app/page.tsx` defined an `openGraph` object without `siteName` or `url`, so the home page share card on Facebook/X/LinkedIn was missing those values even though they were set in the root layout's `siteMetadata`.

## Changes
- `app/page.tsx` — added `siteName: 'GamesForMyKids'` and `url: 'https://games-for-my-kids.vercel.app'` to the `openGraph` object

## Testing
- [x] `npx tsc --noEmit` passes

Closes #716

🤖 Generated with [Claude Code](https://claude.com/claude-code)