### PR TITLE
refactor(store): derive level from poppedCount in bubblesStore

### DIFF
--- a/gamesformykids/app/games/bubbles/bubblesStore.ts
+++ b/gamesformykids/app/games/bubbles/bubblesStore.ts
@@ -13,7 +13,6 @@ export interface BubbleData {
 interface BubblesState {
   isPlaying: boolean;
   score: number;
-  level: number;
   poppedCount: number;
   bubbles: BubbleData[];
 }
@@ -31,23 +30,20 @@ export const useBubblesStore = makeStore<BubblesState & BubblesActions>(
   (set, get) => ({
     isPlaying: false,
     score: 0,
-    level: 1,
     poppedCount: 0,
     bubbles: [],
-    startGame: () => set({ isPlaying: true, score: 0, level: 1, poppedCount: 0, bubbles: [] }, false, 'bubbles/startGame'),
+    startGame: () => set({ isPlaying: true, score: 0, poppedCount: 0, bubbles: [] }, false, 'bubbles/startGame'),
     stopGame: () => set({ isPlaying: false }, false, 'bubbles/stopGame'),
-    resetGame: () => set({ isPlaying: false, score: 0, level: 1, poppedCount: 0, bubbles: [] }, false, 'bubbles/resetGame'),
+    resetGame: () => set({ isPlaying: false, score: 0, poppedCount: 0, bubbles: [] }, false, 'bubbles/resetGame'),
     addBubble: (bubble) => set({ bubbles: [...get().bubbles, bubble] }, false, 'bubbles/addBubble'),
     popBubble: (bubbleId, scored) => {
-      const { bubbles, score, poppedCount, level } = get();
+      const { bubbles, score, poppedCount } = get();
       const newPoppedCount = scored ? poppedCount + 1 : poppedCount;
-      const newLevel = newPoppedCount > 0 && newPoppedCount % 15 === 0 ? level + 1 : level;
       set(
         {
           bubbles: bubbles.filter((b) => b.id !== bubbleId),
           score: scored ? score + 10 : score,
           poppedCount: newPoppedCount,
-          level: newLevel,
         },
         false,
         'bubbles/popBubble',

--- a/gamesformykids/app/games/bubbles/hooks/useBubbleGame.ts
+++ b/gamesformykids/app/games/bubbles/hooks/useBubbleGame.ts
@@ -8,9 +8,10 @@ export function useBubbleGame() {
   const nextBubbleId = useRef(0);
   const gameContainerRef = useRef<HTMLDivElement>(null);
 
-  const { isPlaying, level, score, poppedCount, bubbles } = useBubblesStore(
-    useShallow((s) => ({ isPlaying: s.isPlaying, level: s.level, score: s.score, poppedCount: s.poppedCount, bubbles: s.bubbles })),
+  const { isPlaying, score, poppedCount, bubbles } = useBubblesStore(
+    useShallow((s) => ({ isPlaying: s.isPlaying, score: s.score, poppedCount: s.poppedCount, bubbles: s.bubbles })),
   );
+  const level = Math.floor(poppedCount / 15) + 1;
 
   const bubbleTypes = useMemo(() => [
     { color: '#FF6B6B', frequency: 261.63 },
@@ -25,7 +26,7 @@ export function useBubbleGame() {
 
   const createBubble = useCallback(() => {
     if (!gameContainerRef.current) return;
-    const currentLevel = useBubblesStore.getState().level;
+    const currentLevel = Math.floor(useBubblesStore.getState().poppedCount / 15) + 1;
     const containerWidth = gameContainerRef.current.offsetWidth;
     const bubbleType = bubbleTypes[Math.floor(Math.random() * bubbleTypes.length)]!;
     const size = 40 + Math.random() * 60;


### PR DESCRIPTION
## Summary

`level` in `bubblesStore` was always `Math.floor(poppedCount / 15) + 1` — both fields updated together in every `popBubble` call. Removed `level` from state entirely and compute it from `poppedCount` in the `useBubbleGame` hook, eliminating the possibility of future desync.

## Changes
- `app/games/bubbles/bubblesStore.ts` — removed `level` from `BubblesState`, `INITIAL_STATE`, `startGame`, `resetGame`, and `popBubble`
- `app/games/bubbles/hooks/useBubbleGame.ts` — compute `level = Math.floor(poppedCount / 15) + 1` from `poppedCount`

## Testing
- [ ] `npx tsc --noEmit` passes
- [ ] Bubbles game levels up correctly every 15 pops

Closes #833

🤖 Generated with [Claude Code](https://claude.com/claude-code)