### PR TITLE
perf: snake, drawing, and balloon-pop render loop optimizations (#849-#852)

### DIFF
--- a/gamesformykids/app/games/balloon-pop/useBalloonPopLoop.ts
+++ b/gamesformykids/app/games/balloon-pop/useBalloonPopLoop.ts
@@ -76,21 +76,24 @@ export function useBalloonPopLoop() {
       frameRef.current++;
       let needsUpdate = false;
       const escaped: number[] = [];
+      const kept: typeof st.current.balloons = [];
 
-      st.current.balloons = st.current.balloons.map(b => {
+      for (let i = 0; i < st.current.balloons.length; i++) {
+        const b = st.current.balloons[i]!;
         if (b.popped) {
-          if (b.popAnim < 1) { needsUpdate = true; return { ...b, popAnim: b.popAnim + 0.1 }; }
-          return b;
+          if (b.popAnim >= 1) continue;
+          b.popAnim += 0.1;
+          needsUpdate = true;
+          kept.push(b);
+        } else {
+          const ny = b.y + b.vy;
+          if (ny + b.r < 0 && !b.isBomb) { escaped.push(b.id); needsUpdate = true; continue; }
+          b.y = ny;
+          needsUpdate = true;
+          kept.push(b);
         }
-        const ny = b.y + b.vy;
-        if (ny + b.r < 0 && !b.isBomb) { escaped.push(b.id); needsUpdate = true; }
-        needsUpdate = true;
-        return { ...b, y: ny };
-      }).filter(b => {
-        if (b.popped && b.popAnim >= 1) return false;
-        if (escaped.includes(b.id)) return false;
-        return true;
-      });
+      }
+      st.current.balloons = kept;
 
       if (escaped.length > 0) {
         st.current.lives = Math.max(0, st.current.lives - escaped.length);

--- a/gamesformykids/app/games/drawing/hooks/useDrawingCanvas.ts
+++ b/gamesformykids/app/games/drawing/hooks/useDrawingCanvas.ts
@@ -21,6 +21,7 @@ export interface DrawingState {
 
 export const useDrawingCanvas = () => {
   const canvasRef = useRef<HTMLCanvasElement>(null);
+  const ctxRef   = useRef<CanvasRenderingContext2D | null>(null);
   const [isDrawing, setIsDrawing] = useState(false);
 
   const colors = [
@@ -73,8 +74,9 @@ export const useDrawingCanvas = () => {
     const { x, y } = getEventPosition(e);
     const canvas = canvasRef.current;
     if (!canvas) return;
-    
-    const ctx = canvas.getContext('2d');
+
+    ctxRef.current ??= canvas.getContext('2d');
+    const ctx = ctxRef.current;
     if (!ctx) return;
 
     const { isErasing, eraserSize, brushSize, currentColor } = useDrawingStore.getState();
@@ -99,10 +101,7 @@ export const useDrawingCanvas = () => {
     e.preventDefault();
     
     const { x, y } = getEventPosition(e);
-    const canvas = canvasRef.current;
-    if (!canvas) return;
-    
-    const ctx = canvas.getContext('2d');
+    const ctx = ctxRef.current;
     if (!ctx) return;
 
     const { isErasing, eraserSize, currentColor, brushSize } = useDrawingStore.getState();
@@ -126,22 +125,14 @@ export const useDrawingCanvas = () => {
   // סיום ציור
   const stopDrawing = useCallback(() => {
     setIsDrawing(false);
-    const canvas = canvasRef.current;
-    if (!canvas) return;
-    
-    const ctx = canvas.getContext('2d');
-    if (ctx) {
-      ctx.beginPath();
-    }
+    ctxRef.current?.beginPath();
   }, []);
 
   // ניקוי הקנבס
   const clearCanvas = useCallback(() => {
     const canvas = canvasRef.current;
-    if (!canvas) return;
-    
-    const ctx = canvas.getContext('2d');
-    if (ctx) {
+    const ctx = ctxRef.current;
+    if (canvas && ctx) {
       ctx.clearRect(0, 0, canvas.width, canvas.height);
     }
   }, []);

--- a/gamesformykids/app/games/snake/useSnakeDraw.ts
+++ b/gamesformykids/app/games/snake/useSnakeDraw.ts
@@ -1,78 +1,71 @@
 'use client';
 
 import { useEffect, MutableRefObject } from 'react';
+import { useCanvasLoop } from '@/hooks/canvas/useCanvasLoop';
 import { ROWS, COLS, CELL, type SnakeRefs } from './snakeConstants';
 
+const EYE_OFFSETS: Record<string, [number, number]> = { R: [1, -1], L: [-1, -1], U: [-1, -1], D: [1, 1] };
+
 /**
- * Runs a requestAnimationFrame loop that draws the snake game onto `canvasRef`.
+ * Drives the snake draw loop via useCanvasLoop (rAF lifecycle managed centrally).
+ * Returns the canvas ref to attach to the <canvas> element.
  * Pure rendering concern — no game-state writes.
  */
-export function useSnakeDraw(
-  canvasRef: MutableRefObject<HTMLCanvasElement | null>,
-  st: MutableRefObject<SnakeRefs>,
-) {
-  useEffect(() => {
-    const canvas = canvasRef.current;
-    if (!canvas) return;
-    const ctx = canvas.getContext('2d') as CanvasRenderingContext2D;
-    if (!ctx) return;
+export function useSnakeDraw(st: MutableRefObject<SnakeRefs>) {
+  const canvasRef = useCanvasLoop((ctx) => {
+    const s = st.current;
+    s.animFrame++;
 
-    function draw() {
-      const s = st.current;
-      s.animFrame++;
-
-      // Grid
-      for (let r = 0; r < ROWS; r++) {
-        for (let c = 0; c < COLS; c++) {
-          ctx.fillStyle = (r + c) % 2 === 0 ? '#1a472a' : '#1e5230';
-          ctx.fillRect(c * CELL, r * CELL, CELL, CELL);
-        }
+    // Grid
+    for (let r = 0; r < ROWS; r++) {
+      for (let c = 0; c < COLS; c++) {
+        ctx.fillStyle = (r + c) % 2 === 0 ? '#1a472a' : '#1e5230';
+        ctx.fillRect(c * CELL, r * CELL, CELL, CELL);
       }
-
-      if (s.phase === 'playing' || s.phase === 'dead') {
-        // Food
-        ctx.font = `${CELL - 2}px serif`;
-        ctx.textAlign = 'center';
-        ctx.textBaseline = 'middle';
-        const pulse = 1 + Math.sin(s.animFrame * 0.2) * 0.1;
-        ctx.save();
-        ctx.translate((s.food.x + 0.5) * CELL, (s.food.y + 0.5) * CELL);
-        ctx.scale(pulse, pulse);
-        ctx.fillText(s.foodEmoji, 0, 1);
-        ctx.restore();
-
-        // Snake
-        for (let i = 0; i < s.snake.length; i++) {
-          const p = s.snake[i]!;
-          const isHead = i === 0;
-          const t = 1 - i / s.snake.length;
-          const r = Math.round(50 + t * 100);
-          const g = Math.round(180 + t * 40);
-          ctx.fillStyle = isHead ? '#00E676' : `rgb(${r},${g},40)`;
-          const pad = isHead ? 1 : 2;
-          ctx.beginPath();
-          ctx.roundRect(p.x * CELL + pad, p.y * CELL + pad, CELL - pad * 2, CELL - pad * 2, isHead ? 5 : 3);
-          ctx.fill();
-
-          if (isHead) {
-            const eyeOff = ({ R: [1, -1], L: [-1, -1], U: [-1, -1], D: [1, 1] } as Record<string, [number, number]>)[s.dir]!;
-            ctx.fillStyle = 'white';
-            ctx.beginPath(); ctx.arc(p.x * CELL + CELL * 0.65 + eyeOff[0] * 2, p.y * CELL + CELL * 0.3 + eyeOff[1] * 2, 3, 0, Math.PI * 2); ctx.fill();
-            ctx.fillStyle = '#111';
-            ctx.beginPath(); ctx.arc(p.x * CELL + CELL * 0.65 + eyeOff[0] * 2 + 1, p.y * CELL + CELL * 0.3 + eyeOff[1] * 2 + 1, 1.5, 0, Math.PI * 2); ctx.fill();
-          }
-        }
-      }
-
-      s.raf = requestAnimationFrame(draw);
     }
 
-    st.current.raf = requestAnimationFrame(draw);
+    if (s.phase === 'playing' || s.phase === 'dead') {
+      // Food
+      ctx.font = `${CELL - 2}px serif`;
+      ctx.textAlign = 'center';
+      ctx.textBaseline = 'middle';
+      const pulse = 1 + Math.sin(s.animFrame * 0.2) * 0.1;
+      ctx.save();
+      ctx.translate((s.food.x + 0.5) * CELL, (s.food.y + 0.5) * CELL);
+      ctx.scale(pulse, pulse);
+      ctx.fillText(s.foodEmoji, 0, 1);
+      ctx.restore();
+
+      // Snake
+      for (let i = 0; i < s.snake.length; i++) {
+        const p = s.snake[i]!;
+        const isHead = i === 0;
+        const t = 1 - i / s.snake.length;
+        const r = Math.round(50 + t * 100);
+        const g = Math.round(180 + t * 40);
+        ctx.fillStyle = isHead ? '#00E676' : `rgb(${r},${g},40)`;
+        const pad = isHead ? 1 : 2;
+        ctx.beginPath();
+        ctx.roundRect(p.x * CELL + pad, p.y * CELL + pad, CELL - pad * 2, CELL - pad * 2, isHead ? 5 : 3);
+        ctx.fill();
+
+        if (isHead) {
+          const eyeOff = EYE_OFFSETS[s.dir]!;
+          ctx.fillStyle = 'white';
+          ctx.beginPath(); ctx.arc(p.x * CELL + CELL * 0.65 + eyeOff[0] * 2, p.y * CELL + CELL * 0.3 + eyeOff[1] * 2, 3, 0, Math.PI * 2); ctx.fill();
+          ctx.fillStyle = '#111';
+          ctx.beginPath(); ctx.arc(p.x * CELL + CELL * 0.65 + eyeOff[0] * 2 + 1, p.y * CELL + CELL * 0.3 + eyeOff[1] * 2 + 1, 1.5, 0, Math.PI * 2); ctx.fill();
+        }
+      }
+    }
+  });
+
+  // Clean up the step timer when the canvas unmounts
+  useEffect(() => {
     const stRef = st.current;
-    return () => {
-      cancelAnimationFrame(stRef.raf);
-      clearTimeout(stRef.timer as ReturnType<typeof setTimeout>);
-    };
+    return () => { clearTimeout(stRef.timer as ReturnType<typeof setTimeout>); };
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
+
+  return canvasRef;
 }

--- a/gamesformykids/app/games/snake/useSnakeGame.ts
+++ b/gamesformykids/app/games/snake/useSnakeGame.ts
@@ -16,7 +16,6 @@ import { useSnakeInput } from './useSnakeInput';
 export { W, H } from './snakeConstants';
 
 export function useSnakeGame() {
-  const canvasRef = useRef<HTMLCanvasElement>(null);
   const { saveGameResultRef } = useGameCompletion('snake');
 
   const st = useRef<SnakeRefs>({
@@ -109,7 +108,7 @@ export function useSnakeGame() {
 
   // ─── Sub-hooks ───────────────────────────────────────────────────────────────
 
-  useSnakeDraw(canvasRef, st);
+  const canvasRef = useSnakeDraw(st);
   const { handleTouchStart, handleTouchEnd, controlDir } = useSnakeInput(st);
 
   // ─── Store selectors ─────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Four targeted performance fixes across snake, drawing, and balloon-pop games — all eliminating unnecessary allocations or browser lookups in hot render paths.

## Changes

### #849 — snake: migrate useSnakeDraw from raw rAF to useCanvasLoop
- `app/games/snake/useSnakeDraw.ts` — remove manual `requestAnimationFrame`/`cancelAnimationFrame`; use `useCanvasLoop` hook (rAF lifecycle now managed centrally, matching all other canvas games); API changed to return `canvasRef` instead of accepting it as input
- `app/games/snake/useSnakeGame.ts` — update call site: `useSnakeDraw(canvasRef, st)` → `const canvasRef = useSnakeDraw(st)`

### #850 — snake: hoist eye-offset lookup out of render loop
- `app/games/snake/useSnakeDraw.ts` — `EYE_OFFSETS` hoisted to module-level constant; eliminates ~60 object + 4 array allocations/second that were triggering GC

### #851 — balloon-pop: replace map/filter + spreads with in-place for-loop
- `app/games/balloon-pop/useBalloonPopLoop.ts` — single pass through balloon array mutating in-place (position, popAnim) and building `kept` array; eliminates ~600 object spreads/second at 60fps with 10 balloons

### #852 — drawing: cache canvas context in ref
- `app/games/drawing/hooks/useDrawingCanvas.ts` — add `ctxRef`; `getContext('2d')` called once on first draw and cached; eliminates repeated browser internal lookup on every mousemove/touchmove (~60 calls/sec while drawing)

## Testing

- [x] `npx tsc --noEmit` passes

Closes #849
Closes #850
Closes #851
Closes #852

🤖 Generated with [Claude Code](https://claude.com/claude-code)