### PR TITLE
feat(tech): keyboard 1/2/3/4 + arrow navigation for quiz and card games

### DIFF
--- a/gamesformykids/components/game/quiz/QuizAnswerGrid.tsx
+++ b/gamesformykids/components/game/quiz/QuizAnswerGrid.tsx
@@ -4,6 +4,7 @@ import { type ReactNode } from 'react';
 import { useQuizGameStore } from '@/lib/stores/quizGameStore';
 import { QUIZ_THEMES, type QuizTheme } from './quizTheme';
 import { answerButtonClass } from '@/lib/quiz/answerButtonClass';
+import { useKeyboardAnswerSelect } from '@/hooks/shared/useKeyboardAnswerSelect';
 
 interface Props {
   choices: string[];
@@ -24,27 +25,53 @@ export function QuizAnswerGrid({
 }: Props) {
   const selected = useQuizGameStore(s => s.selected);
   const t = QUIZ_THEMES[theme];
+  const enabled = selected === null;
+
+  const { focusedIdx } = useKeyboardAnswerSelect(
+    choices.length,
+    (idx) => onSelect(choices[idx]!),
+    enabled,
+  );
+
   const gridClass = cols === 1
     ? 'grid grid-cols-1 gap-3 mb-4'
     : 'grid grid-cols-2 gap-3 mb-4';
 
   return (
-    <div className={gridClass}>
-      {choices.map((choice) => (
-        <button
-          key={choice}
-          onClick={() => onSelect(choice)}
-          disabled={selected !== null}
-          className={`p-4 rounded-2xl border-2 font-bold text-base transition-colors text-center ${answerButtonClass(
-            choice === correctValue,
-            choice === selected,
-            selected !== null,
-            `${t.answerIdle} cursor-pointer`,
-          )}`}
-        >
-          {renderChoice ? renderChoice(choice) : choice}
-        </button>
-      ))}
+    <div>
+      <div className={gridClass}>
+        {choices.map((choice, idx) => (
+          <button
+            key={choice}
+            onClick={() => onSelect(choice)}
+            disabled={!enabled}
+            className={`p-4 rounded-2xl border-2 font-bold text-base transition-colors text-center ${answerButtonClass(
+              choice === correctValue,
+              choice === selected,
+              !enabled,
+              `${t.answerIdle} cursor-pointer`,
+            )} ${enabled && idx === focusedIdx ? 'ring-4 ring-offset-2 ring-blue-400' : ''}`}
+          >
+            {renderChoice ? renderChoice(choice) : choice}
+          </button>
+        ))}
+      </div>
+
+      {/* Keyboard hints — desktop only */}
+      <div className="hidden md:flex justify-center gap-3 mt-1 mb-3" aria-hidden>
+        {choices.map((_, idx) => (
+          <span
+            key={idx}
+            className={`text-xs font-mono px-2 py-0.5 rounded border transition-colors ${
+              enabled && idx === focusedIdx
+                ? 'border-blue-400 text-blue-600 bg-blue-50'
+                : 'border-gray-300 text-gray-400 bg-gray-50'
+            }`}
+          >
+            [{idx + 1}]
+          </span>
+        ))}
+      </div>
     </div>
   );
 }

--- a/gamesformykids/components/shared/GameMainContent.tsx
+++ b/gamesformykids/components/shared/GameMainContent.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useUniversalGame } from '@/hooks/shared/game-state/useUniversalGame';
+import { useKeyboardAnswerSelect } from '@/hooks/shared/useKeyboardAnswerSelect';
 import { BaseGameItem } from "@/lib/types/core/base";
 import { GameCardGrid } from "./cards/GameCardGrid";
 import GameHints from "./feedback/GameHints";
