### PR TITLE
feat: add maze game with 5 levels and collectible stars

### DIFF
--- a/gamesformykids/app/games/[gameType]/CustomGameRenderer.tsx
+++ b/gamesformykids/app/games/[gameType]/CustomGameRenderer.tsx
@@ -43,6 +43,7 @@ const GAME_CLIENTS: Record<string, ComponentType> = {
   'whack-a-mole':    dynamic(() => import('../whack-a-mole/WhackAMoleClient'),               { ssr: false }),
   'word-builder':    dynamic(() => import('../word-builder/WordBuilderGameClient')),
   'word-scramble':   dynamic(() => import('../word-scramble/WordScrambleClient')),
+  'maze':            dynamic(() => import('../maze/MazeClient'),                                  { ssr: false }),
 };
 
 interface Props { gameType: string; }

--- a/gamesformykids/app/games/[gameType]/gamePageConstants.ts
+++ b/gamesformykids/app/games/[gameType]/gamePageConstants.ts
@@ -48,6 +48,7 @@ export const SUPPORTED_GAMES = [
   'sorting', 'patterns',
   'skip-counting',
   'life-cycles',
+  'maze',
 ] as const;
 
 export type SupportedGameType = typeof SUPPORTED_GAMES[number];
@@ -59,7 +60,7 @@ export const CUSTOM_GAME_TYPES = new Set([
   'math-race', 'memory', 'meteor-dodge', 'multiplication', 'number-bubbles', 'pong',
   'puzzles', 'reflex', 'shesh-besh', 'simon', 'snake', 'space-defender',
   'stack', 'taki', 'tetris', 'true-false', 'tzedakah', 'whack-a-mole',
-  'word-builder', 'word-scramble',
+  'word-builder', 'word-scramble', 'maze',
 ]);
 
 // ─── מיפוי URL → GameType ──────────────────────────────────────────────────────

