### PR TITLE
refactor(store): move audio playback out of memoryStore resolveMatch into component

### DIFF
--- a/gamesformykids/app/games/memory/stores/memoryStoreTypes.ts
+++ b/gamesformykids/app/games/memory/stores/memoryStoreTypes.ts
@@ -28,6 +28,7 @@ export interface MemoryStoreState {
   gameStats: GameStats;
 
   // Cards
+  lastMatchWasSuccess: boolean;
   cards: MemoryCard[];
   animals: AnimalData[];
   flippedCards: number[];
@@ -43,7 +44,7 @@ export interface MemoryStoreState {
 export interface MemoryStoreActions {
   initializeGame: (targetDifficulty?: DifficultyLevel) => void;
   handleCardClick: (cardIndex: number) => void;
-  resolveMatch: (firstCardIndex: number, secondCardIndex: number, audioContext: AudioContext | null) => void;
+  resolveMatch: (firstCardIndex: number, secondCardIndex: number) => void;
   pauseGame: () => void;
   resumeGame: () => void;
   resetGame: () => void;
@@ -90,6 +91,7 @@ export const initialState: MemoryStoreState = {
   isGamePaused: false,
   difficulty: 'medium',
   gameStats: initialGameStats,
+  lastMatchWasSuccess: false,
   cards: [],
   animals: MEMORY_GAME_ANIMALS.slice(0, MEMORY_GAME_CONSTANTS.DIFFICULTY_LEVELS.medium.pairs),
   flippedCards: [],

--- a/gamesformykids/app/games/memory/stores/useMemoryStore.ts
+++ b/gamesformykids/app/games/memory/stores/useMemoryStore.ts
@@ -2,7 +2,6 @@
 
 import { makeStore } from '@/lib/stores/createStore';
 import {
-  playMemorySuccessSound,
   createShuffledMemoryCards,
 } from '@/lib/utils/game/gameUtils';
 import { MEMORY_GAME_ANIMALS, MEMORY_GAME_CONSTANTS } from '@/lib/constants';
@@ -172,7 +171,7 @@ export const useMemoryStore = makeStore<MemoryStoreState & MemoryStoreActions>(
 
     },
 
-    resolveMatch: (firstCardIndex, secondCardIndex, audioContext) => {
+    resolveMatch: (firstCardIndex, secondCardIndex) => {
       const s = get();
       const config = MEMORY_GAME_CONSTANTS.DIFFICULTY_LEVELS[s.difficulty];
       const outcome = resolveCardMatch(s, firstCardIndex, secondCardIndex, config.pairs);
@@ -183,16 +182,14 @@ export const useMemoryStore = makeStore<MemoryStoreState & MemoryStoreActions>(
           matchedPairs: outcome.matchedPairs,
           flippedCards: outcome.flippedCards,
           gameStats: outcome.gameStats,
+          lastMatchWasSuccess: outcome.isMatch,
         },
         false,
         outcome.isMatch ? 'memory/successMatch' : 'memory/failedMatch',
       );
 
-      if (outcome.isMatch) {
-        playMemorySuccessSound(audioContext);
-        if (outcome.isWon) {
-          set({ phase: 'won' as MemoryPhase }, false, 'memory/gameWon');
-        }
+      if (outcome.isMatch && outcome.isWon) {
+        set({ phase: 'won' as MemoryPhase }, false, 'memory/gameWon');
       }
     },
 

--- a/gamesformykids/app/games/memory/useMemoryGameContent.ts
+++ b/gamesformykids/app/games/memory/useMemoryGameContent.ts
@@ -3,6 +3,7 @@
 import { useEffect, useRef } from "react";
 import { useMemoryStore } from "./stores/useMemoryStore";
 import { MEMORY_GAME_CONSTANTS } from "@/lib/constants";
+import { playMemorySuccessSound } from "@/lib/utils/game/gameUtils";
 import { useGameProgress, useAchievements } from "@/hooks";
 import { useAuth } from "@/hooks/shared/auth/useAuth";
 
@@ -24,6 +25,7 @@ export function useMemoryGameContent(): UseMemoryGameContentReturn {
     isGamePaused,
     timeLeft,
     flippedCards,
+    lastMatchWasSuccess,
     incrementTimer,
     decrementTimeLeft,
     setPhase,
@@ -56,13 +58,19 @@ export function useMemoryGameContent(): UseMemoryGameContentReturn {
     if (flippedCards.length !== 2) return;
     const [first, second] = flippedCards;
     const id = setTimeout(
-      () => resolveMatch(first!, second!, audioContextRef.current),
+      () => resolveMatch(first!, second!),
       MEMORY_GAME_CONSTANTS.FLIP_DURATION * 0.6,
     );
     return () => clearTimeout(id);
   // flippedCards reference changes on every flip; we only want to re-run when length reaches 2
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [flippedCards.length, resolveMatch]);
+
+  // Play success sound when a match is confirmed — audio stays out of the store
+  useEffect(() => {
+    if (!lastMatchWasSuccess) return;
+    playMemorySuccessSound(audioContextRef.current);
+  }, [lastMatchWasSuccess]);
 
   // ── Timer ────────────────────────────────────────────────────────────────
   useEffect(() => {


### PR DESCRIPTION
## Summary

`resolveMatch` previously called `playMemorySuccessSound(audioContext)` directly from inside a Zustand store action, making it impossible to unit-test without a real/mock AudioContext. The fix exposes the match result as state (`lastMatchWasSuccess`) and plays the sound in a `useEffect` in `useMemoryGameContent`, keeping audio as a pure component side-effect.

## Changes

- `stores/memoryStoreTypes.ts` — add `lastMatchWasSuccess: boolean`; remove `audioContext` param from `resolveMatch` signature
- `stores/useMemoryStore.ts` — remove `playMemorySuccessSound` import/call; set `lastMatchWasSuccess: outcome.isMatch` during resolve; remove `audioContext` param
- `useMemoryGameContent.ts` — import `playMemorySuccessSound`; update `resolveMatch(first, second)` call; add `useEffect` watching `lastMatchWasSuccess`

## Testing

- [x] `npx tsc --noEmit` passes
- [ ] Manually verify at `http://localhost:3000/games/memory` — success sound plays on match, silent on mismatch

Closes #905

🤖 Generated with [Claude Code](https://claude.com/claude-code)