### PR TITLE
fix(loader): add visual-opposites and english-cards to loadGameItems switch

### DIFF
--- a/gamesformykids/lib/constants/gameItemsLoader.ts
+++ b/gamesformykids/lib/constants/gameItemsLoader.ts
@@ -124,8 +124,10 @@ export async function loadGameItems(gameType: GameType): Promise<BaseGameItem[]>
     case 'days-of-week':     return (await import('./gameData/daysMonths')).DAYS_OF_WEEK;
     case 'months-of-year':   return (await import('./gameData/daysMonths')).MONTHS_OF_YEAR;
     case 'ordinals':         return (await import('./gameData/ordinals')).ORDINAL_NUMBERS;
-    case 'spatial-concepts': return (await import('./gameData/spatialConcepts')).SPATIAL_CONCEPTS;
-    case 'number-words':     return (await import('./gameData/numberWords')).NUMBER_WORDS;
+    case 'spatial-concepts':   return (await import('./gameData/spatialConcepts')).SPATIAL_CONCEPTS;
+    case 'number-words':       return (await import('./gameData/numberWords')).NUMBER_WORDS;
+    case 'visual-opposites':   return (await import('./gameData/oppositeItems')).OPPOSITES_ITEMS;
+    case 'english-cards':      return (await import('./gameData/englishFirst')).ENGLISH_FIRST_ITEMS;
 
     // newGames.ts (mixed exports — use extractItems boundary)
     case 'world-food': return extractItems(await import('./gameData/newGames'), 'WORLD_FOOD_ITEMS');


### PR DESCRIPTION
## Problem

`visual-opposites` (ניגודים) and `english-cards` (אנגלית ראשונה) are registered as card games in `SUPPORTED_GAMES` and `gameItemsMap.ts`, but were missing `case` entries in the `loadGameItems` server-side switch statement.

The `page.tsx` server component calls `loadGameItems(gameType)` before mounting `UltimateGamePage`. Without a matching case, both games fell through to `default: return []` — so the `GameTypeProvider` received an empty items array and the games had nothing to display or challenge the player with.

## Fix

Added two cases to the `loadGameItems` switch in `gameItemsLoader.ts`:

```ts
case 'visual-opposites':  return (await import('./gameData/oppositeItems')).OPPOSITES_ITEMS;
case 'english-cards':     return (await import('./gameData/englishFirst')).ENGLISH_FIRST_ITEMS;
```

## Testing

- `npx tsc --noEmit` — 0 errors
- Visit `/games/visual-opposites` and `/games/english-cards` — both load with full item sets