### PR TITLE
fix: replace non-null array assertions with safe optional chaining

### DIFF
--- a/gamesformykids/app/dashboard/components/MostPlayedCard.tsx
+++ b/gamesformykids/app/dashboard/components/MostPlayedCard.tsx
@@ -39,7 +39,7 @@ export function MostPlayedCard() {
         <ul className="space-y-3">
           {recent.map((p) => {
             const { name, emoji } = getGameLabel(p.game_type);
-            const maxTime = recent[0]!.total_play_time || 1;
+            const maxTime = recent[0]?.total_play_time ?? 1;
             const pct = Math.round((p.total_play_time / maxTime) * 100);
             return (
               <li key={p.game_type}>

--- a/gamesformykids/app/games/chess/components/ChessMoveHistory.tsx
+++ b/gamesformykids/app/games/chess/components/ChessMoveHistory.tsx
@@ -41,8 +41,10 @@ export default function ChessMoveHistory() {
 
   const pairs: [MoveRecord, MoveRecord | undefined][] = [];
   for (let i = 0; i < moveHistory.length; i += 2) {
-    const white = (moveHistory[i]!.by === 'w' ? moveHistory[i]! : moveHistory[i + 1]) as MoveRecord;
-    const black = moveHistory[i]!.by === 'b' ? moveHistory[i]! : moveHistory[i + 1];
+    const current = moveHistory[i];
+    if (!current) continue;
+    const white = (current.by === 'w' ? current : moveHistory[i + 1]) as MoveRecord;
+    const black = current.by === 'b' ? current : moveHistory[i + 1];
     pairs.push([white, black]);
   }
   const totalPairs = pairs.length;

--- a/gamesformykids/app/games/shesh-besh/components/GameBoard.tsx
+++ b/gamesformykids/app/games/shesh-besh/components/GameBoard.tsx
@@ -69,8 +69,8 @@ export function GameBoard() {
 
         {/* Borne-off tray */}
         <BorneOff
-          playerCount={points[0]!.player}
-          compCount={points[25]!.computer}
+          playerCount={points[0]?.player ?? 0}
+          compCount={points[25]?.computer ?? 0}
           onBearOff={() => selectPoint(0)}
           isBearOffTarget={validTargets.has(0) && selected !== null}
         />

--- a/gamesformykids/hooks/canvas/createCanvasArcadeHook.ts
+++ b/gamesformykids/hooks/canvas/createCanvasArcadeHook.ts
@@ -120,7 +120,7 @@ export function createCanvasArcadeHook<S extends { phase: string }>(
         if (st.current.phase !== 'playing' || !config.onPointerX) return;
         const rect = e.currentTarget.getBoundingClientRect();
         const canvasX =
-          (e.touches[0]!.clientX - rect.left) * (config.width / rect.width);
+          ((e.touches[0]?.clientX ?? 0) - rect.left) * (config.width / rect.width);
         config.onPointerX(st.current, canvasX);
       },
       [],


### PR DESCRIPTION
## Summary
Six locations used `!` on array index access, silencing `noUncheckedIndexedAccess`. Replace with optional chaining + nullish coalescing or a null guard:

| File | Before | After |
|------|--------|-------|
| `MostPlayedCard.tsx:42` | `recent[0]!.total_play_time \|\| 1` | `recent[0]?.total_play_time ?? 1` |
| `ChessMoveHistory.tsx:44-45` | `moveHistory[i]!.by` (×3) | Extract to `current` + `if (!current) continue` |
| `GameBoard.tsx:72` | `points[0]!.player` | `points[0]?.player ?? 0` |
| `GameBoard.tsx:73` | `points[25]!.computer` | `points[25]?.computer ?? 0` |
| `createCanvasArcadeHook.ts:123` | `e.touches[0]!.clientX` | `(e.touches[0]?.clientX ?? 0)` |

## Test plan
- [ ] `npx tsc --noEmit` passes (verified locally)
- [ ] Chess move history renders correctly
- [ ] Shesh-besh borne-off tray shows correct counts
- [ ] Canvas arcade games (pointer tracking) still responds to touch

Closes #936