### PR TITLE
chore: normalize smells-tastes identifier in gameCategories.ts

### DIFF
--- a/gamesformykids/lib/constants/gameCategories.ts
+++ b/gamesformykids/lib/constants/gameCategories.ts
@@ -46,7 +46,7 @@ export const GAME_CATEGORIES: Record<string, GameCategory> = {
     icon: Apple,
     color: "bg-green-500",
     gradient: "from-green-400 to-green-600",
-    gameIds: ["animals","fruits","vegetables","ocean-life","garden-plants","smelltaste","nature-sounds","dinosaurs","birds","bugs-insects","dog-breeds","cat-breeds","exotic-birds","butterflies","nature","healthy-food"],
+    gameIds: ["animals","fruits","vegetables","ocean-life","garden-plants","smells-tastes","nature-sounds","dinosaurs","birds","bugs-insects","dog-breeds","cat-breeds","exotic-birds","butterflies","nature","healthy-food"],
   },
   world: {
     title: "עולם ותחבורה",


### PR DESCRIPTION
## Summary
Replace the URL alias `smelltaste` with the canonical game ID `smells-tastes` in the `nature` category's `gameIds` array. This works at runtime (via `URL_TO_GAME_TYPE_MAP`), but was inconsistent with every other reference in the codebase making grep for `smells-tastes` miss the category entry.

## Changes
- `lib/constants/gameCategories.ts` — `"smelltaste"` → `"smells-tastes"` in `nature.gameIds`

## Testing
- [x] `npx tsc --noEmit` passes
- [ ] Game appears correctly in the nature category on the home page at `/games/smells-tastes`

Closes #969

🤖 Generated with [Claude Code](https://claude.com/claude-code)