### PR TITLE
fix(ux): Tetris start screen background — CSS value not Tailwind class

### DIFF
--- a/gamesformykids/lib/constants/ui/activitiesConfigData/creative.ts
+++ b/gamesformykids/lib/constants/ui/activitiesConfigData/creative.ts
@@ -68,7 +68,7 @@ export const creativeConfigs: Partial<Record<string, GameUIConfig>> = {
       { icon: "🏆", title: "5. ניקוד", description: "השג ניקוד גבוה!" },
     ],
     colors: {
-      background: "bg-gradient-to-br from-purple-600 via-blue-600 to-indigo-700",
+      background: "linear-gradient(135deg, #7c3aed 0%, #2563eb 50%, #4338ca 100%)",
       header: "text-yellow-300",
       subHeader: "text-white/90",
       itemsDescription: "text-blue-100",


### PR DESCRIPTION
## Summary
`GenericStartScreen` applies the background via `style={{ background: resolvedBackground }}`. The Tetris config had a Tailwind class string (`bg-gradient-to-br from-purple-600...`) as the background value — browsers ignore class strings as CSS values, rendering the start screen white. All other games already use valid CSS `linear-gradient(...)` strings.

## Changes
- `lib/constants/ui/activitiesConfigData/creative.ts` — replaced Tailwind class string with equivalent CSS `linear-gradient(135deg, #7c3aed 0%, #2563eb 50%, #4338ca 100%)`

## Testing
- [x] `npx tsc --noEmit` passes

Closes #752

🤖 Generated with [Claude Code](https://claude.com/claude-code)