### PR TITLE
fix: scope middleware matcher to protected routes only

### DIFF
--- a/gamesformykids/middleware.ts
+++ b/gamesformykids/middleware.ts
@@ -73,14 +73,11 @@ export async function middleware(request: NextRequest) {
 
 export const config = {
   matcher: [
-    /*
-     * Match all request paths except for the ones starting with:
-     * - _next/static (static files)
-     * - _next/image (image optimization files)
-     * - favicon.ico (favicon file)
-     * - api routes (handled separately)
-     * - public files
-     */
-    '/((?!_next/static|_next/image|favicon.ico|api|.*\\.(?:svg|png|jpg|jpeg|gif|webp)$).*)',
+    '/dashboard/:path*',
+    '/profile/:path*',
+    '/settings/:path*',
+    '/analytics/:path*',
+    '/login',
+    '/auth/:path*',
   ],
 }


### PR DESCRIPTION
## Summary
The middleware's catch-all matcher was running Supabase `auth.getUser()` on every request — including static game pages (`/games/animals`) and the home page — routes where the middleware does nothing actionable. This eliminates an unnecessary Supabase RTT on the highest-traffic paths in the app.

## Changes
- `middleware.ts` — replace the broad catch-all matcher with an explicit list of the 6 route prefixes that actually require auth checking (`/dashboard`, `/profile`, `/settings`, `/analytics`, `/login`, `/auth`)

## Testing
- [x] `npx tsc --noEmit` passes
- [ ] Verify login redirect still works on `/profile`, `/settings`, `/analytics`, `/dashboard` for unauthenticated users
- [ ] Verify `/games/*` and `/` load without triggering middleware (check Network tab — no extra Supabase calls)

Closes #959

🤖 Generated with [Claude Code](https://claude.com/claude-code)