### PR TITLE
feat: add division quiz game (Style C)

### DIFF
--- a/gamesformykids/app/games/[gameType]/gamePageConstants.ts
+++ b/gamesformykids/app/games/[gameType]/gamePageConstants.ts
@@ -49,6 +49,7 @@ export const SUPPORTED_GAMES = [
   'skip-counting',
   'life-cycles',
   'maze',
+  'division',
 ] as const;
 
 export type SupportedGameType = typeof SUPPORTED_GAMES[number];

--- a/gamesformykids/components/game/quiz/screens/DivisionQuestion.tsx
+++ b/gamesformykids/components/game/quiz/screens/DivisionQuestion.tsx
@@ -1,0 +1,56 @@
+'use client';
+
+import { QuizQuestionShell } from '@/components/game/quiz';
+import type { DivisionQuestion as DivisionQuestionType } from '@/lib/quiz/data/division';
+
+interface Props {
+  current: DivisionQuestionType;
+  choices: string[];
+  onSelect: (choice: string) => void;
+}
+
+function ItemGrid({ dividend, divisor, quotient, emoji }: { dividend: number; divisor: number; quotient: number; emoji: string }) {
+  if (dividend > 30) {
+    return (
+      <div className="flex flex-col items-center gap-1">
+        <div className="text-4xl">{emoji}</div>
+        <p className="text-sm text-gray-500">סה&quot;כ {dividend} פריטים ב-{divisor} קבוצות</p>
+      </div>
+    );
+  }
+  return (
+    <div className="flex flex-col gap-1 items-center">
+      {Array.from({ length: divisor }).map((_, g) => (
+        <div key={g} className="flex gap-1 justify-center px-2 py-0.5 bg-blue-50 rounded-lg">
+          {Array.from({ length: quotient }).map((_, i) => (
+            <span key={i} className="text-lg leading-none">{emoji}</span>
+          ))}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export default function DivisionQuestion({ current, choices, onSelect }: Props) {
+  return (
+    <QuizQuestionShell
+      theme="blue"
+      choices={choices}
+      correctLabel={String(current.quotient)}
+      onSelect={onSelect}
+      correctMsg={`✅ נכון! ${current.dividend} ÷ ${current.divisor} = ${current.quotient}`}
+      wrongMsg={`💙 ${current.dividend} ÷ ${current.divisor} = ${current.quotient}`}
+    >
+      <p className="text-base font-bold text-gray-600 mb-2">כמה בכל קבוצה?</p>
+      <div className="text-3xl font-black text-blue-700 mb-3 tracking-wide" dir="ltr">
+        {current.dividend} ÷ {current.divisor} = ?
+      </div>
+      <ItemGrid
+        dividend={current.dividend}
+        divisor={current.divisor}
+        quotient={current.quotient}
+        emoji={current.emoji}
+      />
+    </QuizQuestionShell>
+  );
+}

--- a/gamesformykids/lib/constants/gameCategories.ts
+++ b/gamesformykids/lib/constants/gameCategories.ts
@@ -70,7 +70,7 @@ export const GAME_CATEGORIES: Record<string, GameCategory> = {
     icon: Calculator,
     color: "bg-indigo-500",
     gradient: "from-indigo-400 to-indigo-600",
-    gameIds: ["counting","math","shopping-money","multiplication","fractions","sequences","arithmetic","ordinals","number-words","spatial-concepts","sorting","patterns","skip-counting"],
+    gameIds: ["counting","math","shopping-money","multiplication","fractions","sequences","arithmetic","ordinals","number-words","spatial-concepts","sorting","patterns","skip-counting","division"],
   },
   games: {
     title: "משחקים מיוחדים",

--- a/gamesformykids/lib/quiz/data/division.ts
+++ b/gamesformykids/lib/quiz/data/division.ts
@@ -1,0 +1,61 @@
+export type DivisionQuestion = {
+  id: number;
+  dividend: number;
+  divisor: number;
+  quotient: number;
+  emoji: string;
+  wrongOptions: [string, string, string];
+};
+
+export const DIVISION_QUESTIONS: DivisionQuestion[] = [
+  // ÷2 — easy
+  { id: 1,  dividend: 4,  divisor: 2, quotient: 2, emoji: '🍎', wrongOptions: ['1', '3', '4'] },
+  { id: 2,  dividend: 6,  divisor: 2, quotient: 3, emoji: '⭐', wrongOptions: ['2', '4', '5'] },
+  { id: 3,  dividend: 8,  divisor: 2, quotient: 4, emoji: '🌸', wrongOptions: ['3', '5', '6'] },
+  { id: 4,  dividend: 10, divisor: 2, quotient: 5, emoji: '🐠', wrongOptions: ['4', '6', '7'] },
+  { id: 5,  dividend: 12, divisor: 2, quotient: 6, emoji: '🍬', wrongOptions: ['5', '7', '8'] },
+
+  // ÷3 — easy
+  { id: 6,  dividend: 6,  divisor: 3, quotient: 2, emoji: '🌈', wrongOptions: ['1', '3', '4'] },
+  { id: 7,  dividend: 9,  divisor: 3, quotient: 3, emoji: '🎈', wrongOptions: ['2', '4', '5'] },
+  { id: 8,  dividend: 12, divisor: 3, quotient: 4, emoji: '🦋', wrongOptions: ['3', '5', '6'] },
+  { id: 9,  dividend: 15, divisor: 3, quotient: 5, emoji: '🍕', wrongOptions: ['4', '6', '7'] },
+  { id: 10, dividend: 18, divisor: 3, quotient: 6, emoji: '🐸', wrongOptions: ['5', '7', '8'] },
+
+  // ÷4 — medium
+  { id: 11, dividend: 8,  divisor: 4, quotient: 2, emoji: '🌟', wrongOptions: ['1', '3', '4'] },
+  { id: 12, dividend: 12, divisor: 4, quotient: 3, emoji: '🍦', wrongOptions: ['2', '4', '5'] },
+  { id: 13, dividend: 16, divisor: 4, quotient: 4, emoji: '🐶', wrongOptions: ['3', '5', '6'] },
+  { id: 14, dividend: 20, divisor: 4, quotient: 5, emoji: '🍓', wrongOptions: ['4', '6', '7'] },
+  { id: 15, dividend: 24, divisor: 4, quotient: 6, emoji: '🎭', wrongOptions: ['5', '7', '8'] },
+
+  // ÷5 — medium
+  { id: 16, dividend: 10, divisor: 5, quotient: 2, emoji: '🚀', wrongOptions: ['1', '3', '4'] },
+  { id: 17, dividend: 15, divisor: 5, quotient: 3, emoji: '🌺', wrongOptions: ['2', '4', '5'] },
+  { id: 18, dividend: 20, divisor: 5, quotient: 4, emoji: '🦊', wrongOptions: ['3', '5', '6'] },
+  { id: 19, dividend: 25, divisor: 5, quotient: 5, emoji: '🎵', wrongOptions: ['4', '6', '7'] },
+  { id: 20, dividend: 30, divisor: 5, quotient: 6, emoji: '🍄', wrongOptions: ['5', '7', '8'] },
+
+  // ÷6 — hard
+  { id: 21, dividend: 12, divisor: 6, quotient: 2, emoji: '🏆', wrongOptions: ['1', '3', '4'] },
+  { id: 22, dividend: 18, divisor: 6, quotient: 3, emoji: '🎯', wrongOptions: ['2', '4', '5'] },
+  { id: 23, dividend: 24, divisor: 6, quotient: 4, emoji: '🌙', wrongOptions: ['3', '5', '6'] },
+
+  // ÷7 — hard
+  { id: 24, dividend: 14, divisor: 7, quotient: 2, emoji: '🐙', wrongOptions: ['1', '3', '4'] },
+  { id: 25, dividend: 21, divisor: 7, quotient: 3, emoji: '🎪', wrongOptions: ['2', '4', '5'] },
+
+  // ÷8 — hard
+  { id: 26, dividend: 16, divisor: 8, quotient: 2, emoji: '🦄', wrongOptions: ['1', '3', '4'] },
+  { id: 27, dividend: 24, divisor: 8, quotient: 3, emoji: '🍩', wrongOptions: ['2', '4', '5'] },
+
+  // ÷9 — hard
+  { id: 28, dividend: 18, divisor: 9, quotient: 2, emoji: '🎨', wrongOptions: ['1', '3', '4'] },
+  { id: 29, dividend: 27, divisor: 9, quotient: 3, emoji: '🌊', wrongOptions: ['2', '4', '5'] },
+
+  // ÷10 — hard
+  { id: 30, dividend: 20, divisor: 10, quotient: 2, emoji: '🎠', wrongOptions: ['1', '3', '4'] },
+  { id: 31, dividend: 30, divisor: 10, quotient: 3, emoji: '🏖️', wrongOptions: ['2', '4', '5'] },
+  { id: 32, dividend: 40, divisor: 10, quotient: 4, emoji: '🌴', wrongOptions: ['3', '5', '6'] },
+  { id: 33, dividend: 50, divisor: 10, quotient: 5, emoji: '🎁', wrongOptions: ['4', '6', '7'] },
+];

--- a/gamesformykids/lib/quiz/registry/customQuizGames.tsx
+++ b/gamesformykids/lib/quiz/registry/customQuizGames.tsx
@@ -3,6 +3,7 @@ import type { ComponentType } from 'react';
 import dynamic from 'next/dynamic';
 import { makeQuizGame } from '../makeQuizGame';
 import { QuizMenuScreen, QuizResultScreen, CategoryIndexedQuestion } from '@/components/game/quiz';
+import { useDivisionGame } from '@/lib/quiz/useDivisionGame';
 
 // Hooks — small, kept static so tree-shaking inlines only what's used
 import { useClockGame } from '@/lib/quiz/useClockGame';
@@ -47,6 +48,7 @@ const PhonicsQuestion    = dynamic(() => import('@/components/game/quiz/screens/
 const SortingQuestion    = dynamic(() => import('@/components/game/quiz/screens/SortingQuestion'));
 const PatternQuestion    = dynamic(() => import('@/components/game/quiz/screens/PatternQuestion'));
 const LifeCyclesQuestion = dynamic(() => import('@/components/game/quiz/screens/LifeCyclesQuestion'));
+const DivisionQuestion   = dynamic(() => import('@/components/game/quiz/screens/DivisionQuestion'));
 
 /**
  * Games built with makeQuizGame — custom hooks + lazy-loaded screen components.
@@ -167,6 +169,15 @@ export const CUSTOM_QUIZ_GAMES: Record<string, ComponentType> = {
       menu:     <QuizMenuScreen emoji="🦋" title="מחזור חיים" description="סדר את שלבי מחזור החיים בסדר הנכון!" theme="green" buttonLabel="🌱 בואו נסדר!" onStart={startGame} />,
       question: current ? <LifeCyclesQuestion current={current} onComplete={completeLifeCycle as () => void} /> : null,
       result:   <QuizResultScreen onRestart={restart} theme="green" />,
+    }),
+  ),
+
+  'division': makeQuizGame(
+    useDivisionGame,
+    ({ current, choices, startGame, selectAnswer, restart }) => ({
+      menu:     <QuizMenuScreen emoji="➗" title="חילוק" description="12 ÷ 3 = ? — חלק פריטים לקבוצות שוות!" theme="blue" buttonLabel="➗ בואו נחלק!" onStart={startGame} />,
+      question: current ? <DivisionQuestion current={current} choices={choices as string[]} onSelect={selectAnswer} /> : null,
+      result:   <QuizResultScreen onRestart={restart} theme="blue" />,
     }),
   ),
 };

--- a/gamesformykids/lib/quiz/useDivisionGame.ts
+++ b/gamesformykids/lib/quiz/useDivisionGame.ts
@@ -1,0 +1,30 @@
+'use client';
+import { useCallback, useMemo } from 'react';
+import { DIVISION_QUESTIONS, type DivisionQuestion } from '@/lib/quiz/data/division';
+import { QUESTIONS_PER_GAME } from '@/lib/quiz/constants';
+import { useQuizSession } from '@/lib/quiz/useQuizSession';
+import { shuffle } from '@/lib/utils';
+
+export function useDivisionGame() {
+  const { phase, current, begin, answer, reset } = useQuizSession<DivisionQuestion>('division');
+
+  const choices = useMemo(
+    () => current ? shuffle([String(current.quotient), ...current.wrongOptions]) : [],
+    [current],
+  );
+
+  const startGame = useCallback(() => {
+    begin(shuffle(DIVISION_QUESTIONS).slice(0, QUESTIONS_PER_GAME));
+  }, [begin]);
+
+  const selectAnswer = useCallback((choice: string) => {
+    if (!current) return;
+    answer(choice, choice === String(current.quotient));
+  }, [answer, current]);
+
+  const restart = useCallback(() => {
+    reset(shuffle(DIVISION_QUESTIONS).slice(0, QUESTIONS_PER_GAME));
+  }, [reset]);
+
+  return { phase, current, choices, startGame, selectAnswer, restart };
+}

--- a/gamesformykids/lib/registry/registryData/batch4.ts
+++ b/gamesformykids/lib/registry/registryData/batch4.ts
@@ -350,6 +350,17 @@ export const gamesRegistryBatch4: GameRegistration[] = [
     order: 153,
   },
   {
+    id: "division",
+    title: "חילוק",
+    description: "12 ÷ 3 = ? — חלק פריטים לקבוצות שוות!",
+    icon: Hash,
+    emoji: "➗",
+    color: "bg-blue-500 hover:bg-blue-600",
+    href: "/games/division",
+    available: true,
+    order: 154,
+  },
+  {
     id: "maze",
     title: "מבוך",
     description: "נווט דרך המבוך, אסוף כוכבים והגע לדלת — 5 רמות מאתגרות!",

--- a/gamesformykids/lib/types/core/base.ts
+++ b/gamesformykids/lib/types/core/base.ts
@@ -134,7 +134,7 @@ export type GameType =
   | 'tools' | 'professions' | 'emotions' | 'vehicles'
   // Math & counting
   | 'counting' | 'math' | 'arithmetic' | 'multiplication' | 'emoji-math'
-  | 'math-race' | 'number-bubbles' | 'skip-counting'
+  | 'math-race' | 'number-bubbles' | 'skip-counting' | 'division'
   // Memory & puzzle
   | 'memory' | 'bubbles' | 'puzzles' | 'building' | 'tetris'
   | 'drawing' | 'coloring'


### PR DESCRIPTION
## Summary

Adds the Division quiz game (#950) using the Style C (`makeQuizGame`) pattern. The game shows a visual layout of emoji items distributed into equal groups alongside the equation `dividend ÷ divisor = ?`, and asks the player to select the correct quotient.

## Changes

- `lib/quiz/data/division.ts` — 33 questions covering easy (÷2, ÷3), medium (÷4, ÷5), and hard (÷6–÷10) division facts
- `lib/quiz/useDivisionGame.ts` — quiz session hook via `useQuizSession`
- `components/game/quiz/screens/DivisionQuestion.tsx` — custom question screen with visual item grid (emoji rows per group) for dividends ≤ 30; equation-only fallback for larger numbers
- `lib/quiz/registry/customQuizGames.tsx` — registered via `makeQuizGame` with `QuizMenuScreen` / `QuizResultScreen`
- `lib/types/core/base.ts` — added `'division'` to Math & counting section of `GameType`
- `app/games/[gameType]/gamePageConstants.ts` — added to `SUPPORTED_GAMES`
- `lib/registry/registryData/batch4.ts` — registry entry (order 153)
- `lib/constants/gameCategories.ts` — added to `math` category

## Testing

- [x] `npx tsc --noEmit` passes (0 errors)
- [ ] Manually verified at `http://localhost:3000/games/division`
- [ ] Game appears in math category on home page

Closes #950

🤖 Generated with [Claude Code](https://claude.com/claude-code)