### PR TITLE
chore: remove dead cacheTag from gameItemsLoader

### DIFF
--- a/gamesformykids/lib/constants/gameItemsLoader.ts
+++ b/gamesformykids/lib/constants/gameItemsLoader.ts
@@ -5,13 +5,12 @@
  *
  * 'use cache' + cacheLife('max') — game data is deploy-immutable (comes from
  * static TypeScript files); Next.js will never revalidate until the next deploy.
- * cacheTag allows on-demand purging per game type if needed.
  *
  * Keep this file SERVER-ONLY (no 'use client').
  */
 import 'server-only';
 
-import { cacheLife, cacheTag } from 'next/cache';
+import { cacheLife } from 'next/cache';
 import type { GameType, BaseGameItem } from '@/lib/types/core/base';
 
 /** Each data module exports named `BaseGameItem[]` arrays alongside non-array constants.
@@ -57,7 +56,6 @@ async function fromFunGames(key: string): Promise<BaseGameItem[]> {
 
 export async function loadGameItems(gameType: GameType): Promise<BaseGameItem[]> {
   'use cache';
-  cacheTag(`game-items-${gameType}`);
   cacheLife('max'); // deploy-immutable — static TS files, never changes between deploys
 
   switch (gameType) {


### PR DESCRIPTION
## Summary

`gameItemsLoader.ts` was calling `cacheTag(\`game-items-\${gameType}\`)` alongside `cacheLife('max')`, but no code anywhere calls `revalidateTag(...)` to invalidate these tags. Game data comes from static TypeScript files and is deploy-immutable — `cacheLife('max')` alone is correct and sufficient. The `cacheTag` call was dead setup.

## Changes
- `lib/constants/gameItemsLoader.ts` — removed `cacheTag(...)` call and its import

## Testing
- [x] `npx tsc --noEmit` passes
- [x] `grep -r 'revalidateTag'` confirms no existing invalidation path exists

Closes #937

🤖 Generated with [Claude Code](https://claude.com/claude-code)