### PR TITLE
fix: tetris saves score to Supabase on gameOver via useGameCompletion

### DIFF
--- a/gamesformykids/app/games/tetris/hooks/useTetrisGame.ts
+++ b/gamesformykids/app/games/tetris/hooks/useTetrisGame.ts
@@ -1,7 +1,8 @@
 'use client';
 
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import { useTetrisStore } from '../store/tetrisStore';
+import { useGameCompletion } from '@/hooks/shared/progress/useGameCompletion';
 
 /**
  * הוק דק שמנהל רק את ה-side-effects של המשחק:
@@ -11,8 +12,13 @@ import { useTetrisStore } from '../store/tetrisStore';
 export const useTetrisGame = () => {
   const setLoaded = useTetrisStore(s => s.setLoaded);
   const isGameRunning = useTetrisStore(s => s.isGameRunning);
+  const gameOver = useTetrisStore(s => s.gameOver);
   const level = useTetrisStore(s => s.level);
   const movePiece = useTetrisStore(s => s.movePiece);
+
+  const { saveGameResultRef } = useGameCompletion('tetris');
+  const startTimeRef = useRef(0);
+  const prevGameOverRef = useRef(false);
 
   // אופטימיזציה למובייל — התחלה לאחר טעינה מלאה
   useEffect(() => {
@@ -20,6 +26,24 @@ export const useTetrisGame = () => {
     return () => clearTimeout(timer);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
+
+  // מעקב אחר זמן תחילת המשחק
+  useEffect(() => {
+    if (isGameRunning) {
+      startTimeRef.current = Date.now();
+      prevGameOverRef.current = false;
+    }
+  }, [isGameRunning]);
+
+  // שמירת ניקוד בסיום המשחק
+  useEffect(() => {
+    if (gameOver && !prevGameOverRef.current) {
+      const { score, level: finalLevel } = useTetrisStore.getState();
+      const durationSeconds = Math.round((Date.now() - startTimeRef.current) / 1000);
+      saveGameResultRef.current({ score, level: finalLevel, durationSeconds });
+    }
+    prevGameOverRef.current = gameOver;
+  }, [gameOver, saveGameResultRef]);
 
   // לולאת נפילה — תלויה ברמה כדי לעדכן מהירות
   useEffect(() => {


### PR DESCRIPTION
## Summary

The Tetris store sets `gameOver: true` when the board tops out but there was no mechanism to persist the final score to Supabase — the game hook only managed the RAF drop loop and keyboard input. Added `useGameCompletion` and a `useEffect` in `useTetrisGame` that watches the `gameOver` boolean: when it transitions from `false` to `true`, the current `score` and `level` are read from the store via `getState()` (avoiding stale closure issues) and written to Supabase via `saveGameResultRef`. A `startTimeRef` tracking when `isGameRunning` becomes `true` provides the `durationSeconds` field.

## Changes
- `app/games/tetris/hooks/useTetrisGame.ts` — added `useGameCompletion('tetris')` + two new `useEffect`s: one to record game-start time when `isGameRunning` becomes `true`, one to call `saveGameResultRef` when `gameOver` transitions to `true`

## Testing
- [x] `npx tsc --noEmit` passes

Closes #723

🤖 Generated with [Claude Code](https://claude.com/claude-code)
