### PR TITLE
perf(ux): replace transition-all with specific transition properties

### DIFF
--- a/gamesformykids/app/dashboard/components/MostPlayedCard.tsx
+++ b/gamesformykids/app/dashboard/components/MostPlayedCard.tsx
@@ -51,7 +51,7 @@ export function MostPlayedCard() {
                 </div>
                 <div className="w-full bg-gray-100 rounded-full h-2">
                   <div
-                    className="bg-purple-400 h-2 rounded-full transition-all"
+                    className="bg-purple-400 h-2 rounded-full transition-[width]"
                     style={{ width: `${pct}%` }}
                   />
                 </div>

--- a/gamesformykids/components/game/CategoryCard.tsx
+++ b/gamesformykids/components/game/CategoryCard.tsx
@@ -14,7 +14,7 @@ export default function CategoryCard({
       type="button"
       onClick={onClick}
       aria-label={`${category.title} — ${gamesCount} משחקים`}
-      className={`w-full relative p-3 md:p-4 lg:p-6 rounded-2xl md:rounded-3xl shadow-lg md:shadow-xl transition-all duration-300 transform hover:scale-105 cursor-pointer hover:shadow-2xl bg-gradient-to-br ${category.gradient}`}
+      className={`w-full relative p-3 md:p-4 lg:p-6 rounded-2xl md:rounded-3xl shadow-lg md:shadow-xl transition-[transform,box-shadow] duration-300 hover:scale-105 cursor-pointer hover:shadow-2xl bg-gradient-to-br ${category.gradient}`}
     >
       <div className="text-center text-white">
         <div className="mb-2 md:mb-4 flex justify-center">

--- a/gamesformykids/components/game/CategoryNavigation.tsx
+++ b/gamesformykids/components/game/CategoryNavigation.tsx
@@ -5,7 +5,7 @@ import { useHomePageStore } from "@/lib/stores";
 import { useFavoritesStore } from "@/lib/stores";
 import { GamesRegistry } from "@/lib/registry/gamesRegistry";
 
-const TAB_BASE = "px-4 py-2 md:px-6 md:py-3 rounded-full font-bold text-sm md:text-base transition-all duration-300 transform hover:scale-105";
+const TAB_BASE = "px-4 py-2 md:px-6 md:py-3 rounded-full font-bold text-sm md:text-base transition-[transform,colors] duration-300 hover:scale-105";
 const TAB_ACTIVE = "bg-purple-600 text-white shadow-lg";
 const TAB_INACTIVE = "bg-white text-purple-600 hover:bg-purple-50 shadow-md";
 const FAV_ACTIVE = "bg-yellow-400 text-white shadow-lg";

--- a/gamesformykids/components/game/GameCard.tsx
+++ b/gamesformykids/components/game/GameCard.tsx
@@ -15,7 +15,7 @@ export default function GameCard({ game }: ComponentTypes.GameCardProps) {
         <Link href={game.href} aria-label={game.title}>
           <div
             className={`
-              relative p-3 md:p-4 lg:p-6 rounded-2xl md:rounded-3xl shadow-lg md:shadow-xl transition-all duration-300 transform hover:scale-105 cursor-pointer hover:shadow-2xl overflow-hidden
+              relative p-3 md:p-4 lg:p-6 rounded-2xl md:rounded-3xl shadow-lg md:shadow-xl transition-[transform,box-shadow] duration-300 hover:scale-105 cursor-pointer hover:shadow-2xl overflow-hidden
               ${game.color}
             `}
           >
@@ -43,7 +43,7 @@ export default function GameCard({ game }: ComponentTypes.GameCardProps) {
             <button
               onClick={(e) => { e.preventDefault(); toggleFavorite(game.id); }}
               aria-label={isFav ? 'הסר ממועדפים' : 'הוסף למועדפים'}
-              className={`absolute top-2 start-2 md:top-4 md:start-4 p-0.5 rounded-full transition-all duration-200 z-10 ${
+              className={`absolute top-2 start-2 md:top-4 md:start-4 p-0.5 rounded-full transition-[transform,opacity] duration-200 z-10 ${
                 isFav ? 'scale-125' : 'opacity-60 hover:opacity-100 hover:scale-110'
               }`}
             >

--- a/gamesformykids/components/game/GameSearchBar.tsx
+++ b/gamesformykids/components/game/GameSearchBar.tsx
@@ -56,7 +56,7 @@ export function GameSearchBar({
             key={key}
             onClick={() => onCatChange(activeCat === key ? null : key)}
             aria-pressed={activeCat === key}
-            className={`flex-shrink-0 px-3 py-1.5 rounded-full text-xs font-semibold transition-all duration-200 ${
+            className={`flex-shrink-0 px-3 py-1.5 rounded-full text-xs font-semibold transition-colors duration-200 ${
               activeCat === key
                 ? 'bg-purple-600 text-white shadow-md'
                 : 'bg-white text-gray-600 hover:bg-purple-50 shadow-sm border border-gray-200'

--- a/gamesformykids/components/game/quiz/GameModeMenuScreen.tsx
+++ b/gamesformykids/components/game/quiz/GameModeMenuScreen.tsx
@@ -53,7 +53,7 @@ export default function GameModeMenuScreen<T extends ModeItem>({
             <button
               key={i}
               onClick={() => onStart(item)}
-              className={`p-5 rounded-2xl text-white shadow-lg hover:scale-105 active:scale-95 transition-all text-start ${sideIcon ? 'flex items-center gap-4' : ''} ${buttonClassName}`}
+              className={`p-5 rounded-2xl text-white shadow-lg hover:scale-105 active:scale-95 transition-transform text-start ${sideIcon ? 'flex items-center gap-4' : ''} ${buttonClassName}`}
             >
               {sideIcon ? (
                 <>

--- a/gamesformykids/components/game/quiz/QuizAnswerGrid.tsx
+++ b/gamesformykids/components/game/quiz/QuizAnswerGrid.tsx
@@ -35,7 +35,7 @@ export function QuizAnswerGrid({
           key={choice}
           onClick={() => onSelect(choice)}
           disabled={selected !== null}
-          className={`p-4 rounded-2xl border-2 font-bold text-base transition-all text-center ${answerButtonClass(
+          className={`p-4 rounded-2xl border-2 font-bold text-base transition-colors text-center ${answerButtonClass(
             choice === correctValue,
             choice === selected,
             selected !== null,

--- a/gamesformykids/components/game/quiz/QuizFeedback.tsx
+++ b/gamesformykids/components/game/quiz/QuizFeedback.tsx
@@ -43,7 +43,7 @@ export function QuizFeedback({
       </div>
       <button
         onClick={next}
-        className={`w-full py-3 rounded-2xl ${t.button} text-white font-bold text-lg transition-all`}
+        className={`w-full py-3 rounded-2xl ${t.button} text-white font-bold text-lg transition-opacity`}
       >
         {isLast ? 'סיום' : '← הבא'}
       </button>

--- a/gamesformykids/components/game/quiz/QuizMenuScreen.tsx
+++ b/gamesformykids/components/game/quiz/QuizMenuScreen.tsx
@@ -33,7 +33,7 @@ export function QuizMenuScreen({
         {preview && <div className={`${t.card} rounded-2xl p-4 mb-6`}>{preview}</div>}
         <button
           onClick={onStart}
-          className={`w-full py-4 rounded-2xl ${t.button} text-white text-xl font-bold transition-all shadow-lg`}
+          className={`w-full py-4 rounded-2xl ${t.button} text-white text-xl font-bold transition-opacity shadow-lg`}
         >
           {emoji} {buttonLabel}
         </button>

--- a/gamesformykids/components/game/quiz/QuizProgress.tsx
+++ b/gamesformykids/components/game/quiz/QuizProgress.tsx
@@ -16,7 +16,7 @@ export function QuizProgress({ theme }: { theme: QuizTheme }) {
       </div>
       <div className="w-full bg-gray-200 rounded-full h-2 mb-5">
         <div
-          className={`${t.progress} h-2 rounded-full transition-all`}
+          className={`${t.progress} h-2 rounded-full transition-[width]`}
           style={{ width: `${((index + 1) / total) * 100}%` }}
         />
       </div>

--- a/gamesformykids/components/game/quiz/QuizQuestionCard.tsx
+++ b/gamesformykids/components/game/quiz/QuizQuestionCard.tsx
@@ -43,7 +43,7 @@ export default function QuizQuestionCard({
             key={idx}
             onClick={() => onSelect(idx)}
             disabled={answered}
-            className={`w-full text-start py-4 px-5 rounded-2xl font-semibold text-lg transition-all duration-200 active:scale-95 ${answerButtonClass(
+            className={`w-full text-start py-4 px-5 rounded-2xl font-semibold text-lg transition-[transform,colors] duration-200 active:scale-95 ${answerButtonClass(
               idx === correctIndex,
               idx === selected,
               answered,
@@ -65,7 +65,7 @@ export default function QuizQuestionCard({
       {answered && (
         <button
           onClick={onNext}
-          className={`w-full py-4 rounded-2xl text-white font-bold text-xl shadow-lg bg-gradient-to-l ${accentGradient} hover:opacity-90 active:scale-95 transition-all duration-200`}
+          className={`w-full py-4 rounded-2xl text-white font-bold text-xl shadow-lg bg-gradient-to-l ${accentGradient} hover:opacity-90 active:scale-95 transition-[transform,opacity] duration-200`}
         >
           {isLast ? 'לתוצאות! 🎉' : 'שאלה הבאה ←'}
         </button>

--- a/gamesformykids/components/game/quiz/QuizResultScreen.tsx
+++ b/gamesformykids/components/game/quiz/QuizResultScreen.tsx
@@ -43,7 +43,7 @@ export function QuizResultScreen({ onRestart, theme, title = 'כל הכבוד!',
         <p className="text-gray-400 text-sm mb-6">נקודות</p>
         <button
           onClick={onRestart}
-          className={`w-full py-3 rounded-2xl ${t.button} text-white font-bold text-lg transition-all`}
+          className={`w-full py-3 rounded-2xl ${t.button} text-white font-bold text-lg transition-opacity`}
         >
           שחק שוב
         </button>

--- a/gamesformykids/components/game/quiz/QuizTopicMenuScreen.tsx
+++ b/gamesformykids/components/game/quiz/QuizTopicMenuScreen.tsx
@@ -39,7 +39,7 @@ export default function QuizTopicMenuScreen<T extends string>({
         </div>
         <button
           onClick={() => onStart('all')}
-          className={`w-full mb-5 p-5 rounded-2xl text-white font-bold text-xl shadow-lg hover:scale-105 active:scale-95 transition-all bg-gradient-to-l ${allButtonClassName}`}
+          className={`w-full mb-5 p-5 rounded-2xl text-white font-bold text-xl shadow-lg hover:scale-105 active:scale-95 transition-transform bg-gradient-to-l ${allButtonClassName}`}
         >
           {allLabel}
         </button>
@@ -48,7 +48,7 @@ export default function QuizTopicMenuScreen<T extends string>({
             <button
               key={t}
               onClick={() => onStart(t)}
-              className={`p-4 rounded-2xl font-bold text-start shadow-md hover:scale-105 active:scale-95 transition-all ${topicClassName}`}
+              className={`p-4 rounded-2xl font-bold text-start shadow-md hover:scale-105 active:scale-95 transition-transform ${topicClassName}`}
             >
               <div className="text-3xl mb-1">{topicEmoji(t)}</div>
               <div>{t}</div>

--- a/gamesformykids/components/game/shared/CanvasGameOverOverlay.tsx
+++ b/gamesformykids/components/game/shared/CanvasGameOverOverlay.tsx
@@ -56,7 +56,7 @@ export default function CanvasGameOverOverlay({
         </div>
         <button
           onClick={onRestart}
-          className={`w-full ${buttonSizeClass} rounded-2xl ${buttonClass} text-white font-black shadow-lg hover:opacity-90 active:scale-95 transition-all`}
+          className={`w-full ${buttonSizeClass} rounded-2xl ${buttonClass} text-white font-black shadow-lg hover:opacity-90 active:scale-95 transition-[transform,opacity]`}
         >
           🔄 שוב!
         </button>

--- a/gamesformykids/components/game/shared/CanvasMenuOverlay.tsx
+++ b/gamesformykids/components/game/shared/CanvasMenuOverlay.tsx
@@ -44,7 +44,7 @@ export function CanvasMenuOverlay({
         )}
         <button
           onClick={onStart}
-          className={`w-full py-4 rounded-2xl text-white font-black text-xl active:scale-95 transition-all ${buttonClass}`}
+          className={`w-full py-4 rounded-2xl text-white font-black text-xl active:scale-95 transition-transform ${buttonClass}`}
         >
           {startLabel}
         </button>

--- a/gamesformykids/components/game/shared/GameMenuCard.tsx
+++ b/gamesformykids/components/game/shared/GameMenuCard.tsx
@@ -65,7 +65,7 @@ export default function GameMenuCard({
         {onStart && (
           <button
             onClick={onStart}
-            className={`w-full py-4 rounded-2xl bg-gradient-to-r ${buttonClass ?? ''} text-white font-black text-xl hover:opacity-90 active:scale-95 transition-all`}
+            className={`w-full py-4 rounded-2xl bg-gradient-to-r ${buttonClass ?? ''} text-white font-black text-xl hover:opacity-90 active:scale-95 transition-[transform,opacity]`}
           >
             {startLabel ?? `${emoji} התחל!`}
           </button>
@@ -73,7 +73,7 @@ export default function GameMenuCard({
         {secondaryAction && (
           <button
             onClick={secondaryAction.onClick}
-            className="w-full mt-3 py-3 rounded-2xl border-2 border-gray-200 text-gray-600 font-semibold text-base hover:bg-gray-50 active:scale-95 transition-all"
+            className="w-full mt-3 py-3 rounded-2xl border-2 border-gray-200 text-gray-600 font-semibold text-base hover:bg-gray-50 active:scale-95 transition-[transform,colors]"
           >
             {secondaryAction.label}
           </button>

--- a/gamesformykids/components/game/shared/GameResultCard.tsx
+++ b/gamesformykids/components/game/shared/GameResultCard.tsx
@@ -55,14 +55,14 @@ export default function GameResultCard({
         <div className="flex gap-3">
           <button
             onClick={onRestart}
-            className={`flex-1 py-4 rounded-2xl bg-gradient-to-l ${buttonClass} text-white font-bold hover:opacity-90 active:scale-95 transition-all`}
+            className={`flex-1 py-4 rounded-2xl bg-gradient-to-l ${buttonClass} text-white font-bold hover:opacity-90 active:scale-95 transition-[transform,opacity]`}
           >
             {restartLabel}
           </button>
           {secondaryAction && (
             <button
               onClick={secondaryAction.onClick}
-              className="flex-1 py-4 rounded-2xl border-2 border-gray-200 text-gray-600 font-semibold hover:bg-gray-50 transition-all"
+              className="flex-1 py-4 rounded-2xl border-2 border-gray-200 text-gray-600 font-semibold hover:bg-gray-50 transition-colors"
             >
               {secondaryAction.label}
             </button>
@@ -71,7 +71,7 @@ export default function GameResultCard({
         {shareText && (
           <button
             onClick={() => share(shareText)}
-            className="mt-3 w-full py-2.5 rounded-2xl border-2 border-gray-200 text-gray-500 font-semibold text-sm hover:bg-gray-50 active:scale-95 transition-all"
+            className="mt-3 w-full py-2.5 rounded-2xl border-2 border-gray-200 text-gray-500 font-semibold text-sm hover:bg-gray-50 active:scale-95 transition-[transform,colors]"
           >
             {copied ? '✅ הועתק!' : '📤 שתף את הניקוד'}
           </button>

--- a/gamesformykids/components/game/shared/LivesDisplay.tsx
+++ b/gamesformykids/components/game/shared/LivesDisplay.tsx
@@ -8,7 +8,7 @@ export default function LivesDisplay({ lives, max = 3, size = 'text-2xl' }: Prop
   return (
     <div className="flex gap-1" role="status" aria-live="polite" aria-label={`${lives} חיים`}>
       {Array.from({ length: max }, (_, i) => (
-        <span key={i} className={`${size} transition-all ${i < lives ? '' : 'opacity-20 grayscale'}`}>❤️</span>
+        <span key={i} className={`${size} transition-[opacity,filter] ${i < lives ? '' : 'opacity-20 grayscale'}`}>❤️</span>
       ))}
     </div>
   );

--- a/gamesformykids/components/game/shared/StoryInterludeCard.tsx
+++ b/gamesformykids/components/game/shared/StoryInterludeCard.tsx
@@ -48,7 +48,7 @@ export default function StoryInterludeCard({
         {scoreLine && <p className="text-gray-500 mb-6">{scoreLine}</p>}
         <button
           onClick={onNext}
-          className={`w-full py-4 rounded-2xl text-white font-bold text-xl bg-gradient-to-l ${buttonGradient} shadow-lg hover:opacity-90 active:scale-95 transition-all`}
+          className={`w-full py-4 rounded-2xl text-white font-bold text-xl bg-gradient-to-l ${buttonGradient} shadow-lg hover:opacity-90 active:scale-95 transition-[transform,opacity]`}
         >
           {nextLabel}
         </button>

--- a/gamesformykids/components/game/shared/TimerProgressBar.tsx
+++ b/gamesformykids/components/game/shared/TimerProgressBar.tsx
@@ -16,7 +16,7 @@ export default function TimerProgressBar({ pct, trackClass = 'h-3 bg-white/30', 
   return (
     <div className={`${trackClass} rounded-full overflow-hidden`}>
       <div
-        className={`h-full rounded-full transition-all duration-1000 ${fillClass}`}
+        className={`h-full rounded-full transition-[width] duration-1000 ${fillClass}`}
         style={{ width: `${pct}%` }}
       />
     </div>

--- a/gamesformykids/components/game/universal/auto-game/AutoGameBody.tsx
+++ b/gamesformykids/components/game/universal/auto-game/AutoGameBody.tsx
@@ -60,8 +60,8 @@ export function AutoGameBody({ renderCard }: AutoGameBodyProps) {
           onClick={() => setShowProgressModal(true)}
           className="
             px-4 py-2 bg-blue-500 text-white rounded-lg shadow-lg
-            hover:bg-blue-600 transform hover:scale-105 
-            transition-all duration-200 font-bold
+            hover:bg-blue-600 hover:scale-105
+            transition-[transform,colors] duration-200 font-bold
           "
         >
           📊 דיוק: {currentAccuracy || 0}%

--- a/gamesformykids/components/game/universal/auto-game/AutoGameHeader.tsx
+++ b/gamesformykids/components/game/universal/auto-game/AutoGameHeader.tsx
@@ -28,8 +28,8 @@ export function AutoGameHeader() {
           onClick={() => setShowProgressModal(true)}
           className="
             px-3 py-2 bg-blue-500 text-white rounded-lg shadow-lg
-            hover:bg-blue-600 transform hover:scale-105 
-            transition-all duration-200 text-sm font-bold
+            hover:bg-blue-600 hover:scale-105
+            transition-[transform,colors] duration-200 text-sm font-bold
           "
           title="הצג סטטיסטיקות"
         >

--- a/gamesformykids/components/game/universal/navigation/UniversalGameNavigation.tsx
+++ b/gamesformykids/components/game/universal/navigation/UniversalGameNavigation.tsx
@@ -45,7 +45,7 @@ export default function UniversalGameNavigation({
         {navigation.previous && (
           <Link
             href={navigation.previous.href}
-            className="bg-blue-500/90 backdrop-blur-sm hover:bg-blue-600 text-white font-bold py-2 px-3 md:py-3 md:px-4 rounded-xl shadow-lg transition-all duration-200 hover:scale-105 active:scale-95 flex items-center gap-2 text-sm md:text-base border-2 border-blue-400 hover:border-blue-300"
+            className="bg-blue-500/90 backdrop-blur-sm hover:bg-blue-600 text-white font-bold py-2 px-3 md:py-3 md:px-4 rounded-xl shadow-lg transition-[transform,colors] duration-200 hover:scale-105 active:scale-95 flex items-center gap-2 text-sm md:text-base border-2 border-blue-400 hover:border-blue-300"
             title={`${navigation.previous.title} (←)`}
             aria-label={`משחק קודם: ${navigation.previous.title}`}
           >
@@ -63,7 +63,7 @@ export default function UniversalGameNavigation({
         {showHomeButton && (
           <Link
             href={ROUTES.HOME}
-            className="bg-white/90 backdrop-blur-sm hover:bg-white text-gray-800 font-bold py-2 px-3 md:py-3 md:px-4 rounded-xl shadow-lg transition-all duration-200 hover:scale-105 active:scale-95 flex items-center gap-2 text-sm md:text-base border-2 border-gray-200 hover:border-purple-300"
+            className="bg-white/90 backdrop-blur-sm hover:bg-white text-gray-800 font-bold py-2 px-3 md:py-3 md:px-4 rounded-xl shadow-lg transition-[transform,colors] duration-200 hover:scale-105 active:scale-95 flex items-center gap-2 text-sm md:text-base border-2 border-gray-200 hover:border-purple-300"
             title="חזרה לעמוד הראשי (ESC)"
             aria-label="חזרה לעמוד הראשי"
           >
@@ -87,7 +87,7 @@ export default function UniversalGameNavigation({
         {navigation.next && (
           <Link
             href={navigation.next.href}
-            className="bg-green-500/90 backdrop-blur-sm hover:bg-green-600 text-white font-bold py-2 px-3 md:py-3 md:px-4 rounded-xl shadow-lg transition-all duration-200 hover:scale-105 active:scale-95 flex items-center gap-2 text-sm md:text-base border-2 border-green-400 hover:border-green-300"
+            className="bg-green-500/90 backdrop-blur-sm hover:bg-green-600 text-white font-bold py-2 px-3 md:py-3 md:px-4 rounded-xl shadow-lg transition-[transform,colors] duration-200 hover:scale-105 active:scale-95 flex items-center gap-2 text-sm md:text-base border-2 border-green-400 hover:border-green-300"
             title={`${navigation.next.title} (→)`}
             aria-label={`משחק הבא: ${navigation.next.title}`}
           >

--- a/gamesformykids/components/shared/buttons/GameStatsButton.tsx
+++ b/gamesformykids/components/shared/buttons/GameStatsButton.tsx
@@ -11,7 +11,7 @@ export default function GameStatsButton() {
       className="
         px-4 py-3 bg-gradient-to-r from-blue-500 to-indigo-500 text-white rounded-xl shadow-lg
         hover:from-blue-600 hover:to-indigo-600 transform hover:scale-105 
-        transition-all duration-200 font-bold flex items-center gap-2
+        transition-[transform,colors] duration-200 font-bold flex items-center gap-2
       "
       title="הצג סטטיסטיקות מפורטות"
     >

--- a/gamesformykids/components/shared/buttons/SimpleGameStartButton.tsx
+++ b/gamesformykids/components/shared/buttons/SimpleGameStartButton.tsx
@@ -33,7 +33,7 @@ export default function SimpleGameStartButton({
         className={`
           px-12 py-4 bg-gradient-to-r ${fromColor} ${toColor} text-white text-2xl font-bold
           rounded-2xl shadow-2xl hover:shadow-3xl transform hover:scale-105
-          transition-all duration-300 border-4 border-white
+          transition-[transform,shadow] duration-300 border-4 border-white
           focus-visible:ring-4 focus-visible:ring-white focus-visible:ring-offset-4 focus-visible:outline-none
         `}
       >

--- a/gamesformykids/components/shared/cards/GameCardGrid.tsx
+++ b/gamesformykids/components/shared/cards/GameCardGrid.tsx
@@ -67,8 +67,8 @@ export function GameCardGrid<T extends GameItemType>({
               <div
                 onClick={() => handleItemClick(item)}
                 className={`
-                  aspect-square rounded-3xl cursor-pointer transition-all 
-                  duration-300 transform hover:scale-110 shadow-xl hover:shadow-2xl
+                  aspect-square rounded-3xl cursor-pointer transition-[transform,box-shadow]
+                  duration-300 hover:scale-110 shadow-xl hover:shadow-2xl
                   bg-gradient-to-br from-gray-400 to-gray-600 
                   border-8 border-white
                   ${isCorrect ? "ring-4 ring-green-400 ring-offset-4" : ""}


### PR DESCRIPTION
## Summary

`transition-all` animates every CSS property including expensive layout props (`width`, `height`, `padding`), causing visible tap lag on mid-range Android devices. Children perceive missed taps and tap again, causing double-submissions or skipped questions.

Fixed 26 instances across shared components by replacing with GPU-composited alternatives:

| Old | New | Reason |
|---|---|---|
| `transition-all` on scale/opacity buttons | `transition-[transform,opacity]` | Only transform + opacity animate |
| `transition-all` on bg/border hover buttons | `transition-[transform,colors]` | Transform + color change |
| `transition-all` on progress bars (width) | `transition-[width]` | Only width changes |
| `transition-all` on hearts/grayscale | `transition-[opacity,filter]` | Only opacity + filter |
| `transition-all` on cards with shadow | `transition-[transform,box-shadow]` | Scale + shadow |

## Changed files (26)
- `QuizAnswerGrid`, `QuizProgress`, `QuizMenuScreen`, `QuizQuestionCard`, `QuizFeedback`, `QuizResultScreen` — core quiz components
- `GameModeMenuScreen`, `QuizTopicMenuScreen` — quiz menu screens
- `GameMenuCard`, `GameResultCard`, `CanvasGameOverOverlay`, `CanvasMenuOverlay`, `LivesDisplay`, `StoryInterludeCard`, `TimerProgressBar` — shared game UI
- `UniversalGameNavigation` (all 3 nav buttons), `AutoGameBody`, `AutoGameHeader`
- `GameCard`, `CategoryCard`, `CategoryNavigation`, `GameSearchBar`
- `SimpleGameStartButton`, `GameStatsButton`, `GameCardGrid`
- `MostPlayedCard` (progress bar)

## Testing
- [x] `npx tsc --noEmit` passes
- [ ] Verify no visual regressions on key game pages

Closes #945

🤖 Generated with [Claude Code](https://claude.com/claude-code)