### PR TITLE
fix(rtl): QuizFeedback next-button arrow points right in RTL

### DIFF
--- a/gamesformykids/components/game/quiz/QuizFeedback.tsx
+++ b/gamesformykids/components/game/quiz/QuizFeedback.tsx
@@ -43,7 +43,7 @@ export function QuizFeedback({
         onClick={next}
         className={`w-full py-3 rounded-2xl ${t.button} text-white font-bold text-lg transition-all`}
       >
-        {isLast ? 'סיום' : 'הבא ←'}
+        {isLast ? 'סיום' : 'הבא →'}
       </button>
     </div>
   );


### PR DESCRIPTION
## Summary
The next-question button in QuizFeedback labeled the arrow with a left arrow. In an RTL document next flows rightward, so the arrow now points right.

## Changes
- `components/game/quiz/QuizFeedback.tsx` — changed arrow from left to right-pointing

## Testing
- [x] `npx tsc --noEmit` passes

Closes #763

Generated with Claude Code