### PR TITLE
fix(runtime): replace non-null assertion on EYE_OFFSETS lookup in useSnakeDraw

### DIFF
--- a/gamesformykids/app/games/snake/useSnakeDraw.ts
+++ b/gamesformykids/app/games/snake/useSnakeDraw.ts
@@ -66,7 +66,7 @@ export function useSnakeDraw(st: MutableRefObject<SnakeRefs>) {
         ctx.fill();
 
         if (isHead) {
-          const eyeOff = EYE_OFFSETS[s.dir]!;
+          const eyeOff = EYE_OFFSETS[s.dir] ?? [1, -1];
           ctx.fillStyle = 'white';
           ctx.beginPath(); ctx.arc(p.x * CELL + CELL * 0.65 + eyeOff[0] * 2, p.y * CELL + CELL * 0.3 + eyeOff[1] * 2, 3, 0, Math.PI * 2); ctx.fill();
           ctx.fillStyle = '#111';


### PR DESCRIPTION
## Summary

Replaces the non-null assertion `EYE_OFFSETS[s.dir]!` with a nullish-coalescing fallback `?? [1, -1]`. `EYE_OFFSETS` only has entries for `R/L/U/D`; if `s.dir` is ever another value (game init race, future direction refactor) the assertion silently returns `undefined`, causing `NaN` coordinates in the eye `arc()` calls and a missing-eyes visual glitch with no console error.

## Changes

- `app/games/snake/useSnakeDraw.ts` line 69: `EYE_OFFSETS[s.dir]!` → `EYE_OFFSETS[s.dir] ?? [1, -1]`

## Testing

- [x] `npx tsc --noEmit` passes
- [ ] Manually verified snake eyes render correctly at `http://localhost:3000/games/snake`

Closes #911

🤖 Generated with [Claude Code](https://claude.com/claude-code)