### PR TITLE
refactor(store): move setInterval/setTimeout out of whackAMoleStore into component

### DIFF
--- a/gamesformykids/app/games/whack-a-mole/WhackAMoleGame.tsx
+++ b/gamesformykids/app/games/whack-a-mole/WhackAMoleGame.tsx
@@ -7,7 +7,7 @@ import WhackHUD from './components/WhackHUD';
 import WhackGrid from './components/WhackGrid';
 
 export default function WhackAMoleGame() {
-  const { phase, bgColor } = useWhackAMoleGame();
+  const { phase, bgColor, whack } = useWhackAMoleGame();
 
   if (phase === 'menu') return <WhackAMoleMenuScreen />;
   if (phase === 'result') return <WhackAMoleResultScreen />;
@@ -15,7 +15,7 @@ export default function WhackAMoleGame() {
   return (
     <div className={`min-h-screen bg-gradient-to-br ${bgColor} flex flex-col items-center justify-center p-4 select-none`} dir="rtl">
       <WhackHUD />
-      <WhackGrid />
+      <WhackGrid onWhack={whack} />
     </div>
   );
 }

--- a/gamesformykids/app/games/whack-a-mole/components/WhackGrid.tsx
+++ b/gamesformykids/app/games/whack-a-mole/components/WhackGrid.tsx
@@ -2,8 +2,10 @@
 
 import { useWhackAMoleStore } from '../whackAMoleStore';
 
-export default function WhackGrid() {
-  const { holes, holeValues, whack: onWhack } = useWhackAMoleStore();
+interface Props { onWhack: (idx: number) => void; }
+
+export default function WhackGrid({ onWhack }: Props) {
+  const { holes, holeValues } = useWhackAMoleStore();
 
   return (
     <>

--- a/gamesformykids/app/games/whack-a-mole/useWhackAMoleGame.ts
+++ b/gamesformykids/app/games/whack-a-mole/useWhackAMoleGame.ts
@@ -1,24 +1,27 @@
 'use client';
-import { useEffect, useRef } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 import { createShallowHook } from '@/lib/stores/utils/sliceUtils';
-import { useWhackAMoleStore, GAME_DURATION } from './whackAMoleStore';
+import { useWhackAMoleStore, GAME_DURATION, MOLES, BAD } from './whackAMoleStore';
 import { useGameCompletion } from '@/hooks/shared/progress/useGameCompletion';
 
 export type { HoleState } from './whackAMoleStore';
 export { GAME_DURATION } from './whackAMoleStore';
 
+const GRID = 9;
+
 const _useStore = createShallowHook(useWhackAMoleStore);
 
 export function useWhackAMoleGame() {
-  const state = _useStore();
+  const state    = _useStore();
+  const store    = useWhackAMoleStore;
   const { saveGameResultRef } = useGameCompletion('whack-a-mole');
-  const startTimeRef = useRef<number>(0);
+  const startTimeRef   = useRef<number>(0);
+  const spawnRef       = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const moleTimersRef  = useRef<(ReturnType<typeof setTimeout> | null)[]>(Array(GRID).fill(null));
 
   // Record start time when game begins
   useEffect(() => {
-    if (state.phase === 'playing') {
-      startTimeRef.current = Date.now();
-    }
+    if (state.phase === 'playing') startTimeRef.current = Date.now();
   }, [state.phase]);
 
   // Persist result when game ends
@@ -30,7 +33,57 @@ export function useWhackAMoleGame() {
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [state.phase]);
 
+  // Mole spawner — runs while phase === 'playing'
+  useEffect(() => {
+    if (state.phase !== 'playing') {
+      if (spawnRef.current) { clearTimeout(spawnRef.current); spawnRef.current = null; }
+      moleTimersRef.current.forEach((t, i) => { if (t) { clearTimeout(t); moleTimersRef.current[i] = null; } });
+      return;
+    }
+
+    function spawnNext() {
+      if (store.getState().phase !== 'playing') return;
+      const { holes } = store.getState();
+      const emptyIdxs = holes
+        .map((h, i) => ({ h, i }))
+        .filter(({ h }) => h === 'empty')
+        .map(({ i }) => i);
+
+      if (emptyIdxs.length > 0) {
+        const idx   = emptyIdxs[Math.floor(Math.random() * emptyIdxs.length)]!;
+        const isBad = Math.random() < 0.15;
+        const val   = isBad ? BAD : MOLES[Math.floor(Math.random() * MOLES.length)]!;
+        store.getState().showMole(idx, val, isBad);
+
+        moleTimersRef.current[idx] = setTimeout(() => {
+          store.getState().hideMole(idx);
+          moleTimersRef.current[idx] = null;
+        }, 800 + Math.random() * 800);
+      }
+
+      spawnRef.current = setTimeout(spawnNext, 400 + Math.random() * 600);
+    }
+
+    spawnRef.current = setTimeout(spawnNext, 400);
+
+    return () => {
+      if (spawnRef.current) { clearTimeout(spawnRef.current); spawnRef.current = null; }
+      moleTimersRef.current.forEach((t, i) => { if (t) { clearTimeout(t); moleTimersRef.current[i] = null; } });
+    };
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [state.phase]);
+
+  // Wrap whack to cancel auto-hide timer + schedule clear after hit/miss animation
+  const whack = useCallback((idx: number) => {
+    if (moleTimersRef.current[idx]) {
+      clearTimeout(moleTimersRef.current[idx]!);
+      moleTimersRef.current[idx] = null;
+    }
+    store.getState().whack(idx);
+    setTimeout(() => store.getState().clearHole(idx), 300);
+  }, [store]);
+
   const pct     = (state.timeLeft / GAME_DURATION) * 100;
   const bgColor = state.timeLeft <= 10 ? 'from-red-100 to-rose-200' : 'from-yellow-50 to-amber-100';
-  return { ...state, bgColor, pct };
+  return { ...state, whack, bgColor, pct };
 }

--- a/gamesformykids/app/games/whack-a-mole/useWhackAMoleGame.ts
+++ b/gamesformykids/app/games/whack-a-mole/useWhackAMoleGame.ts
@@ -65,10 +65,11 @@ export function useWhackAMoleGame() {
     }
 
     spawnRef.current = setTimeout(spawnNext, 400);
+    const moleTimers = moleTimersRef.current;
 
     return () => {
       if (spawnRef.current) { clearTimeout(spawnRef.current); spawnRef.current = null; }
-      moleTimersRef.current.forEach((t, i) => { if (t) { clearTimeout(t); moleTimersRef.current[i] = null; } });
+      moleTimers.forEach((t, i) => { if (t) { clearTimeout(t); moleTimers[i] = null; } });
     };
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [state.phase]);

--- a/gamesformykids/app/games/whack-a-mole/whackAMoleStore.ts
+++ b/gamesformykids/app/games/whack-a-mole/whackAMoleStore.ts
@@ -6,8 +6,8 @@ import type { PhaseResult as Phase } from '@/lib/types';
 
 const GRID = 9;
 export const GAME_DURATION = 30;
-const MOLES = ['🐹', '🐭', '🦔', '🐿️'];
-const BAD   = '💣';
+export const MOLES = ['🐹', '🐭', '🦔', '🐿️'];
+export const BAD   = '💣';
 
 export type HoleState = 'empty' | 'mole' | 'bad' | 'hit' | 'miss';
 
@@ -24,8 +24,11 @@ interface WhackAMoleState {
 }
 
 interface WhackAMoleActions {
-  startGame: () => void;
-  whack:     (idx: number) => void;
+  startGame:  () => void;
+  whack:      (idx: number) => void;
+  showMole:   (idx: number, val: string, isBad: boolean) => void;
+  hideMole:   (idx: number) => void;
+  clearHole:  (idx: number) => void;
 }
 
 function freshState(best = 0): WhackAMoleState {
@@ -41,69 +44,22 @@ export const useWhackAMoleStore = makePersistStore<WhackAMoleState & WhackAMoleA
   'WhackAMoleStore',
   'whack-a-mole-best',
   (set, get) => {
-    let moleSpawnRef: ReturnType<typeof setTimeout>  | null = null;
-    const moleTimers: (ReturnType<typeof setTimeout> | null)[] = Array(GRID).fill(null);
-
     const timer = setupGameTimer({
       name: 'whack',
       set, get,
       onEnd: () => {
-        if (moleSpawnRef) { clearTimeout(moleSpawnRef); moleSpawnRef = null; }
-        moleTimers.forEach((t, i) => { if (t) { clearTimeout(t); moleTimers[i] = null; } });
         const { score, best } = get();
         set({ timeLeft: 0, phase: 'result', best: Math.max(best, score) }, false, 'whack/gameOver');
       },
     });
 
-    function clearAllTimers() {
-      timer.stop();
-      if (moleSpawnRef) { clearTimeout(moleSpawnRef); moleSpawnRef = null; }
-      moleTimers.forEach((t, i) => { if (t) { clearTimeout(t); moleTimers[i] = null; } });
-    }
-
-    function spawnMole() {
-      if (get().phase !== 'playing') return;
-
-      const { holes, holeValues } = get();
-      const emptyIdxs = holes
-        .map((h, i) => ({ h, i }))
-        .filter(({ h }) => h === 'empty')
-        .map(({ i }) => i);
-
-      if (emptyIdxs.length > 0) {
-        const idx    = emptyIdxs[Math.floor(Math.random() * emptyIdxs.length)]!;
-        const isBad  = Math.random() < 0.15;
-        const val    = isBad ? BAD : MOLES[Math.floor(Math.random() * MOLES.length)]!;
-        const newH   = [...holes] as HoleState[];
-        const newV   = [...holeValues];
-        newH[idx]    = isBad ? 'bad' : 'mole';
-        newV[idx]    = val;
-        set({ holes: newH, holeValues: newV }, false, 'whack/spawn');
-
-        moleTimers[idx] = setTimeout(() => {
-          const { holes: cur, holeValues: curV } = get();
-          if (cur[idx] === 'mole' || cur[idx] === 'bad') {
-            const h = [...cur] as HoleState[];
-            const v = [...curV];
-            h[idx] = 'empty';
-            v[idx] = '';
-            set({ holes: h, holeValues: v }, false, 'whack/autoHide');
-          }
-          moleTimers[idx] = null;
-        }, 800 + Math.random() * 800);
-      }
-
-      moleSpawnRef = setTimeout(spawnMole, 400 + Math.random() * 600);
-    }
-
     return {
       ...freshState(),
 
       startGame: () => {
-        clearAllTimers();
+        timer.stop();
         set({ ...freshState(get().best), phase: 'playing' }, false, 'whack/startGame');
         timer.start();
-        moleSpawnRef = setTimeout(spawnMole, 400);
       },
 
       whack: (idx: number) => {
@@ -111,8 +67,6 @@ export const useWhackAMoleStore = makePersistStore<WhackAMoleState & WhackAMoleA
         const { holes, holeValues, score, combo } = get();
         const state = holes[idx];
         if (state !== 'mole' && state !== 'bad') return;
-
-        if (moleTimers[idx]) { clearTimeout(moleTimers[idx]!); moleTimers[idx] = null; }
 
         const newH = [...holes] as HoleState[];
         const newV = [...holeValues];
@@ -123,15 +77,34 @@ export const useWhackAMoleStore = makePersistStore<WhackAMoleState & WhackAMoleA
           newH[idx] = 'miss';
           set({ holes: newH, holeValues: newV, score: Math.max(0, score - 15), combo: 0 }, false, 'whack/bad');
         }
+      },
 
-        setTimeout(() => {
-          const { holes: cur, holeValues: curV } = get();
-          const h = [...cur] as HoleState[];
-          const v = [...curV];
-          h[idx] = 'empty';
-          v[idx] = '';
-          set({ holes: h, holeValues: v }, false, 'whack/clear');
-        }, 300);
+      showMole: (idx: number, val: string, isBad: boolean) => {
+        const { holes, holeValues } = get();
+        const newH = [...holes] as HoleState[];
+        const newV = [...holeValues];
+        newH[idx] = isBad ? 'bad' : 'mole';
+        newV[idx] = val;
+        set({ holes: newH, holeValues: newV }, false, 'whack/spawn');
+      },
+
+      hideMole: (idx: number) => {
+        const { holes, holeValues } = get();
+        if (holes[idx] !== 'mole' && holes[idx] !== 'bad') return;
+        const newH = [...holes] as HoleState[];
+        const newV = [...holeValues];
+        newH[idx] = 'empty';
+        newV[idx] = '';
+        set({ holes: newH, holeValues: newV }, false, 'whack/autoHide');
+      },
+
+      clearHole: (idx: number) => {
+        const { holes, holeValues } = get();
+        const newH = [...holes] as HoleState[];
+        const newV = [...holeValues];
+        newH[idx] = 'empty';
+        newV[idx] = '';
+        set({ holes: newH, holeValues: newV }, false, 'whack/clear');
       },
     };
   },


### PR DESCRIPTION
## Summary
Removed all raw timer side-effects from `whackAMoleStore`. Mole spawning, per-hole auto-hide timers, and the hit/miss clear timer now live in `useWhackAMoleGame` via `useRef` + `useEffect`. Follows the same pattern as the recent refactors of `memoryStore` (#848), `tzedakahStore` (#846), `mathRaceStore` (#844), and `numberBubblesStore` (#843).

## Changes
- `whackAMoleStore.ts`: removed `moleSpawnRef`/`moleTimers` closure variables; added pure `showMole`/`hideMole`/`clearHole` actions; `startGame` and `whack` are now pure
- `useWhackAMoleGame.ts`: manages spawn loop (`spawnRef`) and per-hole timers (`moleTimersRef`) via refs; wraps `whack` to cancel the auto-hide timer before the store action fires
- `WhackGrid.tsx`: receives `onWhack` as a prop instead of reading from the store directly
- `WhackAMoleGame.tsx`: passes hook-provided `whack` to `WhackGrid`

## Testing
- [x] `npx tsc --noEmit` passes
- [ ] Manually verify at `http://localhost:3000/games/whack-a-mole`

Closes #867

🤖 Generated with [Claude Code](https://claude.com/claude-code)