### PR TITLE
refactor(store): move AI turn setTimeout out of damkaStore into useDamkaGame hook

### DIFF
--- a/gamesformykids/app/games/checkers/damkaStore.ts
+++ b/gamesformykids/app/games/checkers/damkaStore.ts
@@ -18,8 +18,9 @@ interface DamkaState {
 }
 
 interface DamkaActions {
-  startGame:  () => void;
-  selectCell: (pos: Pos) => void;
+  startGame:       () => void;
+  selectCell:      (pos: Pos) => void;
+  doComputerMove:  () => void;
 }
 
 const INITIAL: DamkaState = {
@@ -29,99 +30,90 @@ const INITIAL: DamkaState = {
 
 export const useDamkaStore = makeStore<DamkaState & DamkaActions>(
   'DamkaStore',
-  (set, get) => {
-    let timer: ReturnType<typeof setTimeout> | null = null;
+  (set, get) => ({
+    ...INITIAL,
 
-    function scheduleComputerMove() {
-      if (timer) clearTimeout(timer);
-      timer = setTimeout(() => {
-        const { phase, currentTurn, board, playerScore, computerScore } = get();
-        if (phase !== 'playing' || currentTurn !== 'computer') return;
+    startGame: () => {
+      const { playerScore, computerScore } = get();
+      set(
+        { ...INITIAL, phase: 'playing', board: makeInitialBoard(), playerScore, computerScore, message: 'תורך! בחר אסימון אדום' },
+        false, 'damka/startGame',
+      );
+    },
 
-        const move = bestComputerMove(board);
-        if (!move) {
-          set(
-            { phase: 'won', playerScore: playerScore + 1, message: '🎉 ניצחת! למחשב אין מהלכים!' },
-            false, 'damka/computerNoMoves',
-          );
-          return;
-        }
-        const nb = applyMove(board, move);
-        const playerMoves = getAllMoves(nb, 'player');
-        if (playerMoves.length === 0) {
-          set(
-            { board: nb, phase: 'lost', computerScore: computerScore + 1, message: '😢 המחשב ניצח!' },
-            false, 'damka/computerWon',
-          );
-        } else {
-          set(
-            { board: nb, currentTurn: 'player', selected: null, validMoves: [], message: 'תורך!' },
-            false, 'damka/computerMove',
-          );
-        }
-      }, 700);
-    }
+    doComputerMove: () => {
+      const { phase, currentTurn, board, playerScore, computerScore } = get();
+      if (phase !== 'playing' || currentTurn !== 'computer') return;
 
-    return {
-      ...INITIAL,
-
-      startGame: () => {
-        if (timer) clearTimeout(timer);
-        const { playerScore, computerScore } = get();
+      const move = bestComputerMove(board);
+      if (!move) {
         set(
-          { ...INITIAL, phase: 'playing', board: makeInitialBoard(), playerScore, computerScore, message: 'תורך! בחר אסימון אדום' },
-          false, 'damka/startGame',
+          { phase: 'won', playerScore: playerScore + 1, message: '🎉 ניצחת! למחשב אין מהלכים!' },
+          false, 'damka/computerNoMoves',
         );
-      },
+        return;
+      }
+      const nb = applyMove(board, move);
+      const playerMoves = getAllMoves(nb, 'player');
+      if (playerMoves.length === 0) {
+        set(
+          { board: nb, phase: 'lost', computerScore: computerScore + 1, message: '😢 המחשב ניצח!' },
+          false, 'damka/computerWon',
+        );
+      } else {
+        set(
+          { board: nb, currentTurn: 'player', selected: null, validMoves: [], message: 'תורך!' },
+          false, 'damka/computerMove',
+        );
+      }
+    },
 
-      selectCell: (pos: Pos) => {
-        const { phase, currentTurn, board, selected, validMoves, playerScore } = get();
-        if (phase !== 'playing' || currentTurn !== 'player') return;
+    selectCell: (pos: Pos) => {
+      const { phase, currentTurn, board, selected, validMoves, playerScore } = get();
+      if (phase !== 'playing' || currentTurn !== 'player') return;
 
-        const cell = board[pos.row]![pos.col]!;
+      const cell = board[pos.row]![pos.col]!;
 
-        const move = validMoves.find(m => m.to.row === pos.row && m.to.col === pos.col);
-        if (move) {
-          const nb = applyMove(board, move);
-          const compMoves = getAllMoves(nb, 'computer');
-          if (compMoves.length === 0) {
-            set(
-              { board: nb, selected: null, validMoves: [], phase: 'won', playerScore: playerScore + 1, message: '🎉 ניצחת!' },
-              false, 'damka/playerWon',
-            );
-            return;
-          }
+      const move = validMoves.find(m => m.to.row === pos.row && m.to.col === pos.col);
+      if (move) {
+        const nb = applyMove(board, move);
+        const compMoves = getAllMoves(nb, 'computer');
+        if (compMoves.length === 0) {
           set(
-            { board: nb, selected: null, validMoves: [], currentTurn: 'computer', message: 'תור המחשב...' },
-            false, 'damka/playerMove',
+            { board: nb, selected: null, validMoves: [], phase: 'won', playerScore: playerScore + 1, message: '🎉 ניצחת!' },
+            false, 'damka/playerWon',
           );
-          scheduleComputerMove();
           return;
         }
+        set(
+          { board: nb, selected: null, validMoves: [], currentTurn: 'computer', message: 'תור המחשב...' },
+          false, 'damka/playerMove',
+        );
+        return;
+      }
 
-        if (cell.color !== 'player') {
-          set({ selected: null, validMoves: [], message: 'בחר אסימון אדום שלך!' }, false, 'damka/wrongPiece');
-          return;
-        }
+      if (cell.color !== 'player') {
+        set({ selected: null, validMoves: [], message: 'בחר אסימון אדום שלך!' }, false, 'damka/wrongPiece');
+        return;
+      }
 
-        const allMoves = getAllMoves(board, 'player');
-        const mustCapture = allMoves.some(m => m.captures.length > 0);
-        const pieceMoves  = allMoves.filter(m => m.from.row === pos.row && m.from.col === pos.col);
+      const allMoves = getAllMoves(board, 'player');
+      const mustCapture = allMoves.some(m => m.captures.length > 0);
+      const pieceMoves  = allMoves.filter(m => m.from.row === pos.row && m.from.col === pos.col);
 
-        if (pieceMoves.length === 0) {
-          const msg = mustCapture ? 'חובה לקפוץ — בחר אסימון שיכול לקפוץ!' : 'אין מהלכים לאסימון זה';
-          set({ selected: pos, validMoves: [], message: msg }, false, 'damka/noMoves');
-          return;
-        }
+      if (pieceMoves.length === 0) {
+        const msg = mustCapture ? 'חובה לקפוץ — בחר אסימון שיכול לקפוץ!' : 'אין מהלכים לאסימון זה';
+        set({ selected: pos, validMoves: [], message: msg }, false, 'damka/noMoves');
+        return;
+      }
 
-        // Deselect if clicking the already-selected piece
-        if (selected && selected.row === pos.row && selected.col === pos.col) {
-          set({ selected: null, validMoves: [], message: '' }, false, 'damka/deselect');
-          return;
-        }
+      // Deselect if clicking the already-selected piece
+      if (selected && selected.row === pos.row && selected.col === pos.col) {
+        set({ selected: null, validMoves: [], message: '' }, false, 'damka/deselect');
+        return;
+      }
 
-        set({ selected: pos, validMoves: pieceMoves, message: 'לאן לזוז?' }, false, 'damka/selectPiece');
-      },
-    };
-  },
+      set({ selected: pos, validMoves: pieceMoves, message: 'לאן לזוז?' }, false, 'damka/selectPiece');
+    },
+  }),
 );

--- a/gamesformykids/app/games/checkers/useDamkaGame.ts
+++ b/gamesformykids/app/games/checkers/useDamkaGame.ts
@@ -7,27 +7,43 @@ export type { Side, GamePhase, Cell, Board, Pos, DamkaMove } from './damkaStore'
 
 const _useStore = createShallowHook(useDamkaStore);
 
+const AI_DELAY_MS = 700;
+
 export function useDamkaGame() {
   const state = _useStore();
   const { saveGameResultRef } = useGameCompletion('checkers');
 
   const startTimeRef = useRef(0);
   const prevPhaseRef = useRef(state.phase);
+  const aiTimerRef   = useRef<ReturnType<typeof setTimeout> | null>(null);
 
+  // Track game start/end for session stats
   useEffect(() => {
     const prev = prevPhaseRef.current;
     const curr = state.phase;
     prevPhaseRef.current = curr;
 
     if (curr === 'playing' && prev !== 'playing') {
-      // Game (re)started — begin timer
       startTimeRef.current = Date.now();
     } else if ((curr === 'won' || curr === 'lost') && prev === 'playing') {
-      // Game just ended — save result
       const durationSeconds = Math.round((Date.now() - startTimeRef.current) / 1000);
       saveGameResultRef.current({ score: state.playerScore, level: 1, durationSeconds });
     }
   }, [state.phase]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Schedule AI move after player's turn with a short think delay
+  useEffect(() => {
+    if (state.phase === 'playing' && state.currentTurn === 'computer') {
+      if (aiTimerRef.current) clearTimeout(aiTimerRef.current);
+      aiTimerRef.current = setTimeout(() => {
+        useDamkaStore.getState().doComputerMove();
+        aiTimerRef.current = null;
+      }, AI_DELAY_MS);
+    }
+    return () => {
+      if (aiTimerRef.current) { clearTimeout(aiTimerRef.current); aiTimerRef.current = null; }
+    };
+  }, [state.phase, state.currentTurn]);
 
   return state;
 }


### PR DESCRIPTION
## Summary
The 700ms AI-think delay in `damkaStore` was a `timer` closure variable called from `selectCell` — an intentional UX pause before the computer moves, but still a side effect inside a Zustand store action.

Extracted into `useDamkaGame` via `aiTimerRef` + a `useEffect` watching `currentTurn === 'computer'`. Added a pure `doComputerMove()` action that the hook calls after the delay fires. The store's `selectCell` now only updates state (`currentTurn: 'computer'`); the hook observes that state change and schedules the AI computation.

## Changes
- `damkaStore.ts`: removed `timer` closure + `scheduleComputerMove`; added pure `doComputerMove()`; `selectCell` and `startGame` are now pure
- `useDamkaGame.ts`: added `aiTimerRef` + `useEffect` on `[phase, currentTurn]` that schedules `doComputerMove` after 700ms

## Testing
- [x] `npx tsc --noEmit` passes
- [ ] Manually verify at `http://localhost:3000/games/checkers` — computer should still pause ~700ms before moving

Closes #870

🤖 Generated with [Claude Code](https://claude.com/claude-code)