### PR TITLE
refactor(store): derive gameStats.matches from matchedPairs.length in memory store

### DIFF
--- a/gamesformykids/app/games/memory/components/GameTimeoutScreen.tsx
+++ b/gamesformykids/app/games/memory/components/GameTimeoutScreen.tsx
@@ -3,7 +3,7 @@
 import { useMemoryStore } from "../stores/useMemoryStore";
 
 export default function GameTimeoutScreen() {
-  const { gameStats, difficulty, getDifficultyConfig, initializeGame, resetToMenu } = useMemoryStore();
+  const { gameStats, matchedPairs, difficulty, getDifficultyConfig, initializeGame, resetToMenu } = useMemoryStore();
   const difficultyConfig = getDifficultyConfig();
 
   return (
@@ -16,7 +16,7 @@ export default function GameTimeoutScreen() {
         </p>
         <div className="bg-purple-100 rounded-xl p-4 mb-8">
           <div className="text-3xl font-bold text-purple-700">{gameStats.score} נקודות</div>
-          <div className="text-gray-600 mt-1">זוגות שנמצאו: {gameStats.matches}</div>
+          <div className="text-gray-600 mt-1">זוגות שנמצאו: {matchedPairs.length}</div>
         </div>
         <div className="flex gap-4 justify-center flex-wrap">
           <button

--- a/gamesformykids/app/games/memory/stores/memoryMatchLogic.ts
+++ b/gamesformykids/app/games/memory/stores/memoryMatchLogic.ts
@@ -34,17 +34,17 @@ export function resolveCardMatch(
     matched[firstIdx]  = { ...matched[firstIdx]!,  isMatched: true };
     matched[secondIdx] = { ...matched[secondIdx]!, isMatched: true };
 
-    const newMatches = state.gameStats.matches + 1;
-    const newStreak  = state.gameStats.streak  + 1;
-    const newScore   = state.gameStats.score   + 100 * newStreak;
+    const newMatchedPairs = [...state.matchedPairs, firstCard.animal.name];
+    const newStreak  = state.gameStats.streak + 1;
+    const newScore   = state.gameStats.score  + 100 * newStreak;
 
     return {
       isMatch: true,
       cards: matched,
-      matchedPairs: [...state.matchedPairs, firstCard.animal.name],
+      matchedPairs: newMatchedPairs,
       flippedCards: [],
-      gameStats: { ...state.gameStats, matches: newMatches, streak: newStreak, score: newScore },
-      isWon: newMatches === totalPairs,
+      gameStats: { ...state.gameStats, streak: newStreak, score: newScore },
+      isWon: newMatchedPairs.length === totalPairs,
     };
   }
 

--- a/gamesformykids/app/games/memory/stores/memoryStoreTypes.ts
+++ b/gamesformykids/app/games/memory/stores/memoryStoreTypes.ts
@@ -7,7 +7,6 @@ import { DifficultyOption, PerformanceLevel, WinAchievement } from '../types/mem
 
 export const initialGameStats: GameStats = {
   moves: 0,
-  matches: 0,
   score: 0,
   timeElapsed: 0,
   perfectMatches: 0,

--- a/gamesformykids/app/games/memory/stores/useMemoryStore.ts
+++ b/gamesformykids/app/games/memory/stores/useMemoryStore.ts
@@ -50,9 +50,9 @@ export const useMemoryStore = makeStore<MemoryStoreState & MemoryStoreActions>(
     getAnimationDelay: (index) => getAnimationDelay(index),
 
     getGameProgress: () => {
-      const { gameStats, getDifficultyConfig } = get();
+      const { matchedPairs, getDifficultyConfig } = get();
       const totalPairs = getDifficultyConfig().pairs;
-      const completedPairs = gameStats.matches;
+      const completedPairs = matchedPairs.length;
       return {
         totalPairs,
         completedPairs,

--- a/gamesformykids/app/games/memory/types/memory.ts
+++ b/gamesformykids/app/games/memory/types/memory.ts
@@ -18,7 +18,6 @@ export interface MemoryCard {
 
 export interface GameStats {
   moves: number;
-  matches: number;
   score: number;
   timeElapsed: number;
   perfectMatches: number;


### PR DESCRIPTION
## Summary

`gameStats.matches` in the memory store was always equal to `matchedPairs.length` — both updated together in every successful match in `resolveCardMatch`. Removed the redundant field and replaced all reads with `matchedPairs.length` directly, including the win-condition check (`newMatchedPairs.length === totalPairs`).

## Changes
- `app/games/memory/types/memory.ts` — removed `matches` from `GameStats` interface
- `app/games/memory/stores/memoryStoreTypes.ts` — removed `matches: 0` from `initialGameStats`
- `app/games/memory/stores/memoryMatchLogic.ts` — replaced `gameStats.matches + 1` with `matchedPairs.length` for win detection
- `app/games/memory/stores/useMemoryStore.ts` — replaced `gameStats.matches` with `matchedPairs.length` in `getGameProgress`
- `app/games/memory/components/GameTimeoutScreen.tsx` — display `matchedPairs.length` instead of `gameStats.matches`

## Testing
- [ ] `npx tsc --noEmit` passes
- [ ] Memory game win condition fires correctly when all pairs are matched
- [ ] Timeout screen shows correct pair count

Closes #832

🤖 Generated with [Claude Code](https://claude.com/claude-code)