### PR TITLE
feat(game): sorting categories and pattern recognition quiz games

### DIFF
--- a/gamesformykids/app/games/[gameType]/gamePageConstants.ts
+++ b/gamesformykids/app/games/[gameType]/gamePageConstants.ts
@@ -43,6 +43,7 @@ export const SUPPORTED_GAMES = [
   'phonics',
   'rhyming', 'adjectives',
   'soccer',
+  'sorting', 'patterns',
 ] as const;
 
 export type SupportedGameType = typeof SUPPORTED_GAMES[number];

--- a/gamesformykids/components/game/quiz/screens/PatternQuestion.tsx
+++ b/gamesformykids/components/game/quiz/screens/PatternQuestion.tsx
@@ -1,0 +1,36 @@
+'use client';
+
+import { QuizQuestionShell } from '@/components/game/quiz';
+import type { PatternQuestionWithChoices } from '@/lib/quiz/usePatternsGame';
+
+interface Props {
+  current: PatternQuestionWithChoices;
+  onSelect: (choice: string) => void;
+}
+
+export default function PatternQuestion({ current, onSelect }: Props) {
+  const { question, choices } = current;
+
+  return (
+    <QuizQuestionShell
+      theme="sky"
+      choices={choices}
+      correctLabel={question.answer}
+      onSelect={onSelect}
+      correctMsg={`✅ נכון! הדפוס ממשיך עם ${question.answer}`}
+      wrongMsg={`💙 הדפוס ממשיך עם ${question.answer}`}
+    >
+      <p className="text-sm font-semibold text-gray-400 mb-4">מה בא הלאה בדפוס?</p>
+      <div className="flex items-center justify-center gap-2 flex-wrap mb-2">
+        {question.sequence.map((item, i) => (
+          <span
+            key={i}
+            className={`text-4xl ${item === '❓' ? 'bg-gray-100 rounded-xl px-2 py-1 border-2 border-dashed border-gray-300' : ''}`}
+          >
+            {item}
+          </span>
+        ))}
+      </div>
+    </QuizQuestionShell>
+  );
+}

--- a/gamesformykids/components/game/quiz/screens/SortingQuestion.tsx
+++ b/gamesformykids/components/game/quiz/screens/SortingQuestion.tsx
@@ -1,0 +1,40 @@
+'use client';
+
+import { QuizQuestionShell } from '@/components/game/quiz';
+import type { SortingQuestion } from '@/lib/quiz/useSortingGame';
+
+interface Props {
+  current: SortingQuestion;
+  onSelect: (choice: string) => void;
+}
+
+export default function SortingQuestion({ current, onSelect }: Props) {
+  const { item, categoryA, categoryB, itemCategory } = current;
+  const correctLabel = itemCategory === 'A' ? categoryA.name : categoryB.name;
+  const choices = [categoryA.name, categoryB.name];
+
+  return (
+    <QuizQuestionShell
+      theme="emerald"
+      choices={choices}
+      correctLabel={correctLabel}
+      onSelect={onSelect}
+      cols={2}
+      correctMsg={`✅ נכון! ${item.emoji} ${item.name} שייך ל${correctLabel}`}
+      wrongMsg={`💙 ${item.emoji} ${item.name} שייך ל${correctLabel}`}
+      renderChoice={(choice) => {
+        const cat = choice === categoryA.name ? categoryA : categoryB;
+        return (
+          <span className="flex items-center gap-2 justify-center text-lg font-bold">
+            <span className="text-2xl">{cat.emoji}</span>
+            {choice}
+          </span>
+        );
+      }}
+    >
+      <p className="text-sm font-semibold text-gray-400 mb-3">לאיזו קבוצה שייך?</p>
+      <div className="text-7xl mb-3">{item.emoji}</div>
+      <p className="text-3xl font-black text-gray-800">{item.name}</p>
+    </QuizQuestionShell>
+  );
+}

