### PR TITLE
feat: add life cycles sequencing game (Style C)

### DIFF
--- a/gamesformykids/app/games/[gameType]/gamePageConstants.ts
+++ b/gamesformykids/app/games/[gameType]/gamePageConstants.ts
@@ -47,6 +47,7 @@ export const SUPPORTED_GAMES = [
   'soccer',
   'sorting', 'patterns',
   'skip-counting',
+  'life-cycles',
 ] as const;
 
 export type SupportedGameType = typeof SUPPORTED_GAMES[number];

--- a/gamesformykids/components/game/quiz/screens/LifeCyclesQuestion.tsx
+++ b/gamesformykids/components/game/quiz/screens/LifeCyclesQuestion.tsx
@@ -1,0 +1,148 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { useQuizGameStore } from '@/lib/stores';
+import { QUIZ_THEMES } from '@/components/game/quiz/quizTheme';
+import { QuizProgress } from '@/components/game/quiz/QuizProgress';
+import type { LifeCycleQuestion } from '@/lib/quiz/data/life-cycles';
+
+interface Props {
+  current: LifeCycleQuestion;
+  onComplete: () => void;
+}
+
+export default function LifeCyclesQuestion({ current, onComplete }: Props) {
+  const [placed, setPlaced] = useState<number[]>([]);
+  const [shuffled, setShuffled] = useState<number[]>([]);
+  const [wrongIdx, setWrongIdx] = useState<number | null>(null);
+
+  const isCorrect = useQuizGameStore(s => s.isCorrect);
+  const nextQuestion = useQuizGameStore(s => s.nextQuestion);
+  const t = QUIZ_THEMES['green'];
+
+  // Reset state when lifecycle question changes
+  useEffect(() => {
+    const indices: number[] = [0, 1, 2, 3];
+    setShuffled(indices.sort(() => Math.random() - 0.5));
+    setPlaced([]);
+    setWrongIdx(null);
+  }, [current.id]);
+
+  // Auto-advance after lifecycle completion
+  useEffect(() => {
+    if (isCorrect === true) {
+      const t = setTimeout(nextQuestion, 1200);
+      return () => clearTimeout(t);
+    }
+  }, [isCorrect, nextQuestion]);
+
+  function tapStage(stageIndex: number) {
+    if (isCorrect !== null) return;
+    const nextExpected = placed.length;
+    if (stageIndex === nextExpected) {
+      const newPlaced = [...placed, stageIndex];
+      setShuffled(prev => prev.filter(i => i !== stageIndex));
+      setPlaced(newPlaced);
+      if (newPlaced.length === 4) {
+        setTimeout(onComplete, 300);
+      }
+    } else {
+      setWrongIdx(stageIndex);
+      setTimeout(() => setWrongIdx(null), 500);
+    }
+  }
+
+  return (
+    <div className={`min-h-screen bg-linear-to-br ${t.gradient} flex flex-col items-center justify-center p-4`} dir="rtl">
+      <div className="bg-white rounded-3xl shadow-2xl p-6 max-w-md w-full">
+        <QuizProgress theme="green" />
+
+        {/* Header */}
+        <div className="bg-green-50 rounded-2xl p-4 mb-4 text-center">
+          <p className="text-sm text-green-600 font-semibold mb-1">סדר את מחזור החיים:</p>
+          <p className="text-xl font-black text-green-800">{current.name}</p>
+        </div>
+
+        {/* Completed slots */}
+        <div className="mb-4">
+          <p className="text-xs text-gray-500 text-center mb-2">סדר נכון:</p>
+          <div className="flex gap-2 justify-center">
+            {[0, 1, 2, 3].map(pos => {
+              const stageIdx = placed[pos];
+              const stage = stageIdx !== undefined ? current.stages[stageIdx] : undefined;
+              return (
+                <div
+                  key={pos}
+                  className={`flex flex-col items-center gap-0.5 w-16 h-20 rounded-xl border-2 transition-all duration-300 ${
+                    stage
+                      ? 'border-green-400 bg-green-50'
+                      : 'border-dashed border-green-200 bg-gray-50'
+                  }`}
+                >
+                  {stage ? (
+                    <>
+                      <span className="text-2xl mt-2">{stage.emoji}</span>
+                      <span className="text-xs text-green-700 font-bold text-center leading-tight px-1">
+                        {stage.label}
+                      </span>
+                    </>
+                  ) : (
+                    <span className="text-lg text-green-200 mt-4 font-bold">{pos + 1}</span>
+                  )}
+                </div>
+              );
+            })}
+          </div>
+        </div>
+
+        {/* Available tiles */}
+        {shuffled.length > 0 && (
+          <div>
+            <p className="text-xs text-gray-500 text-center mb-2">לחץ על השלב הראשון:</p>
+            <div className="grid grid-cols-2 gap-2">
+              {shuffled.map(stageIndex => {
+                const stage = current.stages[stageIndex];
+                if (!stage) return null;
+                return (
+                  <button
+                    key={stageIndex}
+                    onClick={() => tapStage(stageIndex)}
+                    className={`p-3 rounded-xl border-2 flex flex-col items-center gap-1 transition-all duration-200 active:scale-95 ${
+                      wrongIdx === stageIndex
+                        ? 'border-red-400 bg-red-50 scale-95'
+                        : 'border-gray-200 bg-gray-50 hover:bg-green-50 hover:border-green-300'
+                    }`}
+                  >
+                    <span className="text-3xl">{stage.emoji}</span>
+                    <span className="text-sm font-medium text-gray-700 text-center leading-tight">
+                      {stage.label}
+                    </span>
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+        )}
+
+        {/* Success overlay when all placed */}
+        {isCorrect === true && (
+          <div className="mt-4 text-center animate-pulse">
+            <p className="text-lg font-bold text-green-600">🎉 מעולה! המשך לחידה הבאה...</p>
+          </div>
+        )}
+
+        {/* Progress dots */}
+        <div className="mt-4 flex justify-center gap-1">
+          {[0, 1, 2, 3].map(i => (
+            <div
+              key={i}
+              className={`w-3 h-3 rounded-full transition-colors duration-300 ${
+                i < placed.length ? 'bg-green-500' : 'bg-gray-200'
+              }`}
+            />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/gamesformykids/lib/constants/gameCategories.ts
+++ b/gamesformykids/lib/constants/gameCategories.ts
@@ -94,7 +94,7 @@ export const GAME_CATEGORIES: Record<string, GameCategory> = {
     icon: Microscope,
     color: "bg-cyan-500",
     gradient: "from-cyan-400 to-cyan-600",
-    gameIds: ["recycling","dinosaurs","space-adventure","virtual-reality","new-professions","climate-planet","science"],
+    gameIds: ["recycling","dinosaurs","space-adventure","virtual-reality","new-professions","climate-planet","science","life-cycles"],
   },
   holidays: {
     title: "חגים ועונות",

--- a/gamesformykids/lib/quiz/data/life-cycles.ts
+++ b/gamesformykids/lib/quiz/data/life-cycles.ts
@@ -1,0 +1,113 @@
+export type LifeCycleStage = {
+  emoji: string;
+  label: string;
+};
+
+export type LifeCycleQuestion = {
+  id: number;
+  name: string;
+  stages: [LifeCycleStage, LifeCycleStage, LifeCycleStage, LifeCycleStage];
+};
+
+export const LIFE_CYCLE_QUESTIONS: LifeCycleQuestion[] = [
+  {
+    id: 1,
+    name: 'פרפר',
+    stages: [
+      { emoji: '🥚', label: 'ביצה' },
+      { emoji: '🐛', label: 'זחל' },
+      { emoji: '🫘', label: 'גולם' },
+      { emoji: '🦋', label: 'פרפר' },
+    ],
+  },
+  {
+    id: 2,
+    name: 'צפרדע',
+    stages: [
+      { emoji: '🥚', label: 'ביצה' },
+      { emoji: '🐟', label: 'ראשן' },
+      { emoji: '🦎', label: 'צפרדעון' },
+      { emoji: '🐸', label: 'צפרדע' },
+    ],
+  },
+  {
+    id: 3,
+    name: 'צמח',
+    stages: [
+      { emoji: '🌰', label: 'זרע' },
+      { emoji: '🌱', label: 'נבט' },
+      { emoji: '🌿', label: 'שתיל' },
+      { emoji: '🌸', label: 'פרח' },
+    ],
+  },
+  {
+    id: 4,
+    name: 'תרנגולת',
+    stages: [
+      { emoji: '🥚', label: 'ביצה' },
+      { emoji: '🐣', label: 'פצחון' },
+      { emoji: '🐤', label: 'אפרוח' },
+      { emoji: '🐔', label: 'תרנגולת' },
+    ],
+  },
+  {
+    id: 5,
+    name: 'עץ תפוח',
+    stages: [
+      { emoji: '🌱', label: 'זרע' },
+      { emoji: '🌳', label: 'עץ צעיר' },
+      { emoji: '🍏', label: 'פרי ירוק' },
+      { emoji: '🍎', label: 'תפוח בשל' },
+    ],
+  },
+  {
+    id: 6,
+    name: 'דבורה',
+    stages: [
+      { emoji: '🥚', label: 'ביצה' },
+      { emoji: '🐛', label: 'זחל' },
+      { emoji: '🫘', label: 'גולם' },
+      { emoji: '🐝', label: 'דבורה' },
+    ],
+  },
+  {
+    id: 7,
+    name: 'דג',
+    stages: [
+      { emoji: '🥚', label: 'ביצה' },
+      { emoji: '🐡', label: 'גור דגים' },
+      { emoji: '🐠', label: 'דג צעיר' },
+      { emoji: '🐟', label: 'דג בוגר' },
+    ],
+  },
+  {
+    id: 8,
+    name: 'חמנייה',
+    stages: [
+      { emoji: '🌰', label: 'גרעין' },
+      { emoji: '🌱', label: 'נבט' },
+      { emoji: '🌿', label: 'שתיל' },
+      { emoji: '🌻', label: 'חמנייה' },
+    ],
+  },
+  {
+    id: 9,
+    name: 'פרת משה רבנו',
+    stages: [
+      { emoji: '🥚', label: 'ביצה' },
+      { emoji: '🐛', label: 'זחל' },
+      { emoji: '🫘', label: 'גולם' },
+      { emoji: '🐞', label: 'פרת משה רבנו' },
+    ],
+  },
+  {
+    id: 10,
+    name: 'עגבנייה',
+    stages: [
+      { emoji: '🌱', label: 'זרע' },
+      { emoji: '🌿', label: 'שתיל' },
+      { emoji: '🌼', label: 'פרח' },
+      { emoji: '🍅', label: 'עגבנייה' },
+    ],
+  },
+];

--- a/gamesformykids/lib/quiz/registry/customQuizGames.tsx
+++ b/gamesformykids/lib/quiz/registry/customQuizGames.tsx
@@ -6,6 +6,8 @@ import { useSortingGame } from '@/lib/quiz/useSortingGame';
 import SortingQuestion from '@/components/game/quiz/screens/SortingQuestion';
 import { usePatternsGame } from '@/lib/quiz/usePatternsGame';
 import PatternQuestion from '@/components/game/quiz/screens/PatternQuestion';
+import { useLifeCyclesGame } from '@/lib/quiz/useLifeCyclesGame';
+import LifeCyclesQuestion from '@/components/game/quiz/screens/LifeCyclesQuestion';
 
 import { useClockGame } from '@/lib/quiz/useClockGame';
 import { usePhonicsGame } from '@/lib/quiz/usePhonicsGame';
@@ -152,6 +154,15 @@ export const CUSTOM_QUIZ_GAMES: Record<string, ComponentType> = {
       menu:     <QuizMenuScreen emoji="🔵🔴" title="זיהוי דפוסים" description="🔴🔵🔴🔵🔴❓ — מה בא הלאה?" theme="sky" buttonLabel="🔵 בואו נגלה!" onStart={startGame} />,
       question: current ? <PatternQuestion current={current} onSelect={selectAnswer} /> : null,
       result:   <QuizResultScreen onRestart={restart} theme="sky" />,
+    }),
+  ),
+
+  'life-cycles': makeQuizGame(
+    useLifeCyclesGame,
+    ({ current, startGame, completeLifeCycle, restart }) => ({
+      menu:     <QuizMenuScreen emoji="🦋" title="מחזור חיים" description="סדר את שלבי מחזור החיים בסדר הנכון!" theme="green" buttonLabel="🌱 בואו נסדר!" onStart={startGame} />,
+      question: current ? <LifeCyclesQuestion current={current} onComplete={completeLifeCycle as () => void} /> : null,
+      result:   <QuizResultScreen onRestart={restart} theme="green" />,
     }),
   ),
 };

--- a/gamesformykids/lib/quiz/useLifeCyclesGame.ts
+++ b/gamesformykids/lib/quiz/useLifeCyclesGame.ts
@@ -1,0 +1,28 @@
+'use client';
+import { useCallback, useMemo } from 'react';
+import { LIFE_CYCLE_QUESTIONS, type LifeCycleQuestion } from '@/lib/quiz/data/life-cycles';
+import { useQuizSession } from '@/lib/quiz/useQuizSession';
+import { shuffle } from '@/lib/utils';
+
+const CYCLES_PER_GAME = 5;
+
+export function useLifeCyclesGame() {
+  const { phase, current, begin, answer, reset } = useQuizSession<LifeCycleQuestion>('life-cycles');
+
+  // choices not used — sequencing mechanic handles answer internally
+  const choices = useMemo(() => [] as string[], []);
+
+  const startGame = useCallback(() => {
+    begin(shuffle(LIFE_CYCLE_QUESTIONS).slice(0, CYCLES_PER_GAME));
+  }, [begin]);
+
+  const completeLifeCycle = useCallback(() => {
+    answer('correct', true);
+  }, [answer]);
+
+  const restart = useCallback(() => {
+    reset(shuffle(LIFE_CYCLE_QUESTIONS).slice(0, CYCLES_PER_GAME));
+  }, [reset]);
+
+  return { phase, current, choices, startGame, completeLifeCycle, restart };
+}

--- a/gamesformykids/lib/registry/registryData/batch4.ts
+++ b/gamesformykids/lib/registry/registryData/batch4.ts
@@ -22,6 +22,7 @@ import {
   Zap,
   ArrowLeftRight,
   BookOpen,
+  Leaf,
 } from "lucide-react";
 import type { GameRegistration } from "@/lib/types/games/base";
 
@@ -347,5 +348,16 @@ export const gamesRegistryBatch4: GameRegistration[] = [
     href: "/games/skip-counting",
     available: true,
     order: 153,
+  },
+  {
+    id: "life-cycles",
+    title: "מחזור חיים",
+    description: "סדר את שלבי מחזור החיים — פרפר, צפרדע ועוד!",
+    icon: Leaf,
+    emoji: "🦋",
+    color: "bg-green-500 hover:bg-green-600",
+    href: "/games/life-cycles",
+    available: true,
+    order: 154,
   },
 ];

--- a/gamesformykids/lib/types/core/base.ts
+++ b/gamesformykids/lib/types/core/base.ts
@@ -159,7 +159,7 @@ export type GameType =
   | 'opposites' | 'sports-quiz' | 'trivia' | 'science'
   | 'continents' | 'israel' | 'nature' | 'healthy-food' | 'human-body'
   | 'sequences' | 'color-mix' | 'clock' | 'english-words' | 'shapes-3d'
-  | 'holidays' | 'tzadikim'
+  | 'holidays' | 'tzadikim' | 'life-cycles'
   | 'days-of-week' | 'months-of-year'
   | 'geography-capitals' | 'geography-flags' | 'geography-continents'
   | 'singular-plural' | 'morning-routine'


### PR DESCRIPTION
## Summary

Adds the Life Cycles sequencing game (#951) using the Style C (`makeQuizGame`) pattern. Unlike standard multiple-choice quizzes, the player taps 4 lifecycle stage tiles in the correct order (1→2→3→4). Each correct tap snaps the stage into its slot; a wrong tap flashes red. When all 4 stages are placed, the game auto-advances to the next lifecycle after 1.2 seconds (no "Next" button needed).

## Changes

- `lib/quiz/data/life-cycles.ts` — 10 lifecycle questions (butterfly, frog, plant, chicken, apple tree, bee, fish, sunflower, ladybug, tomato) each with 4 ordered stages
- `lib/quiz/useLifeCyclesGame.ts` — hook via `useQuizSession`, exposing `completeLifeCycle()` that calls `answer('correct', true)`
- `components/game/quiz/screens/LifeCyclesQuestion.tsx` — fully custom sequencing screen: shuffled tiles + snap-to-slot mechanic + auto-advance via `useQuizGameStore.nextQuestion`
- `lib/quiz/registry/customQuizGames.tsx` — registered via `makeQuizGame`
- `lib/types/core/base.ts` — added `'life-cycles'` to Quiz & educational section
- `app/games/[gameType]/gamePageConstants.ts` — added to `SUPPORTED_GAMES`
- `lib/registry/registryData/batch4.ts` — registry entry (order 154, Leaf icon)
- `lib/constants/gameCategories.ts` — added to `science` category

## Testing

- [x] `npx tsc --noEmit` passes (0 errors)
- [ ] Manually verified at `http://localhost:3000/games/life-cycles`
- [ ] Game appears in science category on home page

Closes #951

🤖 Generated with [Claude Code](https://claude.com/claude-code)