### PR TITLE
dead-code: delete PhaseQuiz type and ProgressStats interface — zero consumers

### DIFF
--- a/gamesformykids/lib/types/games/phase.ts
+++ b/gamesformykids/lib/types/games/phase.ts
@@ -12,9 +12,6 @@ export type PhaseResult = 'menu' | 'playing' | 'result';
 /** שלבי משחק ארקייד: תפריט → משחק → מוות */
 export type PhaseDead = 'menu' | 'playing' | 'dead';
 
-/** שלבי משחק חידון: תפריט → משחק → תשובה → סיום */
-export type PhaseQuiz = 'menu' | 'playing' | 'answered' | 'finished';
-
 /** שלבי משחק עם ניצחון ומוות (brick-breaker) */
 export type PhaseWonDead = 'menu' | 'playing' | 'won' | 'dead';
 

--- a/gamesformykids/lib/types/hooks/progress.ts
+++ b/gamesformykids/lib/types/hooks/progress.ts
@@ -25,19 +25,4 @@ export interface GameSession {
   completed: boolean;
 }
 
-export interface ProgressStats {
-  totalSessions: number;
-  totalTime: number;
-  averageScore: number;
-  bestScore: number;
-  totalGamesPlayed: number;
-  gamesCompleted: number;
-  averageAccuracy: number;
-  mostDifficultItems: string[];
-  strongestAreas: GameType[];
-  weakestAreas: GameType[];
-  improvementTrend: 'up' | 'down' | 'stable';
-  recommendedPractice: string[];
-}
-
 


### PR DESCRIPTION
## Summary

`PhaseQuiz` and `ProgressStats` were exported from `lib/types/` but never imported by any file in the codebase — they are pure dead code. `PhaseQuiz` (`'menu' | 'playing' | 'answered' | 'finished'`) had no store or hook using it; all quiz-session hooks use `useQuizGameStore` which has its own phase union. `ProgressStats` was a rich analytics interface (12 fields including trend, strongest/weakest areas, recommendations) with no consumer — the only live type in `lib/types/hooks/progress.ts` is `GameSession` which is used by `useSessionStats` and `progressTrackingStore`.

## Changes
- `lib/types/games/phase.ts` — removed `PhaseQuiz` type (3 lines)
- `lib/types/hooks/progress.ts` — removed `ProgressStats` interface (14 lines)

## Testing
- [x] `npx tsc --noEmit` passes
- [x] No remaining imports of either type in the codebase

Closes #729

🤖 Generated with [Claude Code](https://claude.com/claude-code)