--- a/gamesformykids/app/games/maze/MazeClient.tsx
+++ b/gamesformykids/app/games/maze/MazeClient.tsx
@@ -1,0 +1,112 @@
+'use client';
+import { useMazeGame } from './useMazeGame';
+import { useMazeStore } from './mazeStore';
+import MazeCanvas from './components/MazeCanvas';
+import { GameCompletionCelebration } from '@/components/game/shared/GameCompletionCelebration';
+
+const LEVEL_NAMES = ['מפה קטנה 5×5', 'מפה בינונית 7×7', 'מפה גדולה 9×9', 'מפה ענקית 11×11', 'מבוך המומחים 13×13'];
+const TOTAL_LEVELS = 5;
+
+export default function MazeClient() {
+  const { phase, level, starsCollectedThisLevel, totalStarsCollected, startGame, nextLevel, reset } = useMazeGame();
+  const move = useMazeStore(s => s.move);
+
+  if (phase === 'idle') {
+    return (
+      <div className="min-h-screen bg-linear-to-br from-indigo-900 to-purple-900 flex flex-col items-center justify-center p-6 gap-6">
+        <div className="text-7xl">🧩</div>
+        <h1 className="text-4xl font-black text-white text-center">מבוך</h1>
+        <p className="text-lg text-indigo-200 text-center max-w-xs">
+          נווט את הדמות דרך המבוך, אסוף כוכבים, והגע לדלת!
+        </p>
+        <div className="flex flex-col gap-2 text-sm text-indigo-300 text-center">
+          <p>5 רמות — מ-5×5 עד 13×13</p>
+          <p>חצי מקלדת או כפתורי הכיוון 🕹️</p>
+        </div>
+        <button
+          onClick={startGame}
+          className="px-8 py-4 bg-yellow-400 hover:bg-yellow-300 text-yellow-900 font-black text-xl rounded-2xl shadow-lg transition-transform active:scale-95"
+        >
+          🚀 התחל משחק
+        </button>
+      </div>
+    );
+  }
+
+  if (phase === 'gameComplete') {
+    return (
+      <div className="min-h-screen bg-linear-to-br from-indigo-900 to-purple-900 flex flex-col items-center justify-center p-6 gap-6">
+        <GameCompletionCelebration />
+        <div className="text-7xl">🏆</div>
+        <h2 className="text-3xl font-black text-white text-center">כל הכבוד!</h2>
+        <p className="text-xl text-yellow-300">ניצחת את כל {TOTAL_LEVELS} המבוכים!</p>
+        <p className="text-2xl font-bold text-yellow-200">⭐ {totalStarsCollected} כוכבים</p>
+        <button
+          onClick={reset}
+          className="px-8 py-4 bg-yellow-400 hover:bg-yellow-300 text-yellow-900 font-black text-xl rounded-2xl shadow-lg transition-transform active:scale-95"
+        >
+          🔄 שחק שוב
+        </button>
+      </div>
+    );
+  }
+
+  if (phase === 'levelComplete') {
+    return (
+      <div className="min-h-screen bg-linear-to-br from-indigo-900 to-purple-900 flex flex-col items-center justify-center p-6 gap-6">
+        <div className="text-7xl">🎉</div>
+        <h2 className="text-3xl font-black text-white text-center">רמה {level + 1} הושלמה!</h2>
+        <p className="text-xl text-yellow-300">⭐ {starsCollectedThisLevel} כוכבים ברמה זו</p>
+        <p className="text-lg text-indigo-200">סה&quot;כ: {totalStarsCollected} כוכבים</p>
+        {level + 1 < TOTAL_LEVELS && (
+          <p className="text-sm text-indigo-300">הרמה הבאה: {LEVEL_NAMES[level + 1]}</p>
+        )}
+        <button
+          onClick={nextLevel}
+          className="px-8 py-4 bg-yellow-400 hover:bg-yellow-300 text-yellow-900 font-black text-xl rounded-2xl shadow-lg transition-transform active:scale-95"
+        >
+          ➡️ רמה הבאה
+        </button>
+      </div>
+    );
+  }
+
+  // Playing phase
+  return (
+    <div className="min-h-screen bg-linear-to-br from-indigo-900 to-purple-900 flex flex-col items-center p-4 gap-3">
+      <div className="flex items-center justify-between w-full max-w-sm pt-2" dir="rtl">
+        <span className="text-white font-bold text-sm">רמה {level + 1}/{TOTAL_LEVELS}</span>
+        <span className="text-indigo-300 text-xs">{LEVEL_NAMES[level]}</span>
+        <span className="text-yellow-300 font-bold">⭐ {totalStarsCollected}</span>
+      </div>
+
+      <MazeCanvas />
+
+      <p className="text-xs text-indigo-400">הגע ל-🚪 כדי לסיים</p>
+
+      {/* D-pad for mobile */}
+      <div className="grid grid-cols-3 gap-2">
+        <div />
+        <DPadBtn label="▲" onClick={() => move('N')} />
+        <div />
+        <DPadBtn label="◀" onClick={() => move('W')} />
+        <div className="w-14 h-14" />
+        <DPadBtn label="▶" onClick={() => move('E')} />
+        <div />
+        <DPadBtn label="▼" onClick={() => move('S')} />
+        <div />
+      </div>
+    </div>
+  );
+}
+
+function DPadBtn({ label, onClick }: { label: string; onClick: () => void }) {
+  return (
+    <button
+      onClick={onClick}
+      className="w-14 h-14 bg-indigo-700 hover:bg-indigo-600 active:bg-indigo-500 text-white text-2xl font-bold rounded-xl shadow-md transition-transform active:scale-90 select-none"
+    >
+      {label}
+    </button>
+  );
+}

