### PR TITLE
fix(a11y,ux): aria-live on score/lives + remove red/pulse countdown timers

### DIFF
--- a/gamesformykids/app/games/color-tap/components/ColorTapPlayArea.tsx
+++ b/gamesformykids/app/games/color-tap/components/ColorTapPlayArea.tsx
@@ -30,7 +30,7 @@ export default function ColorTapPlayArea() {
           <LivesDisplay lives={lives} />
         </div>
         <div>
-          <p className={`text-2xl font-black ${timeLeft <= 2 ? 'text-red-500 animate-pulse' : 'text-purple-600'}`}>{timeLeft}</p>
+          <p className={`font-black transition-all ${timeLeft <= 2 ? 'text-orange-500 text-3xl scale-110' : 'text-purple-600 text-2xl'}`}>{timeLeft}</p>
           <p className="text-xs text-purple-400">שניות</p>
         </div>
       </div>

--- a/gamesformykids/app/games/emoji-math/components/EmojiMathPlayArea.tsx
+++ b/gamesformykids/app/games/emoji-math/components/EmojiMathPlayArea.tsx
@@ -36,7 +36,7 @@ export default function EmojiMathPlayArea() {
           <LivesDisplay lives={lives} size="text-xl" />
         </div>
         <div>
-          <p className={`text-2xl font-black ${timeLeft <= 2 ? 'text-red-500 animate-pulse' : 'text-orange-700'}`}>{timeLeft}</p>
+          <p className={`font-black transition-all ${timeLeft <= 2 ? 'text-orange-500 text-3xl scale-110' : 'text-orange-700 text-2xl'}`}>{timeLeft}</p>
           <p className="text-xs text-orange-400">שניות</p>
         </div>
         {streak >= 2 && (

--- a/gamesformykids/app/games/math-race/components/MathRaceProgressBar.tsx
+++ b/gamesformykids/app/games/math-race/components/MathRaceProgressBar.tsx
@@ -18,7 +18,7 @@ export default function MathRaceProgressBar({ timeLeft, score, streak, gameTime 
       <div className="bg-white rounded-full h-3 shadow-inner">
         <div
           className={`h-3 rounded-full transition-all duration-1000 ${
-            timeLeft > 10 ? 'bg-blue-500' : timeLeft > 5 ? 'bg-yellow-500' : 'bg-red-500 animate-pulse'
+            timeLeft > 10 ? 'bg-blue-500' : timeLeft > 5 ? 'bg-yellow-400' : 'bg-orange-400'
           }`}
           style={{ width: `${(timeLeft / gameTime) * 100}%` }}
         />

--- a/gamesformykids/app/games/true-false/components/TrueFalsePlayScreen.tsx
+++ b/gamesformykids/app/games/true-false/components/TrueFalsePlayScreen.tsx
@@ -20,7 +20,7 @@ export default function TrueFalsePlayScreen() {
           <LivesDisplay lives={lives} />
         </div>
         <div>
-          <p className={`text-2xl font-black ${timeLeft <= 2 ? 'text-red-500 animate-pulse' : 'text-cyan-600'}`}>{timeLeft}</p>
+          <p className={`font-black transition-all ${timeLeft <= 2 ? 'text-orange-500 text-3xl scale-110' : 'text-cyan-600 text-2xl'}`}>{timeLeft}</p>
           <p className="text-xs text-cyan-400">שניות</p>
         </div>
       </div>

--- a/gamesformykids/components/game/shared/LivesDisplay.tsx
+++ b/gamesformykids/components/game/shared/LivesDisplay.tsx
@@ -6,7 +6,7 @@ interface Props {
 
 export default function LivesDisplay({ lives, max = 3, size = 'text-2xl' }: Props) {
   return (
-    <div className="flex gap-1">
+    <div className="flex gap-1" role="status" aria-live="polite" aria-label={`${lives} חיים`}>
       {Array.from({ length: max }, (_, i) => (
         <span key={i} className={`${size} transition-all ${i < lives ? '' : 'opacity-20 grayscale'}`}>❤️</span>
       ))}

--- a/gamesformykids/components/game/shared/ScoreTimeLivesHUD.tsx
+++ b/gamesformykids/components/game/shared/ScoreTimeLivesHUD.tsx
@@ -12,7 +12,7 @@ export default function ScoreTimeLivesHUD({ score, lives, timeLeft, mb = 'mb-3' 
   return (
     <div className={`flex gap-5 ${mb} text-white text-center`}>
       <div>
-        <p className="text-2xl font-black text-yellow-300">{score}</p>
+        <p className="text-2xl font-black text-yellow-300" role="status" aria-live="polite" aria-label={`ניקוד: ${score}`}>{score}</p>
         <p className="text-xs text-yellow-500">ניקוד</p>
       </div>
       <div>


### PR DESCRIPTION
## Summary
Two child-accessibility and UX improvements:

1. aria-live (#779): LivesDisplay and ScoreTimeLivesHUD score now announce changes to screen readers via role=status + aria-live=polite.

2. Timer colors (#782): Replaced red + animate-pulse on countdown timers with orange + scale-110 in 4 game files. Pulsing red at critical game moments causes panic/freeze in young children; size and weight change communicates urgency without alarm.

## Changes
- components/game/shared/LivesDisplay.tsx: added role=status aria-live=polite
- components/game/shared/ScoreTimeLivesHUD.tsx: score has aria-live
- app/games/true-false, color-tap, emoji-math timer: red/pulse -> orange/scale
- app/games/math-race/MathRaceProgressBar.tsx: bg-red/pulse -> bg-orange-400

## Testing
- [x] npx tsc --noEmit passes

Closes #779
Closes #782

Generated with Claude Code