### PR TITLE
chore: remove duplicate 'ordinals' entry from SUPPORTED_GAMES quiz section

### DIFF
--- a/gamesformykids/app/games/[gameType]/gamePageConstants.ts
+++ b/gamesformykids/app/games/[gameType]/gamePageConstants.ts
@@ -40,7 +40,6 @@ export const SUPPORTED_GAMES = [
   'sequences', 'color-mix', 'clock', 'english-words', 'shapes-3d',
   'transport', 'holidays', 'tzadikim',
   'singular-plural', 'morning-routine',
-  'ordinals',
   'phonics',
   'rhyming', 'adjectives',
   'soccer',


### PR DESCRIPTION
## Summary
`ordinals` appeared twice in the `SUPPORTED_GAMES` array — once correctly in the card games section (line 23) and once erroneously in the quiz section. The duplicate was harmless at runtime (TypeScript deduplicates the union type and the card renderer handles the game correctly either way), but it inflated the array to 143 entries and made the code misleading.

## Changes
- `app/games/[gameType]/gamePageConstants.ts`: removed the redundant `'ordinals'` entry from the quiz section

## Testing
- [x] `npx tsc --noEmit` passes

Closes #871

🤖 Generated with [Claude Code](https://claude.com/claude-code)