### PR TITLE
fix(ux): improve readability and feedback messages for children

### DIFF
--- a/gamesformykids/components/game/quiz/QuizFeedback.tsx
+++ b/gamesformykids/components/game/quiz/QuizFeedback.tsx
@@ -26,7 +26,7 @@ export function QuizFeedback({
   if (isCorrect === null) return null;
 
   const t = QUIZ_THEMES[theme];
-  const message = isCorrect ? correctMsg : (wrongMsg ?? `❌ הנכון: ${correctLabel}`);
+  const message = isCorrect ? correctMsg : (wrongMsg ?? `כמעט! 💙 הנכון: ${correctLabel}`);
   const isLast = index + 1 >= total;
 
   return (

--- a/gamesformykids/components/game/quiz/screens/SequencesQuestion.tsx
+++ b/gamesformykids/components/game/quiz/screens/SequencesQuestion.tsx
@@ -22,7 +22,7 @@ export default function SequencesQuestion({ level, current, choices, onSelect }:
       wrongMsg={`💙 הנכון: ${current.next}`}
       funFact={`כלל: ${current.rule}`}
     >
-      <p className="text-sm font-semibold text-gray-400 text-center mb-4">מה המספר הבא? <span className="text-xs text-indigo-400">{level.label}</span></p>
+      <p className="text-sm font-semibold text-gray-400 text-center mb-4">מה המספר הבא? <span className="text-sm text-indigo-400">{level.label}</span></p>
       <div className="flex flex-wrap justify-center gap-3 items-center">
         {current.sequence.map((n, i) => (
           <div key={i} className="flex items-center gap-2">

--- a/gamesformykids/components/game/shared/CanvasGameOverOverlay.tsx
+++ b/gamesformykids/components/game/shared/CanvasGameOverOverlay.tsx
@@ -47,11 +47,11 @@ export default function CanvasGameOverOverlay({
         <div className={`grid grid-cols-2 gap-3 ${gridMb}`}>
           <div className={`${scoreBgClass} rounded-2xl p-3`}>
             <p className={`${scoreSize} font-black ${scoreTextClass}`}>{score}{scoreSuffix}</p>
-            <p className={`text-xs ${scoreLabelClass}`}>{scoreLabel}</p>
+            <p className={`text-sm ${scoreLabelClass}`}>{scoreLabel}</p>
           </div>
           <div className="bg-yellow-50 rounded-2xl p-3">
             <p className={`${scoreSize} font-black text-yellow-500`}>{best}{bestSuffix}</p>
-            <p className="text-xs text-yellow-400">שיא</p>
+            <p className="text-sm text-yellow-400">שיא</p>
           </div>
         </div>
         <button

--- a/gamesformykids/components/game/shared/GameMenuCard.tsx
+++ b/gamesformykids/components/game/shared/GameMenuCard.tsx
@@ -56,7 +56,7 @@ export default function GameMenuCard({
         <div className={`text-6xl mb-4 ${animateEmoji ? 'animate-bounce' : ''}`}>{emoji}</div>
         <h1 className="text-3xl font-black text-gray-700 mb-2">{title}</h1>
         <p className="text-gray-500 text-base mb-2">{description}</p>
-        {hint && <p className="text-gray-400 text-xs mb-4">{hint}</p>}
+        {hint && <p className="text-gray-400 text-sm mb-4">{hint}</p>}
         {best !== undefined && best > 0 && (
           <p className="text-yellow-600 font-bold mb-4">🏆 שיא: {best}</p>
         )}

--- a/gamesformykids/components/game/shared/ScoreTimeLivesHUD.tsx
+++ b/gamesformykids/components/game/shared/ScoreTimeLivesHUD.tsx
@@ -13,15 +13,15 @@ export default function ScoreTimeLivesHUD({ score, lives, timeLeft, mb = 'mb-3' 
     <div className={`flex gap-5 ${mb} text-white text-center`}>
       <div>
         <p className="text-2xl font-black text-yellow-300" role="status" aria-live="polite" aria-label={`ניקוד: ${score}`}>{score}</p>
-        <p className="text-xs text-yellow-500">ניקוד</p>
+        <p className="text-sm text-yellow-500">ניקוד</p>
       </div>
       <div>
         <LivesDisplay lives={lives} />
-        <p className="text-xs text-red-400">חיים</p>
+        <p className="text-sm text-red-400">חיים</p>
       </div>
       <div>
-        <p className="text-2xl font-black text-blue-200">{timeLeft}s</p>
-        <p className="text-xs text-blue-400">זמן</p>
+        <p className="text-2xl font-black text-blue-200">{timeLeft} שנ׳</p>
+        <p className="text-sm text-blue-400">זמן</p>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- Bump `text-xs` → `text-sm` in HUD labels (ScoreTimeLivesHUD, CanvasGameOverOverlay, GameMenuCard hint, SequencesQuestion level badge) so small text is legible for young children
- Replace the cold `❌ הנכון:` wrong-answer message with an encouraging `כמעט! 💙 הנכון:` in QuizFeedback
- Replace the English `s` timer suffix with the Hebrew abbreviation `שנ׳` in ScoreTimeLivesHUD

## Test plan
- [ ] Open any canvas game (e.g. Snake) and verify HUD labels (ניקוד/חיים/זמן) are readable at text-sm
- [ ] Verify timer shows `שנ׳` not `s`
- [ ] Answer a question incorrectly in any quiz and confirm the message reads `כמעט! 💙 הנכון: ...`
- [ ] Open Sequences game and confirm the level badge is text-sm

Closes #940
Closes #942
Closes #946