--- a/gamesformykids/lib/constants/gameCategories.ts
+++ b/gamesformykids/lib/constants/gameCategories.ts
@@ -70,7 +70,7 @@ export const GAME_CATEGORIES: Record<string, GameCategory> = {
     icon: Calculator,
     color: "bg-indigo-500",
     gradient: "from-indigo-400 to-indigo-600",
-    gameIds: ["counting","math","shopping-money","multiplication","fractions","sequences","arithmetic","ordinals","number-words","spatial-concepts"],
+    gameIds: ["counting","math","shopping-money","multiplication","fractions","sequences","arithmetic","ordinals","number-words","spatial-concepts","sorting","patterns"],
   },
   games: {
     title: "משחקים מיוחדים",

--- a/gamesformykids/lib/quiz/data/patterns.ts
+++ b/gamesformykids/lib/quiz/data/patterns.ts
@@ -1,0 +1,40 @@
+export type PatternType = 'AB' | 'AAB' | 'ABC' | 'AABB';
+export type PatternDifficulty = 'easy' | 'medium' | 'hard';
+
+export interface PatternQuestion {
+  id: number;
+  sequence: string[];
+  answer: string;
+  wrongOptions: [string, string, string];
+  patternType: PatternType;
+  difficulty: PatternDifficulty;
+}
+
+export const PATTERN_QUESTIONS: PatternQuestion[] = [
+  // AB — easy
+  { id: 1,  sequence: ['🔴', '🔵', '🔴', '🔵', '🔴', '❓'], answer: '🔵', wrongOptions: ['🔴', '🟡', '🟢'],  patternType: 'AB',   difficulty: 'easy' },
+  { id: 2,  sequence: ['🐱', '🐶', '🐱', '🐶', '🐱', '❓'], answer: '🐶', wrongOptions: ['🐱', '🐰', '🐟'],  patternType: 'AB',   difficulty: 'easy' },
+  { id: 3,  sequence: ['⭐', '🌙', '⭐', '🌙', '⭐', '❓'], answer: '🌙', wrongOptions: ['⭐', '☀️', '🌟'],  patternType: 'AB',   difficulty: 'easy' },
+  { id: 4,  sequence: ['🍎', '🍌', '🍎', '🍌', '🍎', '❓'], answer: '🍌', wrongOptions: ['🍎', '🍊', '🍇'],  patternType: 'AB',   difficulty: 'easy' },
+  { id: 5,  sequence: ['🌸', '🌼', '🌸', '🌼', '🌸', '❓'], answer: '🌼', wrongOptions: ['🌸', '🌺', '🌻'],  patternType: 'AB',   difficulty: 'easy' },
+  { id: 6,  sequence: ['🚂', '🚗', '🚂', '🚗', '🚂', '❓'], answer: '🚗', wrongOptions: ['🚂', '✈️', '🚢'],  patternType: 'AB',   difficulty: 'easy' },
+  { id: 17, sequence: ['🔶', '🔷', '🔶', '🔷', '🔶', '❓'], answer: '🔷', wrongOptions: ['🔶', '🔸', '🔹'],  patternType: 'AB',   difficulty: 'easy' },
+  { id: 18, sequence: ['🌈', '⚡', '🌈', '⚡', '🌈', '❓'], answer: '⚡', wrongOptions: ['🌈', '🌀', '💨'],  patternType: 'AB',   difficulty: 'easy' },
+  { id: 19, sequence: ['🎸', '🥁', '🎸', '🥁', '🎸', '❓'], answer: '🥁', wrongOptions: ['🎸', '🎹', '🎷'],  patternType: 'AB',   difficulty: 'easy' },
+  { id: 20, sequence: ['🌊', '🔥', '🌊', '🔥', '🌊', '❓'], answer: '🔥', wrongOptions: ['🌊', '💨', '⛰️'],  patternType: 'AB',   difficulty: 'easy' },
+  // AAB — medium
+  { id: 7,  sequence: ['🟡', '🟡', '🔵', '🟡', '🟡', '❓'], answer: '🔵', wrongOptions: ['🟡', '🔴', '🟢'],  patternType: 'AAB',  difficulty: 'medium' },
+  { id: 8,  sequence: ['🐻', '🐻', '🦁', '🐻', '🐻', '❓'], answer: '🦁', wrongOptions: ['🐻', '🐯', '🦊'],  patternType: 'AAB',  difficulty: 'medium' },
+  { id: 9,  sequence: ['🎈', '🎈', '🎁', '🎈', '🎈', '❓'], answer: '🎁', wrongOptions: ['🎈', '🎀', '🎊'],  patternType: 'AAB',  difficulty: 'medium' },
+  { id: 10, sequence: ['☀️', '☀️', '🌧️', '☀️', '☀️', '❓'], answer: '🌧️', wrongOptions: ['☀️', '❄️', '⛅'], patternType: 'AAB',  difficulty: 'medium' },
+  { id: 21, sequence: ['🏀', '🏀', '⚽', '🏀', '🏀', '❓'], answer: '⚽', wrongOptions: ['🏀', '🎾', '🏈'],  patternType: 'AAB',  difficulty: 'medium' },
+  { id: 22, sequence: ['🌺', '🌺', '🌿', '🌺', '🌺', '❓'], answer: '🌿', wrongOptions: ['🌺', '🌸', '🌻'],  patternType: 'AAB',  difficulty: 'medium' },
+  // ABC — medium
+  { id: 11, sequence: ['🔴', '🟡', '🟢', '🔴', '🟡', '❓'], answer: '🟢', wrongOptions: ['🔴', '🟡', '🔵'],  patternType: 'ABC',  difficulty: 'medium' },
+  { id: 12, sequence: ['🐱', '🐶', '🐰', '🐱', '🐶', '❓'], answer: '🐰', wrongOptions: ['🐱', '🐶', '🐟'],  patternType: 'ABC',  difficulty: 'medium' },
+  { id: 13, sequence: ['🍎', '🍌', '🍊', '🍎', '🍌', '❓'], answer: '🍊', wrongOptions: ['🍎', '🍌', '🍇'],  patternType: 'ABC',  difficulty: 'medium' },
+  // AABB — hard
+  { id: 14, sequence: ['⬛', '⬛', '🔴', '🔴', '⬛', '❓'], answer: '⬛', wrongOptions: ['🔴', '🟡', '🟢'],  patternType: 'AABB', difficulty: 'hard' },
+  { id: 15, sequence: ['🌙', '🌙', '⭐', '⭐', '🌙', '❓'], answer: '🌙', wrongOptions: ['⭐', '☀️', '🌟'],  patternType: 'AABB', difficulty: 'hard' },
+  { id: 16, sequence: ['🐸', '🐸', '🐙', '🐙', '🐸', '❓'], answer: '🐸', wrongOptions: ['🐙', '🐢', '🦀'],  patternType: 'AABB', difficulty: 'hard' },
+];

--- a/gamesformykids/lib/quiz/data/sorting.ts
+++ b/gamesformykids/lib/quiz/data/sorting.ts
@@ -1,0 +1,170 @@
+export interface SortingItem {
+  name: string;
+  emoji: string;
+}
+
+export interface SortingCategory {
+  name: string;
+  emoji: string;
+  items: SortingItem[];
+}
+
+export interface SortingSet {
+  id: string;
+  categoryA: SortingCategory;
+  categoryB: SortingCategory;
+}
+
+export const SORTING_SETS: SortingSet[] = [
+  {
+    id: 'animals-vs-furniture',
+    categoryA: {
+      name: 'חיות',
+      emoji: '🐾',
+      items: [
+        { name: 'כלב', emoji: '🐕' },
+        { name: 'חתול', emoji: '🐱' },
+        { name: 'ציפור', emoji: '🐦' },
+        { name: 'דג', emoji: '🐟' },
+        { name: 'ארנב', emoji: '🐰' },
+        { name: 'פרפר', emoji: '🦋' },
+      ],
+    },
+    categoryB: {
+      name: 'רהיטים',
+      emoji: '🪑',
+      items: [
+        { name: 'שולחן', emoji: '🪑' },
+        { name: 'כסא', emoji: '💺' },
+        { name: 'מיטה', emoji: '🛏️' },
+        { name: 'ארון', emoji: '🚪' },
+        { name: 'ספה', emoji: '🛋️' },
+        { name: 'מדף', emoji: '📚' },
+      ],
+    },
+  },
+  {
+    id: 'food-vs-not-food',
+    categoryA: {
+      name: 'אוכל',
+      emoji: '🍎',
+      items: [
+        { name: 'תפוח', emoji: '🍎' },
+        { name: 'לחם', emoji: '🍞' },
+        { name: 'גזר', emoji: '🥕' },
+        { name: 'ביצה', emoji: '🥚' },
+        { name: 'בננה', emoji: '🍌' },
+        { name: 'גבינה', emoji: '🧀' },
+      ],
+    },
+    categoryB: {
+      name: 'לא אוכל',
+      emoji: '🚫',
+      items: [
+        { name: 'ספר', emoji: '📚' },
+        { name: 'כדור', emoji: '⚽' },
+        { name: 'נעל', emoji: '👟' },
+        { name: 'עיפרון', emoji: '✏️' },
+        { name: 'מפתח', emoji: '🔑' },
+        { name: 'שעון', emoji: '⏰' },
+      ],
+    },
+  },
+  {
+    id: 'sky-vs-sea',
+    categoryA: {
+      name: 'שמיים',
+      emoji: '☁️',
+      items: [
+        { name: 'ציפור', emoji: '🐦' },
+        { name: 'ענן', emoji: '☁️' },
+        { name: 'מטוס', emoji: '✈️' },
+        { name: 'כוכב', emoji: '⭐' },
+        { name: 'ירח', emoji: '🌙' },
+        { name: 'שמש', emoji: '☀️' },
+      ],
+    },
+    categoryB: {
+      name: 'ים',
+      emoji: '🌊',
+      items: [
+        { name: 'דג', emoji: '🐟' },
+        { name: 'תמנון', emoji: '🐙' },
+        { name: 'סירה', emoji: '⛵' },
+        { name: 'לוויתן', emoji: '🐳' },
+        { name: 'צב ים', emoji: '🐢' },
+        { name: 'כריש', emoji: '🦈' },
+      ],
+    },
+  },
+  {
+    id: 'clothing-vs-tools',
+    categoryA: {
+      name: 'בגדים',
+      emoji: '👕',
+      items: [
+        { name: 'חולצה', emoji: '👕' },
+        { name: 'מכנסיים', emoji: '👖' },
+        { name: 'נעל', emoji: '👟' },
+        { name: 'כובע', emoji: '🎩' },
+        { name: 'גרב', emoji: '🧦' },
+        { name: 'שמלה', emoji: '👗' },
+      ],
+    },
+    categoryB: {
+      name: 'כלים',
+      emoji: '🔧',
+      items: [
+        { name: 'פטיש', emoji: '🔨' },
+        { name: 'מברג', emoji: '🪛' },
+        { name: 'מפתח ברגים', emoji: '🔧' },
+        { name: 'מסור', emoji: '🪚' },
+        { name: 'מספריים', emoji: '✂️' },
+        { name: 'מדידה', emoji: '📏' },
+      ],
+    },
+  },
+  {
+    id: 'sports-vs-music',
+    categoryA: {
+      name: 'ספורט',
+      emoji: '⚽',
+      items: [
+        { name: 'כדורגל', emoji: '⚽' },
+        { name: 'כדורסל', emoji: '🏀' },
+        { name: 'טניס', emoji: '🎾' },
+        { name: 'שחייה', emoji: '🏊' },
+        { name: 'אופניים', emoji: '🚴' },
+        { name: 'ריצה', emoji: '🏃' },
+      ],
+    },
+    categoryB: {
+      name: 'מוזיקה',
+      emoji: '🎵',
+      items: [
+        { name: 'גיטרה', emoji: '🎸' },
+        { name: 'תוף', emoji: '🥁' },
+        { name: 'חליל', emoji: '🎷' },
+        { name: 'פסנתר', emoji: '🎹' },
+        { name: 'כינור', emoji: '🎻' },
+        { name: 'מיקרופון', emoji: '🎤' },
+      ],
+    },
+  },
+];
+
+export interface SortingQuestion {
+  item: SortingItem;
+  itemCategory: 'A' | 'B';
+  categoryA: Pick<SortingCategory, 'name' | 'emoji'>;
+  categoryB: Pick<SortingCategory, 'name' | 'emoji'>;
+}
+
+export function buildSortingQuestions(count: number): SortingQuestion[] {
+  const set = SORTING_SETS[Math.floor(Math.random() * SORTING_SETS.length)]!;
+  const allItems: SortingQuestion[] = [
+    ...set.categoryA.items.map(item => ({ item, itemCategory: 'A' as const, categoryA: set.categoryA, categoryB: set.categoryB })),
+    ...set.categoryB.items.map(item => ({ item, itemCategory: 'B' as const, categoryA: set.categoryA, categoryB: set.categoryB })),
+  ];
+  return allItems.sort(() => Math.random() - 0.5).slice(0, count);
+}

--- a/gamesformykids/lib/quiz/registry/customQuizGames.tsx
+++ b/gamesformykids/lib/quiz/registry/customQuizGames.tsx
@@ -2,6 +2,10 @@
 import type { ComponentType } from 'react';
 import { makeQuizGame } from '../makeQuizGame';
 import { QuizMenuScreen, QuizResultScreen } from '@/components/game/quiz';
+import { useSortingGame } from '@/lib/quiz/useSortingGame';
+import SortingQuestion from '@/components/game/quiz/screens/SortingQuestion';
+import { usePatternsGame } from '@/lib/quiz/usePatternsGame';
+import PatternQuestion from '@/components/game/quiz/screens/PatternQuestion';
 
 import { useClockGame } from '@/lib/quiz/useClockGame';
 import { usePhonicsGame } from '@/lib/quiz/usePhonicsGame';
@@ -130,6 +134,24 @@ export const CUSTOM_QUIZ_GAMES: Record<string, ComponentType> = {
       menu:     <QuizMenuScreen emoji="🔊" title="פוניקה עברית" description="שמע צליל ובחר את האות הנכונה!" theme="violet" buttonLabel="🔊 בואו נתחיל!" onStart={startGame} />,
       question: current ? <PhonicsQuestion current={current} choices={choices as string[]} onSelect={selectAnswer} /> : null,
       result:   <QuizResultScreen onRestart={restart} theme="violet" />,
+    }),
+  ),
+
+  'sorting': makeQuizGame(
+    useSortingGame,
+    ({ current, startGame, selectAnswer, restart }) => ({
+      menu:     <QuizMenuScreen emoji="🗂️" title="מיון לקטגוריות" description="כלב או כסא? — מיין כל פריט לקטגוריה שלו!" theme="emerald" buttonLabel="🗂️ בואו נמיין!" onStart={startGame} />,
+      question: current ? <SortingQuestion current={current} onSelect={selectAnswer} /> : null,
+      result:   <QuizResultScreen onRestart={restart} theme="emerald" />,
+    }),
+  ),
+
+  'patterns': makeQuizGame(
+    usePatternsGame,
+    ({ current, startGame, selectAnswer, restart }) => ({
+      menu:     <QuizMenuScreen emoji="🔵" title="זיהוי דפוסים" description="🔴🔵🔴🔵🔴❓ — מה בא הלאה?" theme="sky" buttonLabel="🔵 בואו נגלה!" onStart={startGame} />,
+      question: current ? <PatternQuestion current={current} onSelect={selectAnswer} /> : null,
+      result:   <QuizResultScreen onRestart={restart} theme="sky" />,
     }),
   ),
 };

