### PR TITLE
perf: replace barrel imports with direct leaf imports in client components

### DIFF
--- a/gamesformykids/app/games/layout.tsx
+++ b/gamesformykids/app/games/layout.tsx
@@ -1,4 +1,4 @@
-import { UniversalGameNavigation } from '@/components/shared';
+import UniversalGameNavigation from '@/components/game/universal/navigation/UniversalGameNavigation';
 import { ReactNode } from 'react';
 
 interface GamesLayoutProps {

--- a/gamesformykids/app/games/memory/components/MemoryStartScreen.tsx
+++ b/gamesformykids/app/games/memory/components/MemoryStartScreen.tsx
@@ -3,7 +3,7 @@
 import { createDifficultyMenuScreen } from '@/components/game/shared/createDifficultyMenuScreen';
 import { useMemoryStore } from '../stores/useMemoryStore';
 import { useGameDifficulty } from '@/lib/stores/gameDifficultyStore';
-import { MEMORY_GAME_CONSTANTS } from '@/lib/constants';
+import { MEMORY_GAME_CONSTANTS } from '@/lib/constants/gameData/special';
 import type { DifficultyLevel } from '@/lib/types/games/base';
 
 function useMemoryStartGame() {

--- a/gamesformykids/app/games/memory/stores/useMemoryStore.ts
+++ b/gamesformykids/app/games/memory/stores/useMemoryStore.ts
@@ -4,7 +4,8 @@ import { makeStore } from '@/lib/stores/createStore';
 import {
   createShuffledMemoryCards,
 } from '@/lib/utils/game/gameUtils';
-import { MEMORY_GAME_ANIMALS, MEMORY_GAME_CONSTANTS } from '@/lib/constants';
+import { MEMORY_GAME_ANIMALS } from '@/lib/constants/gameData/natureData/animals';
+import { MEMORY_GAME_CONSTANTS } from '@/lib/constants/gameData/special';
 import { MemoryCard } from '../types/memory';
 import { getDifficultyOptions, getPerformanceLevel, getWinAchievements } from './memoryDisplayHelpers';
 import {

--- a/gamesformykids/app/games/tetris/components/TetrisGame.tsx
+++ b/gamesformykids/app/games/tetris/components/TetrisGame.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { GenericStartScreen } from '@/components/shared';
+import GenericStartScreen from '@/components/shared/screens/GenericStartScreen';
 import { useTetrisGame } from '../hooks/useTetrisGame';
 import { useTetrisState } from '../hooks/useTetrisState';
 import GameBoard from './GameBoard';

--- a/gamesformykids/app/profile/ProfileClient.tsx
+++ b/gamesformykids/app/profile/ProfileClient.tsx
@@ -1,7 +1,9 @@
 'use client';
 
 import { useEffect } from 'react';
-import { useUserProfile, useGameProgress, useAchievements } from '@/hooks';
+import { useUserProfile } from '@/hooks/shared/user/useUserProfile';
+import { useGameProgress } from '@/hooks/shared/progress/useGameProgress';
+import { useAchievements } from '@/hooks/shared/progress/useAchievements';
 import { useAuth } from '@/hooks/shared/auth/useAuth';
 import { ProfileLoadingScreen } from './components/ProfileLoadingScreen';
 import { ProfileUnauthenticated } from './components/ProfileUnauthenticated';

--- a/gamesformykids/app/settings/SettingsClient.tsx
+++ b/gamesformykids/app/settings/SettingsClient.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from 'react';
 import Link from 'next/link';
-import { useUserProfile } from '@/hooks';
+import { useUserProfile } from '@/hooks/shared/user/useUserProfile';
 import { useAuth } from '@/hooks/shared/auth/useAuth';
 import { AudioSection } from '@/components/settings/AudioSection';
 import { AppearanceSection } from '@/components/settings/AppearanceSection';


### PR DESCRIPTION
## Summary
Audits all `'use client'` files for barrel imports from `@/lib/constants`, `@/hooks`, `@/components/game`, and `@/components/shared`. Replaces them with direct leaf imports so the bundler can tree-shake each file independently rather than pulling in the entire barrel.

## Changes

| File | Before | After |
|------|--------|-------|
| `memory/MemoryStartScreen.tsx` | `from '@/lib/constants'` | `from '@/lib/constants/gameData/special'` |
| `memory/useMemoryStore.ts` | `from '@/lib/constants'` | `from '@/lib/constants/gameData/special'` + `gameData/natureData/animals` |
| `ProfileClient.tsx` | `from '@/hooks'` (3 hooks) | 3 direct leaf paths |
| `SettingsClient.tsx` | `from '@/hooks'` | `from '@/hooks/shared/user/useUserProfile'` |
| `TetrisGame.tsx` | `from '@/components/shared'` | `from '@/components/shared/screens/GenericStartScreen'` |
| `games/layout.tsx` | `from '@/components/shared'` | `from '@/components/game/universal/navigation/UniversalGameNavigation'` |

**Not changed:** `import type` barrel imports — these are erased at compile time and have zero bundle cost.

## Testing
- [x] `npx tsc --noEmit` passes
- [ ] Memory game still starts and shows difficulty screen
- [ ] Tetris game still shows start screen
- [ ] Profile page still loads user stats and achievements
- [ ] Settings page still shows user profile data

Closes #960
Closes #931

🤖 Generated with [Claude Code](https://claude.com/claude-code)