### PR TITLE
fix(store): tetrisStore goToStartScreen clears stale gameOver flag

### DIFF
--- a/gamesformykids/app/games/tetris/store/tetrisStore.ts
+++ b/gamesformykids/app/games/tetris/store/tetrisStore.ts
@@ -158,7 +158,7 @@ export const useTetrisStore = makeStore<TetrisGameState & TetrisActions>('Tetris
     }
   },
 
-  goToStartScreen: () => set({ showStartScreen: true, isGameRunning: false }),
+  goToStartScreen: () => set({ showStartScreen: true, isGameRunning: false, gameOver: false }),
 
   getBoardWithCurrentPiece: () => {
     const { board, currentPiece, position } = get();


### PR DESCRIPTION
## Summary

`goToStartScreen` previously only set `showStartScreen: true, isGameRunning: false`, leaving `gameOver: true` after a game-over. Any component reading `gameOver` on the menu screen would see stale `true`. Added `gameOver: false` to the reset so the state is consistent on menu entry.

## Changes
- `app/games/tetris/store/tetrisStore.ts` — added `gameOver: false` to `goToStartScreen`

## Testing
- [ ] `npx tsc --noEmit` passes
- [ ] Play Tetris to game-over, click back to start screen — confirm menu renders cleanly

Closes #824

🤖 Generated with [Claude Code](https://claude.com/claude-code)