### PR TITLE
refactor(store): move setTimeout out of simonStore and reflexStore into components

### DIFF
--- a/gamesformykids/__tests__/stores/simonStore.test.ts
+++ b/gamesformykids/__tests__/stores/simonStore.test.ts
@@ -84,21 +84,21 @@ describe('simonStore', () => {
     });
   });
 
-  describe('startGame', () => {
+  describe('initGame', () => {
     it('creates a sequence with one button', () => {
-      store.getState().startGame();
+      store.getState().initGame();
       expect(store.getState().sequence).toHaveLength(1);
     });
 
     it('sequence contains a valid button id', () => {
-      store.getState().startGame();
+      store.getState().initGame();
       const validIds = BUTTONS.map(b => b.id);
       expect(validIds).toContain(store.getState().sequence[0]);
     });
 
     it('resets round score to 0', () => {
       store.setState({ roundScore: 5 } as unknown as Parameters<typeof store.setState>[0]);
-      store.getState().startGame();
+      store.getState().initGame();
       expect(store.getState().roundScore).toBe(0);
     });
   });

--- a/gamesformykids/app/games/reflex/reflexStore.ts
+++ b/gamesformykids/app/games/reflex/reflexStore.ts
@@ -1,7 +1,7 @@
 import { makeStore } from '@/lib/stores/createStore';
 import { setupGameTimer } from '@/lib/stores/gameTimerHelpers';
 import type { PhaseResult as Phase } from '@/lib/types';
-import { TARGET_EMOJIS, GAME_DURATION, type Target, getLifetime, getSpawnInterval } from './data/targets';
+import { GAME_DURATION, type Target } from './data/targets';
 
 export type { Target } from './data/targets';
 
@@ -16,8 +16,10 @@ interface ReflexState {
 }
 
 interface ReflexActions {
-  startGame: () => void;
-  hitTarget: (id: number) => void;
+  startGame:    () => void;
+  hitTarget:    (id: number) => void;
+  addTarget:    (target: Target) => void;
+  expireTarget: (id: number) => void;
 }
 
 const INITIAL: ReflexState = {
@@ -27,54 +29,20 @@ const INITIAL: ReflexState = {
 export const useReflexStore = makeStore<ReflexState & ReflexActions>(
   'ReflexStore',
   (set, get) => {
-    let nextId  = 0;
-    let spawnId: ReturnType<typeof setTimeout> | null = null;
-
     const timer = setupGameTimer({
       name: 'reflex',
       set, get,
       onEnd: () => {
-        if (spawnId) { clearTimeout(spawnId); spawnId = null; }
         set({ timeLeft: 0, phase: 'result' }, false, 'reflex/gameOver');
       },
     });
-
-    function clearTimers() {
-      timer.stop();
-      if (spawnId) { clearTimeout(spawnId); spawnId = null; }
-    }
-
-    function spawnTarget() {
-      if (get().phase !== 'playing') return;
-      const id = nextId++;
-      const target: Target = {
-        id,
-        x:        5 + Math.random() * 80,
-        y:        10 + Math.random() * 70,
-        emoji:    TARGET_EMOJIS[Math.floor(Math.random() * TARGET_EMOJIS.length)]!,
-        lifetime: getLifetime(get().score),
-        born:     Date.now(),
-      };
-      set({ targets: [...get().targets, target] }, false, 'reflex/spawn');
-
-      setTimeout(() => {
-        const { targets, missed } = get();
-        if (targets.find(t => t.id === id)) {
-          set({ targets: targets.filter(t => t.id !== id), missed: missed + 1 }, false, 'reflex/expire');
-        }
-      }, target.lifetime);
-
-      spawnId = setTimeout(spawnTarget, getSpawnInterval(get().score));
-    }
 
     return {
       ...INITIAL,
 
       startGame: () => {
-        clearTimers();
-        nextId = 0;
+        timer.stop();
         set({ ...INITIAL, phase: 'playing' }, false, 'reflex/startGame');
-        spawnId = setTimeout(spawnTarget, 600);
         timer.start();
       },
 
@@ -82,6 +50,16 @@ export const useReflexStore = makeStore<ReflexState & ReflexActions>(
         const { targets, score } = get();
         if (!targets.find(t => t.id === id)) return;
         set({ targets: targets.filter(t => t.id !== id), score: score + 1 }, false, 'reflex/hit');
+      },
+
+      addTarget: (target: Target) => {
+        set({ targets: [...get().targets, target] }, false, 'reflex/spawn');
+      },
+
+      expireTarget: (id: number) => {
+        const { targets, missed } = get();
+        if (!targets.find(t => t.id === id)) return;
+        set({ targets: targets.filter(t => t.id !== id), missed: missed + 1 }, false, 'reflex/expire');
       },
     };
   },

--- a/gamesformykids/app/games/reflex/useReflexGame.ts
+++ b/gamesformykids/app/games/reflex/useReflexGame.ts
@@ -3,6 +3,7 @@ import { useEffect, useRef } from 'react';
 import { createShallowHook } from '@/lib/stores/utils/sliceUtils';
 import { useReflexStore } from './reflexStore';
 import { useGameCompletion } from '@/hooks/shared/progress/useGameCompletion';
+import { TARGET_EMOJIS, getLifetime, getSpawnInterval } from './data/targets';
 
 export type { Target } from './reflexStore';
 
@@ -12,12 +13,12 @@ export function useReflexGame() {
   const state = _useStore();
   const { saveGameResultRef } = useGameCompletion('reflex');
   const startTimeRef = useRef<number>(0);
+  const nextIdRef    = useRef(0);
+  const spawnIdRef   = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   // Record start time when game begins
   useEffect(() => {
-    if (state.phase === 'playing') {
-      startTimeRef.current = Date.now();
-    }
+    if (state.phase === 'playing') startTimeRef.current = Date.now();
   }, [state.phase]);
 
   // Persist result when game ends
@@ -26,6 +27,44 @@ export function useReflexGame() {
       const durationSeconds = Math.round((Date.now() - startTimeRef.current) / 1000);
       saveGameResultRef.current({ score: state.score, level: 1, durationSeconds });
     }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [state.phase]);
+
+  // Target spawner — runs while phase === 'playing'
+  useEffect(() => {
+    if (state.phase !== 'playing') {
+      if (spawnIdRef.current) { clearTimeout(spawnIdRef.current); spawnIdRef.current = null; }
+      return;
+    }
+
+    nextIdRef.current = 0;
+
+    function spawnNext() {
+      const store = useReflexStore.getState();
+      if (store.phase !== 'playing') return;
+
+      const id      = nextIdRef.current++;
+      const score   = store.score;
+      const target  = {
+        id,
+        x:        5 + Math.random() * 80,
+        y:        10 + Math.random() * 70,
+        emoji:    TARGET_EMOJIS[Math.floor(Math.random() * TARGET_EMOJIS.length)]!,
+        lifetime: getLifetime(score),
+        born:     Date.now(),
+      };
+      store.addTarget(target);
+
+      setTimeout(() => useReflexStore.getState().expireTarget(id), target.lifetime);
+
+      spawnIdRef.current = setTimeout(spawnNext, getSpawnInterval(useReflexStore.getState().score));
+    }
+
+    spawnIdRef.current = setTimeout(spawnNext, 600);
+
+    return () => {
+      if (spawnIdRef.current) { clearTimeout(spawnIdRef.current); spawnIdRef.current = null; }
+    };
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [state.phase]);
 

--- a/gamesformykids/app/games/reflex/useReflexGame.ts
+++ b/gamesformykids/app/games/reflex/useReflexGame.ts
@@ -65,7 +65,6 @@ export function useReflexGame() {
     return () => {
       if (spawnIdRef.current) { clearTimeout(spawnIdRef.current); spawnIdRef.current = null; }
     };
-  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [state.phase]);
 
   return state;

--- a/gamesformykids/app/games/simon/SimonGame.tsx
+++ b/gamesformykids/app/games/simon/SimonGame.tsx
@@ -5,13 +5,13 @@ import SimonBoard from './components/SimonBoard';
 import SimonGameOverScreen from './components/SimonGameOverScreen';
 
 export default function SimonGame() {
-  const { phase, handleTap } = useSimonGame();
+  const { phase, handleTap, startGame } = useSimonGame();
 
   return (
     <div className="min-h-screen bg-gray-900 flex flex-col items-center justify-center p-4 select-none" dir="rtl">
       {phase === 'menu' && <SimonMenuScreen />}
       {(phase === 'showing' || phase === 'input') && <SimonBoard onTap={handleTap} />}
-      {phase === 'dead' && <SimonGameOverScreen />}
+      {phase === 'dead' && <SimonGameOverScreen onRestart={startGame} />}
     </div>
   );
 }

--- a/gamesformykids/app/games/simon/components/SimonGameOverScreen.tsx
+++ b/gamesformykids/app/games/simon/components/SimonGameOverScreen.tsx
@@ -2,8 +2,10 @@
 import ScoreBestResultCard from '@/components/game/shared/ScoreBestResultCard';
 import { useSimonStore } from '../simonStore';
 
-export default function SimonGameOverScreen() {
-  const { roundScore, best, startGame } = useSimonStore();
+interface Props { onRestart: () => void; }
+
+export default function SimonGameOverScreen({ onRestart }: Props) {
+  const { roundScore, best } = useSimonStore();
   return (
     <ScoreBestResultCard
       emoji="😵"
@@ -13,7 +15,7 @@ export default function SimonGameOverScreen() {
       score={roundScore}
       best={best}
       scoreLabel="סיבובים"
-      onRestart={startGame}
+      onRestart={onRestart}
       restartLabel="🔄 שוב!"
       shareText={`🎮 הגעתי לרצף ${roundScore} צבעים בסימון!`}
     />

--- a/gamesformykids/app/games/simon/simonStore.ts
+++ b/gamesformykids/app/games/simon/simonStore.ts
@@ -26,7 +26,7 @@ interface SimonActions {
   updateBest:    (score: number) => void;
   setRoundScore: (score: number) => void;
   setSequence:   (seq: ButtonId[]) => void;
-  startGame:     () => void;
+  initGame:      () => void;
 }
 
 const INITIAL: SimonState = {
@@ -72,11 +72,9 @@ export const useSimonStore = makePersistStore<SimonState & SimonActions>('SimonS
   setRoundScore:  (score) => set({ roundScore: score }, false, 'simon/setRoundScore'),
   setSequence:    (seq)   => set({ sequence: seq }, false, 'simon/setSequence'),
 
-  startGame: () => {
+  initGame: () => {
     const first = BUTTONS[Math.floor(Math.random() * BUTTONS.length)]!.id;
     const seq: ButtonId[] = [first];
-    useSimonStore.getState().setSequence(seq);
-    useSimonStore.getState().setRoundScore(0);
-    showSequence(seq);
+    set({ ...INITIAL, sequence: seq, roundScore: 0 }, false, 'simon/initGame');
   },
 }), { partialize: (s) => ({ best: s.best }) });

--- a/gamesformykids/app/games/simon/useSimonGame.ts
+++ b/gamesformykids/app/games/simon/useSimonGame.ts
@@ -10,8 +10,14 @@ export { BUTTONS };
 import type { PhaseSimon as Phase } from '@/lib/types';
 
 export function useSimonGame() {
-  const { phase, activeColor, playerIdx, best, roundScore, sequence, startGame } =
+  const { phase, activeColor, playerIdx, best, roundScore, sequence, initGame } =
     useSimonStore(useShallow((s) => s));
+
+  const startGame = useCallback(() => {
+    initGame();
+    const { sequence: seq } = useSimonStore.getState();
+    showSequence(seq);
+  }, [initGame]);
 
   const { saveGameResultRef } = useGameCompletion('simon');
   const startTimeRef = useRef<number>(0);


### PR DESCRIPTION
## Summary
Removes all raw timer side-effects from `simonStore` and `reflexStore`, completing the ongoing store-purity refactoring series (memoryStore #848, tzedakahStore #846, mathRaceStore #844, numberBubblesStore #843, whackAMoleStore #876).

**simon:** renamed `startGame` → `initGame` (pure state reset + first sequence). A new `startGame` wrapper in `useSimonGame` calls `initGame()` then the existing `showSequence()` async function. `SimonGameOverScreen` receives `onRestart` as a prop from `SimonGame` instead of pulling `startGame` from the store.

**reflex:** removed `spawnId` closure variable and recursive `spawnTarget` function from the store. Added pure `addTarget` and `expireTarget` actions. The spawn loop (target creation, expiry timeouts, recursive scheduling) now lives in `useReflexGame` via `useRef + useEffect`.

## Changes
- `simonStore.ts`: `startGame` → `initGame` (pure); `showSequence` call removed
- `useSimonGame.ts`: new `startGame` callback wraps `initGame` + `showSequence`
- `SimonGame.tsx`: passes hook `startGame` to `SimonGameOverScreen` as prop
- `SimonGameOverScreen.tsx`: accepts `onRestart` prop; no longer imports store action
- `reflexStore.ts`: removed `spawnId` + `spawnTarget`; added `addTarget`/`expireTarget`; `startGame` pure
- `useReflexGame.ts`: manages target spawn loop in `useEffect` with `spawnIdRef`
- `__tests__/stores/simonStore.test.ts`: `startGame` → `initGame`

## Testing
- [x] `npx tsc --noEmit` passes
- [ ] Manually verify at `http://localhost:3000/games/simon` and `/games/reflex`

Closes #868
Closes #869

🤖 Generated with [Claude Code](https://claude.com/claude-code)