### PR TITLE
refactor(store): consolidate memory store 3-boolean phase machine into single phase field

### DIFF
--- a/gamesformykids/app/games/memory/MemoryClient.tsx
+++ b/gamesformykids/app/games/memory/MemoryClient.tsx
@@ -10,11 +10,11 @@ import { useMemoryGame } from './useMemoryGame';
 
 export default function MemoryClient() {
   useMemoryGameContent();
-  const { gameStarted, isGameWon, isCompleted } = useMemoryGame();
+  const { phase } = useMemoryGame();
 
-  if (!gameStarted) return <MemoryStartScreen />;
-  if (isGameWon)    return <GameWinMessage />;
-  if (isCompleted)  return <GameTimeoutScreen />;
+  if (phase === 'menu')    return <MemoryStartScreen />;
+  if (phase === 'won')     return <GameWinMessage />;
+  if (phase === 'timeout') return <GameTimeoutScreen />;
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-pink-100 via-purple-100 to-indigo-200 p-4">

--- a/gamesformykids/app/games/memory/stores/memoryStoreTypes.ts
+++ b/gamesformykids/app/games/memory/stores/memoryStoreTypes.ts
@@ -12,13 +12,15 @@ export const initialGameStats: GameStats = {
   streak: 0,
 };
 
+// ─── Phase type ───────────────────────────────────────────────────────────────
+
+export type MemoryPhase = 'menu' | 'playing' | 'won' | 'timeout';
+
 // ─── State shape ──────────────────────────────────────────────────────────────
 
 export interface MemoryStoreState {
   // Game flow
-  gameStarted: boolean;
-  isCompleted: boolean;
-  isGameWon: boolean;
+  phase: MemoryPhase;
   timer: number;
   timeLeft: number;
   isGamePaused: boolean;
@@ -51,8 +53,7 @@ export interface MemoryStoreActions {
   // Called from timer useEffect in useMemoryGameContent
   incrementTimer: () => void;
   decrementTimeLeft: () => void;
-  setCompleted: (value: boolean) => void;
-  setGameWon: (value: boolean) => void;
+  setPhase: (phase: MemoryPhase) => void;
 
   // Computed helpers
   getDifficultyConfig: () => { pairs: number; name: string; emoji: string; timeLimit: number };
@@ -83,9 +84,7 @@ export interface MemoryStoreActions {
 // ─── Initial store state ──────────────────────────────────────────────────────
 
 export const initialState: MemoryStoreState = {
-  gameStarted: false,
-  isCompleted: false,
-  isGameWon: false,
+  phase: 'menu',
   timer: 0,
   timeLeft: 0,
   isGamePaused: false,

--- a/gamesformykids/app/games/memory/stores/useMemoryStore.ts
+++ b/gamesformykids/app/games/memory/stores/useMemoryStore.ts
@@ -13,6 +13,7 @@ import {
   MemoryStoreActions,
   initialState,
   initialGameStats,
+  type MemoryPhase,
 } from './memoryStoreTypes';
 import { formatTime, getTimeColor, getGridCols, getAnimationDelay } from './memoryPureHelpers';
 import { resolveCardMatch } from './memoryMatchLogic';
@@ -62,8 +63,8 @@ export const useMemoryStore = makeStore<MemoryStoreState & MemoryStoreActions>(
     },
 
     canClickCard: (cardIndex) => {
-      const { isGamePaused, isCompleted, timeLeft, cards, flippedCards } = get();
-      if (isGamePaused || isCompleted || timeLeft <= 0) return false;
+      const { isGamePaused, phase, timeLeft, cards, flippedCards } = get();
+      if (isGamePaused || phase !== 'playing' || timeLeft <= 0) return false;
       const card = cards[cardIndex];
       if (!card || card.isFlipped || card.isMatched) return false;
       if (flippedCards.includes(cardIndex)) return false;
@@ -72,11 +73,11 @@ export const useMemoryStore = makeStore<MemoryStoreState & MemoryStoreActions>(
     },
 
     getGameStateDescription: () => {
-      const { gameStarted, isGamePaused, isGameWon, isCompleted, timeLeft } = get();
-      if (!gameStarted) return 'לא התחיל';
+      const { phase, isGamePaused, timeLeft } = get();
+      if (phase === 'menu') return 'לא התחיל';
       if (isGamePaused) return 'מושהה';
-      if (isGameWon) return 'ניצחת!';
-      if (isCompleted || timeLeft <= 0) return 'נגמר הזמן';
+      if (phase === 'won') return 'ניצחת!';
+      if (phase === 'timeout' || timeLeft <= 0) return 'נגמר הזמן';
       return 'פעיל';
     },
 
@@ -113,8 +114,7 @@ export const useMemoryStore = makeStore<MemoryStoreState & MemoryStoreActions>(
         'memory/decrementTimeLeft',
       ),
 
-    setCompleted: (value) => set({ isCompleted: value }, false, 'memory/setCompleted'),
-    setGameWon: (value) => set({ isGameWon: value }, false, 'memory/setGameWon'),
+    setPhase: (p: MemoryPhase) => set({ phase: p }, false, 'memory/setPhase'),
 
     // ─── Game lifecycle ──────────────────────────────────────────────────────
 
@@ -139,9 +139,7 @@ export const useMemoryStore = makeStore<MemoryStoreState & MemoryStoreActions>(
           animals,
           cards,
           timeLeft: config.timeLimit,
-          gameStarted: true,
-          isCompleted: false,
-          isGameWon: false,
+          phase: 'playing' as MemoryPhase,
           timer: 0,
           flippedCards: [],
           matchedPairs: [],
@@ -193,7 +191,7 @@ export const useMemoryStore = makeStore<MemoryStoreState & MemoryStoreActions>(
       if (outcome.isMatch) {
         playMemorySuccessSound(audioContext);
         if (outcome.isWon) {
-          set({ isGameWon: true, isCompleted: true }, false, 'memory/gameWon');
+          set({ phase: 'won' as MemoryPhase }, false, 'memory/gameWon');
         }
       }
     },
@@ -204,9 +202,7 @@ export const useMemoryStore = makeStore<MemoryStoreState & MemoryStoreActions>(
     resetGame: () =>
       set(
         {
-          gameStarted: false,
-          isCompleted: false,
-          isGameWon: false,
+          phase: 'menu' as MemoryPhase,
           timer: 0,
           timeLeft: 0,
           isGamePaused: false,

--- a/gamesformykids/app/games/memory/types/memory.ts
+++ b/gamesformykids/app/games/memory/types/memory.ts
@@ -23,11 +23,11 @@ export interface GameStats {
   streak: number;
 }
 
+export type MemoryPhase = 'menu' | 'playing' | 'won' | 'timeout';
+
 export interface MemoryState {
   // Game State
-  gameStarted: boolean;
-  isCompleted: boolean;
-  isGameWon: boolean;
+  phase: MemoryPhase;
   timer: number;
   timeLeft: number;
   isGamePaused: boolean;
@@ -91,7 +91,7 @@ export interface MemoryContextType {
     emoji: string;
     timeLimit: number;
   };
-  isGameWon: boolean;
+  phase: MemoryPhase;
   gridCols: string;
   
   // Game Logic

--- a/gamesformykids/app/games/memory/useMemoryGameContent.ts
+++ b/gamesformykids/app/games/memory/useMemoryGameContent.ts
@@ -7,8 +7,7 @@ import { useGameProgress, useAchievements } from "@/hooks";
 import { useAuth } from "@/hooks/shared/auth/useAuth";
 
 export interface UseMemoryGameContentReturn {
-  gameStarted: boolean;
-  isGameWon: boolean;
+  phase: import('./stores/memoryStoreTypes').MemoryPhase;
 }
 
 /**
@@ -18,19 +17,16 @@ export interface UseMemoryGameContentReturn {
  */
 export function useMemoryGameContent(): UseMemoryGameContentReturn {
   const {
-    gameStarted,
-    isGameWon,
+    phase,
     gameStats,
     timer,
     difficulty,
     isGamePaused,
-    isCompleted,
     timeLeft,
     flippedCards,
     incrementTimer,
     decrementTimeLeft,
-    setCompleted,
-    setGameWon,
+    setPhase,
     resolveMatch,
   } = useMemoryStore();
 
@@ -50,10 +46,10 @@ export function useMemoryGameContent(): UseMemoryGameContentReturn {
 
   // Cancel speech on new game so old utterances don't play into the new game
   useEffect(() => {
-    if (gameStarted && typeof window !== 'undefined' && window.speechSynthesis) {
+    if (phase === 'playing' && typeof window !== 'undefined' && window.speechSynthesis) {
       window.speechSynthesis.cancel();
     }
-  }, [gameStarted]);
+  }, [phase]);
 
   // Resolve card match after flip animation delay
   useEffect(() => {
@@ -70,28 +66,27 @@ export function useMemoryGameContent(): UseMemoryGameContentReturn {
 
   // ── Timer ────────────────────────────────────────────────────────────────
   useEffect(() => {
-    if (!gameStarted || isGamePaused || isCompleted) return;
+    if (phase !== 'playing' || isGamePaused) return;
     const id = setInterval(() => {
       incrementTimer();
       decrementTimeLeft();
     }, 1000);
     return () => clearInterval(id);
-  }, [gameStarted, isGamePaused, isCompleted, incrementTimer, decrementTimeLeft]);
+  }, [phase, isGamePaused, incrementTimer, decrementTimeLeft]);
 
   // ── Time-up check ────────────────────────────────────────────────────────
   useEffect(() => {
-    if (timeLeft <= 0 && gameStarted && !isCompleted) {
-      setCompleted(true);
-      setGameWon(false);
+    if (timeLeft <= 0 && phase === 'playing') {
+      setPhase('timeout');
     }
-  }, [timeLeft, gameStarted, isCompleted, setCompleted, setGameWon]);
+  }, [timeLeft, phase, setPhase]);
 
   const { user } = useAuth();
   const { updateScore, updateLevel, addPlayTime } = useGameProgress("memory");
   const { checkScoreAchievements, checkLevelAchievements } = useAchievements("memory");
 
   useEffect(() => {
-    if (!isGameWon || !user || gameStats.score <= 0) return;
+    if (phase !== 'won' || !user || gameStats.score <= 0) return;
 
     updateScore("memory", gameStats.score);
 
@@ -106,7 +101,7 @@ export function useMemoryGameContent(): UseMemoryGameContentReturn {
     checkScoreAchievements("memory", gameStats.score);
     checkLevelAchievements("memory", currentLevel);
   }, [
-    isGameWon,
+    phase,
     user,
     gameStats.score,
     timer,
@@ -118,5 +113,5 @@ export function useMemoryGameContent(): UseMemoryGameContentReturn {
     checkLevelAchievements,
   ]);
 
-  return { gameStarted, isGameWon };
+  return { phase };
 }


### PR DESCRIPTION
## Summary

Replaces the three-boolean phase encoding (`gameStarted`, `isCompleted`, `isGameWon`) in the memory game store with a single discriminated `phase: 'menu' | 'playing' | 'won' | 'timeout'` field. Follows the same pattern applied to the Tetris store in PR #847. Any future 5th state only requires changing one field instead of three.

## Changes

- `stores/memoryStoreTypes.ts` — add `MemoryPhase` type; replace 3 booleans with `phase`; replace `setCompleted`/`setGameWon` with `setPhase`
- `stores/useMemoryStore.ts` — update `canClickCard`, `getGameStateDescription`, `initializeGame`, `resolveMatch`, `resetGame` to use `phase`
- `useMemoryGameContent.ts` — update timer, time-up, and win `useEffect`s to use `phase`; call `setPhase('timeout')` instead of `setCompleted`/`setGameWon`
- `MemoryClient.tsx` — switch on `phase` instead of 3 booleans
- `types/memory.ts` — update legacy `MemoryState` and `MemoryContextType`

## Testing

- [x] `npx tsc --noEmit` passes
- [ ] Manually verify at `http://localhost:3000/games/memory` — menu shows, game plays, win/timeout screens render correctly

Closes #909

🤖 Generated with [Claude Code](https://claude.com/claude-code)