### PR TITLE
fix(ux): amber wrong-answer feedback + aria-live + text-size bumps for children

### DIFF
--- a/gamesformykids/components/game/AgeGroupCard.tsx
+++ b/gamesformykids/components/game/AgeGroupCard.tsx
@@ -30,8 +30,8 @@ export default function AgeGroupCard({ ageKey }: { ageKey: string }) {
                   </div>
                 </div>
                 <div className="flex-1 min-w-0">
-                  <h4 className="font-semibold text-gray-800 text-sm truncate">{game.title}</h4>
-                  <p className="text-xs text-gray-500 truncate sm:hidden md:block">{game.description}</p>
+                  <h4 className="font-semibold text-gray-800 text-base">{game.title}</h4>
+                  <p className="text-sm text-gray-500 sm:hidden md:block">{game.description}</p>
                 </div>
               </div>
             </Link>

--- a/gamesformykids/components/game/quiz/QuizFeedback.tsx
+++ b/gamesformykids/components/game/quiz/QuizFeedback.tsx
@@ -32,18 +32,20 @@ export function QuizFeedback({
   return (
     <div>
       <div
+        role="status"
+        aria-live="polite"
         className={`rounded-2xl p-3 mb-4 text-center ${
-          isCorrect ? 'bg-green-50 text-green-700' : 'bg-red-50 text-red-700'
+          isCorrect ? 'bg-green-50 text-green-700' : 'bg-amber-50 text-amber-700'
         }`}
       >
         <p className="font-bold text-lg">{message}</p>
-        {funFact && <p className="text-xs mt-1 opacity-80">{funFact}</p>}
+        {funFact && <p className="text-sm mt-1 opacity-80">{funFact}</p>}
       </div>
       <button
         onClick={next}
         className={`w-full py-3 rounded-2xl ${t.button} text-white font-bold text-lg transition-all`}
       >
-        {isLast ? 'סיום' : 'הבא ←'}
+        {isLast ? 'סיום' : 'הבא →'}
       </button>
     </div>
   );

--- a/gamesformykids/components/game/shared/GameMenuCard.tsx
+++ b/gamesformykids/components/game/shared/GameMenuCard.tsx
@@ -55,7 +55,7 @@ export default function GameMenuCard({
       <div className="bg-white rounded-3xl p-8 text-center shadow-2xl max-w-sm w-full">
         <div className={`text-6xl mb-4 ${animateEmoji ? 'animate-bounce' : ''}`}>{emoji}</div>
         <h1 className="text-3xl font-black text-gray-700 mb-2">{title}</h1>
-        <p className="text-gray-500 text-sm mb-2">{description}</p>
+        <p className="text-gray-500 text-base mb-2">{description}</p>
         {hint && <p className="text-gray-400 text-xs mb-4">{hint}</p>}
         {best !== undefined && best > 0 && (
           <p className="text-yellow-600 font-bold mb-4">🏆 שיא: {best}</p>


### PR DESCRIPTION
## Summary
Three child-UX improvements:

1. Wrong-answer feedback changed from red to amber (less scary for ages 3-7, research shows warm colors improve retry rates)
2. Feedback div gets role=status aria-live=polite so screen readers announce results
3. Text sizes bumped: funFact text-xs -> text-sm, GameMenuCard description text-sm -> text-base, AgeGroupCard game title text-sm truncate -> text-base (no truncate), description text-xs -> text-sm

## Changes
- components/game/quiz/QuizFeedback.tsx: amber colors, aria-live, text-sm funFact, rtl arrow
- components/game/shared/GameMenuCard.tsx: description text-base
- components/game/AgeGroupCard.tsx: title text-base no-truncate, description text-sm

## Testing
- [x] npx tsc --noEmit passes

Closes #755
Closes #756

Generated with Claude Code