### PR TITLE
fix(rtl): replace physical left/right with Tailwind logical properties

### DIFF
--- a/gamesformykids/components/game/CategoryGamesView.tsx
+++ b/gamesformykids/components/game/CategoryGamesView.tsx
@@ -28,7 +28,7 @@ export default function CategoryGamesView() {
           onClick={backToCategories}
           className="mb-3 md:mb-4 px-4 py-2 bg-gray-200 hover:bg-gray-300 text-gray-700 rounded-full font-medium transition-colors text-sm md:text-base"
         >
-          → חזור לקטגוריות
+          חזור לקטגוריות ←
         </button>
         <h2 className="text-2xl md:text-3xl font-bold text-gray-800 mb-1 md:mb-2">
           {category.title}

--- a/gamesformykids/components/game/GameCard.tsx
+++ b/gamesformykids/components/game/GameCard.tsx
@@ -43,7 +43,7 @@ export default function GameCard({ game }: ComponentTypes.GameCardProps) {
             <button
               onClick={(e) => { e.preventDefault(); toggleFavorite(game.id); }}
               aria-label={isFav ? 'הסר ממועדפים' : 'הוסף למועדפים'}
-              className={`absolute top-2 right-2 md:top-4 md:right-4 p-0.5 rounded-full transition-all duration-200 z-10 ${
+              className={`absolute top-2 start-2 md:top-4 md:start-4 p-0.5 rounded-full transition-all duration-200 z-10 ${
                 isFav ? 'scale-125' : 'opacity-60 hover:opacity-100 hover:scale-110'
               }`}
             >

--- a/gamesformykids/components/game/GameSearchBar.tsx
+++ b/gamesformykids/components/game/GameSearchBar.tsx
@@ -23,7 +23,7 @@ export function GameSearchBar({
   return (
     <div dir="rtl" className="mb-4 md:mb-6 space-y-3">
       <div className="relative max-w-md mx-auto">
-        <span className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-400 pointer-events-none">
+        <span className="absolute start-3 top-1/2 -translate-y-1/2 text-gray-400 pointer-events-none">
           <Search className="w-4 h-4" />
         </span>
         <input
@@ -38,7 +38,7 @@ export function GameSearchBar({
           <button
             onClick={onClear}
             aria-label="נקה חיפוש"
-            className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-600 transition-colors"
+            className="absolute end-3 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-600 transition-colors"
           >
             <X className="w-4 h-4" />
           </button>

--- a/gamesformykids/components/game/quiz/QuizFeedback.tsx
+++ b/gamesformykids/components/game/quiz/QuizFeedback.tsx
@@ -45,7 +45,7 @@ export function QuizFeedback({
         onClick={next}
         className={`w-full py-3 rounded-2xl ${t.button} text-white font-bold text-lg transition-all`}
       >
-        {isLast ? 'סיום' : 'הבא →'}
+        {isLast ? 'סיום' : '← הבא'}
       </button>
     </div>
   );

--- a/gamesformykids/components/marketing/ClientOnlyFeaturedGame.tsx
+++ b/gamesformykids/components/marketing/ClientOnlyFeaturedGame.tsx
@@ -19,7 +19,7 @@ const FeaturedGameContent = dynamic(() => import('./FeaturedGameContent'), {
               <div className="w-16 h-16 bg-gray-400 rounded-lg animate-pulse"></div>
             </div>
             
-            <div className="flex-1 text-center md:text-right">
+            <div className="flex-1 text-center md:text-start">
               <div className="h-8 bg-gray-400 rounded mb-4 animate-pulse"></div>
               <div className="h-4 bg-gray-400 rounded mb-6 animate-pulse"></div>
               

--- a/gamesformykids/components/marketing/FeaturedGameContent.tsx
+++ b/gamesformykids/components/marketing/FeaturedGameContent.tsx
@@ -23,7 +23,7 @@ const FeaturedGameContent = () => {
                 <div className="w-16 h-16 bg-gray-400 rounded-lg animate-pulse"></div>
               </div>
               
-              <div className="flex-1 text-center md:text-right">
+              <div className="flex-1 text-center md:text-start">
                 <div className="h-8 bg-gray-400 rounded mb-4 animate-pulse"></div>
                 <div className="h-4 bg-gray-400 rounded mb-6 animate-pulse"></div>
                 
@@ -56,7 +56,7 @@ const FeaturedGameContent = () => {
               </Link>
             </div>
             
-            <div className="flex-1 text-center md:text-right">
+            <div className="flex-1 text-center md:text-start">
               <h3 className="text-2xl md:text-3xl font-bold text-white mb-4">
                 {featuredGame.title}
               </h3>

--- a/gamesformykids/components/settings/AccountSection.tsx
+++ b/gamesformykids/components/settings/AccountSection.tsx
@@ -8,13 +8,13 @@ export function AccountSection({ onSignOut }: AccountSectionProps) {
       <div className="space-y-4">
         <Link
           href="/profile"
-          className="block w-full text-left p-3 text-purple-600 hover:bg-purple-50 rounded-lg transition-colors"
+          className="block w-full text-start p-3 text-purple-600 hover:bg-purple-50 rounded-lg transition-colors"
         >
           ערוך פרופיל
         </Link>
         <button
           onClick={onSignOut}
-          className="block w-full text-left p-3 text-red-600 hover:bg-red-50 rounded-lg transition-colors"
+          className="block w-full text-start p-3 text-red-600 hover:bg-red-50 rounded-lg transition-colors"
         >
           התנתק מהחשבון
         </button>

--- a/gamesformykids/components/shared/feedback/GameHints.tsx
+++ b/gamesformykids/components/shared/feedback/GameHints.tsx
@@ -44,7 +44,7 @@ export default function GameHints({
             disabled={currentHintIndex === hints.length - 1}
             className="px-3 py-1 bg-blue-200 text-blue-800 rounded disabled:opacity-50"
           >
-            הבא →
+            ← הבא
           </button>
         </div>
       )}

--- a/gamesformykids/components/shared/headers/UnifiedHeader.tsx
+++ b/gamesformykids/components/shared/headers/UnifiedHeader.tsx
@@ -32,7 +32,7 @@ export default function UnifiedHeader({
               aria-label="חזור לעמוד הקודם"
               className="flex items-center gap-1 px-4 py-2 bg-purple-500 text-white rounded-lg hover:bg-purple-600 active:scale-95 transition-all duration-200 font-bold text-sm md:text-base shadow-md"
             >
-              → חזור
+              חזור ←
             </button>
           )}
 

--- a/gamesformykids/components/ui/NotificationToast.tsx
+++ b/gamesformykids/components/ui/NotificationToast.tsx
@@ -66,7 +66,7 @@ function Toast({ notif }: { notif: Notification }) {
       {notif.duration > 0 && (
         <div
           ref={barRef}
-          className="absolute bottom-0 left-0 h-0.5 bg-white/40 rounded-full"
+          className="absolute bottom-0 start-0 h-0.5 bg-white/40 rounded-full"
           style={{ width: '100%' }}
         />
       )}

--- a/gamesformykids/components/user/UserProfile.tsx
+++ b/gamesformykids/components/user/UserProfile.tsx
@@ -48,7 +48,7 @@ export function UserProfile() {
       </button>
 
       {isMenuOpen && (
-        <div className="absolute right-0 mt-2 w-48 bg-white border border-gray-200 rounded-lg shadow-lg z-50">
+        <div className="absolute start-0 mt-2 w-48 bg-white border border-gray-200 rounded-lg shadow-lg z-50">
           <div className="py-1">
             <div className="px-4 py-2 text-sm text-gray-700 border-b">
               <div className="font-medium">{user.user_metadata?.full_name || L.defaultName}</div>
@@ -63,7 +63,7 @@ export function UserProfile() {
               {L.settings}
             </Link>
             <button onClick={handleSignOut}
-              className="block w-full text-right px-4 py-2 text-sm text-red-600 hover:bg-gray-100">
+              className="block w-full text-start px-4 py-2 text-sm text-red-600 hover:bg-gray-100">
               {L.signOut}
             </button>
           </div>


### PR DESCRIPTION
## Summary
- Fix RTL arrow direction in QuizFeedback and GameHints (← instead of →)
- Replace `text-right`/`text-left` with `text-start`/`text-end` in 5 components
- Replace `right-N`/`left-N` absolute positioning with `start-N`/`end-N` in GameCard, GameSearchBar, NotificationToast, UserProfile
- Fix back-button arrows in CategoryGamesView and UnifiedHeader (`חזור ←`)

## Test plan
- [ ] Verify favorite-star button appears on correct side of GameCard in RTL
- [ ] Verify search icon and clear-button positions in GameSearchBar look correct
- [ ] Verify "← הבא" button in QuizFeedback advances correctly
- [ ] Verify "חזור ←" back buttons in category view and game headers
- [ ] Verify dropdown menu opens on correct side in UserProfile
- [ ] Verify toast progress bar animates from correct side

Closes #938
Closes #941
Closes #943
Closes #947