--- a/gamesformykids/app/games/maze/components/MazeCanvas.tsx
+++ b/gamesformykids/app/games/maze/components/MazeCanvas.tsx
@@ -1,0 +1,98 @@
+'use client';
+import { useRef } from 'react';
+import { useCanvasLoop } from '@/hooks/canvas/useCanvasLoop';
+import { useMazeStore } from '../mazeStore';
+
+const CANVAS_SIZE = 340;
+const WALL_COLOR = '#e2e8f0';
+const BG_COLOR = '#1e293b';
+const CELL_COLOR = '#0f172a';
+const EXIT_CELL_COLOR = '#14532d';
+
+export default function MazeCanvas() {
+  const dprRef = useRef<number | null>(null);
+
+  const canvasRef = useCanvasLoop((ctx) => {
+    if (dprRef.current === null) {
+      const dpr = window.devicePixelRatio || 1;
+      dprRef.current = dpr;
+      const c = ctx.canvas;
+      c.width = CANVAS_SIZE * dpr;
+      c.height = CANVAS_SIZE * dpr;
+      c.style.width = `${CANVAS_SIZE}px`;
+      c.style.height = `${CANVAS_SIZE}px`;
+    }
+    ctx.setTransform(dprRef.current!, 0, 0, dprRef.current!, 0, 0);
+
+    const { grid, rows, cols, playerPos, exitPos, stars, collected, phase } = useMazeStore.getState();
+    if (!grid.length || phase === 'idle') {
+      ctx.fillStyle = BG_COLOR;
+      ctx.fillRect(0, 0, CANVAS_SIZE, CANVAS_SIZE);
+      return;
+    }
+
+    const CELL = CANVAS_SIZE / Math.max(rows, cols);
+    const offsetX = (CANVAS_SIZE - cols * CELL) / 2;
+    const offsetY = (CANVAS_SIZE - rows * CELL) / 2;
+
+    ctx.fillStyle = BG_COLOR;
+    ctx.fillRect(0, 0, CANVAS_SIZE, CANVAS_SIZE);
+
+    // Draw cell backgrounds
+    for (let r = 0; r < rows; r++) {
+      for (let c = 0; c < cols; c++) {
+        const x = offsetX + c * CELL;
+        const y = offsetY + r * CELL;
+        const isExit = r === exitPos[0] && c === exitPos[1];
+        ctx.fillStyle = isExit ? EXIT_CELL_COLOR : CELL_COLOR;
+        ctx.fillRect(x + 1, y + 1, CELL - 2, CELL - 2);
+      }
+    }
+
+    // Draw walls
+    ctx.strokeStyle = WALL_COLOR;
+    ctx.lineWidth = 2;
+    ctx.lineCap = 'square';
+    for (let r = 0; r < rows; r++) {
+      for (let c = 0; c < cols; c++) {
+        const cell = grid[r]?.[c];
+        if (!cell) continue;
+        const x = offsetX + c * CELL;
+        const y = offsetY + r * CELL;
+        ctx.beginPath();
+        if (cell.N) { ctx.moveTo(x, y);          ctx.lineTo(x + CELL, y); }
+        if (cell.E) { ctx.moveTo(x + CELL, y);   ctx.lineTo(x + CELL, y + CELL); }
+        if (cell.S) { ctx.moveTo(x, y + CELL);   ctx.lineTo(x + CELL, y + CELL); }
+        if (cell.W) { ctx.moveTo(x, y);           ctx.lineTo(x, y + CELL); }
+        ctx.stroke();
+      }
+    }
+
+    // Draw emojis
+    const fontSize = Math.max(10, CELL * 0.55);
+    ctx.font = `${fontSize}px serif`;
+    ctx.textAlign = 'center';
+    ctx.textBaseline = 'middle';
+
+    // Stars
+    stars.forEach(([sr, sc], i) => {
+      if (collected[i]) return;
+      ctx.fillText('⭐', offsetX + (sc + 0.5) * CELL, offsetY + (sr + 0.5) * CELL);
+    });
+
+    // Exit door
+    ctx.fillText('🚪', offsetX + (exitPos[1] + 0.5) * CELL, offsetY + (exitPos[0] + 0.5) * CELL);
+
+    // Player
+    ctx.fillText('🧒', offsetX + (playerPos[1] + 0.5) * CELL, offsetY + (playerPos[0] + 0.5) * CELL);
+  });
+
+  return (
+    <canvas
+      ref={canvasRef}
+      width={CANVAS_SIZE}
+      height={CANVAS_SIZE}
+      style={{ display: 'block', margin: '0 auto', borderRadius: '12px', border: '2px solid #334155' }}
+    />
+  );
+}

