### PR TITLE
fix(runtime): correct double-DPR coordinate scaling and undo in Drawing + Hebrew Letters

### DIFF
--- a/gamesformykids/app/games/drawing/hooks/useDrawingCanvas.ts
+++ b/gamesformykids/app/games/drawing/hooks/useDrawingCanvas.ts
@@ -76,8 +76,8 @@ export const useDrawingCanvas = () => {
       clientY = e.clientY;
     }
     
-    const x = (clientX - rect.left) * (canvas.width / rect.width);
-    const y = (clientY - rect.top) * (canvas.height / rect.height);
+    const x = clientX - rect.left;
+    const y = clientY - rect.top;
     
     return { x, y };
   }, []);

--- a/gamesformykids/app/games/hebrew-letters/components/canvas/useWritingCanvas.ts
+++ b/gamesformykids/app/games/hebrew-letters/components/canvas/useWritingCanvas.ts
@@ -36,7 +36,7 @@ export function useWritingCanvas({ width, height, backgroundColor }: UseWritingC
     initializeCanvas(width, height, backgroundColor);
   }, [initializeCanvas, width, height, backgroundColor]);
 
-  // אתחול DOM של הקנבס
+  // אתחול DOM של הקנבס — runs only when canvas dimensions or background change
   useEffect(() => {
     const canvas = canvasRef.current;
     if (!canvas) return;
@@ -52,14 +52,15 @@ export function useWritingCanvas({ width, height, backgroundColor }: UseWritingC
 
     ctx.lineCap = 'round';
     ctx.lineJoin = 'round';
-    ctx.strokeStyle = drawingState.currentStrokeColor;
-    ctx.lineWidth = drawingState.currentStrokeWidth;
 
     ctx.fillStyle = backgroundColor;
     ctx.fillRect(0, 0, width, height);
 
     contextRef.current = ctx;
-  }, [width, height, backgroundColor, drawingState.currentStrokeColor, drawingState.currentStrokeWidth]);
+  // Stroke style deps intentionally excluded — handled by the effect below.
+  // Including them here would reset canvas.width (clearing drawings) on every brush change.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [width, height, backgroundColor]);
 
   // עדכון צבע/עובי על שינוי state
   useEffect(() => {
@@ -91,7 +92,8 @@ export function useWritingCanvas({ width, height, backgroundColor }: UseWritingC
     (x: number, y: number) => {
       const ctx = contextRef.current;
       if (!ctx) return;
-      const imageData = ctx.getImageData(0, 0, width, height);
+      const dpr = window.devicePixelRatio || 1;
+      const imageData = ctx.getImageData(0, 0, width * dpr, height * dpr);
       saveCanvasState(imageData);
       startDrawingStore(x, y);
       ctx.beginPath();

--- a/gamesformykids/app/games/hebrew-letters/components/canvas/useWritingCanvas.ts
+++ b/gamesformykids/app/games/hebrew-letters/components/canvas/useWritingCanvas.ts
@@ -57,9 +57,6 @@ export function useWritingCanvas({ width, height, backgroundColor }: UseWritingC
     ctx.fillRect(0, 0, width, height);
 
     contextRef.current = ctx;
-  // Stroke style deps intentionally excluded — handled by the effect below.
-  // Including them here would reset canvas.width (clearing drawings) on every brush change.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [width, height, backgroundColor]);
 
   // עדכון צבע/עובי על שינוי state

--- a/gamesformykids/app/games/hebrew-letters/store/hebrewLettersStore.ts
+++ b/gamesformykids/app/games/hebrew-letters/store/hebrewLettersStore.ts
@@ -100,8 +100,11 @@ export function getCanvasPosition(
   canvas: HTMLCanvasElement,
 ): { x: number; y: number } {
   const rect = canvas.getBoundingClientRect();
-  const scaleX = canvas.width / rect.width;
-  const scaleY = canvas.height / rect.height;
+  // canvas.width is the physical pixel buffer; divide out DPR so we return logical coords.
+  // ctx.scale(dpr, dpr) is already applied — passing physical coords would double-scale.
+  const dpr = window.devicePixelRatio || 1;
+  const scaleX = (canvas.width / rect.width) / dpr;
+  const scaleY = (canvas.height / rect.height) / dpr;
   let clientX: number, clientY: number;
   if (event instanceof MouseEvent) {
     clientX = event.clientX;


### PR DESCRIPTION
## Summary

PR #885 added `ctx.scale(dpr, dpr)` to canvas games for retina sharpness, but did not update the event-coordinate formulas that pre-dated it. This introduced three regressions on retina displays (dpr=2), plus a pre-existing canvas-clear-on-brush-change issue that the DPR change made worse:

1. **Drawing game strokes fly off-screen** — `getEventPosition` computed `x = (clientX - rect.left) * (canvas.width / rect.width)`, which equals `(clientX - rect.left) * dpr` after PR #885. Then `ctx.moveTo(x, y)` with `ctx.scale(dpr, dpr)` active multiplies by `dpr` again → strokes land at `dpr²` the cursor distance.

2. **Hebrew Letters strokes misplaced** — `getCanvasPosition` in `hebrewLettersStore` used the same `canvas.width / rect.width` formula, now returning `dpr` instead of 1.

3. **Undo corrupts drawing on retina** — `ctx.getImageData(0, 0, width, height)` ignores `ctx.scale` and operates in physical pixels. The canvas buffer is `width*dpr × height*dpr` physical pixels, so this captured only the top-left quarter. Every undo call overwrote the drawing with a tiny patch.

4. **Brush change erases drawing** — The DOM-init effect in `useWritingCanvas` included `drawingState.currentStrokeColor` and `drawingState.currentStrokeWidth` in its deps. Every brush change re-ran `canvas.width = width * dpr` (clearing the buffer) and `ctx.fillRect` (filling with background). A separate child effect already handles style-only updates correctly.

## Changes

| File | Fix |
|------|-----|
| `app/games/drawing/hooks/useDrawingCanvas.ts` | `getEventPosition`: use `clientX - rect.left` (no ratio) — context transform handles DPR |
| `app/games/hebrew-letters/store/hebrewLettersStore.ts` | `getCanvasPosition`: divide `scaleX`/`scaleY` by `window.devicePixelRatio` |
| `app/games/hebrew-letters/components/canvas/useWritingCanvas.ts` | `getImageData(0, 0, width*dpr, height*dpr)`; remove stroke deps from DOM-init effect |

## Testing

- [x] `npx tsc --noEmit` passes (zero errors)
- [ ] Drawing strokes follow cursor on retina — `/games/drawing`
- [ ] Hebrew letter writing strokes follow touch on retina — `/games/hebrew-letters`
- [ ] Undo in Hebrew Letters restores full drawing on retina
- [ ] Changing brush color does not erase drawn content

Closes #904
Closes #906
Closes #908
Closes #910

🤖 Generated with [Claude Code](https://claude.com/claude-code)