### PR TITLE
refactor(store): move raw setInterval/setTimeout out of mathRaceStore into component

### DIFF
--- a/gamesformykids/__tests__/stores/mathRaceStore.test.ts
+++ b/gamesformykids/__tests__/stores/mathRaceStore.test.ts
@@ -125,20 +125,21 @@ describe('mathRaceStore', () => {
   });
 
   describe('feedback transition', () => {
-    it('clears feedback after 500ms', () => {
+    it('tap sets feedback; nextQuestion clears it', () => {
       store.getState().startGame();
       store.getState().tap(store.getState().q.answer);
-      vi.advanceTimersByTime(500);
+      expect(store.getState().feedback).toBe('correct');
+      store.getState().nextQuestion();
       expect(store.getState().feedback).toBeNull();
     });
 
-    it('generates new question after feedback clears', () => {
+    it('nextQuestion generates a new question', () => {
       store.getState().startGame();
-      const firstQ = store.getState().q;
-      store.getState().tap(firstQ.answer);
-      vi.advanceTimersByTime(500);
-      // New question is generated — may or may not be the same, but feedback is gone
-      expect(store.getState().feedback).toBeNull();
+      store.setState({ score: 0 } as Parameters<typeof store.setState>[0]);
+      store.getState().tap(store.getState().q.answer);
+      store.getState().nextQuestion();
+      expect(store.getState().q).toBeDefined();
+      expect(store.getState().q.choices).toHaveLength(4);
     });
   });
 

--- a/gamesformykids/app/games/math-race/components/MathRacePlayScreen.tsx
+++ b/gamesformykids/app/games/math-race/components/MathRacePlayScreen.tsx
@@ -1,4 +1,5 @@
 'use client';
+import { useEffect } from 'react';
 import { useMathRaceGame, GAME_TIME } from '../useMathRaceGame';
 import MathRaceProgressBar from './MathRaceProgressBar';
 import MathRaceQuestion from './MathRaceQuestion';
@@ -6,7 +7,13 @@ import { useKeyboardControls } from '@/hooks/shared/game-controls/useKeyboardCon
 import { KeyboardHint } from '@/components/game/shared/KeyboardHint';
 
 export default function MathRacePlayScreen() {
-  const { q, score, timeLeft, feedback, streak, correct, total, tap, accuracy } = useMathRaceGame();
+  const { q, score, timeLeft, feedback, streak, correct, total, tap, nextQuestion, accuracy } = useMathRaceGame();
+
+  useEffect(() => {
+    if (!feedback) return;
+    const id = setTimeout(nextQuestion, 500);
+    return () => clearTimeout(id);
+  }, [feedback, nextQuestion]);
 
   useKeyboardControls(
     {

--- a/gamesformykids/app/games/math-race/mathRaceStore.ts
+++ b/gamesformykids/app/games/math-race/mathRaceStore.ts
@@ -1,4 +1,5 @@
 import { makePersistStore } from '@/lib/stores/createStore';
+import { setupGameTimer } from '@/lib/stores/gameTimerHelpers';
 import { useGameDifficulty } from '@/lib/stores/gameDifficultyStore';
 import type { ArithOp as Op, PhaseDead as Phase } from '@/lib/types';
 import { randInt as rnd } from '@/lib/utils';
@@ -51,8 +52,9 @@ interface MathRaceState {
 }
 
 interface MathRaceActions {
-  startGame: () => void;
-  tap:       (choice: number) => void;
+  startGame:    () => void;
+  tap:          (choice: number) => void;
+  nextQuestion: () => void;
 }
 
 const INITIAL: MathRaceState = {
@@ -64,35 +66,24 @@ export const useMathRaceStore = makePersistStore<MathRaceState & MathRaceActions
   'MathRaceStore',
   'math-race-best',
   (set, get) => {
-    let gameTimerId:  ReturnType<typeof setInterval> | null = null;
-    let feedbackId:   ReturnType<typeof setTimeout>  | null = null;
-
-    function clearTimers() {
-      if (gameTimerId) { clearInterval(gameTimerId); gameTimerId = null; }
-      if (feedbackId)  { clearTimeout(feedbackId);   feedbackId  = null; }
-    }
-
-    function startGameTimer() {
-      if (typeof window === 'undefined') return;
-      gameTimerId = setInterval(() => {
-        const { timeLeft, score, best } = get();
-        if (timeLeft <= 1) {
-          clearTimers();
-          set({ timeLeft: 0, phase: 'dead', best: Math.max(best, score) }, false, 'mathRace/gameOver');
-        } else {
-          set({ timeLeft: timeLeft - 1 }, false, 'mathRace/tick');
-        }
-      }, 1000);
-    }
+    const timer = setupGameTimer({
+      name: 'mathRace',
+      set,
+      get,
+      onEnd: () => {
+        const { score, best } = get();
+        set({ timeLeft: 0, phase: 'dead', best: Math.max(best, score) }, false, 'mathRace/gameOver');
+      },
+    });
 
     return {
       ...INITIAL,
 
       startGame: () => {
         const diff = useGameDifficulty.getState().difficulty;
-        clearTimers();
+        timer.stop();
         set({ ...INITIAL, phase: 'playing', best: get().best, q: makeQ(0), timeLeft: DIFFICULTY_TIME[diff] }, false, 'mathRace/startGame');
-        startGameTimer();
+        timer.start();
       },
 
       tap: (choice: number) => {
@@ -103,18 +94,14 @@ export const useMathRaceStore = makePersistStore<MathRaceState & MathRaceActions
         if (choice === q.answer) {
           const newStreak  = streak + 1;
           const pts        = newStreak >= 3 ? 20 : 10;
-          const newScore   = score + pts;
-          const newCorrect = correct + 1;
-          set({ score: newScore, streak: newStreak, total: newTotal, correct: newCorrect, feedback: 'correct' }, false, 'mathRace/correct');
-          feedbackId = setTimeout(() => {
-            set({ feedback: null, q: makeQ(get().score) }, false, 'mathRace/nextQ');
-          }, 500);
+          set({ score: score + pts, streak: newStreak, total: newTotal, correct: correct + 1, feedback: 'correct' }, false, 'mathRace/correct');
         } else {
           set({ streak: 0, total: newTotal, feedback: 'wrong' }, false, 'mathRace/wrong');
-          feedbackId = setTimeout(() => {
-            set({ feedback: null, q: makeQ(get().score) }, false, 'mathRace/nextQ');
-          }, 500);
         }
+      },
+
+      nextQuestion: () => {
+        set({ feedback: null, q: makeQ(get().score) }, false, 'mathRace/nextQ');
       },
     };
   },


### PR DESCRIPTION
## Summary

`mathRaceStore.ts` had module-level `gameTimerId` and `feedbackId` that bypassed the project's shared timer helpers. Module-level interval vars survive hot-reloads and StrictMode double-invocations.

## Changes

- `app/games/math-race/mathRaceStore.ts`
  - Replace the hand-rolled countdown interval with `setupGameTimer` from `lib/stores/gameTimerHelpers.ts` (same helper used by `reflexStore` and `whackAMoleStore`)
  - Add `nextQuestion()` action for clean state transition from the component
  - Remove all `setTimeout`/`setInterval` calls and the `clearTimers()` / `startGameTimer()` helpers

- `app/games/math-race/components/MathRacePlayScreen.tsx`
  - Add `useEffect` that watches `feedback !== null` and calls `nextQuestion()` after 500ms with proper cleanup

## Testing

- [x] `npx tsc --noEmit` passes

Closes #825

🤖 Generated with [Claude Code](https://claude.com/claude-code)