### PR TITLE
fix(rtl): remove tracking-wide from Hebrew text elements

### DIFF
--- a/gamesformykids/app/games/chess/components/ChessTitleCard.tsx
+++ b/gamesformykids/app/games/chess/components/ChessTitleCard.tsx
@@ -28,7 +28,7 @@ export default function ChessTitleCard() {
           ♟
         </div>
         <h1
-          className="text-5xl font-extrabold mb-2 tracking-wide"
+          className="text-5xl font-extrabold mb-2"
           style={{
             background: 'linear-gradient(180deg, #fde68a 0%, #f59e0b 50%, #d97706 100%)',
             WebkitBackgroundClip: 'text',

--- a/gamesformykids/app/games/math-race/components/MathRaceQuestion.tsx
+++ b/gamesformykids/app/games/math-race/components/MathRaceQuestion.tsx
@@ -20,7 +20,7 @@ export default function MathRaceQuestion({ q, feedback, streak, onTap }: Props) 
         feedback === 'correct' ? 'bg-green-50 ring-4 ring-green-400 scale-105' :
         feedback === 'wrong' ? 'bg-red-50 ring-4 ring-red-400' : ''
       }`}>
-        <p className="text-4xl font-black text-gray-700 tracking-wide">{q.text}</p>
+        <p className="text-4xl font-black text-gray-700">{q.text}</p>
         {feedback && (
           <p className={`text-2xl mt-3 font-bold ${feedback === 'correct' ? 'text-green-500' : 'text-red-500'}`}>
             {feedback === 'correct' ? `✅ ${streak >= 3 ? 'בום! +20' : 'נכון! +10'}` : `❌ התשובה: ${q.answer}`}

--- a/gamesformykids/app/games/memory/components/MemoryCard.tsx
+++ b/gamesformykids/app/games/memory/components/MemoryCard.tsx
@@ -47,7 +47,7 @@ export default function MemoryCard({ card, onClick }: MemoryCardProps) {
         ) : (
           <div className="text-center text-white">
             <span className="text-4xl md:text-5xl animate-pulse filter drop-shadow-lg">❓</span>
-            <div className="text-sm mt-2 opacity-90 font-bold tracking-wide">לחץ</div>
+            <div className="text-sm mt-2 opacity-90 font-bold">לחץ</div>
           </div>
         )}
       </div>

--- a/gamesformykids/app/games/shesh-besh/components/GameOverScreen.tsx
+++ b/gamesformykids/app/games/shesh-besh/components/GameOverScreen.tsx
@@ -12,7 +12,7 @@ export function GameOverScreen() {
     <div className="flex flex-col items-center gap-6 text-center mt-12">
       <div className="text-8xl drop-shadow-2xl">{won ? '🎉' : '😢'}</div>
       <div className={[
-        'text-5xl font-extrabold tracking-wide bg-clip-text text-transparent',
+        'text-5xl font-extrabold bg-clip-text text-transparent',
         won
           ? 'bg-gradient-to-b from-yellow-200 to-amber-400'
           : 'bg-gradient-to-b from-slate-300 to-slate-500',

--- a/gamesformykids/app/games/shesh-besh/components/MenuScreen.tsx
+++ b/gamesformykids/app/games/shesh-besh/components/MenuScreen.tsx
@@ -9,7 +9,7 @@ export function MenuScreen() {
       {/* Title */}
       <div className="flex flex-col items-center gap-2">
         <div className="text-6xl drop-shadow-2xl">🎲</div>
-        <h1 className="text-6xl font-extrabold tracking-wide bg-gradient-to-b from-yellow-200 via-amber-300 to-amber-500 bg-clip-text text-transparent drop-shadow-lg">
+        <h1 className="text-6xl font-extrabold bg-gradient-to-b from-yellow-200 via-amber-300 to-amber-500 bg-clip-text text-transparent drop-shadow-lg">
           שש-בש
         </h1>
         <p className="text-amber-200/70 text-sm">


### PR DESCRIPTION
## Summary
Removed tracking-wide from 5 Hebrew text elements. Positive letter-spacing is a Latin typographic convention; Hebrew uses ligatures and vowel marks that are disrupted by tracking-wide, resulting in visually wrong spacing for young readers.

## Changes
- app/games/shesh-besh/components/MenuScreen.tsx: h1 title
- app/games/shesh-besh/components/GameOverScreen.tsx: game-over heading
- app/games/math-race/components/MathRaceQuestion.tsx: question text
- app/games/memory/components/MemoryCard.tsx: card label
- app/games/chess/components/ChessTitleCard.tsx: h1 title

## Testing
- [x] npx tsc --noEmit passes

Closes #757

Generated with Claude Code