### PR TITLE
perf: wrap CustomGameRenderer dynamic() imports in Suspense

### DIFF
--- a/gamesformykids/app/games/[gameType]/CustomGameRenderer.tsx
+++ b/gamesformykids/app/games/[gameType]/CustomGameRenderer.tsx
@@ -1,7 +1,9 @@
 'use client';
 
+import { Suspense } from 'react';
 import dynamic from 'next/dynamic';
 import type { ComponentType } from 'react';
+import GameSpinnerScreen from '@/components/ui/GameSpinnerScreen';
 
 const GAME_CLIENTS: Record<string, ComponentType> = {
   arithmetic:        dynamic(() => import('../arithmetic/ArithmeticGameClient')),
@@ -48,5 +50,9 @@ interface Props { gameType: string; }
 export default function CustomGameRenderer({ gameType }: Props) {
   const Component = GAME_CLIENTS[gameType];
   if (!Component) return null;
-  return <Component />;
+  return (
+    <Suspense fallback={<GameSpinnerScreen />}>
+      <Component />
+    </Suspense>
+  );
 }


### PR DESCRIPTION
## Summary

All 34 game clients in `CustomGameRenderer` were loaded with `next/dynamic()` but had no `loading` option. On client-side navigation (e.g. going from one game to another without a full page reload) the screen would go blank while the JS chunk resolved — visible on slower connections and first visits.

The route-level `loading.tsx` only fires during SSR/initial page load; it does **not** activate during client-side lazy resolution of `dynamic()` imports. A `<Suspense>` boundary is the correct client-side fix.

## Changes

- `app/games/[gameType]/CustomGameRenderer.tsx` — wrap `<Component />` in `<Suspense fallback={<GameSpinnerScreen />}>` using the existing `GameSpinnerScreen` component from `components/ui/`; add `Suspense` import

## Testing
- [x] `npx tsc --noEmit` passes
- [ ] Manually verify loading state at `http://localhost:3000/games/snake`, `http://localhost:3000/games/chess`, `http://localhost:3000/games/tetris`

Closes #924

🤖 Generated with [Claude Code](https://claude.com/claude-code)