### PR TITLE
refactor(store): consolidate tetrisStore phase machine (3 booleans → single phase field)

### DIFF
--- a/gamesformykids/app/games/tetris/components/TetrisGame.tsx
+++ b/gamesformykids/app/games/tetris/components/TetrisGame.tsx
@@ -15,16 +15,16 @@ function TetrisGame(){
   // רישום side-effects (game loop, מקלדת, טעינה)
   useTetrisGame();
 
-  const { isLoading, showStartScreen, startNewGame, getBoardWithCurrentPiece } = useTetrisState();
+  const { phase, startNewGame, getBoardWithCurrentPiece } = useTetrisState();
 
   // Computed directly — React Compiler is opted out via 'use no memo' above
   const displayBoard = getBoardWithCurrentPiece();
 
-  if (isLoading) {
+  if (phase === 'loading') {
     return <LoadingScreen />;
   }
 
-  if (showStartScreen) {
+  if (phase === 'menu') {
     return (
       <div className="min-h-screen bg-gradient-to-br from-purple-600 via-blue-600 to-indigo-700">
         <GenericStartScreen

--- a/gamesformykids/app/games/tetris/components/TouchControls.tsx
+++ b/gamesformykids/app/games/tetris/components/TouchControls.tsx
@@ -6,7 +6,9 @@ interface TouchControlsProps {
 }
 
 const TouchControls = ({ isDesktop = false }: TouchControlsProps) => {
-  const { isGameRunning, gameOver, score, startNewGame: onStartGame } = useTetrisState();
+  const { phase, score, startNewGame: onStartGame } = useTetrisState();
+  const isGameRunning = phase === 'playing';
+  const gameOver = phase === 'gameover';
   const { handleMove, handleRotate } = useTouchControls();
 
   // פריסה למחשב

--- a/gamesformykids/app/games/tetris/components/useTouchControls.ts
+++ b/gamesformykids/app/games/tetris/components/useTouchControls.ts
@@ -4,7 +4,7 @@ import { useCallback } from 'react';
 import { useTetrisStore } from '../store/tetrisStore';
 
 export function useTouchControls() {
-  const isGameRunning = useTetrisStore(s => s.isGameRunning);
+  const isGameRunning = useTetrisStore(s => s.phase === 'playing');
   const movePiece = useTetrisStore(s => s.movePiece);
   const handleRotateAction = useTetrisStore(s => s.handleRotate);
 

--- a/gamesformykids/app/games/tetris/hooks/useTetrisGame.ts
+++ b/gamesformykids/app/games/tetris/hooks/useTetrisGame.ts
@@ -11,8 +11,7 @@ import { useGameCompletion } from '@/hooks/shared/progress/useGameCompletion';
  */
 export const useTetrisGame = () => {
   const setLoaded = useTetrisStore(s => s.setLoaded);
-  const isGameRunning = useTetrisStore(s => s.isGameRunning);
-  const gameOver = useTetrisStore(s => s.gameOver);
+  const phase = useTetrisStore(s => s.phase);
   const level = useTetrisStore(s => s.level);
   const movePiece = useTetrisStore(s => s.movePiece);
 
@@ -27,38 +26,41 @@ export const useTetrisGame = () => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
+  const isPlaying = phase === 'playing';
+  const isGameOver = phase === 'gameover';
+
   // מעקב אחר זמן תחילת המשחק
   useEffect(() => {
-    if (isGameRunning) {
+    if (isPlaying) {
       startTimeRef.current = Date.now();
       prevGameOverRef.current = false;
     }
-  }, [isGameRunning]);
+  }, [isPlaying]);
 
   // שמירת ניקוד בסיום המשחק
   useEffect(() => {
-    if (gameOver && !prevGameOverRef.current) {
+    if (isGameOver && !prevGameOverRef.current) {
       const { score, level: finalLevel } = useTetrisStore.getState();
       const durationSeconds = Math.round((Date.now() - startTimeRef.current) / 1000);
       saveGameResultRef.current({ score, level: finalLevel, durationSeconds });
     }
-    prevGameOverRef.current = gameOver;
-  }, [gameOver, saveGameResultRef]);
+    prevGameOverRef.current = isGameOver;
+  }, [isGameOver, saveGameResultRef]);
 
   // לולאת נפילה — תלויה ברמה כדי לעדכן מהירות
   useEffect(() => {
-    if (!isGameRunning) return;
+    if (!isPlaying) return;
     const dropSpeed = Math.max(200, 1000 - (level - 1) * 100);
     const gameLoop = setInterval(() => {
       movePiece(0, 1);
     }, dropSpeed);
     return () => clearInterval(gameLoop);
-  }, [isGameRunning, level, movePiece]);
+  }, [isPlaying, level, movePiece]);
 
   // פקדי מקלדת — משתמש ב-getState() כדי להמנע מ-stale closures
   useEffect(() => {
     const handleKeyPress = (e: KeyboardEvent) => {
-      if (!useTetrisStore.getState().isGameRunning) return;
+      if (useTetrisStore.getState().phase !== 'playing') return;
 
       // מנע גלילת מסך במהלך המשחק
       if (['ArrowLeft', 'ArrowRight', 'ArrowDown', 'ArrowUp', ' '].includes(e.key)) {

--- a/gamesformykids/app/games/tetris/store/tetrisStore.ts
+++ b/gamesformykids/app/games/tetris/store/tetrisStore.ts
@@ -77,12 +77,9 @@ const INITIAL_STATE: TetrisGameState = {
   position: { x: 4, y: 0 },
   score: 0,
   level: 1,
-  isGameRunning: false,
-  gameOver: false,
+  phase: 'loading',
   nextPiece: null,
   linesCleared: 0,
-  showStartScreen: true,
-  isLoading: true,
 };
 
 // ── Store ──────────────────────────────────────────────────────────────────────
@@ -90,7 +87,7 @@ const INITIAL_STATE: TetrisGameState = {
 export const useTetrisStore = makeStore<TetrisGameState & TetrisActions>('TetrisStore', (set, get) => ({
   ...INITIAL_STATE,
 
-  setLoaded: () => set({ isLoading: false }),
+  setLoaded: () => set({ phase: 'menu' }),
 
   startNewGame: () => {
     set({
@@ -99,18 +96,15 @@ export const useTetrisStore = makeStore<TetrisGameState & TetrisActions>('Tetris
       position: { x: 4, y: 0 },
       score: 0,
       level: 1,
-      isGameRunning: true,
-      gameOver: false,
+      phase: 'playing',
       nextPiece: getRandomPiece(),
       linesCleared: 0,
-      showStartScreen: false,
-      isLoading: false,
     });
   },
 
   movePiece: (dx, dy) => {
-    const { currentPiece, gameOver, position, board, score, level, nextPiece, linesCleared } = get();
-    if (!currentPiece || gameOver) return;
+    const { currentPiece, phase, position, board, score, level, nextPiece, linesCleared } = get();
+    if (!currentPiece || phase !== 'playing') return;
 
     const newPos = { x: position.x + dx, y: position.y + dy };
 
@@ -139,8 +133,7 @@ export const useTetrisStore = makeStore<TetrisGameState & TetrisActions>('Tetris
       } else {
         set({
           board: clearedBoard,
-          gameOver: true,
-          isGameRunning: false,
+          phase: 'gameover',
           score: newScore,
           level: newLevel,
           linesCleared: linesCleared + newLines,
@@ -150,15 +143,15 @@ export const useTetrisStore = makeStore<TetrisGameState & TetrisActions>('Tetris
   },
 
   handleRotate: () => {
-    const { currentPiece, gameOver, position, board } = get();
-    if (!currentPiece || gameOver) return;
+    const { currentPiece, phase, position, board } = get();
+    if (!currentPiece || phase !== 'playing') return;
     const rotated = rotatePiece(currentPiece);
     if (checkValidPosition(rotated, position, board)) {
       set({ currentPiece: rotated });
     }
   },
 
-  goToStartScreen: () => set({ showStartScreen: true, isGameRunning: false, gameOver: false }),
+  goToStartScreen: () => set({ phase: 'menu' }),
 
   getBoardWithCurrentPiece: () => {
     const { board, currentPiece, position } = get();

--- a/gamesformykids/app/games/tetris/types/index.ts
+++ b/gamesformykids/app/games/tetris/types/index.ts
@@ -10,18 +10,17 @@ export interface Piece {
 
 export type Board = (string | number)[][];
 
+export type TetrisPhase = 'loading' | 'menu' | 'playing' | 'gameover';
+
 export interface TetrisGameState {
   board: Board;
   currentPiece: Piece | null;
   position: Position;
   score: number;
   level: number;
-  isGameRunning: boolean;
-  gameOver: boolean;
+  phase: TetrisPhase;
   nextPiece: Piece | null;
   linesCleared: number;
-  showStartScreen: boolean;
-  isLoading: boolean;
 }
 
 export interface GameBoardProps {


### PR DESCRIPTION
## Summary

`tetrisStore` encoded the game phase as three separate booleans (`isGameRunning`, `gameOver`, `showStartScreen`). This allowed an invalid combination: `showStartScreen=true, gameOver=true` — a bug that could occur when `goToStartScreen` only cleared two of the three flags. A single `phase` field makes impossible states unrepresentable.

## Changes

- `types/index.ts` — replace `isGameRunning`, `gameOver`, `showStartScreen`, `isLoading` with `phase: 'loading' | 'menu' | 'playing' | 'gameover'`
- `store/tetrisStore.ts` — update `INITIAL_STATE`, `setLoaded`, `startNewGame`, `movePiece`, `handleRotate`, `goToStartScreen` to set/read `phase`
- `hooks/useTetrisGame.ts` — derive `isPlaying` / `isGameOver` from `phase`; fix `getState().isGameRunning` → `getState().phase === 'playing'`
- `components/TetrisGame.tsx` — `isLoading` → `phase === 'loading'`; `showStartScreen` → `phase === 'menu'`
- `components/TouchControls.tsx` — derive `isGameRunning` and `gameOver` from `phase` locally
- `components/useTouchControls.ts` — read `phase === 'playing'` instead of `isGameRunning`

## Testing

- [x] `npx tsc --noEmit` passes

Closes #834

🤖 Generated with [Claude Code](https://claude.com/claude-code)