### PR TITLE
chore: remove duplicate animate-shake from tzedakah/charity.module.css

### DIFF
--- a/gamesformykids/app/games/tzedakah/charity.module.css
+++ b/gamesformykids/app/games/tzedakah/charity.module.css
@@ -29,18 +29,6 @@
   }
 }
 
-@keyframes shake {
-  0%, 100% {
-    transform: translateX(0);
-  }
-  25% {
-    transform: translateX(-2px);
-  }
-  75% {
-    transform: translateX(2px);
-  }
-}
-
 .animate-twinkle {
   animation: twinkle 2s ease-in-out infinite;
 }
@@ -51,10 +39,6 @@
 
 .animate-glow {
   animation: glow 2s ease-in-out infinite;
-}
-
-.animate-shake {
-  animation: shake 0.5s ease-in-out;
 }
 
 /* אפקט הקבעה של הסל */


### PR DESCRIPTION
## Summary
Removed duplicate @keyframes shake and .animate-shake from charity.module.css. These are already defined globally in globals.css. The tzedakah components use the global class directly (not via CSS Modules styles[]), so removing the module definition has no effect on behavior.

## Changes
- app/games/tzedakah/charity.module.css: removed duplicate @keyframes shake and .animate-shake

## Testing
- [x] npx tsc --noEmit passes

Closes #787

Generated with Claude Code