### PR TITLE
fix(rtl): logical margin classes + remove redundant text-right in app/games/

### DIFF
--- a/gamesformykids/app/games/arithmetic/arithmeticConfig.tsx
+++ b/gamesformykids/app/games/arithmetic/arithmeticConfig.tsx
@@ -29,7 +29,7 @@ export const ARITHMETIC_CONFIG: TimedMathConfig<ArithmeticLevel, ArithmeticQuest
   ),
   levelColumns: 2,
   levelGap: 4,
-  levelButtonClass: 'p-5 rounded-2xl text-white font-bold text-lg shadow-lg hover:scale-105 active:scale-95 transition-all bg-gradient-to-br from-indigo-500 to-blue-600 text-right',
+  levelButtonClass: 'p-5 rounded-2xl text-white font-bold text-lg shadow-lg hover:scale-105 active:scale-95 transition-all bg-gradient-to-br from-indigo-500 to-blue-600 text-start',
 
   renderLevelLabel: (lv) => lv.label,
   renderEquation: (q) => `${q.a} ${q.op} ${q.b} = ?`,

--- a/gamesformykids/app/games/checkers/components/DamkaMenuScreen.tsx
+++ b/gamesformykids/app/games/checkers/components/DamkaMenuScreen.tsx
@@ -22,7 +22,7 @@ export default function DamkaMenuScreen() {
           <span>⚪ מחשב: {computerScore}</span>
         </div>
       )}
-      <div className="bg-amber-50 rounded-xl p-4 text-gray-600 text-sm text-right space-y-1">
+      <div className="bg-amber-50 rounded-xl p-4 text-gray-600 text-sm space-y-1">
         <p className="font-bold text-gray-700 mb-2">כללים:</p>
         <p>🔴 האסימונים שלך = אדום (מלמטה↑)</p>
         <p>⚪ המחשב = לבן (מלמעלה↓)</p>

--- a/gamesformykids/app/games/chess/components/ChessMoveHistory.tsx
+++ b/gamesformykids/app/games/chess/components/ChessMoveHistory.tsx
@@ -23,8 +23,8 @@ function MoveCell({ record, isLastRow }: { record: MoveRecord | undefined; isLas
         : isWhite ? 'text-slate-300' : 'text-slate-500'
     }`}>
       <span>{record.notation}</span>
-      {record.gaveCheck && <span className="text-red-400 mr-0.5 text-[9px] font-bold">+</span>}
-      {badge.label && <span className={`mr-0.5 ${badge.cls}`}>{badge.label}</span>}
+      {record.gaveCheck && <span className="text-red-400 me-0.5 text-[9px] font-bold">+</span>}
+      {badge.label && <span className={`me-0.5 ${badge.cls}`}>{badge.label}</span>}
     </td>
   );
 }
@@ -68,7 +68,7 @@ export default function ChessMoveHistory() {
 
       {/* Table */}
       <div className="max-h-44 overflow-y-auto">
-        <table className="w-full text-right border-collapse">
+        <table className="w-full border-collapse">
           <thead
             className="sticky top-0"
             style={{ background: 'rgba(8,8,16,0.95)' }}

--- a/gamesformykids/app/games/chess/components/ChessPieceLegend.tsx
+++ b/gamesformykids/app/games/chess/components/ChessPieceLegend.tsx
@@ -12,13 +12,13 @@ const PIECES = [
 export default function ChessPieceLegend() {
   return (
     <div className="bg-white/5 border border-white/10 rounded-2xl p-4 w-full">
-      <p className="font-bold text-white mb-2 text-sm text-right">כללי הכלים:</p>
-      <div className="grid grid-cols-2 gap-x-4 gap-y-1 text-xs text-slate-400 text-right">
+      <p className="font-bold text-white mb-2 text-sm">כללי הכלים:</p>
+      <div className="grid grid-cols-2 gap-x-4 gap-y-1 text-xs text-slate-400">
         {PIECES.map(({ sym, name, rule }) => (
           <p key={name}>{sym} {name} — {rule}</p>
         ))}
       </div>
-      <p className="mt-2 text-slate-500 text-xs text-right">🏰 רוקד: מלך זז 2 שלבים כשניתן</p>
+      <p className="mt-2 text-slate-500 text-xs">🏰 רוקד: מלך זז 2 שלבים כשניתן</p>
     </div>
   );
 }

--- a/gamesformykids/app/games/drawing/components/DrawingStatusBadge.tsx
+++ b/gamesformykids/app/games/drawing/components/DrawingStatusBadge.tsx
@@ -15,7 +15,7 @@ export default function DrawingStatusBadge() {
         }`}
       >
         {isErasing ? '🧹 מצב מחיקה' : '🖌️ מצב ציור'}
