### PR TITLE
refactor(store): remove duplicate totalQuestions from gameProgressStore

### DIFF
--- a/gamesformykids/__tests__/stores/gameProgressStore.test.ts
+++ b/gamesformykids/__tests__/stores/gameProgressStore.test.ts
@@ -49,7 +49,6 @@ describe('gameProgressStore', () => {
       const s = useGameProgressStore.getState();
       expect(s.correctAnswers).toBe(1);
       expect(s.attempts).toBe(1);
-      expect(s.totalQuestions).toBe(1);
       expect(s.streakCount).toBe(1);
       expect(s.score).toBe(10);
     });

--- a/gamesformykids/components/game/universal/auto-game/AutoGamePage.tsx
+++ b/gamesformykids/components/game/universal/auto-game/AutoGamePage.tsx
@@ -25,12 +25,12 @@ import { AutoGameBody } from "./AutoGameBody";
  */
 export function AutoGamePage() {
   const { gameState, isPlaying, config } = useAutoGame();
-  const totalQuestions = useGameProgressStore((s) => s.totalQuestions);
+  const attempts       = useGameProgressStore((s) => s.attempts);
   const correctAnswers = useGameProgressStore((s) => s.correctAnswers);
   const streakCount    = useGameProgressStore((s) => s.streakCount);
   const timeSpent      = useGameProgressStore((s) => s.timeSpent);
 
-  const accuracy     = totalQuestions > 0 ? Math.round((correctAnswers / totalQuestions) * 100) : 0;
+  const accuracy     = attempts > 0 ? Math.round((correctAnswers / attempts) * 100) : 0;
   const averageTime  = correctAnswers > 0 ? Math.round(timeSpent / correctAnswers) : 0;
 
   // 🖥️ אם לא במשחק או gameState לא קיים, הראה StartScreen
@@ -50,7 +50,7 @@ export function AutoGamePage() {
         {/* מודל סטטיסטיקות */}
         <ProgressDisplay
           stats={{
-            totalItems: totalQuestions,
+            totalItems: attempts,
             completedItems: correctAnswers,
             averageTime,
             accuracy,

--- a/gamesformykids/lib/stores/gameProgressStore.ts
+++ b/gamesformykids/lib/stores/gameProgressStore.ts
@@ -17,7 +17,6 @@ export interface GameProgressState {
   level: number;
   attempts: number;
   correctAnswers: number;
-  totalQuestions: number;
   timeSpent: number;
   startTime: number;
   streakCount: number;
@@ -43,7 +42,6 @@ const INITIAL_STATE: GameProgressState = {
   level: 1,
   attempts: 0,
   correctAnswers: 0,
-  totalQuestions: 0,
   timeSpent: 0,
   startTime: 0,
   streakCount: 0,
@@ -72,7 +70,6 @@ export const useGameProgressStore = makeStore<GameProgressState & GameProgressAc
             return {
               attempts: s.attempts + 1,
               correctAnswers: s.correctAnswers + (isCorrect ? 1 : 0),
-              totalQuestions: s.totalQuestions + 1,
               streakCount: newStreakCount,
               bestStreak: Math.max(newStreakCount, s.bestStreak),
               score: isCorrect ? s.score + pointsPerCorrect : s.score,


### PR DESCRIPTION
## Summary

`totalQuestions` and `attempts` in `gameProgressStore` were always identical: both incremented by +1 on every `recordAttempt` call and never modified independently. Removed `totalQuestions` from the state interface and `INITIAL_STATE`, and replaced its single external consumer (`AutoGamePage`) with `attempts`.

## Changes
- `lib/stores/gameProgressStore.ts` — removed `totalQuestions` from `GameProgressState` interface, `INITIAL_STATE`, and `recordAttempt`
- `components/game/universal/auto-game/AutoGamePage.tsx` — replaced `s.totalQuestions` selector with `s.attempts`
- `__tests__/stores/gameProgressStore.test.ts` — removed stale `expect(s.totalQuestions).toBe(1)` assertion

## Testing
- [ ] `npx tsc --noEmit` passes
- [ ] `AutoGamePage` accuracy stat still displays correctly

Closes #822

🤖 Generated with [Claude Code](https://claude.com/claude-code)