### PR TITLE
refactor(hook): replace manual startTimeRef/useEffect in useReflexGame with usePhaseGameCompletion

### DIFF
--- a/gamesformykids/app/games/reflex/useReflexGame.ts
+++ b/gamesformykids/app/games/reflex/useReflexGame.ts
@@ -3,6 +3,7 @@ import { useEffect, useRef } from 'react';
 import { createShallowHook } from '@/lib/stores/utils/sliceUtils';
 import { useReflexStore } from './reflexStore';
 import { useGameCompletion } from '@/hooks/shared/progress/useGameCompletion';
+import { usePhaseGameCompletion } from '@/hooks/shared/progress/usePhaseGameCompletion';
 import { TARGET_EMOJIS, getLifetime, getSpawnInterval } from './data/targets';
 
 export type { Target } from './reflexStore';
@@ -12,23 +13,10 @@ const _useStore = createShallowHook(useReflexStore);
 export function useReflexGame() {
   const state = _useStore();
   const { saveGameResultRef } = useGameCompletion('reflex');
-  const startTimeRef = useRef<number>(0);
-  const nextIdRef    = useRef(0);
-  const spawnIdRef   = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const nextIdRef  = useRef(0);
+  const spawnIdRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  // Record start time when game begins
-  useEffect(() => {
-    if (state.phase === 'playing') startTimeRef.current = Date.now();
-  }, [state.phase]);
-
-  // Persist result when game ends
-  useEffect(() => {
-    if (state.phase === 'result') {
-      const durationSeconds = Math.round((Date.now() - startTimeRef.current) / 1000);
-      saveGameResultRef.current({ score: state.score, level: 1, durationSeconds });
-    }
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [state.phase]);
+  usePhaseGameCompletion(state.phase, saveGameResultRef, () => ({ score: state.score, level: 1 }));
 
   // Target spawner — runs while phase === 'playing'
   useEffect(() => {


### PR DESCRIPTION
## Summary

Removes the manual 12-line \`startTimeRef\` + dual-\`useEffect\` completion-tracking boilerplate from \`useReflexGame\` and replaces it with a single call to \`usePhaseGameCompletion\` — the shared primitive that already handles exactly this pattern for balloon-pop, color-tap, emoji-math, and word-scramble.

The reflex game has a standard \`menu → playing → result\` phase flow, making it a perfect fit: the hook's default \`completionPhases\` set includes \`'result'\`, and start time is captured on the \`'playing'\` transition — exactly what the manual code was doing.

## Changes

- \`app/games/reflex/useReflexGame.ts\`: removed \`startTimeRef\`, removed two \`useEffect\` hooks; added \`usePhaseGameCompletion\` call and import (-12 lines, +4 lines)

## Testing

- [x] \`npx tsc --noEmit\` passes (zero errors)
- [ ] Manually verify at \`http://localhost:3000/games/reflex\` — game result should still persist on completion

Closes #879

🤖 Generated with [Claude Code](https://claude.com/claude-code)