### PR TITLE
refactor(store): move setTimeout/AudioContext side effects out of memoryStore

### DIFF
--- a/gamesformykids/app/games/memory/stores/memoryStoreTypes.ts
+++ b/gamesformykids/app/games/memory/stores/memoryStoreTypes.ts
@@ -31,9 +31,6 @@ export interface MemoryStoreState {
   flippedCards: number[];
   matchedPairs: string[];
 
-  // Audio
-  audioContext: AudioContext | null;
-
   // UI
   showHints: boolean;
   showDebug: boolean;
@@ -44,6 +41,7 @@ export interface MemoryStoreState {
 export interface MemoryStoreActions {
   initializeGame: (targetDifficulty?: DifficultyLevel) => void;
   handleCardClick: (cardIndex: number) => void;
+  resolveMatch: (firstCardIndex: number, secondCardIndex: number, audioContext: AudioContext | null) => void;
   pauseGame: () => void;
   resumeGame: () => void;
   resetGame: () => void;
@@ -97,7 +95,6 @@ export const initialState: MemoryStoreState = {
   animals: MEMORY_GAME_ANIMALS.slice(0, MEMORY_GAME_CONSTANTS.DIFFICULTY_LEVELS.medium.pairs),
   flippedCards: [],
   matchedPairs: [],
-  audioContext: null,
   showHints: false,
   showDebug: false,
 };

--- a/gamesformykids/app/games/memory/stores/useMemoryStore.ts
+++ b/gamesformykids/app/games/memory/stores/useMemoryStore.ts
@@ -119,28 +119,9 @@ export const useMemoryStore = makeStore<MemoryStoreState & MemoryStoreActions>(
     // ─── Game lifecycle ──────────────────────────────────────────────────────
 
     initializeGame: (targetDifficulty) => {
-      if (typeof window !== 'undefined' && window.speechSynthesis) {
-        window.speechSynthesis.cancel();
-      }
-
       const state = get();
       const currentDifficulty = targetDifficulty ?? state.difficulty;
       const config = MEMORY_GAME_CONSTANTS.DIFFICULTY_LEVELS[currentDifficulty];
-
-      let audioContext = state.audioContext;
-      if (!audioContext && typeof window !== 'undefined') {
-        try {
-          const AudioContextClass =
-            window.AudioContext ||
-            (window as typeof window & { webkitAudioContext?: typeof AudioContext })
-              .webkitAudioContext;
-          if (AudioContextClass) {
-            audioContext = new AudioContextClass();
-          }
-        } catch (error) {
-          console.warn('Failed to initialize audio context:', error);
-        }
-      }
 
       const shuffled = [...MEMORY_GAME_ANIMALS].sort(() => Math.random() - 0.5);
       const animals = shuffled.slice(0, config.pairs);
@@ -165,7 +146,6 @@ export const useMemoryStore = makeStore<MemoryStoreState & MemoryStoreActions>(
           flippedCards: [],
           matchedPairs: [],
           gameStats: initialGameStats,
-          ...(audioContext !== state.audioContext ? { audioContext } : {}),
         },
         false,
         'memory/initializeGame',
@@ -192,32 +172,29 @@ export const useMemoryStore = makeStore<MemoryStoreState & MemoryStoreActions>(
         'memory/flipCard',
       );
 
-      if (flippedCards.length === 1) {
-        const firstCardIndex = flippedCards[0]!;
+    },
 
-        setTimeout(() => {
-          const s = get();
-          const config = MEMORY_GAME_CONSTANTS.DIFFICULTY_LEVELS[s.difficulty];
-          const outcome = resolveCardMatch(s, firstCardIndex, cardIndex, config.pairs);
+    resolveMatch: (firstCardIndex, secondCardIndex, audioContext) => {
+      const s = get();
+      const config = MEMORY_GAME_CONSTANTS.DIFFICULTY_LEVELS[s.difficulty];
+      const outcome = resolveCardMatch(s, firstCardIndex, secondCardIndex, config.pairs);
 
-          set(
-            {
-              cards: outcome.cards,
-              matchedPairs: outcome.matchedPairs,
-              flippedCards: outcome.flippedCards,
-              gameStats: outcome.gameStats,
-            },
-            false,
-            outcome.isMatch ? 'memory/successMatch' : 'memory/failedMatch',
-          );
+      set(
+        {
+          cards: outcome.cards,
+          matchedPairs: outcome.matchedPairs,
+          flippedCards: outcome.flippedCards,
+          gameStats: outcome.gameStats,
+        },
+        false,
+        outcome.isMatch ? 'memory/successMatch' : 'memory/failedMatch',
+      );
 
-          if (outcome.isMatch) {
-            playMemorySuccessSound(s.audioContext);
-            if (outcome.isWon) {
-              set({ isGameWon: true, isCompleted: true }, false, 'memory/gameWon');
-            }
-          }
-        }, MEMORY_GAME_CONSTANTS.FLIP_DURATION * 0.6);
+      if (outcome.isMatch) {
+        playMemorySuccessSound(audioContext);
+        if (outcome.isWon) {
+          set({ isGameWon: true, isCompleted: true }, false, 'memory/gameWon');
+        }
       }
     },
 

--- a/gamesformykids/app/games/memory/types/memory.ts
+++ b/gamesformykids/app/games/memory/types/memory.ts
@@ -40,9 +40,6 @@ export interface MemoryState {
   flippedCards: number[];
   matchedPairs: string[];
   
-  // Audio
-  audioContext: AudioContext | null;
-  
   // UI State
   showHints: boolean;
   showDebug: boolean;

--- a/gamesformykids/app/games/memory/useMemoryGameContent.ts
+++ b/gamesformykids/app/games/memory/useMemoryGameContent.ts
@@ -1,7 +1,8 @@
 'use client';
 
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import { useMemoryStore } from "./stores/useMemoryStore";
+import { MEMORY_GAME_CONSTANTS } from "@/lib/constants";
 import { useGameProgress, useAchievements } from "@/hooks";
 import { useAuth } from "@/hooks/shared/auth/useAuth";
 
@@ -25,11 +26,47 @@ export function useMemoryGameContent(): UseMemoryGameContentReturn {
     isGamePaused,
     isCompleted,
     timeLeft,
+    flippedCards,
     incrementTimer,
     decrementTimeLeft,
     setCompleted,
     setGameWon,
+    resolveMatch,
   } = useMemoryStore();
+
+  const audioContextRef = useRef<AudioContext | null>(null);
+
+  // Create AudioContext once on first user interaction (browser policy requires this)
+  useEffect(() => {
+    if (audioContextRef.current || typeof window === 'undefined') return;
+    try {
+      const AC = window.AudioContext ||
+        (window as typeof window & { webkitAudioContext?: typeof AudioContext }).webkitAudioContext;
+      if (AC) audioContextRef.current = new AC();
+    } catch {
+      // AudioContext unavailable — sounds will be silent
+    }
+  }, []);
+
+  // Cancel speech on new game so old utterances don't play into the new game
+  useEffect(() => {
+    if (gameStarted && typeof window !== 'undefined' && window.speechSynthesis) {
+      window.speechSynthesis.cancel();
+    }
+  }, [gameStarted]);
+
+  // Resolve card match after flip animation delay
+  useEffect(() => {
+    if (flippedCards.length !== 2) return;
+    const [first, second] = flippedCards;
+    const id = setTimeout(
+      () => resolveMatch(first!, second!, audioContextRef.current),
+      MEMORY_GAME_CONSTANTS.FLIP_DURATION * 0.6,
+    );
+    return () => clearTimeout(id);
+  // flippedCards reference changes on every flip; we only want to re-run when length reaches 2
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [flippedCards.length, resolveMatch]);
 
   // ── Timer ────────────────────────────────────────────────────────────────
   useEffect(() => {


### PR DESCRIPTION
## Summary

Two impure patterns existed in `useMemoryStore.ts`:
1. `handleCardClick` scheduled card-match resolution via `setTimeout` — untestable synchronously and vulnerable to StrictMode double-invocation
2. `initializeGame` created an `AudioContext` and called `window.speechSynthesis.cancel()` — heavy DOM side effects in a Zustand store action

## Changes

- `stores/memoryStoreTypes.ts` — remove `audioContext` from `MemoryStoreState`; add `resolveMatch(firstCardIndex, secondCardIndex, audioContext)` action signature
- `types/memory.ts` — remove `audioContext` from `MemoryState` interface
- `stores/useMemoryStore.ts`
  - `handleCardClick` — remove `setTimeout` block; only flips the card
  - `initializeGame` — remove `AudioContext` creation and `speechSynthesis.cancel()`
  - Add `resolveMatch(first, second, audioContext)` action: resolves the match, updates state, plays success sound
- `useMemoryGameContent.ts`
  - Add `audioContextRef` (`useRef<AudioContext | null>`) created once in `useEffect`
  - Add `useEffect` watching `gameStarted` to call `speechSynthesis.cancel()` on new game
  - Add `useEffect` watching `flippedCards.length === 2` to schedule `resolveMatch` after `FLIP_DURATION × 0.6` ms with proper cleanup

## Testing

- [x] `npx tsc --noEmit` passes

Closes #830

🤖 Generated with [Claude Code](https://claude.com/claude-code)