### PR TITLE
fix(runtime): wire missing mappings for newly added card games

### DIFF
--- a/gamesformykids/components/shared/GameCardMap.tsx
+++ b/gamesformykids/components/shared/GameCardMap.tsx
@@ -119,6 +119,11 @@ export const GameCardMap: Partial<Record<GameType, ComponentType<GameItemCardPro
   'nba-teams': createPhotoCard('nba-teams'),
   'exotic-birds': createPhotoCard('exotic-birds'),
   'butterflies': createPhotoCard('butterflies'),
+  'days-of-week': DefaultGameCard,
+  'months-of-year': DefaultGameCard,
+  'ordinals': DefaultGameCard,
+  'spatial-concepts': DefaultGameCard,
+  'number-words': DefaultGameCard,
 };
 
 export default GameCardMap;

--- a/gamesformykids/hooks/shared/game-state/gameHooksMap.ts
+++ b/gamesformykids/hooks/shared/game-state/gameHooksMap.ts
@@ -54,6 +54,11 @@ export type AutoGameType =
   | 'exotic-birds'
   | 'butterflies'
   | 'counting'
+  | 'days-of-week'
+  | 'months-of-year'
+  | 'ordinals'
+  | 'spatial-concepts'
+  | 'number-words'
   | 'geography-flags'
   | 'geography-capitals'
   | 'geography-continents';
@@ -135,6 +140,11 @@ export const GAME_HOOKS_MAP: Record<AutoGameType, AnyGameHookFn> = {
   'exotic-birds':     g('exotic-birds'),
   butterflies:            g('butterflies'),
   counting:               useCountingGame,
+  'days-of-week':         g('days-of-week'),
+  'months-of-year':       g('months-of-year'),
+  ordinals:               g('ordinals'),
+  'spatial-concepts':     g('spatial-concepts'),
+  'number-words':         g('number-words'),
   math:                   useMathGame,
   'geography-flags':      g('geography-flags'),
   'geography-capitals':   useGeographyCapitalsGame,

--- a/gamesformykids/lib/constants/gameItemsLoader.ts
+++ b/gamesformykids/lib/constants/gameItemsLoader.ts
@@ -129,6 +129,8 @@ export async function loadGameItems(gameType: GameType): Promise<BaseGameItem[]>
     case 'days-of-week':     return (await import('./gameData/daysMonths')).DAYS_OF_WEEK;
     case 'months-of-year':   return (await import('./gameData/daysMonths')).MONTHS_OF_YEAR;
     case 'ordinals':         return (await import('./gameData/ordinals')).ORDINAL_NUMBERS;
+    case 'spatial-concepts': return (await import('./gameData/spatialConcepts')).SPATIAL_CONCEPTS;
+    case 'number-words':     return (await import('./gameData/numberWords')).NUMBER_WORDS;
 
     // newGames.ts (mixed exports — use extractItems boundary)
     case 'world-food': return extractItems(await import('./gameData/newGames'), 'WORLD_FOOD_ITEMS');


### PR DESCRIPTION
## Summary
- adds missing runtime loader mappings for spatial-concepts and 
umber-words
- adds missing auto-game hook mappings for days-of-week, months-of-year, ordinals, spatial-concepts, and 
umber-words
- adds missing card component mappings for days-of-week, months-of-year, ordinals, spatial-concepts, and 
umber-words

## Root cause
Several newly added card-style game IDs were present in route/type registries but not fully wired in runtime maps used by the universal card-game engine.

## Files changed
- gamesformykids/lib/constants/gameItemsLoader.ts
- gamesformykids/hooks/shared/game-state/gameHooksMap.ts
- gamesformykids/components/shared/GameCardMap.tsx

## Validation
- 
px vitest run __tests__/gamesRegistry.test.ts __tests__/gameItemsMap.test.ts ✅
- 
px tsc --noEmit ✅

Closes #865