### PR TITLE
fix(ux,rtl,a11y): bundle of 10 UX/RTL/a11y fixes (#854-#864)

### DIFF
--- a/gamesformykids/app/games/[gameType]/error.tsx
+++ b/gamesformykids/app/games/[gameType]/error.tsx
@@ -22,13 +22,13 @@ export default function GameError({ error, reset }: ErrorProps) {
         <div className="flex gap-3 justify-center">
           <button
             onClick={reset}
-            className="px-6 py-3 bg-purple-500 text-white font-bold rounded-2xl hover:bg-purple-600 transition-colors"
+            className="px-6 py-3 bg-purple-500 text-white font-bold rounded-2xl hover:bg-purple-600 transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-purple-500"
           >
             נסה שוב
           </button>
           <Link
             href="/"
-            className="px-6 py-3 bg-gray-100 text-gray-700 font-bold rounded-2xl hover:bg-gray-200 transition-colors"
+            className="px-6 py-3 bg-gray-100 text-gray-700 font-bold rounded-2xl hover:bg-gray-200 transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-gray-400"
           >
             בחר משחק אחר
           </Link>

--- a/gamesformykids/app/games/bubbles/components/BubbleGame.tsx
+++ b/gamesformykids/app/games/bubbles/components/BubbleGame.tsx
@@ -46,7 +46,7 @@ export default function BubbleGame() {
       </div>
 
       {/* סטטיסטיקות נוספות */}
-      <div className="absolute top-20 right-4 z-20 bg-white bg-opacity-80 rounded-2xl p-4 shadow-lg">
+      <div className="absolute top-20 end-4 z-20 bg-white bg-opacity-80 rounded-2xl p-4 shadow-lg">
         <div className="text-center">
           <div className="text-lg font-bold text-blue-800">בועות פוצצו:</div>
           <div className="text-2xl font-bold text-blue-600">{poppedCount}</div>
@@ -63,7 +63,7 @@ export default function BubbleGame() {
       {/* כפתור עצירה */}
       <button
         onClick={stopGame}
-        className="absolute top-4 left-4 z-20 px-6 py-3 bg-red-500 text-white rounded-full font-bold hover:bg-red-600 transition-colors shadow-lg"
+        className="absolute top-4 start-4 z-20 px-6 py-3 bg-blue-500 text-white rounded-full font-bold hover:bg-blue-600 transition-colors shadow-lg"
       >
         עצור משחק
       </button>
@@ -71,13 +71,13 @@ export default function BubbleGame() {
       {/* אפקטים ויזואליים נוספים */}
       <div className="absolute inset-0 pointer-events-none">
         {/* עננים מאחורה */}
-        <div className="absolute top-10 left-10 w-20 h-12 bg-white bg-opacity-40 rounded-full animate-pulse"></div>
-        <div className="absolute top-32 right-20 w-16 h-10 bg-white bg-opacity-30 rounded-full animate-pulse"></div>
-        <div className="absolute top-20 left-1/2 w-24 h-14 bg-white bg-opacity-35 rounded-full animate-pulse"></div>
-        
+        <div className="absolute top-10 left-10 w-20 h-12 bg-white bg-opacity-40 rounded-full"></div>
+        <div className="absolute top-32 right-20 w-16 h-10 bg-white bg-opacity-30 rounded-full"></div>
+        <div className="absolute top-20 left-1/2 w-24 h-14 bg-white bg-opacity-35 rounded-full"></div>
+
         {/* ציפורים קטנות */}
-        <div className="absolute top-16 right-1/4 text-white text-opacity-60 animate-bounce">🐦</div>
-        <div className="absolute top-40 left-1/3 text-white text-opacity-60 animate-bounce" style={{ animationDelay: '0.5s' }}>🐦</div>
+        <div className="absolute top-16 right-1/4 text-white text-opacity-60">🐦</div>
+        <div className="absolute top-40 left-1/3 text-white text-opacity-60">🐦</div>
       </div>
     </div>
   );

--- a/gamesformykids/app/games/building/components/canvas/BlockRenderer.tsx
+++ b/gamesformykids/app/games/building/components/canvas/BlockRenderer.tsx
@@ -66,8 +66,8 @@ export default function BlockRenderer({ blockId }: BlockRendererProps) {
       
       {block.sparkles && (
         <div className="absolute inset-0 pointer-events-none">
-          <Sparkles className="w-4 h-4 text-yellow-300 animate-ping absolute top-0 left-0" />
-          <Sparkles className="w-3 h-3 text-pink-300 animate-ping absolute bottom-0 right-0" style={{ animationDelay: '0.5s' }} />
+          <Sparkles className="w-4 h-4 text-yellow-300 absolute top-0 left-0" />
+          <Sparkles className="w-3 h-3 text-pink-300 absolute bottom-0 right-0" />
         </div>
       )}
       

--- a/gamesformykids/app/games/building/components/controls/ColorPicker.tsx
+++ b/gamesformykids/app/games/building/components/controls/ColorPicker.tsx
@@ -10,7 +10,7 @@ export default function ColorPicker() {
   return (
     <div className="bg-white/20 backdrop-blur-sm rounded-2xl p-3 md:p-4">
       <h3 className="text-white font-bold text-base md:text-lg mb-2 md:mb-3 text-center flex items-center justify-center gap-1 md:gap-2">
-        <Palette className="w-4 h-4 md:w-5 md:h-5 animate-pulse" />
+        <Palette className="w-4 h-4 md:w-5 md:h-5" />
         בחירת צבע
       </h3>
       <div className="grid grid-cols-4 md:grid-cols-5 gap-1 md:gap-2 mb-2 md:mb-3">

--- a/gamesformykids/app/games/coloring/components/ColoringCanvas.tsx
+++ b/gamesformykids/app/games/coloring/components/ColoringCanvas.tsx
@@ -17,7 +17,7 @@ export function ColoringCanvas() {
     <div className="relative bg-white rounded-3xl shadow-xl p-4 mb-4 border-4 border-purple-200">
       {showDone && (
         <div className="absolute inset-0 bg-white/90 rounded-3xl flex flex-col items-center justify-center z-10">
-          <div className="text-6xl mb-2 animate-bounce">🌟</div>
+          <div className="text-6xl mb-2">🌟</div>
           <p className="text-2xl font-bold text-purple-700">כל הכבוד! צוין!</p>
           <button
             onClick={clearImage}

--- a/gamesformykids/app/games/memory/components/MemoryCard.tsx
+++ b/gamesformykids/app/games/memory/components/MemoryCard.tsx
@@ -42,7 +42,7 @@ export default function MemoryCard({ card, onClick }: MemoryCardProps) {
           </span>
         ) : (
           <div className="text-center text-white">
-            <span className="text-4xl md:text-5xl animate-pulse filter drop-shadow-lg">❓</span>
+            <span className="text-4xl md:text-5xl filter drop-shadow-lg">❓</span>
             <div className="text-sm mt-2 opacity-90 font-bold">לחץ</div>
           </div>
         )}

--- a/gamesformykids/components/game/shared/CanvasDPadControls.tsx
+++ b/gamesformykids/components/game/shared/CanvasDPadControls.tsx
@@ -24,11 +24,11 @@ export function CanvasDPadControls({
   return (
     <div className={`${mt} grid grid-cols-3 gap-2`} style={style}>
       <div />
-      <button onPointerDown={onUp} className={buttonClass}>▲</button>
+      <button onPointerDown={onUp} className={buttonClass} aria-label="למעלה">▲</button>
       <div />
-      <button onPointerDown={onLeft} className={buttonClass}>◀</button>
-      <button onPointerDown={onDown} className={buttonClass}>▼</button>
-      <button onPointerDown={onRight} className={buttonClass}>▶</button>
+      <button onPointerDown={onLeft} className={buttonClass} aria-label="שמאלה">◀</button>
+      <button onPointerDown={onDown} className={buttonClass} aria-label="למטה">▼</button>
+      <button onPointerDown={onRight} className={buttonClass} aria-label="ימינה">▶</button>
     </div>
   );
 }

--- a/gamesformykids/components/shared/screens/GameErrorScreen.tsx
+++ b/gamesformykids/components/shared/screens/GameErrorScreen.tsx
@@ -10,20 +10,20 @@ export default function GameErrorScreen({
   errorDetails
 }: ComponentTypes.GameErrorScreenProps) {
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-red-100 to-pink-100">
+    <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-blue-50 to-purple-100">
       <div className="text-center p-8 bg-white rounded-xl shadow-2xl max-w-md mx-4">
         <div className="text-8xl mb-6">😔</div>
-        <h2 className="text-2xl font-bold text-red-600 mb-4">{title}</h2>
+        <h2 className="text-2xl font-bold text-purple-700 mb-4">{title}</h2>
         <p className="text-gray-600 mb-6">{message}</p>
         {errorDetails && (
-          <details className="mb-4 text-left">
+          <details className="mb-4 text-start">
             <summary className="cursor-pointer text-sm text-gray-500 hover:text-gray-700">פרטים טכניים</summary>
             <p className="mt-2 text-xs text-gray-400 font-mono bg-gray-100 p-2 rounded">{errorDetails}</p>
           </details>
         )}
         <button
           onClick={onRetry}
-          className="px-8 py-3 bg-gradient-to-r from-red-500 to-pink-500 hover:from-red-600 hover:to-pink-600 text-white rounded-lg font-bold transition-all duration-200 transform hover:scale-105"
+          className="px-8 py-3 bg-gradient-to-r from-purple-500 to-pink-500 hover:from-purple-600 hover:to-pink-600 text-white rounded-lg font-bold transition-all duration-200 transform hover:scale-105 focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-purple-500"
         >
           🔄 נסה שוב
         </button>


### PR DESCRIPTION
## Summary

10 small, mechanical fixes discovered in ux-ui and a11y review scans — all one-liner or two-liner changes.

## Changes

| Issue | File | Change |
|-------|------|--------|
| #854 | `BubbleGame.tsx` | Stop button `bg-red-500` → `bg-blue-500` (red signals crash to children) |
| #855 | `BubbleGame.tsx` | Remove `animate-pulse` from 3 cloud divs and `animate-bounce` from 2 bird emojis (5 infinite background animations during gameplay) |
| #856 | `MemoryCard.tsx` | Remove `animate-pulse` from face-down ❓ icon (16 simultaneously pulsing cards disrupts concentration) |
| #857 | `GameErrorScreen.tsx` | Change red color scheme → calm purple/blue; retry button red → purple |
| #858 | `CanvasDPadControls.tsx` | Add `aria-label` to all 4 direction buttons (screen readers announced "triangle") |
| #860 | `BlockRenderer.tsx` + `ColorPicker.tsx` | Remove `animate-ping` from sparkle icons, `animate-pulse` from palette icon |
| #861 | `GameErrorScreen.tsx` | `text-left` → `text-start` on details element (RTL fix) |
| #862 | `BubbleGame.tsx` | `right-4` → `end-4` (stats), `left-4` → `start-4` (stop button) — RTL logical positioning |
| #863 | `ColoringCanvas.tsx` | Remove infinite `animate-bounce` from completion star |
| #864 | `error.tsx` | Add `focus-visible:ring` to retry button and home link |

## Testing

- [x] `npx tsc --noEmit` passes

Closes #854
Closes #855
Closes #856
Closes #857
Closes #858
Closes #860
Closes #861
Closes #862
Closes #863
Closes #864

🤖 Generated with [Claude Code](https://claude.com/claude-code)