### PR TITLE
fix: add useGameCompletion to chess and checkers games

### DIFF
--- a/gamesformykids/app/games/checkers/useDamkaGame.ts
+++ b/gamesformykids/app/games/checkers/useDamkaGame.ts
@@ -1,7 +1,33 @@
 'use client';
+import { useEffect, useRef } from 'react';
 import { createShallowHook } from '@/lib/stores/utils/sliceUtils';
 import { useDamkaStore } from './damkaStore';
-
+import { useGameCompletion } from '@/hooks/shared/progress/useGameCompletion';
 export type { Side, GamePhase, Cell, Board, Pos, DamkaMove } from './damkaStore';
 
-export const useDamkaGame = createShallowHook(useDamkaStore);
+const _useStore = createShallowHook(useDamkaStore);
+
+export function useDamkaGame() {
+  const state = _useStore();
+  const { saveGameResultRef } = useGameCompletion('checkers');
+
+  const startTimeRef = useRef(0);
+  const prevPhaseRef = useRef(state.phase);
+
+  useEffect(() => {
+    const prev = prevPhaseRef.current;
+    const curr = state.phase;
+    prevPhaseRef.current = curr;
+
+    if (curr === 'playing' && prev !== 'playing') {
+      // Game (re)started — begin timer
+      startTimeRef.current = Date.now();
+    } else if ((curr === 'won' || curr === 'lost') && prev === 'playing') {
+      // Game just ended — save result
+      const durationSeconds = Math.round((Date.now() - startTimeRef.current) / 1000);
+      saveGameResultRef.current({ score: state.playerScore, level: 1, durationSeconds });
+    }
+  }, [state.phase]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  return state;
+}

--- a/gamesformykids/app/games/chess/useChessGame.ts
+++ b/gamesformykids/app/games/chess/useChessGame.ts
@@ -1,5 +1,37 @@
 'use client';
+import { useEffect, useRef } from 'react';
 import { createShallowHook } from '@/lib/stores/utils/sliceUtils';
 import { useChessStore } from './store/useChessStore';
+import { useGameCompletion } from '@/hooks/shared/progress/useGameCompletion';
 
-export const useChessGame = createShallowHook(useChessStore);
+const _useStore = createShallowHook(useChessStore);
+
+const TERMINAL_PHASES = ['checkmate', 'stalemate'] as const;
+
+export function useChessGame() {
+  const state = _useStore();
+  const { saveGameResultRef } = useGameCompletion('chess');
+
+  const startTimeRef = useRef(0);
+  const prevPhaseRef = useRef(state.phase);
+
+  useEffect(() => {
+    const prev = prevPhaseRef.current;
+    const curr = state.phase;
+    prevPhaseRef.current = curr;
+
+    if (curr === 'playing' && prev !== 'playing') {
+      // Game (re)started — begin timer
+      startTimeRef.current = Date.now();
+    } else if (
+      (TERMINAL_PHASES as readonly string[]).includes(curr) &&
+      !(TERMINAL_PHASES as readonly string[]).includes(prev)
+    ) {
+      // Game just ended (from 'playing' or 'check' → terminal)
+      const durationSeconds = Math.round((Date.now() - startTimeRef.current) / 1000);
+      saveGameResultRef.current({ score: state.playerScore, level: 1, durationSeconds });
+    }
+  }, [state.phase]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  return state;
+}


### PR DESCRIPTION
## Summary
Chess and checkers both reach terminal game phases (`checkmate`/`stalemate` for chess, `won`/`lost` for checkers) but never persisted the score to Supabase. This PR adds `useGameCompletion` tracking to both game hooks, converting each from a bare `createShallowHook` constant to a named function that wraps the store subscription with phase-aware completion logic.

Both stores use `playerScore` (not `score`), so `createPhaseGameHook` cannot be used — the manual `prevPhaseRef`/`startTimeRef` pattern is used instead (same approach as taki).

## Changes
- `app/games/chess/useChessGame.ts` — converted to named function; added `useGameCompletion('chess')` + `useEffect` that tracks game start on `'playing'` and saves score on `'checkmate'`/`'stalemate'` (handles the `'check'` → `'checkmate'` path correctly)
- `app/games/checkers/useDamkaGame.ts` — same pattern; terminal phases are `'won'` and `'lost'`

## Testing
- [x] `npx tsc --noEmit` passes
- [ ] Manually verified chess game at `http://localhost:3000/games/chess`
- [ ] Manually verified checkers game at `http://localhost:3000/games/checkers`

Closes #733

🤖 Generated with [Claude Code](https://claude.com/claude-code)