### PR TITLE
refactor: useQuizSession adds useGameCompletion — quiz scores now saved to Supabase

### DIFF
--- a/gamesformykids/lib/quiz/useQuizSession.ts
+++ b/gamesformykids/lib/quiz/useQuizSession.ts
@@ -1,22 +1,29 @@
 'use client';
 
-import { useState, useCallback, useEffect } from 'react';
+import { useState, useCallback, useEffect, useRef } from 'react';
 import { useQuizGameStore } from '@/lib/stores/quizGameStore';
 import { useGameStore } from '@/lib/stores/gameStore';
 import { useGameProgressStore } from '@/lib/stores/gameProgressStore';
+import { useGameCompletion } from '@/hooks/shared/progress/useGameCompletion';
+import type { GameType } from '@/lib/types';
 
 export function useQuizSession<Q>(gameType: string) {
   const phase    = useQuizGameStore(s => s.phase);
   const index    = useQuizGameStore(s => s.index);
   const selected = useQuizGameStore(s => s.selected);
+  const score    = useQuizGameStore(s => s.score);
   const { startQuiz, selectAnswer: storeSelect, restartQuiz } = useQuizGameStore();
 
   const [questions, setQuestions] = useState<Q[]>([]);
   const current = questions[index] ?? null;
 
+  const { saveGameResultRef } = useGameCompletion(gameType as GameType);
+  const startTimeRef = useRef(0);
+
   const begin = useCallback((qs: Q[]) => {
     setQuestions(qs);
     startQuiz(gameType, qs.length);
+    startTimeRef.current = Date.now();
     useGameStore.getState().startGame(gameType);
     useGameProgressStore.getState().resetProgress();
     useGameProgressStore.getState().setGameActive(true);
@@ -31,6 +38,7 @@ export function useQuizSession<Q>(gameType: string) {
   const reset = useCallback((qs: Q[]) => {
     setQuestions(qs);
     restartQuiz();
+    startTimeRef.current = Date.now();
     useGameStore.getState().startGame(gameType);
     useGameProgressStore.getState().resetProgress();
     useGameProgressStore.getState().setGameActive(true);
@@ -38,10 +46,12 @@ export function useQuizSession<Q>(gameType: string) {
 
   useEffect(() => {
     if (phase === 'result') {
+      const durationSeconds = Math.round((Date.now() - startTimeRef.current) / 1000);
+      saveGameResultRef.current({ score, level: 1, durationSeconds });
       useGameStore.getState().endGame();
       useGameProgressStore.getState().setGameActive(false);
     }
-  }, [phase]);
+  }, [phase, score, saveGameResultRef]);
 
   return { phase, current, begin, answer, reset };
 }


### PR DESCRIPTION
## Summary

`useQuizSession` powers all `createCategoryIndexQuizHook` quiz games (transport, human-body, israel, nature, science, trivia) as well as `useClockGame`, `useColorMixGame`, `useGenericQuizGame`, `useHumanBodyGame`, and `useSequencesGame`. It called three legacy stores (`useGameStore.startGame`, `useGameProgressStore.resetProgress/setGameActive/recordAttempt`) on every lifecycle event but never called `useGameCompletion`, so quiz game scores were never written to Supabase. Added `useGameCompletion` with a `startTimeRef` (reset on each `begin`/`reset` call) so that when `phase` transitions to `'result'`, `saveGameResultRef` is called with the current `score` from `useQuizGameStore` and the elapsed `durationSeconds`. The legacy store calls are preserved to avoid breaking any existing local progress tracking.

## Changes
- `lib/quiz/useQuizSession.ts` — added `useGameCompletion(gameType as GameType)` + `startTimeRef` to track game duration; `saveGameResultRef.current(...)` called inside the existing `phase === 'result'` effect; `startTimeRef.current = Date.now()` set in both `begin` and `reset`; added `score` selector from `useQuizGameStore`

## Testing
- [x] `npx tsc --noEmit` passes
- [x] All existing quiz hook tests in `__tests__/quiz/quizHooks.test.ts` still compile

Closes #725

🤖 Generated with [Claude Code](https://claude.com/claude-code)
