### PR TITLE
fix(seo): use relative OG url in generateGameMetadata and hebrew-letters page

### DIFF
--- a/gamesformykids/app/games/hebrew-letters/[letter]/page.tsx
+++ b/gamesformykids/app/games/hebrew-letters/[letter]/page.tsx
@@ -25,7 +25,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
       title: `תרגול האות ${letterData.letter} - ${letterData.name}`,
       description: `דף תרגול אינטראקטיבי לכתיבת האות ${letterData.letter} בעברית`,
       type: 'article',
-      url: `https://gamesformykids.vercel.app/games/hebrew-letters/${letter}`,
+      url: `/games/hebrew-letters/${letter}`,
     },
     twitter: {
       card: 'summary',

--- a/gamesformykids/lib/utils/game/gameMetadata.ts
+++ b/gamesformykids/lib/utils/game/gameMetadata.ts
@@ -8,7 +8,6 @@ import { GAME_UI_CONFIGS } from "@/lib/constants/ui/gameConfigs";
 export function generateGameMetadata(
   gameType: string,
   gameUrlType?: string,
-  baseUrl: string = 'https://gamesformykids.vercel.app'
 ): Metadata {
   const config = GAME_UI_CONFIGS[gameType as keyof typeof GAME_UI_CONFIGS];
   const urlGameType = gameUrlType || gameType;
@@ -46,7 +45,7 @@ export function generateGameMetadata(
       title: config.title,
       description,
       type: 'article',
-      url: `${baseUrl}/games/${urlGameType}`,
+      url: `/games/${urlGameType}`,
       ...(ogImagePath
         ? { images: [{ url: ogImagePath, width: 1200, height: 630, alt: config.title }] }
         : {}),


### PR DESCRIPTION
## Summary
Two files hardcoded `https://gamesformykids.vercel.app` as the base for `openGraph.url` — a different deployment URL from the canonical `https://games-for-my-kids.vercel.app` used everywhere else. This caused every card game OG url and all hebrew-letter page OG urls to point to the wrong domain, breaking social share previews. Switching to relative paths lets `metadataBase` in the root layout resolve them correctly.

## Changes
- `lib/utils/game/gameMetadata.ts` — `openGraph.url` changed from `` `${baseUrl}/games/${urlGameType}` `` to `` `/games/${urlGameType}` ``; removed the now-unused `baseUrl` parameter (no caller ever passed a non-default value)
- `app/games/hebrew-letters/[letter]/page.tsx` — `openGraph.url` changed from absolute wrong-domain URL to relative `` `/games/hebrew-letters/${letter}` ``

## Testing
- [x] `npx tsc --noEmit` passes
- [x] No callers pass a third `baseUrl` argument to `generateGameMetadata`

Closes #742

🤖 Generated with [Claude Code](https://claude.com/claude-code)