### PR TITLE
perf(canvas): add devicePixelRatio scaling to 4 canvas games (#853)

### DIFF
--- a/gamesformykids/app/games/drawing/hooks/useDrawingCanvas.ts
+++ b/gamesformykids/app/games/drawing/hooks/useDrawingCanvas.ts
@@ -24,6 +24,25 @@ export const useDrawingCanvas = () => {
   const ctxRef   = useRef<CanvasRenderingContext2D | null>(null);
   const [isDrawing, setIsDrawing] = useState(false);
 
+  // Apply DPR scaling on mount so strokes are crisp on retina/hi-DPI screens
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+    const dpr = window.devicePixelRatio || 1;
+    if (dpr === 1) { ctxRef.current = ctx; return; }
+    const logicalW = canvas.width;
+    const logicalH = canvas.height;
+    canvas.width  = logicalW * dpr;
+    canvas.height = logicalH * dpr;
+    canvas.style.width  = `${logicalW}px`;
+    canvas.style.height = `${logicalH}px`;
+    ctx.scale(dpr, dpr);
+    ctxRef.current = ctx;
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
   const colors = [
     '#000000', '#FF0000', '#00FF00', '#0000FF', 
     '#FFFF00', '#FF00FF', '#00FFFF', '#FFA500',
@@ -72,10 +91,7 @@ export const useDrawingCanvas = () => {
     setIsDrawing(true);
     
     const { x, y } = getEventPosition(e);
-    const canvas = canvasRef.current;
-    if (!canvas) return;
-
-    ctxRef.current ??= canvas.getContext('2d');
+    ctxRef.current ??= canvasRef.current?.getContext('2d') ?? null;
     const ctx = ctxRef.current;
     if (!ctx) return;
 
@@ -133,7 +149,8 @@ export const useDrawingCanvas = () => {
     const canvas = canvasRef.current;
     const ctx = ctxRef.current;
     if (canvas && ctx) {
-      ctx.clearRect(0, 0, canvas.width, canvas.height);
+      const dpr = window.devicePixelRatio || 1;
+      ctx.clearRect(0, 0, canvas.width / dpr, canvas.height / dpr);
     }
   }, []);
 

--- a/gamesformykids/app/games/drawing/hooks/useDrawingCanvas.ts
+++ b/gamesformykids/app/games/drawing/hooks/useDrawingCanvas.ts
@@ -40,7 +40,6 @@ export const useDrawingCanvas = () => {
     canvas.style.height = `${logicalH}px`;
     ctx.scale(dpr, dpr);
     ctxRef.current = ctx;
-  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   const colors = [

--- a/gamesformykids/app/games/hebrew-letters/components/canvas/useLetterGuideOverlay.ts
+++ b/gamesformykids/app/games/hebrew-letters/components/canvas/useLetterGuideOverlay.ts
@@ -25,6 +25,13 @@ export function useLetterGuideOverlay({
     const ctx = canvas.getContext('2d');
     if (!ctx) return;
 
+    const dpr = window.devicePixelRatio || 1;
+    canvas.width  = width  * dpr;
+    canvas.height = height * dpr;
+    canvas.style.width  = `${width}px`;
+    canvas.style.height = `${height}px`;
+    ctx.scale(dpr, dpr);
+
     ctx.clearRect(0, 0, width, height);
 
     const fontSize = Math.min(width, height) * 0.6;

--- a/gamesformykids/app/games/hebrew-letters/components/canvas/useWritingCanvas.ts
+++ b/gamesformykids/app/games/hebrew-letters/components/canvas/useWritingCanvas.ts
@@ -43,6 +43,13 @@ export function useWritingCanvas({ width, height, backgroundColor }: UseWritingC
     const ctx = canvas.getContext('2d');
     if (!ctx) return;
 
+    const dpr = window.devicePixelRatio || 1;
+    canvas.width  = width  * dpr;
+    canvas.height = height * dpr;
+    canvas.style.width  = `${width}px`;
+    canvas.style.height = `${height}px`;
+    ctx.scale(dpr, dpr);
+
     ctx.lineCap = 'round';
     ctx.lineJoin = 'round';
     ctx.strokeStyle = drawingState.currentStrokeColor;

--- a/gamesformykids/app/games/snake/useSnakeDraw.ts
+++ b/gamesformykids/app/games/snake/useSnakeDraw.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, MutableRefObject } from 'react';
+import { useEffect, useRef, MutableRefObject } from 'react';
 import { useCanvasLoop } from '@/hooks/canvas/useCanvasLoop';
 import { ROWS, COLS, CELL, type SnakeRefs } from './snakeConstants';
 
@@ -12,7 +12,23 @@ const EYE_OFFSETS: Record<string, [number, number]> = { R: [1, -1], L: [-1, -1],
  * Pure rendering concern — no game-state writes.
  */
 export function useSnakeDraw(st: MutableRefObject<SnakeRefs>) {
+  const dprRef = useRef<number | null>(null);
+
   const canvasRef = useCanvasLoop((ctx) => {
+    // Apply DPR on first frame; use setTransform every frame so scale is always correct
+    if (dprRef.current === null) {
+      const dpr = window.devicePixelRatio || 1;
+      dprRef.current = dpr;
+      if (dpr !== 1) {
+        const c = ctx.canvas;
+        c.width  = COLS * CELL * dpr;
+        c.height = ROWS * CELL * dpr;
+        c.style.width  = `${COLS * CELL}px`;
+        c.style.height = `${ROWS * CELL}px`;
+      }
+    }
+    ctx.setTransform(dprRef.current, 0, 0, dprRef.current, 0, 0);
+
     const s = st.current;
     s.animFrame++;
 


### PR DESCRIPTION
## Summary

Four canvas games set `canvas.width`/`canvas.height` without accounting for `devicePixelRatio`. On retina and hi-DPI screens (every modern iPhone, Pixel, Samsung Galaxy), the canvas renders at 1× resolution and is CSS-scaled up — resulting in blurry lines and fuzzy text. This is most harmful in the **letter-tracing and drawing games** where crisp strokes are critical for children learning to write.

## Changes

- `app/games/snake/useSnakeDraw.ts` — scale canvas to `COLS×CELL×dpr` / `ROWS×CELL×dpr`; `ctx.scale(dpr, dpr)` before the rAF loop starts
- `app/games/drawing/hooks/useDrawingCanvas.ts` — DPR setup on mount (reads logical dimensions from canvas element set in JSX); also caches ctx in `ctxRef` to eliminate repeated `getContext()` calls on every pointer event
- `app/games/hebrew-letters/components/canvas/useLetterGuideOverlay.ts` — DPR setup at the start of the draw effect (re-applies whenever letter, width, height, or opacity change)
- `app/games/hebrew-letters/components/canvas/useWritingCanvas.ts` — DPR setup in the DOM init effect, before the context is stored in `contextRef`

**Note**: `useCanvasLoop` and `CanvasGameShell` intentionally do not apply DPR — each game is responsible for its own canvas setup. This PR addresses the 4 games that were missing it.

## Testing

- [x] `npx tsc --noEmit` passes

Closes #853

🤖 Generated with [Claude Code](https://claude.com/claude-code)