### PR TITLE
refactor: remove redundant useCallback/useMemo in 3 arcade game hooks

### DIFF
--- a/gamesformykids/app/games/brick-breaker/useBrickBreakerGame.ts
+++ b/gamesformykids/app/games/brick-breaker/useBrickBreakerGame.ts
@@ -196,14 +196,14 @@ export function useBrickBreakerGame() {
     else if (s.phase === 'menu') { startGame(1); }
   }, [st, startGame]);
 
-  const handleTouchStart = useCallback((e: React.TouchEvent<HTMLCanvasElement>) => {
+  const handleTouchStart = (e: React.TouchEvent<HTMLCanvasElement>) => {
     e.preventDefault();
     handleClick();
     handlers.onTouchMove(e);
-  }, [handleClick, handlers]);
+  };
 
-  const nudgeLeft = useCallback(() => { st.current.padX = Math.max(0, st.current.padX - 40); }, [st]);
-  const nudgeRight = useCallback(() => { st.current.padX = Math.min(W - PAD_W, st.current.padX + 40); }, [st]);
+  const nudgeLeft = () => { st.current.padX = Math.max(0, st.current.padX - 40); };
+  const nudgeRight = () => { st.current.padX = Math.min(W - PAD_W, st.current.padX + 40); };
 
 
   useEffect(() => {

--- a/gamesformykids/app/games/bubbles/hooks/useBubbleGame.ts
+++ b/gamesformykids/app/games/bubbles/hooks/useBubbleGame.ts
@@ -1,7 +1,18 @@
-import { useEffect, useRef, useCallback, useMemo } from 'react';
+import { useEffect, useRef, useCallback } from 'react';
 import { useShallow } from 'zustand/react/shallow';
 import { useGameAudio } from '@/hooks/shared/audio/useGameAudio';
 import { useBubblesStore, type BubbleData } from '../bubblesStore';
+
+const BUBBLE_TYPES = [
+  { color: '#FF6B6B', frequency: 261.63 },
+  { color: '#4ECDC4', frequency: 293.66 },
+  { color: '#45B7D1', frequency: 329.63 },
+  { color: '#96CEB4', frequency: 349.23 },
+  { color: '#FECA57', frequency: 392.00 },
+  { color: '#FF9FF3', frequency: 440.00 },
+  { color: '#54A0FF', frequency: 493.88 },
+  { color: '#5F27CD', frequency: 523.25 },
+];
 
 export function useBubbleGame() {
   const { audioContext } = useGameAudio();
@@ -13,22 +24,11 @@ export function useBubbleGame() {
   );
   const level = Math.floor(poppedCount / 15) + 1;
 
-  const bubbleTypes = useMemo(() => [
-    { color: '#FF6B6B', frequency: 261.63 },
-    { color: '#4ECDC4', frequency: 293.66 },
-    { color: '#45B7D1', frequency: 329.63 },
-    { color: '#96CEB4', frequency: 349.23 },
-    { color: '#FECA57', frequency: 392.00 },
-    { color: '#FF9FF3', frequency: 440.00 },
-    { color: '#54A0FF', frequency: 493.88 },
-    { color: '#5F27CD', frequency: 523.25 },
-  ], []);
-
   const createBubble = useCallback(() => {
     if (!gameContainerRef.current) return;
     const currentLevel = Math.floor(useBubblesStore.getState().poppedCount / 15) + 1;
     const containerWidth = gameContainerRef.current.offsetWidth;
-    const bubbleType = bubbleTypes[Math.floor(Math.random() * bubbleTypes.length)]!;
+    const bubbleType = BUBBLE_TYPES[Math.floor(Math.random() * BUBBLE_TYPES.length)]!;
     const size = 40 + Math.random() * 60;
 
     const newBubble: BubbleData = {
@@ -42,7 +42,7 @@ export function useBubbleGame() {
     };
 
     useBubblesStore.getState().addBubble(newBubble);
-  }, [bubbleTypes]);
+  }, []);
 
   const playBubbleSound = useCallback((frequency: number) => {
     if (!audioContext || frequency === 0) return;
@@ -81,13 +81,8 @@ export function useBubbleGame() {
     setTimeout(createBubble, 200);
   }, [createBubble]);
 
-  const stopGame = useCallback(() => {
-    useBubblesStore.getState().stopGame();
-  }, []);
-
-  const resetGame = useCallback(() => {
-    useBubblesStore.getState().resetGame();
-  }, []);
+  const stopGame = () => { useBubblesStore.getState().stopGame(); };
+  const resetGame = () => { useBubblesStore.getState().resetGame(); };
 
   return { gameContainerRef, startGame, stopGame, resetGame, handleBubblePop, isPlaying, score, level, poppedCount, bubbles };
 }

--- a/gamesformykids/app/games/catch-fruit/useCatchFruitGame.ts
+++ b/gamesformykids/app/games/catch-fruit/useCatchFruitGame.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { useRef, useCallback } from 'react';
+import { useRef } from 'react';
 import { useShallow } from 'zustand/react/shallow';
 import { useCatchFruitStore, GAME_DURATION } from './catchFruitStore';
 import { createCanvasArcadeHook } from '@/hooks/canvas';
@@ -114,22 +114,21 @@ export function useCatchFruitGame() {
   const dragging = useRef(false);
   const pointerDown = useRef(false);
 
-  const startGame = useCallback(() => {
+  const startGame = () => {
     const s = st.current;
     s.phase = 'playing';
     s.basketX = W / 2 - BASKET_W / 2;
     s.items = [];
     s.score = 0; s.lives = 3; s.timeLeft = GAME_DURATION; s.frame = 0; s.nextItem = 40; s.startTime = Date.now();
     useCatchFruitStore.getState().startGame();
-  }, [st]);
+  };
 
-  const handleMouseUp = useCallback(() => {
+  const handleMouseUp = () => {
     pointerDown.current = false;
     dragging.current = false;
-  }, []);
+  };
 
-
-  const handleMouseMove = useCallback((e: React.MouseEvent<HTMLCanvasElement>) => {
+  const handleMouseMove = (e: React.MouseEvent<HTMLCanvasElement>) => {
     if (!pointerDown.current) return;
     const canvas = canvasRef.current;
     if (!canvas) return;
@@ -137,9 +136,9 @@ export function useCatchFruitGame() {
     const scaleX = W / rect.width;
     const mx = (e.clientX - rect.left) * scaleX;
     st.current.basketX = Math.max(0, Math.min(W - BASKET_W, mx - BASKET_W / 2));
-  }, [canvasRef, st]);
+  };
 
-  const handleMouseDown = useCallback((e: React.MouseEvent<HTMLCanvasElement>) => {
+  const handleMouseDown = (e: React.MouseEvent<HTMLCanvasElement>) => {
     pointerDown.current = true;
     const canvas = canvasRef.current;
     if (!canvas) return;
@@ -147,9 +146,9 @@ export function useCatchFruitGame() {
     const scaleX = W / rect.width;
     const mx = (e.clientX - rect.left) * scaleX;
     st.current.basketX = Math.max(0, Math.min(W - BASKET_W, mx - BASKET_W / 2));
-  }, [canvasRef, st]);
+  };
 
-  const handleTouchMove = useCallback((e: React.TouchEvent<HTMLCanvasElement>) => {
+  const handleTouchMove = (e: React.TouchEvent<HTMLCanvasElement>) => {
     e.preventDefault();
     const canvas = canvasRef.current;
     if (!canvas) return;
@@ -157,9 +156,9 @@ export function useCatchFruitGame() {
     const scaleX = W / rect.width;
     const mx = (e.touches[0]!.clientX - rect.left) * scaleX;
     st.current.basketX = Math.max(0, Math.min(W - BASKET_W, mx - BASKET_W / 2));
-  }, [canvasRef, st]);
+  };
 
-  const handleTouchStart = useCallback((e: React.TouchEvent<HTMLCanvasElement>) => {
+  const handleTouchStart = (e: React.TouchEvent<HTMLCanvasElement>) => {
     e.preventDefault();
     const canvas = canvasRef.current;
     if (!canvas) return;
@@ -168,7 +167,7 @@ export function useCatchFruitGame() {
     const mx = (e.touches[0]!.clientX - rect.left) * scaleX;
     st.current.basketX = Math.max(0, Math.min(W - BASKET_W, mx - BASKET_W / 2));
     if (st.current.phase !== 'playing') startGame();
-  }, [canvasRef, st, startGame]);
+  };
 
   const { phase, best, score, lives, timeLeft } = useCatchFruitStore(useShallow(s => ({ phase: s.phase, best: s.best, score: s.score, lives: s.lives, timeLeft: s.timeLeft })));
 


### PR DESCRIPTION
## Summary
Removes unnecessary \`useCallback\`/\`useMemo\` wrappers from the three heaviest arcade game hooks. These were applied defensively but don't help performance — the wrapped functions are JSX event props (React's event system doesn't care about reference stability) and static arrays (can be module-level constants).

## Changes

**`useCatchFruitGame.ts`** — removed all 5 `useCallback` calls  
No `window.addEventListener` in this hook; every handler is a React canvas event prop. All deps (`canvasRef`, `st`) are stable refs anyway — `useCallback` added zero value.

**`useBrickBreakerGame.ts`** — removed `useCallback` from 3 handlers  
Kept on `startGame` and `handleClick` because they appear in the keyboard `useEffect` dep array (which calls `window.addEventListener`). Removed from `handleTouchStart`, `nudgeLeft`, `nudgeRight` (JSX props only).

**`useBubbleGame.ts`** — removed `useMemo` and 2 `useCallback` calls  
`bubbleTypes` is a static constant — hoisted to module level. `stopGame` and `resetGame` have empty dep arrays and are JSX props — no reason to memoize.

## Testing
- [x] `npx tsc --noEmit` passes
- [ ] brick-breaker: keyboard controls still work, level progression works
- [ ] catch-fruit: drag/touch basket movement still works
- [ ] bubbles: bubble pop still works, interval still fires

Closes #961

🤖 Generated with [Claude Code](https://claude.com/claude-code)