### PR TITLE
feat: dark mode Phase 1 — OS dark mode support for home page

### DIFF
--- a/gamesformykids/app/HomePageClient.tsx
+++ b/gamesformykids/app/HomePageClient.tsx
@@ -16,7 +16,7 @@ export default function HomePageClient() {
   }
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-blue-100 via-purple-100 to-pink-100">
+    <div className="min-h-screen bg-gradient-to-br from-blue-100 via-purple-100 to-pink-100 dark:from-gray-900 dark:via-gray-800 dark:to-gray-900">
       <Header />
       <main>
         <FeaturedGame />

--- a/gamesformykids/app/globals.css
+++ b/gamesformykids/app/globals.css
@@ -179,6 +179,7 @@ body {
 :root {
   --background: #ffffff;
   --foreground: #171717;
+  color-scheme: light dark;
 }
 
 @media (prefers-color-scheme: dark) {

--- a/gamesformykids/app/layout.tsx
+++ b/gamesformykids/app/layout.tsx
@@ -27,7 +27,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
         <HeadLinks />
         <StructuredData />
       </head>
-      <body className={rubik.className}>
+      <body className={`${rubik.className} dark:bg-gray-900 dark:text-white`}>
         {process.env.NODE_ENV === 'production' && process.env.NEXT_PUBLIC_GA_ID && (
           <GoogleAnalytics GA_MEASUREMENT_ID={process.env.NEXT_PUBLIC_GA_ID} />
         )}

--- a/gamesformykids/components/game/CategoryNavigation.tsx
+++ b/gamesformykids/components/game/CategoryNavigation.tsx
@@ -7,9 +7,9 @@ import { GamesRegistry } from "@/lib/registry/gamesRegistry";
 
 const TAB_BASE = "px-4 py-2 md:px-6 md:py-3 rounded-full font-bold text-sm md:text-base transition-all duration-300 transform hover:scale-105";
 const TAB_ACTIVE = "bg-purple-600 text-white shadow-lg";
-const TAB_INACTIVE = "bg-white text-purple-600 hover:bg-purple-50 shadow-md";
+const TAB_INACTIVE = "bg-white dark:bg-gray-700 text-purple-600 dark:text-purple-300 hover:bg-purple-50 dark:hover:bg-gray-600 shadow-md";
 const FAV_ACTIVE = "bg-yellow-400 text-white shadow-lg";
-const FAV_INACTIVE = "bg-white text-yellow-500 hover:bg-yellow-50 shadow-md";
+const FAV_INACTIVE = "bg-white dark:bg-gray-700 text-yellow-500 dark:text-yellow-300 hover:bg-yellow-50 dark:hover:bg-gray-600 shadow-md";
 
 export default function CategoryNavigation() {
   const selectedCategory = useHomePageStore((s) => s.selectedCategory);

--- a/gamesformykids/components/game/GameSearchBar.tsx
+++ b/gamesformykids/components/game/GameSearchBar.tsx
@@ -32,7 +32,7 @@ export function GameSearchBar({
           onChange={(e) => onQueryChange(e.target.value)}
           placeholder="חפש משחק..."
           aria-label="חיפוש משחקים"
-          className="w-full pe-10 ps-10 py-2.5 rounded-full border border-gray-200 bg-white shadow-sm text-sm text-gray-800 placeholder:text-gray-400 focus:outline-none focus:ring-2 focus:ring-purple-400 focus:border-transparent"
+          className="w-full pe-10 ps-10 py-2.5 rounded-full border border-gray-200 dark:border-gray-600 bg-white dark:bg-gray-700 shadow-sm text-sm text-gray-800 dark:text-gray-100 placeholder:text-gray-400 dark:placeholder:text-gray-400 focus:outline-none focus:ring-2 focus:ring-purple-400 focus:border-transparent"
         />
         {hasFilter && (
           <button
@@ -59,7 +59,7 @@ export function GameSearchBar({
             className={`flex-shrink-0 px-3 py-1.5 rounded-full text-xs font-semibold transition-all duration-200 ${
               activeCat === key
                 ? 'bg-purple-600 text-white shadow-md'
-                : 'bg-white text-gray-600 hover:bg-purple-50 shadow-sm border border-gray-200'
+                : 'bg-white dark:bg-gray-700 text-gray-600 dark:text-gray-300 hover:bg-purple-50 dark:hover:bg-gray-600 shadow-sm border border-gray-200 dark:border-gray-600'
             }`}
           >
             {cat.title}

--- a/gamesformykids/components/layout/header/HeaderHero.tsx
+++ b/gamesformykids/components/layout/header/HeaderHero.tsx
@@ -1,10 +1,10 @@
 export function HeaderHero() {
   return (
     <>
-      <h1 className="text-3xl md:text-4xl lg:text-6xl font-bold text-purple-800 mb-2 md:mb-4">
+      <h1 className="text-3xl md:text-4xl lg:text-6xl font-bold text-purple-800 dark:text-purple-300 mb-2 md:mb-4">
         🎮 משחקים לילדים 🎮
       </h1>
-      <p className="text-base md:text-lg lg:text-2xl text-purple-600 font-semibold mb-4 md:mb-6">
+      <p className="text-base md:text-lg lg:text-2xl text-purple-600 dark:text-purple-400 font-semibold mb-4 md:mb-6">
         משחקים מהנים לגיל 3-10!
       </p>
     </>


### PR DESCRIPTION
## Summary
Adds OS dark mode support so the home page no longer shows a blinding white background when the user's system is in dark mode. Uses Tailwind's `dark:` media-query variant (Tailwind v4 defaults to `prefers-color-scheme`).

## Changes
- `app/globals.css` — added `color-scheme: light dark` to `:root` so the browser renders system UI (scrollbars, inputs) in dark style
- `app/layout.tsx` — `dark:bg-gray-900 dark:text-white` on `<body>` for the base layer
- `app/HomePageClient.tsx` — dark gradient (`dark:from-gray-900 dark:via-gray-800 dark:to-gray-900`) on the main wrapper
- `components/layout/header/HeaderHero.tsx` — `dark:text-purple-300` / `dark:text-purple-400` so the page title/subtitle are readable
- `components/game/CategoryNavigation.tsx` — dark variants for inactive tab buttons (`dark:bg-gray-700 dark:text-purple-300`)
- `components/game/GameSearchBar.tsx` — `dark:bg-gray-700 dark:text-gray-100` on the search input and filter chips

## Testing
- [x] `npx tsc --noEmit` passes
- [ ] Verified in browser with OS dark mode toggled: home page shows dark background, header text visible, search bar readable, tab buttons readable

Closes #944

🤖 Generated with [Claude Code](https://claude.com/claude-code)