### PR TITLE
feat: add nikud Hebrew vowels quiz game (Style C)

### DIFF
--- a/gamesformykids/app/games/[gameType]/gamePageConstants.ts
+++ b/gamesformykids/app/games/[gameType]/gamePageConstants.ts
@@ -49,6 +49,7 @@ export const SUPPORTED_GAMES = [
   'skip-counting',
   'life-cycles',
   'maze',
+  'nikud',
 ] as const;
 
 export type SupportedGameType = typeof SUPPORTED_GAMES[number];

--- a/gamesformykids/components/game/quiz/screens/NikudQuestion.tsx
+++ b/gamesformykids/components/game/quiz/screens/NikudQuestion.tsx
@@ -1,0 +1,50 @@
+'use client';
+
+import { useEffect } from 'react';
+import { QuizQuestionShell } from '@/components/game/quiz';
+import { speakHebrew } from '@/lib/utils/speech/speaker';
+import type { NikudQuestion as NikudQuestionType } from '@/lib/quiz/data/nikud';
+
+interface Props {
+  current: NikudQuestionType;
+  choices: string[];
+  onSelect: (choice: string) => void;
+}
+
+export default function NikudQuestion({ current, choices, onSelect }: Props) {
+  // Auto-play TTS when question changes
+  useEffect(() => {
+    speakHebrew(current.syllable);
+  }, [current.id, current.syllable]);
+
+  return (
+    <QuizQuestionShell
+      theme="violet"
+      choices={choices}
+      correctLabel={current.answer}
+      onSelect={onSelect}
+      correctMsg={`✅ נכון! ${current.syllable} — ${current.answer}`}
+      wrongMsg={`💜 ${current.syllable} — ${current.answer}`}
+      cols={1}
+    >
+      <p className="text-sm font-semibold text-violet-600 mb-2">מה שם הניקוד?</p>
+
+      {/* Large nikud display */}
+      <div
+        className="text-8xl font-bold text-violet-800 mb-3 leading-none"
+        style={{ fontFamily: 'serif', direction: 'rtl' }}
+      >
+        {current.syllable}
+      </div>
+
+      {/* TTS replay button */}
+      <button
+        onClick={() => speakHebrew(current.syllable)}
+        className="inline-flex items-center gap-1 px-3 py-1 rounded-full bg-violet-100 hover:bg-violet-200 text-violet-700 text-sm font-medium transition-colors"
+        type="button"
+      >
+        🔊 שמע שוב
+      </button>
+    </QuizQuestionShell>
+  );
+}

