### PR TITLE
fix: taki useTakiGame adds useGameCompletion via usePhaseGameCompletion

### DIFF
--- a/gamesformykids/app/games/taki/useTakiGame.ts
+++ b/gamesformykids/app/games/taki/useTakiGame.ts
@@ -1,5 +1,19 @@
 'use client';
 import { createShallowHook } from '@/lib/stores/utils/sliceUtils';
 import { useTakiStore } from './takiGameStore';
+import { useGameCompletion } from '@/hooks/shared/progress/useGameCompletion';
+import { usePhaseGameCompletion } from '@/hooks/shared/progress/usePhaseGameCompletion';
 
-export const useTakiGame = createShallowHook(useTakiStore);
+const _useStore = createShallowHook(useTakiStore);
+
+export function useTakiGame() {
+  const state = _useStore();
+  const { saveGameResultRef } = useGameCompletion('taki');
+  usePhaseGameCompletion(
+    state.phase,
+    saveGameResultRef,
+    () => ({ score: state.playerScore, level: 1 }),
+    ['won', 'lost'],
+  );
+  return state;
+}


### PR DESCRIPTION
## Summary

`useTakiGame` was a bare `createShallowHook` wrapper that subscribed to the store but never reported the result to Supabase. The taki store already transitions through `phase: 'won'` and `'lost'` when a round ends, and tracks `playerScore`. Added `useGameCompletion` + `usePhaseGameCompletion` so that every time phase transitions from `'playing'` to `'won'` or `'lost'`, the player score is persisted. Note: `createPhaseGameHook` was not used directly here because its generic constraint requires a `score` field on the store state, while the taki store uses `playerScore` — using the two composable primitives directly is both correct and avoids a type-system workaround.

## Changes
- `app/games/taki/useTakiGame.ts` — replaced bare `createShallowHook` with a `useTakiGame` function that calls `useGameCompletion('taki')` and `usePhaseGameCompletion` with `completionPhases: ['won', 'lost']`

## Testing
- [x] `npx tsc --noEmit` passes

Closes #722

🤖 Generated with [Claude Code](https://claude.com/claude-code)
