### PR TITLE
chore: add server-only guard to gameItemsLoader

### DIFF
--- a/gamesformykids/lib/constants/gameItemsLoader.ts
+++ b/gamesformykids/lib/constants/gameItemsLoader.ts
@@ -9,6 +9,7 @@
  *
  * Keep this file SERVER-ONLY (no 'use client').
  */
+import 'server-only';
 
 import { cacheLife, cacheTag } from 'next/cache';
 import type { GameType, BaseGameItem } from '@/lib/types/core/base';

--- a/gamesformykids/package-lock.json
+++ b/gamesformykids/package-lock.json
@@ -19,6 +19,7 @@
         "next": "16.2.6",
         "react": "^19.1.0",
         "react-dom": "^19.0.0",
+        "server-only": "^0.0.1",
         "tailwind-merge": "^3.3.1",
         "zustand": "^5.0.12"
       },
@@ -527,30 +528,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
-      }
-    },
-    "node_modules/@emnapi/core": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
-      "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
-      "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/wasi-threads": {
@@ -9031,6 +9008,12 @@
       "bin": {
         "semver": "bin/semver.js"
       }
+    },
+    "node_modules/server-only": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/server-only/-/server-only-0.0.1.tgz",
+      "integrity": "sha512-qepMx2JxAa5jjfzxG79yPPq+8BuFToHd1hm7kI+Z4zAq1ftQiP7HcxMhDDItrbtwVeLg/cY2JnKnrcFkmiswNA==",
+      "license": "MIT"
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",

--- a/gamesformykids/package-lock.json
+++ b/gamesformykids/package-lock.json
@@ -530,6 +530,30 @@
         "node": ">=10.0.0"
       }
     },
+    "node_modules/@emnapi/core": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
+      "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
+      "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",

--- a/gamesformykids/package.json
+++ b/gamesformykids/package.json
@@ -36,6 +36,7 @@
     "next": "16.2.6",
     "react": "^19.1.0",
     "react-dom": "^19.0.0",
+    "server-only": "^0.0.1",
     "tailwind-merge": "^3.3.1",
     "zustand": "^5.0.12"
   },


### PR DESCRIPTION
## Summary

`lib/constants/gameItemsLoader.ts` serves all game item data exclusively on the server via `'use cache'`. Adding `import 'server-only'` makes any accidental import from a client component a **build-time error** rather than silent bundle bloat. The file was only imported from one server component (`app/games/[gameType]/page.tsx`), so no existing behaviour changes.

Note: Step 2 from the issue (replacing `export *` with explicit named exports in `lib/constants/index.ts`) is intentionally deferred — the issue marks it as "progressive" cleanup to be done during normal file touch.

## Changes
- `lib/constants/gameItemsLoader.ts` — added `import 'server-only'` as first import
- `package.json` — added `server-only` as a production dependency
- `package-lock.json` — lock file updated

## Testing
- [x] `npx tsc --noEmit` passes
- [x] Only server component imports `gameItemsLoader` — no client import breakage

Closes #927

🤖 Generated with [Claude Code](https://claude.com/claude-code)