### PR TITLE
fix(ux): add loading spinner fallback to dynamic quiz imports

### DIFF
--- a/gamesformykids/lib/quiz/registry/complexQuizGames.tsx
+++ b/gamesformykids/lib/quiz/registry/complexQuizGames.tsx
@@ -1,12 +1,13 @@
 'use client';
 import dynamic from 'next/dynamic';
 import type { ComponentType } from 'react';
+import GameSpinnerScreen from '@/components/ui/GameSpinnerScreen';
 
 /**
  * Games with their own store / multi-phase rendering — loaded lazily.
  */
 export const COMPLEX_QUIZ_GAMES: Record<string, ComponentType> = {
-  'transport': dynamic(() => import('@/app/games/transport/TransportGame')),
-  'holidays':  dynamic(() => import('@/app/games/holidays/HolidaysGame')),
-  'tzadikim':  dynamic(() => import('@/app/games/tzadikim/TzadikimGame')),
+  'transport': dynamic(() => import('@/app/games/transport/TransportGame'), { loading: () => <GameSpinnerScreen /> }),
+  'holidays':  dynamic(() => import('@/app/games/holidays/HolidaysGame'),   { loading: () => <GameSpinnerScreen /> }),
+  'tzadikim':  dynamic(() => import('@/app/games/tzadikim/TzadikimGame'),   { loading: () => <GameSpinnerScreen /> }),
 };

--- a/gamesformykids/lib/quiz/registry/genericQuizGames.tsx
+++ b/gamesformykids/lib/quiz/registry/genericQuizGames.tsx
@@ -1,8 +1,11 @@
 'use client';
 import dynamic from 'next/dynamic';
 import type { ComponentType } from 'react';
+import GameSpinnerScreen from '@/components/ui/GameSpinnerScreen';
 
-const GenericQuizGame = dynamic(() => import('@/components/game/quiz/GenericQuizGame'));
+const GenericQuizGame = dynamic(() => import('@/components/game/quiz/GenericQuizGame'), {
+  loading: () => <GameSpinnerScreen />,
+});
 
 /**
  * Games that use the config-driven GenericQuizGame component.


### PR DESCRIPTION
## Summary
`GenericQuizGame` and the 3 complex quiz games (`transport`, `holidays`, `tzadikim`) were loaded via `next/dynamic` without a `loading` prop, resulting in a blank screen while the chunk downloads. Add `GameSpinnerScreen` as the loading fallback for all four dynamic imports.

## Test plan
- [ ] Open a quiz game on a slow connection (Network throttle: Slow 3G in DevTools)
- [ ] Verify a spinner appears before the game component loads (not a blank screen)
- [ ] Verify normal game function after loading completes

Closes #933