### PR TITLE
fix(ux): replace sub-12px font sizes in chess components with text-xs

### DIFF
--- a/gamesformykids/app/games/chess/components/ChessBoard.tsx
+++ b/gamesformykids/app/games/chess/components/ChessBoard.tsx
@@ -15,7 +15,7 @@ export default function ChessBoard() {
       <div className="flex flex-col">
         {RANKS.map(rank => (
           <div key={rank} className="w-4 h-10 sm:h-12 flex items-center justify-center">
-            <span className="text-amber-800/60 text-[10px] font-semibold">{rank}</span>
+            <span className="text-amber-800/60 text-xs font-semibold">{rank}</span>
           </div>
         ))}
       </div>
@@ -45,7 +45,7 @@ export default function ChessBoard() {
         <div className="flex mt-1 px-1.5">
           {FILES.map(f => (
             <div key={f} className="w-10 sm:w-12 flex items-center justify-center">
-              <span className="text-amber-800/60 text-[10px] font-semibold">{f}</span>
+              <span className="text-amber-800/60 text-xs font-semibold">{f}</span>
             </div>
           ))}
         </div>

--- a/gamesformykids/app/games/chess/components/ChessCaptured.tsx
+++ b/gamesformykids/app/games/chess/components/ChessCaptured.tsx
@@ -36,7 +36,7 @@ export default function ChessCaptured() {
       {/* Computer's captures (white pieces eaten by computer) */}
       <div className="flex flex-wrap gap-px min-w-0 flex-1">
         {byComputer.length === 0
-          ? <span className="text-[10px] text-slate-700">—</span>
+          ? <span className="text-xs text-slate-700">—</span>
           : byComputer.map((p, i) => (
               <span key={i} className="text-base leading-none" style={{ opacity: 0.65 }}>{PIECE_SYMBOLS[p]}</span>
             ))}
@@ -44,8 +44,8 @@ export default function ChessCaptured() {
 
       {/* Material advantage badge */}
       <div className="flex flex-col items-center gap-0.5 shrink-0">
-        <span className="text-[9px] text-slate-600 uppercase tracking-wider">יתרון</span>
-        <span className={`text-[11px] font-bold px-1.5 py-0.5 rounded-md ${
+        <span className="text-xs text-slate-600 uppercase tracking-wider">יתרון</span>
+        <span className={`text-xs font-bold px-1.5 py-0.5 rounded-md ${
           diff > 0 ? 'text-emerald-400 bg-emerald-400/10' :
           diff < 0 ? 'text-red-400 bg-red-400/10' :
           'text-slate-600 bg-white/5'
@@ -57,7 +57,7 @@ export default function ChessCaptured() {
       {/* Player's captures (black pieces eaten by player) */}
       <div className="flex flex-wrap gap-px min-w-0 flex-1 justify-end">
         {byPlayer.length === 0
-          ? <span className="text-[10px] text-slate-700">—</span>
+          ? <span className="text-xs text-slate-700">—</span>
           : byPlayer.map((p, i) => (
               <span key={i} className="text-base leading-none" style={{ opacity: 0.85 }}>{PIECE_SYMBOLS[p]}</span>
             ))}

--- a/gamesformykids/app/games/chess/components/ChessMoveHistory.tsx
+++ b/gamesformykids/app/games/chess/components/ChessMoveHistory.tsx
@@ -7,7 +7,7 @@ import { useChessGame } from '../useChessGame';
 const RATING_BADGE: Record<string, { label: string; cls: string }> = {
   excellent: { label: '⭐', cls: 'text-yellow-300' },
   great:     { label: '💥', cls: 'text-orange-400' },
-  good:      { label: '✓',  cls: 'text-emerald-400 text-[10px]' },
+  good:      { label: '✓',  cls: 'text-emerald-400 text-xs' },
   castle:    { label: '🏰', cls: 'text-blue-300' },
   normal:    { label: '',   cls: '' },
 };
@@ -23,7 +23,7 @@ function MoveCell({ record, isLastRow }: { record: MoveRecord | undefined; isLas
         : isWhite ? 'text-slate-300' : 'text-slate-500'
     }`}>
       <span>{record.notation}</span>
-      {record.gaveCheck && <span className="text-red-400 me-0.5 text-[9px] font-bold">+</span>}
+      {record.gaveCheck && <span className="text-red-400 me-0.5 text-xs font-bold">+</span>}
       {badge.label && <span className={`me-0.5 ${badge.cls}`}>{badge.label}</span>}
     </td>
   );
@@ -57,9 +57,9 @@ export default function ChessMoveHistory() {
         className="flex items-center justify-between px-3 py-2"
         style={{ borderBottom: '1px solid rgba(255,255,255,0.05)', background: 'rgba(255,255,255,0.025)' }}
       >
-        <span className="text-[10px] text-slate-400 tracking-wider font-semibold uppercase">היסטוריית מהלכים</span>
+        <span className="text-xs text-slate-400 tracking-wider font-semibold uppercase">היסטוריית מהלכים</span>
         <span
-          className="text-[9px] font-mono px-1.5 py-0.5 rounded-md"
+          className="text-xs font-mono px-1.5 py-0.5 rounded-md"
           style={{ background: 'rgba(255,255,255,0.06)', color: 'rgba(255,255,255,0.3)' }}
         >
           {moveHistory.length}
@@ -74,9 +74,9 @@ export default function ChessMoveHistory() {
             style={{ background: 'rgba(8,8,16,0.95)' }}
           >
             <tr>
-              <th className="px-2 py-1 text-[9px] text-slate-700 w-5 text-center">#</th>
-              <th className="px-2 py-1 text-[9px] text-slate-600">♙ לבן</th>
-              <th className="px-2 py-1 text-[9px] text-slate-600">♟ שחור</th>
+              <th className="px-2 py-1 text-xs text-slate-700 w-5 text-center">#</th>
+              <th className="px-2 py-1 text-xs text-slate-600">♙ לבן</th>
+              <th className="px-2 py-1 text-xs text-slate-600">♟ שחור</th>
             </tr>
           </thead>
           <tbody>
@@ -93,7 +93,7 @@ export default function ChessMoveHistory() {
                         : {}
                   }
                 >
-                  <td className="px-2 py-1.5 text-[9px] text-slate-700 text-center font-mono">{i + 1}</td>
+                  <td className="px-2 py-1.5 text-xs text-slate-700 text-center font-mono">{i + 1}</td>
                   <MoveCell record={white} isLastRow={isLastRow} />
                   <MoveCell record={black} isLastRow={isLastRow && !!black} />
                 </tr>

--- a/gamesformykids/app/games/chess/components/ChessPlayerPanel.tsx
+++ b/gamesformykids/app/games/chess/components/ChessPlayerPanel.tsx
@@ -22,7 +22,7 @@ export default function ChessPlayerPanel({ symbol, label, score, isActive, rever
         {symbol}
       </span>
       <div className={`${reversed ? 'text-right' : ''} flex-1`}>
-        <div className="text-slate-400 text-[10px] uppercase tracking-wider leading-none">{label}</div>
+        <div className="text-slate-400 text-xs uppercase tracking-wider leading-none">{label}</div>
         <div className={`text-sm font-extrabold leading-tight mt-0.5 transition-all duration-300 ${isActive ? 'text-amber-300' : 'text-slate-500'}`}>
           {score > 0 ? `${score} ✓` : '0'}
         </div>

--- a/gamesformykids/app/games/chess/components/ChessScoreCards.tsx
+++ b/gamesformykids/app/games/chess/components/ChessScoreCards.tsx
@@ -10,12 +10,12 @@ export default function ChessScoreCards() {
       <div className="flex-1 bg-white/10 border border-white/10 rounded-2xl py-3 text-center">
         <div className="text-3xl leading-none mb-1">♙</div>
         <div className="text-amber-300 font-extrabold text-lg leading-none">{playerScore}</div>
-        <div className="text-slate-400 text-[11px] mt-0.5">ניצחונות</div>
+        <div className="text-slate-400 text-xs mt-0.5">ניצחונות</div>
       </div>
       <div className="flex-1 bg-white/10 border border-white/10 rounded-2xl py-3 text-center">
         <div className="text-3xl leading-none mb-1">♟</div>
         <div className="text-amber-300 font-extrabold text-lg leading-none">{computerScore}</div>
-        <div className="text-slate-400 text-[11px] mt-0.5">ניצחונות</div>
+        <div className="text-slate-400 text-xs mt-0.5">ניצחונות</div>
       </div>
     </div>
   );

--- a/gamesformykids/app/games/chess/components/ChessStatusBar.tsx
+++ b/gamesformykids/app/games/chess/components/ChessStatusBar.tsx
@@ -12,7 +12,7 @@ export default function ChessStatusBar() {
 
       <div className="flex flex-col items-center justify-between gap-1 py-0.5">
         <div className={[
-          'text-[11px] font-extrabold px-3 py-1.5 rounded-xl whitespace-nowrap transition-all duration-300 leading-none',
+          'text-xs font-extrabold px-3 py-1.5 rounded-xl whitespace-nowrap transition-all duration-300 leading-none',
           turn === 'w'
             ? 'bg-[#f0d9b5] text-[#3d1f0a] shadow-md shadow-amber-900/40'
             : 'bg-slate-700/80 text-slate-400',
@@ -21,7 +21,7 @@ export default function ChessStatusBar() {
         </div>
         <button
           onClick={startGame}
-          className="text-[9px] font-semibold text-slate-600 hover:text-slate-300 transition-colors leading-none"
+          className="text-xs font-semibold text-slate-600 hover:text-slate-300 transition-colors leading-none"
         >
           🔄 חדש
         </button>


### PR DESCRIPTION
## Summary

Six chess component files used `text-[9px]`, `text-[10px]`, and `text-[11px]` — sizes below the 12px minimum readable threshold on mobile screens for any age group. Chess targets children ages 8–10+. All occurrences replaced with `text-xs` (12px).

## Changes

- `ChessMoveHistory.tsx` — 7 occurrences
- `ChessCaptured.tsx` — 4 occurrences
- `ChessPlayerPanel.tsx` — 1 occurrence
- `ChessBoard.tsx` — 2 occurrences
- `ChessScoreCards.tsx` — 2 occurrences
- `ChessStatusBar.tsx` — 2 occurrences

## Testing

- [x] `npx tsc --noEmit` passes

Closes #859

🤖 Generated with [Claude Code](https://claude.com/claude-code)