### PR TITLE
fix(a11y): skip confetti animation when prefers-reduced-motion is set

### DIFF
--- a/gamesformykids/components/game/shared/GameCompletionCelebration.tsx
+++ b/gamesformykids/components/game/shared/GameCompletionCelebration.tsx
@@ -27,6 +27,10 @@ export function GameCompletionCelebration() {
 
   useEffect(() => {
     playSuccessSound();
+    if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
+      setVisible(false);
+      return;
+    }
     const id = setTimeout(() => setVisible(false), 2500);
     return () => clearTimeout(id);
     // eslint-disable-next-line react-hooks/exhaustive-deps


### PR DESCRIPTION
## Summary
The `GameCompletionCelebration` component injects a `<style>` tag with `@keyframes gfk-confetti-fall` at runtime. This bypasses the global `prefers-reduced-motion` CSS rule in `globals.css` because the keyframe is not in the stylesheet — it's injected dynamically.

Fix: check `window.matchMedia('(prefers-reduced-motion: reduce)').matches` inside the `useEffect`. If true, immediately hide the overlay instead of running the 2.5 s timer. The success sound still plays.

## Test plan
- [ ] Enable "Reduce motion" in OS accessibility settings
- [ ] Complete any game and verify no animated confetti appears
- [ ] Verify success sound still plays when reduced motion is on
- [ ] Disable reduced motion — confetti animation should appear as normal

Closes #939