--- a/gamesformykids/lib/constants/gameCategories.ts
+++ b/gamesformykids/lib/constants/gameCategories.ts
@@ -30,7 +30,7 @@ export const GAME_CATEGORIES: Record<string, GameCategory> = {
     icon: Book,
     color: "bg-blue-500",
     gradient: "from-blue-400 to-blue-600",
-    gameIds: ["letters","hebrew-letters","numbers","shapes","colored-shapes","colors","advanced-colors","shapes-3d","phonics","rhyming"],
+    gameIds: ["letters","hebrew-letters","numbers","shapes","colored-shapes","colors","advanced-colors","shapes-3d","phonics","rhyming","nikud"],
   },
   creative: {
     title: "יצירתיות ואומנות",

--- a/gamesformykids/lib/quiz/data/nikud.ts
+++ b/gamesformykids/lib/quiz/data/nikud.ts
@@ -1,0 +1,62 @@
+export type NikudQuestion = {
+  id: number;
+  syllable: string;
+  answer: string;
+  wrongOptions: [string, string, string];
+};
+
+// Consistent vowel choice labels used across all questions
+export const NIKUD_VOWELS = {
+  a: 'פַּתַח / קָמַץ — a',
+  i: 'חִירִיק — i',
+  e: 'צֵירֵי / סֶגּוֹל — e',
+  o: 'חוֹלֵם — o',
+  u: 'שׁוּרוּק / קֻבּוּץ — u',
+} as const;
+
+const { a, i, e, o, u } = NIKUD_VOWELS;
+
+export const NIKUD_QUESTIONS: NikudQuestion[] = [
+  // ── פַּתַח (a) ──────────────────────────────────────────────────────────────
+  { id: 1,  syllable: 'בַּ', answer: a, wrongOptions: [i, e, o] },
+  { id: 2,  syllable: 'מַ',  answer: a, wrongOptions: [u, e, i] },
+  { id: 3,  syllable: 'שַׁ',  answer: a, wrongOptions: [e, i, o] },
+
+  // ── קָמַץ (a) ──────────────────────────────────────────────────────────────
+  { id: 4,  syllable: 'דָּ',  answer: a, wrongOptions: [i, o, e] },
+  { id: 5,  syllable: 'כָּ',  answer: a, wrongOptions: [u, i, o] },
+
+  // ── חִירִיק (i) ─────────────────────────────────────────────────────────────
+  { id: 6,  syllable: 'בִּ',  answer: i, wrongOptions: [a, o, e] },
+  { id: 7,  syllable: 'מִ',   answer: i, wrongOptions: [a, u, e] },
+  { id: 8,  syllable: 'כִּ',  answer: i, wrongOptions: [o, a, e] },
+  { id: 9,  syllable: 'לִ',   answer: i, wrongOptions: [u, a, o] },
+  { id: 10, syllable: 'שִׁ',  answer: i, wrongOptions: [a, e, o] },
+
+  // ── צֵירֵי (e) ─────────────────────────────────────────────────────────────
+  { id: 11, syllable: 'בֵּ',  answer: e, wrongOptions: [a, i, o] },
+  { id: 12, syllable: 'מֵ',   answer: e, wrongOptions: [u, a, i] },
+  { id: 13, syllable: 'כֵּ',  answer: e, wrongOptions: [i, o, a] },
+
+  // ── סֶגּוֹל (e) ────────────────────────────────────────────────────────────
+  { id: 14, syllable: 'כֶּ',  answer: e, wrongOptions: [i, o, a] },
+  { id: 15, syllable: 'לֶ',   answer: e, wrongOptions: [u, i, a] },
+  { id: 16, syllable: 'שֶׁ',  answer: e, wrongOptions: [a, i, o] },
+  { id: 17, syllable: 'מֶ',   answer: e, wrongOptions: [a, u, o] },
+
+  // ── חוֹלֵם (o) ─────────────────────────────────────────────────────────────
+  { id: 18, syllable: 'בוֹ',  answer: o, wrongOptions: [a, i, u] },
+  { id: 19, syllable: 'מוֹ',  answer: o, wrongOptions: [a, e, i] },
+  { id: 20, syllable: 'כּוֹ', answer: o, wrongOptions: [u, a, e] },
+  { id: 21, syllable: 'לוֹ',  answer: o, wrongOptions: [i, a, u] },
+  { id: 22, syllable: 'שׁוֹ', answer: o, wrongOptions: [a, e, i] },
+
+  // ── שׁוּרוּק (u) ────────────────────────────────────────────────────────────
+  { id: 23, syllable: 'בּוּ', answer: u, wrongOptions: [o, i, a] },
+  { id: 24, syllable: 'מוּ',  answer: u, wrongOptions: [e, a, o] },
+  { id: 25, syllable: 'לוּ',  answer: u, wrongOptions: [o, i, e] },
+
+  // ── קֻבּוּץ (u) ─────────────────────────────────────────────────────────────
+  { id: 26, syllable: 'כֻּ',  answer: u, wrongOptions: [i, o, a] },
+  { id: 27, syllable: 'שֻׁ',  answer: u, wrongOptions: [o, i, e] },
+];

--- a/gamesformykids/lib/quiz/registry/customQuizGames.tsx
+++ b/gamesformykids/lib/quiz/registry/customQuizGames.tsx
@@ -3,6 +3,7 @@ import type { ComponentType } from 'react';
 import dynamic from 'next/dynamic';
 import { makeQuizGame } from '../makeQuizGame';
 import { QuizMenuScreen, QuizResultScreen, CategoryIndexedQuestion } from '@/components/game/quiz';
+import { useNikudGame } from '@/lib/quiz/useNikudGame';
 
 // Hooks — small, kept static so tree-shaking inlines only what's used
 import { useClockGame } from '@/lib/quiz/useClockGame';
@@ -47,6 +48,7 @@ const PhonicsQuestion    = dynamic(() => import('@/components/game/quiz/screens/
 const SortingQuestion    = dynamic(() => import('@/components/game/quiz/screens/SortingQuestion'));
 const PatternQuestion    = dynamic(() => import('@/components/game/quiz/screens/PatternQuestion'));
 const LifeCyclesQuestion = dynamic(() => import('@/components/game/quiz/screens/LifeCyclesQuestion'));
+const NikudQuestion      = dynamic(() => import('@/components/game/quiz/screens/NikudQuestion'));
 
 /**
  * Games built with makeQuizGame — custom hooks + lazy-loaded screen components.
@@ -167,6 +169,15 @@ export const CUSTOM_QUIZ_GAMES: Record<string, ComponentType> = {
       menu:     <QuizMenuScreen emoji="🦋" title="מחזור חיים" description="סדר את שלבי מחזור החיים בסדר הנכון!" theme="green" buttonLabel="🌱 בואו נסדר!" onStart={startGame} />,
       question: current ? <LifeCyclesQuestion current={current} onComplete={completeLifeCycle as () => void} /> : null,
       result:   <QuizResultScreen onRestart={restart} theme="green" />,
+    }),
+  ),
+
+  'nikud': makeQuizGame(
+    useNikudGame,
+    ({ current, choices, startGame, selectAnswer, restart }) => ({
+      menu:     <QuizMenuScreen emoji="🔤" title="ניקוד עברי" description="זהה את הניקוד — פַּתַח, חִירִיק, חוֹלֵם ועוד!" theme="violet" buttonLabel="🔤 בואו נלמד!" onStart={startGame} />,
+      question: current ? <NikudQuestion current={current} choices={choices as string[]} onSelect={selectAnswer} /> : null,
+      result:   <QuizResultScreen onRestart={restart} theme="violet" />,
     }),
   ),
 };

--- a/gamesformykids/lib/quiz/useNikudGame.ts
+++ b/gamesformykids/lib/quiz/useNikudGame.ts
@@ -1,0 +1,30 @@
+'use client';
+import { useCallback, useMemo } from 'react';
+import { NIKUD_QUESTIONS, type NikudQuestion } from '@/lib/quiz/data/nikud';
+import { QUESTIONS_PER_GAME } from '@/lib/quiz/constants';
+import { useQuizSession } from '@/lib/quiz/useQuizSession';
+import { shuffle } from '@/lib/utils';
+
+export function useNikudGame() {
+  const { phase, current, begin, answer, reset } = useQuizSession<NikudQuestion>('nikud');
+
+  const choices = useMemo(
+    () => current ? shuffle([current.answer, ...current.wrongOptions]) : [],
+    [current],
+  );
+
+  const startGame = useCallback(() => {
+    begin(shuffle(NIKUD_QUESTIONS).slice(0, QUESTIONS_PER_GAME));
+  }, [begin]);
+
+  const selectAnswer = useCallback((choice: string) => {
+    if (!current) return;
+    answer(choice, choice === current.answer);
+  }, [answer, current]);
+
+  const restart = useCallback(() => {
+    reset(shuffle(NIKUD_QUESTIONS).slice(0, QUESTIONS_PER_GAME));
+  }, [reset]);
+
+  return { phase, current, choices, startGame, selectAnswer, restart };
+}

--- a/gamesformykids/lib/registry/registryData/batch4.ts
+++ b/gamesformykids/lib/registry/registryData/batch4.ts
@@ -371,4 +371,15 @@ export const gamesRegistryBatch4: GameRegistration[] = [
     available: true,
     order: 156,
   },
+  {
+    id: "nikud",
+    title: "ניקוד עברי",
+    description: "זהה את הניקוד — פַּתַח, חִירִיק, חוֹלֵם ועוד!",
+    icon: BookOpen,
+    emoji: "🔤",
+    color: "bg-violet-500 hover:bg-violet-600",
+    href: "/games/nikud",
+    available: true,
+    order: 157,
+  },
 ];

--- a/gamesformykids/lib/types/core/base.ts
+++ b/gamesformykids/lib/types/core/base.ts
@@ -159,7 +159,7 @@ export type GameType =
   | 'opposites' | 'sports-quiz' | 'trivia' | 'science'
   | 'continents' | 'israel' | 'nature' | 'healthy-food' | 'human-body'
   | 'sequences' | 'color-mix' | 'clock' | 'english-words' | 'shapes-3d'
-  | 'holidays' | 'tzadikim' | 'life-cycles'
+  | 'holidays' | 'tzadikim' | 'life-cycles' | 'nikud'
   | 'days-of-week' | 'months-of-year'
   | 'geography-capitals' | 'geography-flags' | 'geography-continents'
   | 'singular-plural' | 'morning-routine'


### PR DESCRIPTION
## Summary

Adds the Nikud (ניקוד) Hebrew vowel marks quiz game (#949) using the Style C (`makeQuizGame`) pattern. The game shows a nikud-marked Hebrew syllable at very large size (8rem / 128px) and asks the child to identify the vowel name. Hebrew TTS auto-plays on each new question via `speakHebrew`, with a "🔊 שמע שוב" button for manual replay.

## Changes

- `lib/quiz/data/nikud.ts` — 27 questions covering all 5 vowel families: פַּתַח/קָמַץ (a), חִירִיק (i), צֵירֵי/סֶגּוֹל (e), חוֹלֵם (o), שׁוּרוּק/קֻבּוּץ (u)
- `lib/quiz/useNikudGame.ts` — hook via `useQuizSession`, shuffling choices from `[answer, ...wrongOptions]`
- `components/game/quiz/screens/NikudQuestion.tsx` — custom question screen: syllable at `text-8xl` serif font + auto-TTS on question change + manual replay button
- `lib/quiz/registry/customQuizGames.tsx` — registered via `makeQuizGame`
- `lib/types/core/base.ts` — added `'nikud'` to Quiz & educational section
- `app/games/[gameType]/gamePageConstants.ts` — added to `SUPPORTED_GAMES`
- `lib/registry/registryData/batch4.ts` — registry entry (order 155, BookOpen icon)
- `lib/constants/gameCategories.ts` — added to `basic` category

## Testing

- [x] `npx tsc --noEmit` passes (0 errors)
- [ ] Manually verified at `http://localhost:3000/games/nikud`
- [ ] Game appears in basic category on home page
- [ ] Hebrew TTS plays correctly on each question

Closes #949

🤖 Generated with [Claude Code](https://claude.com/claude-code)