### PR TITLE
perf: memoize GamesRegistry.getAllGameRegistrations() in navigation hooks

### DIFF
--- a/gamesformykids/app/games/tzedakah/useCharityCoinGame.ts
+++ b/gamesformykids/app/games/tzedakah/useCharityCoinGame.ts
@@ -1,5 +1,5 @@
 'use client';
-import { useEffect } from 'react';
+import { useEffect, useMemo } from 'react';
 import { useShallow } from 'zustand/react/shallow';
 import { useTzedakahStore } from './tzedakahStore';
 import { GamesRegistry } from '@/lib/registry/gamesRegistry';
@@ -31,10 +31,12 @@ export function useCharityCoinGame() {
     return () => window.removeEventListener('keydown', onKey);
   }, [gameStarted, isMobile, stepBasket]);
 
-  const availableGames = GamesRegistry.getAllGameRegistrations()
-    .filter(g => g.available).sort((a, b) => a.order - b.order);
-  const idx      = availableGames.findIndex(g => g.id === 'tzedakah');
-  const nextGame = idx < availableGames.length - 1 ? availableGames[idx + 1] : availableGames[0];
+  const nextGame = useMemo(() => {
+    const all = GamesRegistry.getAllGameRegistrations()
+      .filter(g => g.available).sort((a, b) => a.order - b.order);
+    const idx = all.findIndex(g => g.id === 'tzedakah');
+    return idx < all.length - 1 ? all[idx + 1] : all[0];
+  }, []);
 
   const handleMouseMove = (e: React.MouseEvent) => {
     const rect = e.currentTarget.getBoundingClientRect();

--- a/gamesformykids/components/game/universal/navigation/useUniversalGameNavigation.ts
+++ b/gamesformykids/components/game/universal/navigation/useUniversalGameNavigation.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect } from "react";
+import { useEffect, useMemo } from "react";
 import { usePathname, useRouter } from "next/navigation";
 import { getGameNavigation } from "@/lib/utils/game/gameNavigation";
 import { GamesRegistry } from "@/lib/registry/gamesRegistry";
@@ -37,7 +37,7 @@ export function useUniversalGameNavigation({
   const gamesIndex = pathSegments.indexOf("games");
   const gameId = gamesIndex >= 0 ? pathSegments[gamesIndex + 1] || "" : "";
   const currentGame = GamesRegistry.getGameById(gameId);
-  const navigation = getGameNavigation(gameId);
+  const navigation = useMemo(() => getGameNavigation(gameId), [gameId]);
 
   const shouldRender = Boolean(gameId && currentGame && gameId !== "games");
 


### PR DESCRIPTION
## Summary

`GamesRegistry.getAllGameRegistrations()` runs an O(130) filter + sort/findIndex on every render in two hooks. The registry never changes at runtime — wrapping the calls in `useMemo` computes the result once and caches it for the lifetime of the component.

- `useUniversalGameNavigation` — `getGameNavigation(gameId)` internally calls `getAllGameRegistrations()`, runs on every keystroke/navigation event. Wrapped in `useMemo` with `[gameId]` dep so it only recomputes when navigating to a different game.
- `useCharityCoinGame` — the next-game computation ran on every render (mouse move, coin spawn, score update). The `tzedakah` game's position in the registry never changes, so `[]` dep is correct.

## Changes
- `components/game/universal/navigation/useUniversalGameNavigation.ts` — added `useMemo` import; wrapped `getGameNavigation(gameId)` call with `useMemo(() => ..., [gameId])`
- `app/games/tzedakah/useCharityCoinGame.ts` — added `useMemo` import; extracted `nextGame` derivation into `useMemo(() => ..., [])`

## Testing
- [x] `npx tsc --noEmit` passes

Closes #730

🤖 Generated with [Claude Code](https://claude.com/claude-code)