--- a/gamesformykids/app/games/maze/lib/mazeGenerator.ts
+++ b/gamesformykids/app/games/maze/lib/mazeGenerator.ts
@@ -1,0 +1,45 @@
+export type Wall = { N: boolean; E: boolean; S: boolean; W: boolean };
+
+/** Generate a perfect maze with the recursive-backtracker algorithm. */
+export function generateMaze(rows: number, cols: number): Wall[][] {
+  const grid: Wall[][] = Array.from({ length: rows }, () =>
+    Array.from({ length: cols }, () => ({ N: true, E: true, S: true, W: true })),
+  );
+  const visited: boolean[][] = Array.from({ length: rows }, () => Array(cols).fill(false));
+
+  function backtrack(r: number, c: number): void {
+    visited[r]![c] = true;
+    const dirs: Array<[number, number, keyof Wall, keyof Wall]> = [
+      [-1, 0, 'N', 'S'], [0, 1, 'E', 'W'], [1, 0, 'S', 'N'], [0, -1, 'W', 'E'],
+    ];
+    for (let i = dirs.length - 1; i > 0; i--) {
+      const j = Math.floor(Math.random() * (i + 1));
+      [dirs[i], dirs[j]] = [dirs[j]!, dirs[i]!];
+    }
+    for (const [dr, dc, from, to] of dirs) {
+      const nr = r + dr, nc = c + dc;
+      if (nr >= 0 && nr < rows && nc >= 0 && nc < cols && !visited[nr]![nc]) {
+        grid[r]![c]![from] = false;
+        grid[nr]![nc]![to] = false;
+        backtrack(nr, nc);
+      }
+    }
+  }
+
+  backtrack(0, 0);
+  return grid;
+}
+
+export function placeStars(rows: number, cols: number, count: number): Array<[number, number]> {
+  const out: Array<[number, number]> = [];
+  const taken = new Set<string>(['0,0', `${rows - 1},${cols - 1}`]);
+  let tries = 0;
+  while (out.length < count && tries < 1000) {
+    tries++;
+    const r = Math.floor(Math.random() * rows);
+    const c = Math.floor(Math.random() * cols);
+    const key = `${r},${c}`;
+    if (!taken.has(key)) { taken.add(key); out.push([r, c]); }
+  }
+  return out;
+}