--- a/gamesformykids/lib/quiz/usePatternsGame.ts
+++ b/gamesformykids/lib/quiz/usePatternsGame.ts
@@ -1,0 +1,33 @@
+'use client';
+import { useCallback } from 'react';
+import { PATTERN_QUESTIONS, type PatternQuestion } from '@/lib/quiz/data/patterns';
+import { QUESTIONS_PER_GAME } from '@/lib/quiz/constants';
+import { useQuizSession } from '@/lib/quiz/useQuizSession';
+import { shuffle } from '@/lib/utils';
+
+export interface PatternQuestionWithChoices {
+  question: PatternQuestion;
+  choices: string[];
+}
+
+function buildQuestions(): PatternQuestionWithChoices[] {
+  return [...PATTERN_QUESTIONS]
+    .sort(() => Math.random() - 0.5)
+    .slice(0, QUESTIONS_PER_GAME)
+    .map(q => ({ question: q, choices: shuffle([q.answer, ...q.wrongOptions]) }));
+}
+
+export function usePatternsGame() {
+  const { phase, current, begin, answer, reset } = useQuizSession<PatternQuestionWithChoices>('patterns');
+
+  const startGame = useCallback(() => begin(buildQuestions()), [begin]);
+
+  const selectAnswer = useCallback((choice: string) => {
+    if (!current) return;
+    answer(choice, choice === current.question.answer);
+  }, [answer, current]);
+
+  const restart = useCallback(() => reset(buildQuestions()), [reset]);
+
+  return { phase, current, startGame, selectAnswer, restart };
+}

