### PR TITLE
fix(seo): /games/educational Hebrew metadata

### DIFF
--- a/gamesformykids/app/games/educational/page.tsx
+++ b/gamesformykids/app/games/educational/page.tsx
@@ -1,9 +1,19 @@
+import { type Metadata } from 'next';
 import Link from 'next/link';
-import { generateGameMetadata } from '@/lib/utils/game/gameMetadata';
 import { GAME_CATEGORIES } from '@/lib/constants/gameCategories';
 import { GamesRegistry } from '@/lib/registry/gamesRegistry';
 
-export const metadata = generateGameMetadata('educational');
+export const metadata: Metadata = {
+  title: 'משחקים חינוכיים | GamesForMyKids',
+  description: 'אוסף המשחקים החינוכיים שלנו לילדים — צבעים, מספרים, עברית ועוד',
+  openGraph: {
+    title: 'משחקים חינוכיים',
+    description: 'אוסף המשחקים החינוכיים שלנו לילדים — צבעים, מספרים, עברית ועוד',
+    type: 'website',
+    url: '/games/educational',
+  },
+  alternates: { canonical: '/games/educational' },
+};
 
 export default function EducationalPage() {
   const category = GAME_CATEGORIES.educational!;


### PR DESCRIPTION
## Summary
Replaced English fallback metadata on /games/educational with proper Hebrew title and description. generateGameMetadata hit the English fallback because 'educational' has no GAME_UI_CONFIGS entry.

## Changes
- app/games/educational/page.tsx -- removed generateGameMetadata import; added inline Hebrew metadata

## Testing
- [x] npx tsc --noEmit passes

Closes #750

Generated with Claude Code