--- a/gamesformykids/app/games/maze/mazeStore.ts
+++ b/gamesformykids/app/games/maze/mazeStore.ts
@@ -1,0 +1,126 @@
+'use client';
+import { create } from 'zustand';
+import { generateMaze, placeStars, type Wall } from './lib/mazeGenerator';
+
+const LEVELS = [
+  { rows: 5,  cols: 5,  stars: 3 },
+  { rows: 7,  cols: 7,  stars: 3 },
+  { rows: 9,  cols: 9,  stars: 4 },
+  { rows: 11, cols: 11, stars: 5 },
+  { rows: 13, cols: 13, stars: 5 },
+];
+
+export type MazePhase = 'idle' | 'playing' | 'levelComplete' | 'gameComplete';
+
+interface MazeState {
+  phase: MazePhase;
+  level: number;
+  grid: Wall[][];
+  rows: number;
+  cols: number;
+  playerPos: [number, number];
+  exitPos: [number, number];
+  stars: Array<[number, number]>;
+  collected: boolean[];
+  starsCollectedThisLevel: number;
+  totalStarsCollected: number;
+}
+
+interface MazeActions {
+  startGame: () => void;
+  move: (dir: 'N' | 'E' | 'S' | 'W') => void;
+  nextLevel: () => void;
+  reset: () => void;
+}
+
+function buildLevel(levelIdx: number): Partial<MazeState> {
+  const cfg = LEVELS[levelIdx]!;
+  const grid = generateMaze(cfg.rows, cfg.cols);
+  const stars = placeStars(cfg.rows, cfg.cols, cfg.stars);
+  return {
+    grid,
+    rows: cfg.rows,
+    cols: cfg.cols,
+    playerPos: [0, 0],
+    exitPos: [cfg.rows - 1, cfg.cols - 1],
+    stars,
+    collected: Array(stars.length).fill(false),
+    starsCollectedThisLevel: 0,
+  };
+}
+
+export const useMazeStore = create<MazeState & MazeActions>((set, get) => ({
+  phase: 'idle',
+  level: 0,
+  grid: [],
+  rows: 5,
+  cols: 5,
+  playerPos: [0, 0],
+  exitPos: [4, 4],
+  stars: [],
+  collected: [],
+  starsCollectedThisLevel: 0,
+  totalStarsCollected: 0,
+
+  startGame: () => {
+    set({ phase: 'playing', level: 0, totalStarsCollected: 0, ...buildLevel(0) });
+  },
+
+  move: (dir) => {
+    const { phase, grid, rows, cols, playerPos, exitPos, stars, collected } = get();
+    if (phase !== 'playing') return;
+
+    const [pr, pc] = playerPos;
+    const cell = grid[pr]?.[pc];
+    if (!cell) return;
+    if (cell[dir]) return; // wall blocks
+
+    const deltas: Record<'N'|'E'|'S'|'W', [number, number]> = {
+      N: [-1, 0], E: [0, 1], S: [1, 0], W: [0, -1],
+    };
+    const [dr, dc] = deltas[dir];
+    const nr = pr + dr, nc = pc + dc;
+    if (nr < 0 || nr >= rows || nc < 0 || nc >= cols) return;
+
+    const newPos: [number, number] = [nr, nc];
+
+    // Check star collection
+    const newCollected = [...collected];
+    let newStarsThisLevel = get().starsCollectedThisLevel;
+    let newTotalStars = get().totalStarsCollected;
+    stars.forEach(([sr, sc], i) => {
+      if (!newCollected[i] && sr === nr && sc === nc) {
+        newCollected[i] = true;
+        newStarsThisLevel++;
+        newTotalStars++;
+      }
+    });
+
+    // Check exit
+    const atExit = nr === exitPos[0] && nc === exitPos[1];
+    const { level } = get();
+    const isLastLevel = level >= LEVELS.length - 1;
+
+    set({
+      playerPos: newPos,
+      collected: newCollected,
+      starsCollectedThisLevel: newStarsThisLevel,
+      totalStarsCollected: newTotalStars,
+      phase: atExit ? (isLastLevel ? 'gameComplete' : 'levelComplete') : 'playing',
+    });
+  },
+
+  nextLevel: () => {
+    const { level } = get();
+    const next = level + 1;
+    if (next >= LEVELS.length) {
+      set({ phase: 'gameComplete' });
+    } else {
+      set({ phase: 'playing', level: next, ...buildLevel(next) });
+    }
+  },
+
+  reset: () => {
+    set({ phase: 'idle', level: 0, totalStarsCollected: 0 });
+  },
+}));

--- a/gamesformykids/app/games/maze/useMazeGame.ts
+++ b/gamesformykids/app/games/maze/useMazeGame.ts
@@ -1,0 +1,30 @@
+'use client';
+import { useEffect } from 'react';
+import { useMazeStore } from './mazeStore';
+
+export function useMazeGame() {
+  const phase = useMazeStore(s => s.phase);
+  const level = useMazeStore(s => s.level);
+  const starsCollectedThisLevel = useMazeStore(s => s.starsCollectedThisLevel);
+  const totalStarsCollected = useMazeStore(s => s.totalStarsCollected);
+  const startGame = useMazeStore(s => s.startGame);
+  const move = useMazeStore(s => s.move);
+  const nextLevel = useMazeStore(s => s.nextLevel);
+  const reset = useMazeStore(s => s.reset);
+
+  useEffect(() => {
+    if (phase !== 'playing') return;
+    function handleKey(e: KeyboardEvent) {
+      switch (e.key) {
+        case 'ArrowUp':    e.preventDefault(); move('N'); break;
+        case 'ArrowDown':  e.preventDefault(); move('S'); break;
+        case 'ArrowLeft':  e.preventDefault(); move('W'); break;
+        case 'ArrowRight': e.preventDefault(); move('E'); break;
+      }
+    }
+    window.addEventListener('keydown', handleKey);
+    return () => window.removeEventListener('keydown', handleKey);
+  }, [phase, move]);
+
+  return { phase, level, starsCollectedThisLevel, totalStarsCollected, startGame, nextLevel, reset };
+}