-        <span className="mr-2 font-bold">
+        <span className="me-2 font-bold">
           {isErasing ? ` ${eraserSize}px` : ` ${brushSize}px`}
         </span>
       </div>

--- a/gamesformykids/app/games/hebrew-letters/components/practice/HebrewLetterPractice.tsx
+++ b/gamesformykids/app/games/hebrew-letters/components/practice/HebrewLetterPractice.tsx
@@ -52,10 +52,10 @@ export default function HebrewLetterPractice({ letterData }: Props) {
                 onClick={() => goToStep(index)}
                 className={`px-4 py-2 rounded-full text-sm font-medium transition-all duration-200 hover:scale-105 cursor-pointer ${getStepTabStyle(index)}`}
               >
-                <span className="ml-1">{index + 1}</span>
+                <span className="ms-1">{index + 1}</span>
                 {step}
                 {getStepTabIcon(index) && (
-                  <span className="mr-1">{getStepTabIcon(index)}</span>
+                  <span className="me-1">{getStepTabIcon(index)}</span>
                 )}
               </button>
             ))}
@@ -65,7 +65,7 @@ export default function HebrewLetterPractice({ letterData }: Props) {
             onClick={toggleAudio}
             variant="outline"
             size="sm"
-            className={`ml-2 ${isAudioEnabled ? 'bg-green-100 border-green-400' : 'bg-red-100 border-red-400'}`}
+            className={`ms-2 ${isAudioEnabled ? 'bg-green-100 border-green-400' : 'bg-red-100 border-red-400'}`}
           >
             {isAudioEnabled ? <Volume2 className="w-4 h-4" /> : <VolumeX className="w-4 h-4" />}
           </Button>

--- a/gamesformykids/app/games/hebrew-letters/components/stats/LetterSpecificStats.tsx
+++ b/gamesformykids/app/games/hebrew-letters/components/stats/LetterSpecificStats.tsx
@@ -20,19 +20,19 @@ export function LetterSpecificStats({ letterName, letterStats, formatTime }: Let
       <div className="grid grid-cols-2 gap-4 text-sm">
         <div>
           <span className="text-gray-600">פעמים שהתחלתי:</span>
-          <span className="font-bold mr-2">{letterStats.timesStarted}</span>
+          <span className="font-bold me-2">{letterStats.timesStarted}</span>
         </div>
         <div>
           <span className="text-gray-600">פעמים שהשלמתי:</span>
-          <span className="font-bold mr-2">{letterStats.timesCompleted}</span>
+          <span className="font-bold me-2">{letterStats.timesCompleted}</span>
         </div>
         <div>
           <span className="text-gray-600">זמן כולל:</span>
-          <span className="font-bold mr-2">{formatTime(letterStats.totalTimeSpent)}</span>
+          <span className="font-bold me-2">{formatTime(letterStats.totalTimeSpent)}</span>
         </div>
         <div>
           <span className="text-gray-600">ממוצע לשלב:</span>
-          <span className="font-bold mr-2">{formatTime(letterStats.averageTimePerStep)}</span>
+          <span className="font-bold me-2">{formatTime(letterStats.averageTimePerStep)}</span>
         </div>
       </div>
     </div>

--- a/gamesformykids/app/games/memory/components/GameControls.tsx
+++ b/gamesformykids/app/games/memory/components/GameControls.tsx
@@ -15,8 +15,8 @@ export default function GameControls() {
           className="px-4 py-2 bg-white rounded-full shadow-lg text-lg font-bold text-gray-600 hover:bg-gray-50 transition-all duration-300"
         >
           {isGamePaused
-            ? <Play className="inline w-5 h-5 ml-2" />
-            : <Pause className="inline w-5 h-5 ml-2" />}
+            ? <Play className="inline w-5 h-5 ms-2" />
+            : <Pause className="inline w-5 h-5 ms-2" />}
           {isGamePaused ? 'המשך' : 'השהה'}
         </button>
 
@@ -24,7 +24,7 @@ export default function GameControls() {
           onClick={resetGame}
           className="px-4 py-2 bg-white rounded-full shadow-lg text-lg font-bold text-gray-600 hover:bg-gray-50 transition-all duration-300"
         >
-          <RotateCcw className="inline w-5 h-5 ml-2" /> מחדש
+          <RotateCcw className="inline w-5 h-5 ms-2" /> מחדש
         </button>
       </div>
 

--- a/gamesformykids/app/games/puzzles/custom/FileUploadButton.tsx
+++ b/gamesformykids/app/games/puzzles/custom/FileUploadButton.tsx
@@ -22,7 +22,7 @@ export default function FileUploadButton() {
         onClick={() => inputRef.current?.click()}
         className="inline-flex items-center justify-center rounded-xl font-bold transition-all duration-200 bg-gradient-to-r from-blue-500 to-purple-500 hover:from-blue-600 hover:to-purple-600 text-white px-8 py-4 text-lg shadow-lg hover:shadow-xl transform hover:scale-105"
       >
-        <Upload className="w-6 h-6 mr-3" />
+        <Upload className="w-6 h-6 me-3" />
         העלה תמונה מהמחשב
       </button>
       <p className="text-sm sm:text-base text-gray-600 mt-4 font-medium">

--- a/gamesformykids/app/games/shesh-besh/components/MenuScreen.tsx
+++ b/gamesformykids/app/games/shesh-besh/components/MenuScreen.tsx
@@ -47,7 +47,7 @@ export function MenuScreen() {
       </button>
 
       {/* Rules */}
-      <div className="bg-black/30 border border-amber-800/30 rounded-2xl p-4 text-sm text-right w-full space-y-1.5">
+      <div className="bg-black/30 border border-amber-800/30 rounded-2xl p-4 text-sm w-full space-y-1.5">
         <p className="font-bold text-amber-300 mb-2.5 text-center text-base">כיצד לשחק</p>
         {([
           ['🔴', 'אתה = אדום · זזים מ-24 ל-1'],

--- a/gamesformykids/app/games/soccer/components/SoccerCategoryGrid.tsx
+++ b/gamesformykids/app/games/soccer/components/SoccerCategoryGrid.tsx
@@ -15,7 +15,7 @@ export default function SoccerCategoryGrid() {
           onClick={() => startGame(cat)}
           className={`py-3 px-4 rounded-xl font-bold text-white shadow-lg active:scale-95 transition-all bg-gradient-to-br ${CATEGORY_COLORS[cat] ?? 'from-green-500 to-emerald-600'} ${cat === 'הכל' ? 'col-span-2 py-4 text-xl' : ''}`}
         >
-          <span className="mr-1">{CATEGORY_ICONS[cat] ?? '⚽'}</span> {cat}
+          <span className="me-1">{CATEGORY_ICONS[cat] ?? '⚽'}</span> {cat}
         </button>
       ))}
     </div>

--- a/gamesformykids/app/games/taki/components/TakiMenuScreen.tsx
+++ b/gamesformykids/app/games/taki/components/TakiMenuScreen.tsx
@@ -22,7 +22,7 @@ export default function TakiMenuScreen() {
           <span>🤖 מחשב: {computerScore}</span>
         </div>
       )}
-      <div className="bg-green-50 rounded-xl p-4 text-gray-600 text-sm text-right space-y-1">
+      <div className="bg-green-50 rounded-xl p-4 text-gray-600 text-sm space-y-1">
         <p className="font-bold text-gray-700 mb-2">כללים בקצרה:</p>
         <p>🃏 <strong>טאקי</strong> — שחק קלפים באותו צבע ולחץ &ldquo;סגור&rdquo;</p>
         <p>✋ <strong>עצור</strong> — המתנגד מדלג תור</p>


### PR DESCRIPTION
## Summary
Extends the RTL logical property fixes from #754 (components/) into app/games/:

#783: 11 physical mr-/ml- margin classes converted to me-/ms- logical equivalents across 7 files.

#784: Removed 8 redundant text-right occurrences that are already handled by the global RTL direction. For intentional start-alignment (button text), replaced with text-start.

## Files Changed
- chess/ChessMoveHistory.tsx, chess/ChessPieceLegend.tsx
- drawing/DrawingStatusBadge.tsx
- hebrew-letters/practice/HebrewLetterPractice.tsx, stats/LetterSpecificStats.tsx
- memory/GameControls.tsx
- puzzles/FileUploadButton.tsx
- soccer/SoccerCategoryGrid.tsx
- arithmetic/arithmeticConfig.tsx
- checkers/DamkaMenuScreen.tsx
- shesh-besh/MenuScreen.tsx, taki/TakiMenuScreen.tsx

## Testing
- [x] npx tsc --noEmit passes

Closes #783
Closes #784

Generated with Claude Code