### PR TITLE
feat(game): add ספירה לפי קפיצות (skip counting) quiz

### DIFF
--- a/gamesformykids/app/games/[gameType]/gamePageConstants.ts
+++ b/gamesformykids/app/games/[gameType]/gamePageConstants.ts
@@ -46,6 +46,7 @@ export const SUPPORTED_GAMES = [
   'verbs',
   'soccer',
   'sorting', 'patterns',
+  'skip-counting',
 ] as const;
 
 export type SupportedGameType = typeof SUPPORTED_GAMES[number];

--- a/gamesformykids/lib/constants/gameCategories.ts
+++ b/gamesformykids/lib/constants/gameCategories.ts
@@ -70,7 +70,7 @@ export const GAME_CATEGORIES: Record<string, GameCategory> = {
     icon: Calculator,
     color: "bg-indigo-500",
     gradient: "from-indigo-400 to-indigo-600",
-    gameIds: ["counting","math","shopping-money","multiplication","fractions","sequences","arithmetic","ordinals","number-words","spatial-concepts","sorting","patterns"],
+    gameIds: ["counting","math","shopping-money","multiplication","fractions","sequences","arithmetic","ordinals","number-words","spatial-concepts","sorting","patterns","skip-counting"],
   },
   games: {
     title: "משחקים מיוחדים",

--- a/gamesformykids/lib/quiz/configs/math.tsx
+++ b/gamesformykids/lib/quiz/configs/math.tsx
@@ -2,8 +2,23 @@ import { shuffle } from '@/lib/utils';
 import { QUESTIONS_PER_GAME } from '@/lib/quiz/constants';
 import { FRACTION_QUESTIONS } from '@/lib/quiz/data/fractions';
 import { QUIZ_QUESTIONS, SHAPES_3D } from '@/lib/quiz/data/shapes-3d';
+import { SKIP_COUNTING_QUESTIONS } from '@/lib/quiz/data/skip-counting';
 import FractionBar from '@/components/game/quiz/FractionBar';
 import { defineConfig } from './types';
+
+export const skipCountingConfig = defineConfig({
+  gameType: 'skip-counting', emoji: '🔢', title: 'ספירה לפי קפיצות',
+  description: 'ספור לפי 2, 5 ו-10 — מלא את המספר החסר!', theme: 'blue',
+  questions: SKIP_COUNTING_QUESTIONS, questionsPerGame: QUESTIONS_PER_GAME,
+  getChoices: (q) => shuffle([q.answer, ...q.wrongOptions]),
+  isCorrect: (c, q) => c === q.answer,
+  getCorrectLabel: (q) => q.answer,
+  renderQuestion: (q) => (
+    <><div className="text-4xl mb-3">{q.emoji}</div>
+      <p className="text-gray-600 text-sm mb-2">מה המספר החסר?</p>
+      <p className="text-2xl font-bold text-blue-700 mb-1">{q.question}</p></>
+  ),
+});
 
 export const fractionsConfig = defineConfig({
   gameType: 'fractions', emoji: '🔢', title: 'שברים פשוטים',

--- a/gamesformykids/lib/quiz/data/skip-counting.ts
+++ b/gamesformykids/lib/quiz/data/skip-counting.ts
@@ -1,0 +1,44 @@
+export type SkipCountingQuestion = {
+  id: number;
+  question: string;
+  answer: string;
+  emoji: string;
+  wrongOptions: [string, string, string];
+};
+
+export const SKIP_COUNTING_QUESTIONS: SkipCountingQuestion[] = [
+  // ×2 forward
+  { id: 1,  question: '2, 4, 6, ___',           answer: '8',   emoji: '🐾', wrongOptions: ['7','9','10'] },
+  { id: 2,  question: '4, 6, 8, ___',            answer: '10',  emoji: '🐾', wrongOptions: ['9','11','12'] },
+  { id: 3,  question: '6, 8, 10, ___',           answer: '12',  emoji: '🐾', wrongOptions: ['11','13','14'] },
+  { id: 4,  question: '10, 12, 14, ___',         answer: '16',  emoji: '🐾', wrongOptions: ['15','17','18'] },
+  { id: 5,  question: '16, 18, 20, ___',         answer: '22',  emoji: '🐾', wrongOptions: ['21','23','24'] },
+  // ×2 with blank in middle
+  { id: 6,  question: '2, 4, ___, 8',            answer: '6',   emoji: '🦘', wrongOptions: ['5','7','9'] },
+  { id: 7,  question: '8, ___, 12, 14',          answer: '10',  emoji: '🦘', wrongOptions: ['9','11','13'] },
+  // ×5 forward
+  { id: 8,  question: '5, 10, 15, ___',          answer: '20',  emoji: '⭐', wrongOptions: ['16','18','25'] },
+  { id: 9,  question: '10, 15, 20, ___',         answer: '25',  emoji: '⭐', wrongOptions: ['22','24','30'] },
+  { id: 10, question: '25, 30, 35, ___',         answer: '40',  emoji: '⭐', wrongOptions: ['36','38','45'] },
+  { id: 11, question: '40, 45, 50, ___',         answer: '55',  emoji: '⭐', wrongOptions: ['52','53','60'] },
+  { id: 12, question: '55, 60, 65, ___',         answer: '70',  emoji: '⭐', wrongOptions: ['68','69','75'] },
+  // ×5 with blank in middle
+  { id: 13, question: '5, 10, ___, 20',          answer: '15',  emoji: '🌟', wrongOptions: ['12','14','16'] },
+  { id: 14, question: '20, ___, 30, 35',         answer: '25',  emoji: '🌟', wrongOptions: ['22','24','28'] },
+  // ×10 forward
+  { id: 15, question: '10, 20, 30, ___',         answer: '40',  emoji: '🔢', wrongOptions: ['35','38','50'] },
+  { id: 16, question: '30, 40, 50, ___',         answer: '60',  emoji: '🔢', wrongOptions: ['55','58','70'] },
+  { id: 17, question: '60, 70, 80, ___',         answer: '90',  emoji: '🔢', wrongOptions: ['85','88','100'] },
+  { id: 18, question: '70, 80, 90, ___',         answer: '100', emoji: '🔢', wrongOptions: ['95','98','110'] },
+  // ×10 with blank in middle
+  { id: 19, question: '10, ___, 30, 40',         answer: '20',  emoji: '💯', wrongOptions: ['15','22','25'] },
+  { id: 20, question: '40, ___, 60, 70',         answer: '50',  emoji: '💯', wrongOptions: ['45','48','55'] },
+  // Backwards ×2
+  { id: 21, question: '10, 8, 6, ___',           answer: '4',   emoji: '⬇️', wrongOptions: ['3','5','2'] },
+  { id: 22, question: '20, 18, 16, ___',         answer: '14',  emoji: '⬇️', wrongOptions: ['12','15','13'] },
+  // Backwards ×5
+  { id: 23, question: '25, 20, 15, ___',         answer: '10',  emoji: '⬇️', wrongOptions: ['8','12','5'] },
+  { id: 24, question: '50, 45, 40, ___',         answer: '35',  emoji: '⬇️', wrongOptions: ['30','36','34'] },
+  // Mixed
+  { id: 25, question: '2, ___, 6, 8, 10',        answer: '4',   emoji: '🎯', wrongOptions: ['3','5','1'] },
+];

--- a/gamesformykids/lib/quiz/quizGameConfigs.tsx
+++ b/gamesformykids/lib/quiz/quizGameConfigs.tsx
@@ -2,7 +2,7 @@ import type { GameType } from '@/lib/types/core/base';
 import { spellingConfig, oppositesConfig, englishWordsConfig, worldLanguagesConfig, rhymingConfig, adjectivesConfig, verbsConfig } from './configs/language';
 import { riddlesConfig, capitalsConfig, instrumentsConfig, sportsQuizConfig, continentsConfig } from './configs/knowledge';
 import { emotionsConfig, familyConfig, healthyFoodConfig, singularPluralConfig, morningRoutineConfig } from './configs/social';
-import { fractionsConfig, shapes3dConfig } from './configs/math';
+import { fractionsConfig, shapes3dConfig, skipCountingConfig } from './configs/math';
 
 export type { QuizGameConfig } from './configs/types';
 import type { QuizGameConfig } from './configs/types';
@@ -29,4 +29,5 @@ export const QUIZ_GAME_CONFIGS: Partial<Record<GameType, QuizGameConfig<unknown>
   rhyming: rhymingConfig,
   adjectives: adjectivesConfig,
   verbs: verbsConfig,
+  'skip-counting': skipCountingConfig,
 };

--- a/gamesformykids/lib/quiz/registry/genericQuizGames.tsx
+++ b/gamesformykids/lib/quiz/registry/genericQuizGames.tsx
@@ -30,4 +30,5 @@ export const GENERIC_QUIZ_GAMES: Record<string, ComponentType> = {
   'rhyming':               GenericQuizGame,
   'adjectives':            GenericQuizGame,
   'verbs':                 GenericQuizGame,
+  'skip-counting':         GenericQuizGame,
 };

--- a/gamesformykids/lib/registry/registryData/batch4.ts
+++ b/gamesformykids/lib/registry/registryData/batch4.ts
@@ -337,4 +337,15 @@ export const gamesRegistryBatch4: GameRegistration[] = [
     available: true,
     order: 152,
   },
+  {
+    id: "skip-counting",
+    title: "ספירה לפי קפיצות",
+    description: "ספור לפי 2, 5 ו-10 — מלא את המספר החסר!",
+    icon: Hash,
+    emoji: "🔢",
+    color: "bg-teal-500 hover:bg-teal-600",
+    href: "/games/skip-counting",
+    available: true,
+    order: 153,
+  },
 ];

--- a/gamesformykids/lib/types/core/base.ts
+++ b/gamesformykids/lib/types/core/base.ts
@@ -134,7 +134,7 @@ export type GameType =
   | 'tools' | 'professions' | 'emotions' | 'vehicles'
   // Math & counting
   | 'counting' | 'math' | 'arithmetic' | 'multiplication' | 'emoji-math'
-  | 'math-race' | 'number-bubbles'
+  | 'math-race' | 'number-bubbles' | 'skip-counting'
   // Memory & puzzle
   | 'memory' | 'bubbles' | 'puzzles' | 'building' | 'tetris'
   | 'drawing' | 'coloring'


### PR DESCRIPTION
## Summary
Adds a skip-counting quiz game (Style B — GenericQuizGame) covering count-by-2s, 5s, and 10s. No custom UI needed — the standard 4-choice quiz layout works perfectly for this content.

## Game details
- **Hebrew title**: ספירה לפי קפיצות
- **Category**: Math
- **Ages**: 5–8 (Grade 1)
- **Questions**: 25 (forwards, backwards, and blank-in-middle)
- **Style**: B (GenericQuizGame) — zero custom components

## Files changed
- `lib/quiz/data/skip-counting.ts` — 25 questions (1 new file)
- `lib/quiz/configs/math.tsx` — `skipCountingConfig`
- `lib/quiz/quizGameConfigs.tsx` — registered
- `lib/quiz/registry/genericQuizGames.tsx` — registered
- `lib/types/core/base.ts` — `'skip-counting'` added to GameType union
- `app/games/[gameType]/gamePageConstants.ts` — added to SUPPORTED_GAMES
- `lib/registry/registryData/batch4.ts` — registry entry (order 153)
- `lib/constants/gameCategories.ts` — added to math category

## Testing
- [x] `npx tsc --noEmit` passes
- [ ] Game reachable at `/games/skip-counting`
- [ ] Game appears in math category on home page
- [ ] 4 choices shown per question, correct answer accepted

Closes #948

🤖 Generated with [Claude Code](https://claude.com/claude-code)