@@ -8,6 +9,16 @@ import TipsBox from "./feedback/TipsBox";
 
 export default function GameMainContent() {
   const game = useUniversalGame();
+  const keyboardEnabled = game.isPlaying && !game.showCelebration;
+
+  const { focusedIdx } = useKeyboardAnswerSelect(
+    game.options.length,
+    (idx) => {
+      const item = game.options[idx] as BaseGameItem | undefined;
+      if (item) game.handleItemClick(item);
+    },
+    keyboardEnabled,
+  );
 
   return (
     <div className="space-y-8">
@@ -19,16 +30,35 @@ export default function GameMainContent() {
           currentChallenge={game.currentChallenge}
           gridCols="grid-cols-2 md:grid-cols-4"
           maxWidth="max-w-4xl"
+          {...(keyboardEnabled ? { focusedIdx } : {})}
           renderCustomCard={(item: BaseGameItem) => (
             <game.CardComponent item={item} onClick={game.handleItemClick} />
           )}
         />
+
+        {/* Keyboard hints — desktop only */}
+        {keyboardEnabled && (
+          <div className="hidden md:flex justify-center gap-3 mt-4" aria-hidden>
+            {game.options.slice(0, 4).map((_, idx) => (
+              <span
+                key={idx}
+                className={`text-xs font-mono px-2 py-0.5 rounded border transition-colors ${
+                  idx === focusedIdx
+                    ? 'border-blue-400 text-blue-600 bg-blue-50'
+                    : 'border-gray-300 text-gray-400 bg-gray-50'
+                }`}
+              >
+                [{idx + 1}]
+              </span>
+            ))}
+          </div>
+        )}
       </div>
 
       {/* 💡 Hints */}
       {game.hints.length > 0 && (
         <div className="bg-yellow-50/80 backdrop-blur-sm rounded-2xl p-6 shadow-lg">
-          <GameHints 
+          <GameHints
             hints={[]}
             showHints={false}
           />
@@ -40,8 +70,8 @@ export default function GameMainContent() {
         <button
           onClick={() => game.setShowProgressModal(true)}
           className="
-            px-6 py-3 bg-gradient-to-r from-purple-500 to-pink-500 text-white rounded-xl shadow-lg
-            hover:from-purple-600 hover:to-pink-600 transform hover:scale-105 
+            px-6 py-3 bg-linear-to-r from-purple-500 to-pink-500 text-white rounded-xl shadow-lg
+            hover:from-purple-600 hover:to-pink-600 transform hover:scale-105
             transition-all duration-200 font-bold
           "
         >

--- a/gamesformykids/components/shared/cards/GameCardGrid.tsx
+++ b/gamesformykids/components/shared/cards/GameCardGrid.tsx
@@ -1,7 +1,8 @@
+'use client';
+
 import { ComponentTypes } from "@/lib/types";
 import { useGridFillers } from "@/hooks";
 
-// Use the new organized type from ComponentTypes
 type GameItemType = ComponentTypes.GameItemType;
 type GameCardGridProps<T extends GameItemType> = ComponentTypes.GameCardGridProps<T>;
 
@@ -16,87 +17,72 @@ export function GameCardGrid<T extends GameItemType>({
   compareKey = 'name' as keyof T,
   renderCustomCard,
   cardClassName = "",
+  focusedIdx,
 }: GameCardGridProps<T>) {
-  // 🔢 fillers להשלמת שורה אחרונה
   const fillerCount = useGridFillers(
     items.length,
     typeof gridCols === 'string' ? gridCols : { mobile: gridCols, tablet: gridCols, desktop: gridCols }
   );
 
   const handleItemClick = propOnItemClick ?? (() => {});
-  // Helper function to determine if an item is the current challenge
+
   const isCurrentItem = (item: T, challenge?: T | null): boolean => {
     if (!challenge) return false;
-    
-    // Safe comparison for objects
     if (typeof item === 'object' && item !== null && typeof challenge === 'object' && challenge !== null) {
       if (compareKey in item && compareKey in challenge) {
         return item[compareKey] === challenge[compareKey];
       }
     }
-    
-    // Direct comparison for primitives
     return item === challenge;
   };
 
-  // Helper function to get a unique key for each item
   const getItemKey = (item: T): string => {
-    // Check if item is an object and has a name property
-    if (typeof item === 'object' && item !== null && 'name' in item) {
-      return String(item.name);
-    }
-    // Fallback to compareKey or item itself as string
-    if (typeof item === 'object' && item !== null && compareKey in item) {
-      return String(item[compareKey]);
-    }
-    // If item is a primitive (number, string), use it directly
+    if (typeof item === 'object' && item !== null && 'name' in item) return String(item.name);
+    if (typeof item === 'object' && item !== null && compareKey in item) return String(item[compareKey]);
     return String(item);
   };
 
   return (
     <div className={`grid ${gridCols} ${gap} ${maxWidth} mx-auto`}>
-      {items.map((item) => {
+      {items.map((item, idx) => {
         const isCorrect = isCurrentItem(item, currentChallenge);
-        
+        const isFocused = typeof focusedIdx === 'number' && focusedIdx === idx;
+
         return (
-          <div key={getItemKey(item)}>
+          <div
+            key={getItemKey(item)}
+            className={isFocused ? 'ring-4 ring-blue-400 ring-offset-2 rounded-3xl' : ''}
+          >
             {renderCustomCard ? (
               renderCustomCard(item, isCorrect)
             ) : (
-              // Default card rendering
               <div
                 onClick={() => handleItemClick(item)}
                 className={`
                   aspect-square rounded-3xl cursor-pointer transition-[transform,box-shadow]
                   duration-300 hover:scale-110 shadow-xl hover:shadow-2xl
-                  bg-gradient-to-br from-gray-400 to-gray-600 
+                  bg-linear-to-br from-gray-400 to-gray-600
                   border-8 border-white
                   ${isCorrect ? "ring-4 ring-green-400 ring-offset-4" : ""}
                   ${cardClassName}
                 `}
               >
                 <div className="w-full h-full flex flex-col items-center justify-center text-white">
-                  {/* Display the hebrew property if it exists */}
                   {'hebrew' in item && (
                     <div className="text-4xl md:text-6xl font-bold mb-2">
                       {String(item.hebrew)}
                     </div>
                   )}
-                  
-                  {/* Display the english property if it exists */}
                   {'english' in item && (
                     <div className="text-lg md:text-xl font-semibold">
                       {String(item.english)}
                     </div>
                   )}
-                  
-                  {/* Display the digit property if it exists */}
                   {'digit' in item && (
                     <div className="text-6xl md:text-8xl font-bold mb-2">
                       {String(item.digit)}
                     </div>
                   )}
-                  
                   {showSoundIcon && (
                     <div className="mt-2 opacity-70">
                       <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="w-6 h-6 mx-auto">

--- a/gamesformykids/hooks/shared/useKeyboardAnswerSelect.ts
+++ b/gamesformykids/hooks/shared/useKeyboardAnswerSelect.ts
@@ -1,0 +1,79 @@
+'use client';
+import { useState, useEffect, useRef } from 'react';
+
+/**
+ * Enables keyboard navigation for answer grids:
+ * - 1/2/3/4 → immediately select that answer
+ * - ArrowRight/Down → move focus right/down
+ * - ArrowLeft/Up   → move focus left/up
+ * - Enter/Space    → confirm focused answer
+ *
+ * Only active when `enabled` is true (e.g. question phase, not result/menu).
+ */
+export function useKeyboardAnswerSelect(
+  count: number,
+  onSelect: (idx: number) => void,
+  enabled: boolean,
+) {
+  const [focusedIdx, setFocusedIdx] = useState(0);
+  const focusedRef = useRef(0);
+  const onSelectRef = useRef(onSelect);
+  onSelectRef.current = onSelect;
+
+  // Reset focus when a new set of choices arrives
+  useEffect(() => {
+    setFocusedIdx(0);
+    focusedRef.current = 0;
+  }, [count]);
+
+  useEffect(() => {
+    if (!enabled || count === 0) return;
+
+    const handleKey = (e: KeyboardEvent) => {
+      // Ignore when typing in an input / textarea
+      const tag = (e.target as HTMLElement).tagName;
+      if (tag === 'INPUT' || tag === 'TEXTAREA') return;
+
+      const { key } = e;
+
+      if (key >= '1' && key <= '4') {
+        const idx = parseInt(key, 10) - 1;
+        if (idx < count) {
+          e.preventDefault();
+          onSelectRef.current(idx);
+        }
+        return;
+      }
+
+      if (key === 'ArrowRight' || key === 'ArrowDown') {
+        e.preventDefault();
+        setFocusedIdx(prev => {
+          const next = (prev + 1) % count;
+          focusedRef.current = next;
+          return next;
+        });
+        return;
+      }
+
+      if (key === 'ArrowLeft' || key === 'ArrowUp') {
+        e.preventDefault();
+        setFocusedIdx(prev => {
+          const next = (prev - 1 + count) % count;
+          focusedRef.current = next;
+          return next;
+        });
+        return;
+      }
+
+      if (key === 'Enter' || key === ' ') {
+        e.preventDefault();
+        onSelectRef.current(focusedRef.current);
+      }
+    };
+
+    window.addEventListener('keydown', handleKey);
+    return () => window.removeEventListener('keydown', handleKey);
+  }, [count, enabled]);
+
+  return { focusedIdx };
+}

--- a/gamesformykids/lib/types/components/cards.ts
+++ b/gamesformykids/lib/types/components/cards.ts
@@ -176,6 +176,7 @@ export interface GameCardGridProps<T extends GameItemType> {
   compareKey?: keyof T;
   renderCustomCard?: (item: T, isCorrect: boolean) => React.ReactNode;
   cardClassName?: string;
+  focusedIdx?: number;
   
   // Context usage
   useContext?: boolean;


### PR DESCRIPTION
## Summary

Adds full keyboard navigation to both quiz answer grids and card game answer grids, enabling desktop/accessibility users to select answers without a mouse or touch.

## Changes

- **`hooks/shared/useKeyboardAnswerSelect.ts`** — new hook: `1`/`2`/`3`/`4` immediately select answer at that index; `ArrowRight`/`ArrowDown` and `ArrowLeft`/`ArrowUp` move keyboard focus; `Enter`/`Space` confirm the focused answer. Hook is only active when `enabled` is true and cleans up event listeners on unmount.
- **`components/game/quiz/QuizAnswerGrid.tsx`** — wires up the hook (enabled when `selected === null`), highlights the focused answer with a blue ring, and shows `[1][2][3][4]` hints row below the grid (desktop only via `hidden md:flex`).
- **`components/shared/GameMainContent.tsx`** — wires up the hook (enabled when `isPlaying && !showCelebration`), passes `focusedIdx` to `GameCardGrid`, shows keyboard hints row on desktop.
- **`components/shared/cards/GameCardGrid.tsx`** — added optional `focusedIdx` prop; the card at that index gets a `ring-4 ring-blue-400` focus indicator.
- **`lib/types/components/cards.ts`** — added `focusedIdx?: number` to `GameCardGridProps`.

## Testing

- [ ] `npx tsc --noEmit` passes ✅
- [ ] Pressing `1`/`2`/`3`/`4` selects corresponding answer in quiz games
- [ ] Pressing `1`/`2`/`3`/`4` selects corresponding answer in card games
- [ ] Arrow keys cycle focus between answer buttons
- [ ] `Enter`/`Space` confirms the focused answer
- [ ] Keyboard hints `[1][2][3][4]` visible on desktop, hidden on mobile
- [ ] Event listeners cleaned up on component unmount

Closes #995

🤖 Generated with [Claude Code](https://claude.com/claude-code)