### PR TITLE
fix(ux): remove animate-pulse from BuildingGame h1

### DIFF
--- a/gamesformykids/app/games/building/components/ui/BuildingGameHeader.tsx
+++ b/gamesformykids/app/games/building/components/ui/BuildingGameHeader.tsx
@@ -8,7 +8,7 @@ export default function BuildingGameHeader() {
 
   return (
     <div className="text-center mb-4 md:mb-6">
-      <h1 className="text-3xl md:text-5xl font-bold text-white mb-2 md:mb-4 drop-shadow-xl animate-pulse">
+      <h1 className="text-3xl md:text-5xl font-bold text-white mb-2 md:mb-4 drop-shadow-xl">
         🏗️ סטודיו הבנייה הקסום 🏗️
       </h1>
       <div className="flex flex-col sm:flex-row justify-center items-center gap-2 md:gap-6 mb-2 md:mb-4">


### PR DESCRIPTION
## Summary
`BuildingGameHeader.tsx` applied `animate-pulse` to the main `<h1>` heading during active gameplay. `animate-pulse` is a loading/skeleton pattern — using it on static content continuously pulls children's peripheral attention away from the play area.

## Changes
- `app/games/building/components/ui/BuildingGameHeader.tsx` — removed `animate-pulse` from the `<h1>` className

## Testing
- [x] `npx tsc --noEmit` passes

Closes #761

🤖 Generated with [Claude Code](https://claude.com/claude-code)