--- a/gamesformykids/lib/constants/gameCategories.ts
+++ b/gamesformykids/lib/constants/gameCategories.ts
@@ -122,7 +122,7 @@ export const GAME_CATEGORIES: Record<string, GameCategory> = {
       "flappy-bird","snake","dino-runner","catch-fruit","space-defender",
       "whack-a-mole","brick-breaker","balloon-pop","pong","meteor-dodge",
       "frogger","stack","color-tap","jumper","simon",
-      "reflex","taki","checkers","chess","shesh-besh",
+      "reflex","taki","checkers","chess","shesh-besh","maze",
     ],
   },
   educational: {

--- a/gamesformykids/lib/registry/registryData/batch4.ts
+++ b/gamesformykids/lib/registry/registryData/batch4.ts
@@ -350,6 +350,17 @@ export const gamesRegistryBatch4: GameRegistration[] = [
     order: 153,
   },
   {
+    id: "maze",
+    title: "מבוך",
+    description: "נווט דרך המבוך, אסוף כוכבים והגע לדלת — 5 רמות מאתגרות!",
+    icon: Gamepad2,
+    emoji: "🧩",
+    color: "bg-indigo-600 hover:bg-indigo-700",
+    href: "/games/maze",
+    available: true,
+    order: 155,
+  },
+  {
     id: "life-cycles",
     title: "מחזור חיים",
     description: "סדר את שלבי מחזור החיים — פרפר, צפרדע ועוד!",
@@ -358,6 +369,6 @@ export const gamesRegistryBatch4: GameRegistration[] = [
     color: "bg-green-500 hover:bg-green-600",
     href: "/games/life-cycles",
     available: true,
-    order: 154,
+    order: 156,
   },
 ];

--- a/gamesformykids/lib/types/core/base.ts
+++ b/gamesformykids/lib/types/core/base.ts
@@ -169,6 +169,7 @@ export type GameType =
   | 'spatial-concepts' | 'number-words'
   | 'visual-opposites' | 'english-cards'
   // Arcade & action games
+  | 'maze'
   | 'true-false' | 'flappy-bird' | 'snake' | 'pong' | 'frogger'
   | 'dino-runner' | 'brick-breaker' | 'balloon-pop' | 'catch-fruit'
   | 'whack-a-mole' | 'meteor-dodge' | 'space-defender' | 'reflex'


### PR DESCRIPTION
## Summary

Implements a canvas-based maze game (Style D) using the recursive backtracker algorithm. Players navigate through 5 progressively larger mazes, collecting stars and reaching the exit door.

## Changes

- `app/games/maze/lib/mazeGenerator.ts` — recursive-backtracker maze generator + random star placement
- `app/games/maze/mazeStore.ts` — Zustand store (phases: idle/playing/levelComplete/gameComplete, movement with wall collision, star collection)
- `app/games/maze/useMazeGame.ts` — keyboard listener hook (ArrowKeys → N/S/E/W)
- `app/games/maze/components/MazeCanvas.tsx` — canvas renderer via `useCanvasLoop` with DPR scaling (snake pattern)
- `app/games/maze/MazeClient.tsx` — entry component with D-pad for mobile, phase-based UI (idle/playing/levelComplete/gameComplete)
- `CustomGameRenderer.tsx` — registered `maze` with `ssr: false`
- `gamePageConstants.ts` — added to both `SUPPORTED_GAMES` and `CUSTOM_GAME_TYPES`
- `lib/types/core/base.ts` — added `'maze'` to GameType union
- `lib/registry/registryData/batch4.ts` — registry entry (order 155, arcade)
- `lib/constants/gameCategories.ts` — added to `arcade.gameIds`

## Levels

| Level | Grid | Stars |
|-------|------|-------|
| 1 | 5×5 | 3 |
| 2 | 7×7 | 3 |
| 3 | 9×9 | 4 |
| 4 | 11×11 | 5 |
| 5 | 13×13 | 5 |

## Testing

- [x] `npx tsc --noEmit` passes (0 errors)
- [ ] Manually verified at `http://localhost:3000/games/maze`
- [ ] Appears in arcade category on home page

Closes #952

🤖 Generated with [Claude Code](https://claude.com/claude-code)