### PR TITLE
fix: move theme-color to siteViewport themeColor (Viewport API)

### DIFF
--- a/gamesformykids/components/layout/HeadLinks.tsx
+++ b/gamesformykids/components/layout/HeadLinks.tsx
@@ -12,7 +12,6 @@ export default function HeadLinks() {
       <meta name="build-timestamp" content={BUILD_INFO.timestamp.toString()} />
 
       <link rel="manifest" href="/manifest.json" />
-      <meta name="theme-color" content="#8b5cf6" />
       <meta name="mobile-web-app-capable" content="yes" />
       <meta name="apple-mobile-web-app-capable" content="yes" />
       <meta name="apple-mobile-web-app-status-bar-style" content="default" />

--- a/gamesformykids/lib/constants/siteMetadata.ts
+++ b/gamesformykids/lib/constants/siteMetadata.ts
@@ -44,6 +44,7 @@ export const siteViewport: Viewport = {
   initialScale: 1,
   maximumScale: 1,
   userScalable: false,
+  themeColor: '#8b5cf6',
 };
 
 export const structuredData = {


### PR DESCRIPTION
## Summary
Moved theme-color declaration from a raw JSX meta tag in HeadLinks.tsx to the siteViewport Viewport export. Raw meta tags bypass Next.js Viewport API deduplication, risking duplicate tags in future.

## Changes
- lib/constants/siteMetadata.ts: added themeColor: '#8b5cf6' to siteViewport
- components/layout/HeadLinks.tsx: removed raw meta name=theme-color

## Testing
- [x] npx tsc --noEmit passes

Closes #776

Generated with Claude Code