### PR TITLE
fix(ux,rtl,a11y): bundle of 9 fixes (#888-#903)

### DIFF
--- a/gamesformykids/app/dashboard/components/DashboardHeader.tsx
+++ b/gamesformykids/app/dashboard/components/DashboardHeader.tsx
@@ -11,7 +11,7 @@ export function DashboardHeader() {
         href="/"
         className="inline-block mt-4 text-purple-600 hover:text-purple-800 text-sm font-medium transition-colors"
       >
-        ← חזרה לעמוד הראשי
+        → חזרה לעמוד הראשי
       </Link>
     </div>
   );

--- a/gamesformykids/app/games/color-tap/components/ColorTapPlayArea.tsx
+++ b/gamesformykids/app/games/color-tap/components/ColorTapPlayArea.tsx
@@ -37,7 +37,7 @@ export default function ColorTapPlayArea() {
 
       <div className={`mb-6 rounded-3xl p-6 text-center shadow-xl w-full max-w-xs transition-all duration-200 ${
         feedback === 'correct' ? 'bg-green-100 ring-4 ring-green-400' :
-        feedback === 'wrong' ? 'bg-red-100 ring-4 ring-red-400' : 'bg-white'
+        feedback === 'wrong' ? 'bg-amber-50 ring-4 ring-amber-400' : 'bg-white'
       }`}>
         <p className="text-gray-400 text-sm mb-3">בחר את הצבע:</p>
         <div className="flex items-center gap-4 justify-center mb-3">

--- a/gamesformykids/app/games/educational/page.tsx
+++ b/gamesformykids/app/games/educational/page.tsx
@@ -64,7 +64,7 @@ export default function EducationalPage() {
             href="/"
             className="inline-flex items-center gap-2 text-teal-700 hover:text-teal-900 font-semibold transition-colors"
           >
-            ← חזרה לדף הבית
+            → חזרה לדף הבית
           </Link>
         </div>
       </div>

--- a/gamesformykids/app/games/emoji-math/components/EmojiMathPlayArea.tsx
+++ b/gamesformykids/app/games/emoji-math/components/EmojiMathPlayArea.tsx
@@ -49,7 +49,7 @@ export default function EmojiMathPlayArea() {
 
       <div className={`w-full max-w-sm bg-white rounded-3xl p-5 shadow-2xl mb-5 transition-all duration-200 ${
         feedback === 'correct' ? 'ring-4 ring-green-400 bg-green-50' :
-        feedback === 'wrong' ? 'ring-4 ring-red-400 bg-red-50' : ''
+        feedback === 'wrong' ? 'ring-4 ring-amber-400 bg-amber-50' : ''
       }`}>
         <p className="text-center text-gray-400 text-xs mb-3">רמה {level}</p>
         <div className="flex flex-wrap gap-1 justify-center mb-3 min-h-12 p-2 bg-orange-50 rounded-2xl">

--- a/gamesformykids/app/games/math-race/components/MathRaceQuestion.tsx
+++ b/gamesformykids/app/games/math-race/components/MathRaceQuestion.tsx
@@ -18,11 +18,11 @@ export default function MathRaceQuestion({ q, feedback, streak, onTap }: Props) 
     <>
       <div className={`w-full max-w-sm bg-white rounded-3xl p-8 text-center shadow-2xl mb-5 transition-all duration-150 ${
         feedback === 'correct' ? 'bg-green-50 ring-4 ring-green-400 scale-105' :
-        feedback === 'wrong' ? 'bg-red-50 ring-4 ring-red-400' : ''
+        feedback === 'wrong' ? 'bg-amber-50 ring-4 ring-amber-400' : ''
       }`}>
         <p className="text-4xl font-black text-gray-700">{q.text}</p>
         {feedback && (
-          <p className={`text-2xl mt-3 font-bold ${feedback === 'correct' ? 'text-green-500' : 'text-red-500'}`}>
+          <p className={`text-2xl mt-3 font-bold ${feedback === 'correct' ? 'text-green-500' : 'text-amber-600'}`}>
             {feedback === 'correct' ? `✅ ${streak >= 3 ? 'בום! +20' : 'נכון! +10'}` : `❌ התשובה: ${q.answer}`}
           </p>
         )}

--- a/gamesformykids/app/games/taki/components/TakiCardView.tsx
+++ b/gamesformykids/app/games/taki/components/TakiCardView.tsx
@@ -44,7 +44,7 @@ export default function TakiCardView({ card, onClick, disabled, small, canPlay =
         ) : (
           <>
             <span className={small ? 'text-base leading-none' : 'text-xl leading-none'}>{emoji}</span>
-            <span className={small ? 'text-[9px] mt-0.5 leading-tight' : 'text-[10px] mt-1 leading-tight text-center px-0.5'}>
+            <span className={small ? 'text-xs mt-0.5 leading-tight' : 'text-xs mt-1 leading-tight text-center px-0.5'}>
               {label}
             </span>
           </>

--- a/gamesformykids/app/games/taki/components/TakiTable.tsx
+++ b/gamesformykids/app/games/taki/components/TakiTable.tsx
@@ -21,7 +21,7 @@ export default function TakiTable() {
           title="משוך קלף"
         >
           <FaceDownCard />
-          <span className="absolute -bottom-5 left-0 right-0 text-center text-gray-300 text-[10px]">משוך</span>
+          <span className="absolute -bottom-5 inset-x-0 text-center text-gray-300 text-xs">משוך</span>
         </button>
       </div>
 

--- a/gamesformykids/app/games/true-false/components/TrueFalsePlayScreen.tsx
+++ b/gamesformykids/app/games/true-false/components/TrueFalsePlayScreen.tsx
@@ -26,12 +26,12 @@ export default function TrueFalsePlayScreen() {
       </div>
       <div className={`w-full max-w-sm bg-white rounded-3xl p-6 text-center shadow-2xl mb-6 transition-all duration-200 ${
         feedback === 'correct' ? 'ring-4 ring-green-400 bg-green-50' :
-        feedback === 'wrong'   ? 'ring-4 ring-red-400 bg-red-50' : ''
+        feedback === 'wrong'   ? 'ring-4 ring-amber-400 bg-amber-50' : ''
       }`}>
         <div className="text-5xl mb-4">{q?.emoji}</div>
         <p className="text-xl font-bold text-gray-700 leading-relaxed">{q?.fact}</p>
         {feedback && (
-          <p className={`text-3xl mt-3 ${feedback === 'correct' ? 'text-green-500' : 'text-red-500'}`}>
+          <p className={`text-3xl mt-3 ${feedback === 'correct' ? 'text-green-500' : 'text-amber-600'}`}>
             {feedback === 'correct' ? '✅ נכון!' : q?.answer ? '❌ אוי! זה נכון' : '❌ אוי! זה לא נכון'}
           </p>
         )}

--- a/gamesformykids/app/games/tzadikim/components/StoryReadingView.tsx
+++ b/gamesformykids/app/games/tzadikim/components/StoryReadingView.tsx
@@ -32,7 +32,7 @@ export default function StoryReadingView({
             onClick={onBack}
             className="absolute top-4 right-4 text-white/80 hover:text-white text-sm font-medium bg-white/20 rounded-full px-3 py-1"
           >
-            ← חזור
+            → חזור
           </button>
           <div className="text-6xl mb-2">{story.emoji}</div>
           <h1 className="text-3xl font-bold mb-1">{story.name}</h1>

--- a/gamesformykids/app/login/components/GoogleSignInButton.tsx
+++ b/gamesformykids/app/login/components/GoogleSignInButton.tsx
@@ -20,7 +20,7 @@ export default function GoogleSignInButton({ onSignIn }: GoogleSignInButtonProps
         onClick={onSignIn}
         className="w-full flex items-center justify-center px-4 py-3 border border-gray-300 rounded-lg shadow-sm bg-white text-gray-700 hover:bg-gray-50 transition-colors"
       >
-        <svg className="w-5 h-5 mr-3" viewBox="0 0 24 24">
+        <svg className="w-5 h-5 me-3" viewBox="0 0 24 24">
           <path fill="#4285F4" d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z" />
           <path fill="#34A853" d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z" />
           <path fill="#FBBC05" d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z" />

--- a/gamesformykids/app/login/components/GuestButton.tsx
+++ b/gamesformykids/app/login/components/GuestButton.tsx
@@ -11,7 +11,7 @@ export default function GuestButton({ onContinueAsGuest }: GuestButtonProps) {
         onClick={onContinueAsGuest}
         className="w-full flex items-center justify-center px-4 py-4 rounded-lg shadow-sm bg-green-600 text-white hover:bg-green-700 transition-colors text-lg font-semibold"
       >
-        <span className="text-2xl mr-3">{LOGIN_LABELS.guestEmoji}</span>
+        <span className="text-2xl me-3">{LOGIN_LABELS.guestEmoji}</span>
         {LOGIN_LABELS.guestPlay}
       </button>
 

--- a/gamesformykids/app/profile/components/ProfilePageHeader.tsx
+++ b/gamesformykids/app/profile/components/ProfilePageHeader.tsx
@@ -4,7 +4,7 @@ export function ProfilePageHeader() {
   return (
     <div className="text-center mb-8">
       <Link href="/" className="inline-flex items-center text-purple-600 hover:text-purple-800 mb-4">
-        ← חזור לדף הבית
+        → חזור לדף הבית
       </Link>
       <h1 className="text-3xl font-bold text-purple-800">הפרופיל שלי</h1>
     </div>

--- a/gamesformykids/app/settings/SettingsClient.tsx
+++ b/gamesformykids/app/settings/SettingsClient.tsx
@@ -7,6 +7,7 @@ import { useAuth } from '@/hooks/shared/auth/useAuth';
 import { AudioSection } from '@/components/settings/AudioSection';
 import { AppearanceSection } from '@/components/settings/AppearanceSection';
 import { AccountSection } from '@/components/settings/AccountSection';
+import GameSpinnerScreen from '@/components/ui/GameSpinnerScreen';
 
 export default function SettingsClient() {
   const { user, loading: authLoading, signOut } = useAuth();
@@ -14,11 +15,7 @@ export default function SettingsClient() {
   const [saving, setSaving] = useState(false);
 
   if (authLoading || settingsLoading) {
-    return (
-      <div className="min-h-screen bg-gradient-to-br from-purple-100 to-blue-100 flex items-center justify-center">
-        <div className="text-xl">טוען...</div>
-      </div>
-    );
+    return <GameSpinnerScreen />;
   }
 
   if (!user) {
@@ -53,7 +50,7 @@ export default function SettingsClient() {
       <div className="max-w-2xl mx-auto">
         <div className="text-center mb-8">
           <Link href="/" className="inline-flex items-center text-purple-600 hover:text-purple-800 mb-4">
-            ← חזור לדף הבית
+            → חזור לדף הבית
           </Link>
           <h1 className="text-3xl font-bold text-purple-800">הגדרות</h1>
         </div>
@@ -77,7 +74,7 @@ export default function SettingsClient() {
         </div>
 
         {saving && (
-          <div className="fixed bottom-4 right-4 bg-purple-600 text-white px-4 py-2 rounded-lg shadow-lg">
+          <div role="status" aria-live="polite" className="fixed bottom-4 end-4 bg-purple-600 text-white px-4 py-2 rounded-lg shadow-lg">
             שומר...
           </div>
         )}

--- a/gamesformykids/components/settings/SettingToggle.tsx
+++ b/gamesformykids/components/settings/SettingToggle.tsx
@@ -15,7 +15,7 @@ export function SettingToggle({ label, description, checked, onChange, disabled 
           disabled={disabled}
           className="sr-only peer"
         />
-        <div className="w-11 h-6 bg-gray-200 peer-focus:outline-none peer-focus:ring-4 peer-focus:ring-purple-300 rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-purple-600" />
+        <div className="w-11 h-6 bg-gray-200 peer-focus:outline-none peer-focus:ring-4 peer-focus:ring-purple-300 rounded-full peer peer-checked:after:translate-x-full rtl:peer-checked:after:-translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:start-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-purple-600" />
       </label>
     </div>
   );

--- a/gamesformykids/components/ui/NotificationToast.tsx
+++ b/gamesformykids/components/ui/NotificationToast.tsx
@@ -81,7 +81,7 @@ export default function NotificationToast() {
   return (
     <div
       aria-live="assertive"
-      className="fixed bottom-6 left-6 z-[9999] flex flex-col gap-2 pointer-events-none"
+      className="fixed bottom-6 start-6 z-[9999] flex flex-col gap-2 pointer-events-none"
     >
       {notifications.map((n) => (
         <div key={n.id} className="pointer-events-auto animate-slide-in-up">

--- a/gamesformykids/components/ui/OfflineBanner.tsx
+++ b/gamesformykids/components/ui/OfflineBanner.tsx
@@ -22,7 +22,7 @@ export function OfflineBanner() {
     <div
       role="alert"
       dir="rtl"
-      className="fixed top-0 inset-x-0 z-[9999] bg-red-500 text-white text-center py-2 px-4 text-sm font-semibold"
+      className="fixed top-0 inset-x-0 z-[9999] bg-amber-500 text-white text-center py-2 px-4 text-sm font-semibold"
     >
       📵 אין חיבור לאינטרנט — משחקים שנטענו בעבר עדיין זמינים
     </div>


### PR DESCRIPTION
## Summary

9 targeted UX, RTL, and accessibility fixes discovered by ux-ui review scans.

## Changes

| Issue | File(s) | Change |
|-------|---------|--------|
| #888 | `SettingToggle.tsx` | `after:left-[2px]` → `after:start-[2px]`; add `rtl:peer-checked:after:-translate-x-full` so knob moves in the correct direction in Hebrew RTL |
| #890 | 6 files | `← חזרה/חזור` → `→ חזרה/חזור` — right-pointing arrow is the correct "back" symbol in RTL |
| #891 | `ColorTapPlayArea`, `EmojiMathPlayArea`, `MathRaceQuestion`, `TrueFalsePlayScreen` | Wrong-answer `bg-red-*/ring-red-*` → `bg-amber-*/ring-amber-*`; `text-red-500` → `text-amber-600` |
| #894 | `NotificationToast.tsx` | `left-6` → `start-6` so toasts appear at the leading corner for Hebrew readers |
| #897 | `TakiCardView.tsx`, `TakiTable.tsx` | `text-[9px]/text-[10px]` → `text-xs`; `left-0 right-0` → `inset-x-0` |
| #898 | `OfflineBanner.tsx` | `bg-red-500` → `bg-amber-500` — informational offline message should not use alarming red |
| #900 | `GoogleSignInButton.tsx`, `GuestButton.tsx` | `mr-3` → `me-3` (logical end margin) |
| #901 | `SettingsClient.tsx` | `right-4` → `end-4`; add `role="status" aria-live="polite"` to saving indicator |
| #903 | `SettingsClient.tsx` | Replace bare `טוען...` text with `<GameSpinnerScreen />` |

## Testing

- [x] `npx tsc --noEmit` passes

Closes #888
Closes #890
Closes #891
Closes #894
Closes #897
Closes #898
Closes #900
Closes #901
Closes #903

🤖 Generated with [Claude Code](https://claude.com/claude-code)