### PR TITLE
fix(a11y,ux): Simon shape labels, memory static ring, WordBuilder amber

### DIFF
--- a/gamesformykids/app/games/memory/components/MemoryCard.tsx
+++ b/gamesformykids/app/games/memory/components/MemoryCard.tsx
@@ -20,7 +20,7 @@ export default function MemoryCard({ card, onClick }: MemoryCardProps) {
         ${card.isFlipped || card.isMatched
           ? "bg-gradient-to-br from-white to-gray-50 border-8 border-white"
           : "bg-gradient-to-br from-purple-400 via-pink-400 to-indigo-400 hover:from-purple-500 hover:via-pink-500 hover:to-indigo-500 border-8 border-white"}
-        ${card.isMatched ? "ring-4 ring-green-400 ring-offset-4 animate-glow" : ""}
+        ${card.isMatched ? "ring-4 ring-green-400 ring-offset-4 scale-105" : ""}
         ${card.isFlipped && !card.isMatched ? "animate-bounce-gentle" : ""}
       `}
     >
@@ -29,10 +29,6 @@ export default function MemoryCard({ card, onClick }: MemoryCardProps) {
         <div className="absolute inset-4 bg-gradient-to-br from-blue-100 to-purple-100 rounded-2xl opacity-50"></div>
       )}
 
-      {/* Glow effect when card is matched */}
-      {card.isMatched && (
-        <div className="absolute inset-0 animate-ping bg-gradient-to-r from-yellow-400 to-orange-400 opacity-30 rounded-2xl"></div>
-      )}
       
       {/* Card content */}
       <div className="w-full h-full flex items-center justify-center relative z-10">

--- a/gamesformykids/app/games/simon/components/SimonBoard.tsx
+++ b/gamesformykids/app/games/simon/components/SimonBoard.tsx
@@ -27,10 +27,13 @@ export default function SimonBoard({ onTap }: Props) {
             key={btn.id}
             onClick={() => onTap(btn.id)}
             disabled={phase === 'showing'}
-            className={`w-32 h-32 rounded-3xl shadow-2xl transition-all duration-100 ${
+            aria-label={btn.id}
+            className={`w-32 h-32 rounded-3xl shadow-2xl transition-all duration-100 flex items-center justify-center text-white/70 text-4xl font-black ${
               activeColor === btn.id ? btn.active + ' scale-90' : btn.bg
             } ${phase === 'input' ? 'hover:brightness-110 active:scale-90 cursor-pointer' : 'cursor-default opacity-60'}`}
-          />
+          >
+            {btn.label}
+          </button>
         ))}
       </div>
     </div>

--- a/gamesformykids/app/games/simon/simonStore.ts
+++ b/gamesformykids/app/games/simon/simonStore.ts
@@ -2,10 +2,10 @@ import { makePersistStore } from '@/lib/stores/createStore';
 import type { PhaseSimon as Phase } from '@/lib/types';
 
 export const BUTTONS = [
-  { id: 'red',    bg: 'bg-red-500',    active: 'bg-red-200',    label: '' },
-  { id: 'blue',   bg: 'bg-blue-500',   active: 'bg-blue-200',   label: '' },
-  { id: 'green',  bg: 'bg-green-500',  active: 'bg-green-200',  label: '' },
-  { id: 'yellow', bg: 'bg-yellow-400', active: 'bg-yellow-100', label: '' },
+  { id: 'red',    bg: 'bg-red-500',    active: 'bg-red-200',    label: '▲' },
+  { id: 'blue',   bg: 'bg-blue-500',   active: 'bg-blue-200',   label: '●' },
+  { id: 'green',  bg: 'bg-green-500',  active: 'bg-green-200',  label: '■' },
+  { id: 'yellow', bg: 'bg-yellow-400', active: 'bg-yellow-100', label: '◆' },
 ] as const;
 
 export type ButtonId = typeof BUTTONS[number]['id'];

--- a/gamesformykids/app/games/word-builder/components/WordBuilderQuestion.tsx
+++ b/gamesformykids/app/games/word-builder/components/WordBuilderQuestion.tsx
@@ -30,7 +30,7 @@ export default function WordBuilderQuestion() {
             <div key={i} className={`
               w-12 h-12 rounded-xl border-2 flex items-center justify-center text-2xl font-black
               ${status === 'correct' ? 'bg-green-500 border-green-600 text-white' :
-                status === 'wrong' ? 'bg-red-400 border-red-500 text-white' :
+                status === 'wrong' ? 'bg-amber-400 border-amber-500 text-white' :
                 typed[i] ? 'bg-amber-100 border-amber-400 text-amber-800' :
                 'bg-gray-100 border-dashed border-gray-300 text-transparent'}
             `}>
@@ -44,8 +44,8 @@ export default function WordBuilderQuestion() {
           </div>
         )}
         {status === 'wrong' && (
-          <div className="bg-red-100 text-red-700 rounded-2xl p-3 mb-4 text-center font-bold">
-            ❌ לא נכון! נסה שוב — המילה: {current.word}
+          <div className="bg-amber-50 text-amber-700 rounded-2xl p-3 mb-4 text-center font-bold">
+            💛 נסה שוב! המילה: {current.word}
           </div>
         )}
         {status === 'idle' && (


### PR DESCRIPTION
## Summary
Three child-UX improvements in a single PR:

1. Simon (#777): Added distinct geometric shape labels (triangle/circle/square/diamond) to the 4 game buttons. Color was the only differentiator, violating WCAG 1.4.1. ~8% of boys have red-green color deficiency.

2. MemoryCard (#785): Replaced infinite animate-glow + animate-ping on matched cards with static scale-105 + green ring. When all 8 pairs are found, all 16 cards glowing indefinitely creates a noisy end-state.

3. WordBuilderQuestion (#788): Wrong-answer feedback changed from red to amber with encouraging tone, consistent with #755 fix.

## Changes
- app/games/simon/simonStore.ts: added geometric shape labels
- app/games/simon/components/SimonBoard.tsx: render btn.label + aria-label
- app/games/memory/components/MemoryCard.tsx: static ring instead of infinite glow
- app/games/word-builder/components/WordBuilderQuestion.tsx: amber feedback + tone

## Testing
- [x] npx tsc --noEmit passes

Closes #777
Closes #785
Closes #788

Generated with Claude Code