### PR TITLE
fix(ux): remove full-screen red flash (NumberBubbles) + infinite twinkle (tzedakah)

### DIFF
--- a/gamesformykids/app/games/number-bubbles/NumberBubblesGame.tsx
+++ b/gamesformykids/app/games/number-bubbles/NumberBubblesGame.tsx
@@ -12,9 +12,11 @@ export default function NumberBubblesGame() {
   if (phase === 'results') return <NumberBubblesResultScreen />;
 
   return (
-    <div className={`min-h-screen flex flex-col items-center p-3 select-none transition-all ${wrong ? 'bg-red-100' : 'bg-gradient-to-br from-sky-100 to-blue-200'}`} dir="rtl">
+    <div className="min-h-screen flex flex-col items-center p-3 select-none bg-gradient-to-br from-sky-100 to-blue-200" dir="rtl">
       <NumberBubblesHUD />
-      <NumberBubbleGrid />
+      <div className={`w-full flex-1 ${wrong ? 'ring-4 ring-amber-400 ring-inset rounded-3xl' : ''}`}>
+        <NumberBubbleGrid />
+      </div>
     </div>
   );
 }

--- a/gamesformykids/app/games/tzedakah/components/GameAreaBackground.tsx
+++ b/gamesformykids/app/games/tzedakah/components/GameAreaBackground.tsx
@@ -39,7 +39,7 @@ export default function GameAreaBackground() {
       {[...Array(6)].map((_, i) => (
         <div
           key={i}
-          className="absolute text-yellow-300 opacity-70 animate-twinkle"
+          className="absolute text-yellow-300 opacity-70"
           style={{ left: `${15 + i * 15}%`, top: `${10 + (i % 2) * 20}%`, animationDelay: `${i * 0.5}s`, fontSize: isMobile ? '8px' : '12px' }}
         >
           ✨


### PR DESCRIPTION
## Summary
Two UX improvements:

#778: NumberBubblesGame removed the full-screen bg-red-100 background flash on wrong answers. Wrong feedback now shows as a localized amber ring border on the grid container.

#786: tzedakah GameAreaBackground stars had infinite animate-twinkle during active gameplay, competing with the foreground coin/basket mechanic. Stars are now static.

## Changes
- app/games/number-bubbles/NumberBubblesGame.tsx
- app/games/tzedakah/components/GameAreaBackground.tsx

## Testing
- [x] npx tsc --noEmit passes

Closes #778
Closes #786

Generated with Claude Code