--- a/gamesformykids/lib/quiz/useSortingGame.ts
+++ b/gamesformykids/lib/quiz/useSortingGame.ts
@@ -1,0 +1,25 @@
+'use client';
+import { useCallback } from 'react';
+import { buildSortingQuestions, type SortingQuestion } from '@/lib/quiz/data/sorting';
+import { QUESTIONS_PER_GAME } from '@/lib/quiz/constants';
+import { useQuizSession } from '@/lib/quiz/useQuizSession';
+
+export type { SortingQuestion };
+
+export function useSortingGame() {
+  const { phase, current, begin, answer, reset } = useQuizSession<SortingQuestion>('sorting');
+
+  const startGame = useCallback(() => begin(buildSortingQuestions(QUESTIONS_PER_GAME)), [begin]);
+
+  const selectAnswer = useCallback((choice: string) => {
+    if (!current) return;
+    const correct = current.itemCategory === 'A'
+      ? choice === current.categoryA.name
+      : choice === current.categoryB.name;
+    answer(choice, correct);
+  }, [answer, current]);
+
+  const restart = useCallback(() => reset(buildSortingQuestions(QUESTIONS_PER_GAME)), [reset]);
+
+  return { phase, current, startGame, selectAnswer, restart };
+}

--- a/gamesformykids/lib/registry/registryData/batch4.ts
+++ b/gamesformykids/lib/registry/registryData/batch4.ts
@@ -3,6 +3,8 @@ import {
   CircleDot,
   Car,
   Landmark,
+  Layers,
+  Repeat,
   Star,
   Palette,
   Cpu,
@@ -47,4 +49,6 @@ export const gamesRegistryBatch4: GameRegistration[] = [
   { id: "adjectives",       title: "שמות תואר",                      description: "גדול, קטן, שמח, עצוב — למד לתאר עצמים!",           icon: PenLine,        emoji: "🎨", color: "bg-pink-500 hover:bg-pink-600",                                                                         href: "/games/adjectives",      available: true, order: 145 },
   { id: "spatial-concepts", title: "מושגי מרחב",                     description: "מעל, מתחת, בתוך — למד מושגי מיקום!",               icon: MapPin,         emoji: "🗺️", color: "bg-green-500 hover:bg-green-600",                                                                       href: "/games/spatial-concepts",available: true, order: 146 },
   { id: "number-words",     title: "מספרים כמילים",                  description: "אחד, שתיים, שלוש — קרא מספרים בעברית!",            icon: Hash,           emoji: "🔢", color: "bg-orange-500 hover:bg-orange-600",                                                                     href: "/games/number-words",    available: true, order: 147 },
+  { id: "sorting",          title: "מיון לקטגוריות",                  description: "כלב או כסא? — מיין פריטים לקטגוריות!",              icon: Layers,         emoji: "🗂️", color: "bg-emerald-500 hover:bg-emerald-600",                                                                   href: "/games/sorting",         available: true, order: 151 },
+  { id: "patterns",         title: "זיהוי דפוסים",                    description: "🔴🔵🔴❓ — מה בא הלאה בדפוס?",                       icon: Repeat,         emoji: "🔵", color: "bg-sky-500 hover:bg-sky-600",                                                                           href: "/games/patterns",        available: true, order: 152 },
 ];

--- a/gamesformykids/lib/types/core/base.ts
+++ b/gamesformykids/lib/types/core/base.ts
@@ -177,4 +177,6 @@ export type GameType =
   // Word games
   | 'word-builder' | 'word-scramble'
   // Special games
-  | 'hebrew-letters' | 'tzedakah';
+  | 'hebrew-letters' | 'tzedakah'
+  // Logic & patterns
+  | 'sorting' | 'patterns';


### PR DESCRIPTION
## Summary

Two new Style C (makeQuizGame) educational games for children ages 4–7:

1. **מיון לקטגוריות (Sorting) — #893**: Children see an item emoji (e.g., 🐕 כלב) and tap which of 2 category buckets it belongs to. Five themed sorting sets: animals/furniture, food/not-food, sky/sea, clothing/tools, sports/music. Teaches pre-STEM classification thinking.

2. **זיהוי דפוסים (Patterns) — #896**: Children see a repeating emoji sequence with ❓ at the end and pick what comes next from 4 choices. 22 questions across 4 pattern types (AB, AAB, ABC, AABB) with easy/medium/hard difficulty. Develops pattern recognition — foundational for algebra and coding.

Both use the existing `makeQuizGame` factory + `useQuizSession` session hook — no new stores or infrastructure.

## Changes

| File | Description |
|------|-------------|
| `lib/quiz/data/sorting.ts` | 5 sorting sets, 6 items per category |
| `lib/quiz/useSortingGame.ts` | Hook via `useQuizSession` |
| `components/game/quiz/screens/SortingQuestion.tsx` | Emerald theme, 2-column category buttons |
| `lib/quiz/data/patterns.ts` | 22 pattern questions (AB/AAB/ABC/AABB) |
| `lib/quiz/usePatternsGame.ts` | Hook via `useQuizSession` with shuffled choices |
| `components/game/quiz/screens/PatternQuestion.tsx` | Sky theme, sequence row with ❓ placeholder |
| `lib/quiz/registry/customQuizGames.tsx` | Register both via `makeQuizGame` |
| `lib/types/core/base.ts` | Add `sorting`, `patterns` to `GameType` |
| `app/games/[gameType]/gamePageConstants.ts` | Add both to `SUPPORTED_GAMES` |
| `lib/registry/registryData/batch4.ts` | Registry entries (order 151–152) |
| `lib/constants/gameCategories.ts` | Add both to math/thinking category |

## Testing

- [x] `npx tsc --noEmit` passes (zero errors)
- [ ] Manually verify at `http://localhost:3000/games/sorting`
- [ ] Manually verify at `http://localhost:3000/games/patterns`
- [ ] Both appear in the math/thinking category on home page

Closes #893
Closes #896

🤖 Generated with [Claude Code](https://claude.com/claude-code)