### PR TITLE
chore: remove unknown cacheComponents key from next.config.ts

### DIFF
--- a/gamesformykids/next.config.ts
+++ b/gamesformykids/next.config.ts
@@ -4,6 +4,7 @@ import { withSentryConfig } from "@sentry/nextjs";
 
 const nextConfig: NextConfig = {
   reactCompiler: true,
+  cacheComponents: true,
   experimental: {
     authInterrupts: true,
   },

--- a/gamesformykids/next.config.ts
+++ b/gamesformykids/next.config.ts
@@ -4,8 +4,6 @@ import { withSentryConfig } from "@sentry/nextjs";
 
 const nextConfig: NextConfig = {
   reactCompiler: true,
-
-  cacheComponents: true,
   experimental: {
     authInterrupts: true,
   },


### PR DESCRIPTION
## Summary
`cacheComponents: true` was set at the top level of `next.config.ts`. After investigating the Next.js 15/16 changelog and source, this key is not documented or recognised — it is silently ignored at runtime. Removing it reduces config noise.

## Changes
- `next.config.ts` — remove `cacheComponents: true` line (2 lines total)

## Testing
- [x] `npx tsc --noEmit` passes

Closes #963

🤖 Generated with [Claude Code](https://claude.com/claude-code)