### PR TITLE
fix(ux): add solid color fallback to bg-clip-text gradient headings

### DIFF
--- a/gamesformykids/app/games/puzzles/custom/ImageUploadSection.tsx
+++ b/gamesformykids/app/games/puzzles/custom/ImageUploadSection.tsx
@@ -8,7 +8,7 @@ export default function ImageUploadSection() {
   return (
     <div className="text-center mb-8">
       <div className="rounded-2xl border border-gray-200 shadow-xl p-6 sm:p-8 max-w-5xl mx-auto backdrop-blur-sm bg-white/95">
-        <h3 className="text-3xl font-bold bg-gradient-to-r from-purple-600 to-blue-600 bg-clip-text text-transparent mb-8">🎨 בחר תמונה לפאזל</h3>
+        <h3 className="text-3xl font-bold text-purple-700 bg-gradient-to-r from-purple-600 to-blue-600 bg-clip-text text-transparent mb-8">🎨 בחר תמונה לפאזל</h3>
         <PreMadeImagesPicker />
         <DifficultySelector variant="select" />
         <FileUploadButton />

--- a/gamesformykids/app/games/puzzles/shared/PuzzleHeader.tsx
+++ b/gamesformykids/app/games/puzzles/shared/PuzzleHeader.tsx
@@ -9,7 +9,7 @@ export default function PuzzleHeader({ title, subtitle }: { title: string; subti
     <div className="text-center mb-6 sm:mb-8">
       <div className="flex flex-col sm:flex-row justify-between items-center gap-3 sm:gap-4 mb-6">
         <div className="order-first sm:order-none">
-          <h1 className="text-3xl sm:text-5xl font-bold bg-gradient-to-r from-purple-600 to-blue-600 bg-clip-text text-transparent mb-2">{title}</h1>
+          <h1 className="text-3xl sm:text-5xl font-bold text-purple-700 bg-gradient-to-r from-purple-600 to-blue-600 bg-clip-text text-transparent mb-2">{title}</h1>
           <p className="text-lg sm:text-xl text-gray-600 font-medium">{subtitle}</p>
         </div>
         <button

--- a/gamesformykids/app/games/puzzles/shared/ReferenceImage.tsx
+++ b/gamesformykids/app/games/puzzles/shared/ReferenceImage.tsx
@@ -8,7 +8,7 @@ export default function ReferenceImage() {
   if (!displayImage) return null;
   return (
     <div className="bg-white/90 backdrop-blur-sm rounded-2xl border border-gray-200 shadow-xl p-4 lg:p-6">
-      <h3 className="text-lg lg:text-xl font-bold bg-gradient-to-r from-purple-600 to-blue-600 bg-clip-text text-transparent mb-3 lg:mb-4 text-center">
+      <h3 className="text-lg lg:text-xl font-bold text-purple-700 bg-gradient-to-r from-purple-600 to-blue-600 bg-clip-text text-transparent mb-3 lg:mb-4 text-center">
         🖼️ תמונת עזר
       </h3>
       <div className="aspect-square relative rounded-xl overflow-hidden max-w-48 mx-auto lg:max-w-none shadow-lg">

--- a/gamesformykids/app/games/shesh-besh/components/MenuScreen.tsx
+++ b/gamesformykids/app/games/shesh-besh/components/MenuScreen.tsx
@@ -9,7 +9,7 @@ export function MenuScreen() {
       {/* Title */}
       <div className="flex flex-col items-center gap-2">
         <div className="text-6xl drop-shadow-2xl">🎲</div>
-        <h1 className="text-6xl font-extrabold bg-gradient-to-b from-yellow-200 via-amber-300 to-amber-500 bg-clip-text text-transparent drop-shadow-lg">
+        <h1 className="text-6xl font-extrabold text-amber-300 bg-gradient-to-b from-yellow-200 via-amber-300 to-amber-500 bg-clip-text text-transparent drop-shadow-lg">
           שש-בש
         </h1>
         <p className="text-amber-200/70 text-sm">

--- a/gamesformykids/app/games/tzedakah/components/CharityGameHeader.tsx
+++ b/gamesformykids/app/games/tzedakah/components/CharityGameHeader.tsx
@@ -9,7 +9,7 @@ export default function CharityGameHeader() {
     <>
       {/* כותרת מעוצבת */}
       <div className="text-center mb-6">
-        <h1 className={`font-black text-transparent bg-clip-text bg-gradient-to-r from-yellow-500 via-orange-500 to-red-500 mb-2 drop-shadow-lg ${
+        <h1 className={`font-black text-orange-500 text-transparent bg-clip-text bg-gradient-to-r from-yellow-500 via-orange-500 to-red-500 mb-2 drop-shadow-lg ${
           isMobile ? 'text-3xl' : 'text-5xl'
         }`}>
           🪙 משחק קופת הצדקה 🪙


### PR DESCRIPTION
## Summary

Five headings used `bg-clip-text text-transparent` without a solid color fallback. On older Android WebViews and certain browsers that don't support `background-clip: text`, the text renders as fully invisible. Adding a solid `text-*` color before the gradient classes ensures legibility as a fallback.

## Changes

- `app/games/puzzles/shared/PuzzleHeader.tsx` — `text-purple-700` fallback (purple-to-blue gradient)
- `app/games/puzzles/custom/ImageUploadSection.tsx` — `text-purple-700` fallback
- `app/games/puzzles/shared/ReferenceImage.tsx` — `text-purple-700` fallback
- `app/games/shesh-besh/components/MenuScreen.tsx` — `text-amber-300` fallback (yellow-amber gradient)
- `app/games/tzedakah/components/CharityGameHeader.tsx` — `text-orange-500` fallback (yellow-orange-red gradient)

## Testing

- [x] `npx tsc --noEmit` passes
- [ ] Gradient still renders in Chrome/Safari/Firefox
- [ ] Text is readable in browsers without background-clip: text support

Closes #762

🤖 Generated with [Claude Code](https://claude.com/claude-code)