### PR TITLE
feat(ux): wrong-answer shake animation, haptic feedback, and TTS encouragement

### DIFF
--- a/gamesformykids/components/game/quiz/QuizAnswerGrid.tsx
+++ b/gamesformykids/components/game/quiz/QuizAnswerGrid.tsx
@@ -1,10 +1,14 @@
 'use client';
 
-import { type ReactNode } from 'react';
+import { useState, useEffect, type ReactNode } from 'react';
 import { useQuizGameStore } from '@/lib/stores/quizGameStore';
 import { QUIZ_THEMES, type QuizTheme } from './quizTheme';
 import { answerButtonClass } from '@/lib/quiz/answerButtonClass';
 import { useKeyboardAnswerSelect } from '@/hooks/shared/useKeyboardAnswerSelect';
+import { useHaptic } from '@/hooks/shared/haptic/useHaptic';
+import { speakHebrew } from '@/lib/utils/speech/speaker';
+
+const WRONG_PHRASES = ['כמעט!', 'נסה שוב!', 'לא נורא, תנסה שוב!'] as const;
 
 interface Props {
   choices: string[];
@@ -26,12 +30,26 @@ export function QuizAnswerGrid({
   const selected = useQuizGameStore(s => s.selected);
   const t = QUIZ_THEMES[theme];
   const enabled = selected === null;
+  const { wrong: hapticWrong } = useHaptic();
+  const [shakingChoice, setShakingChoice] = useState<string | null>(null);
 
   const { focusedIdx } = useKeyboardAnswerSelect(
     choices.length,
     (idx) => onSelect(choices[idx]!),
     enabled,
   );
+
+  useEffect(() => {
+    if (selected !== null && selected !== correctValue) {
+      hapticWrong();
+      const phrase = WRONG_PHRASES[Math.floor(Math.random() * WRONG_PHRASES.length)]!;
+      void speakHebrew(phrase);
+      setShakingChoice(selected);
+      const id = setTimeout(() => setShakingChoice(null), 600);
+      return () => clearTimeout(id);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [selected]);
 
   const gridClass = cols === 1
     ? 'grid grid-cols-1 gap-3 mb-4'
@@ -50,7 +68,7 @@ export function QuizAnswerGrid({
               choice === selected,
               !enabled,
               `${t.answerIdle} cursor-pointer`,
-            )} ${enabled && idx === focusedIdx ? 'ring-4 ring-offset-2 ring-blue-400' : ''} ${!enabled && choice === selected && choice !== correctValue ? 'animate-shake' : ''}`}
+            )} ${enabled && idx === focusedIdx ? 'ring-4 ring-offset-2 ring-blue-400' : ''} ${choice === shakingChoice ? 'animate-shake' : ''}`}
           >
             {renderChoice ? renderChoice(choice) : choice}
           </button>

--- a/gamesformykids/hooks/shared/haptic/useHaptic.ts
+++ b/gamesformykids/hooks/shared/haptic/useHaptic.ts
@@ -1,0 +1,12 @@
+'use client';
+
+/**
+ * Haptic feedback via navigator.vibrate() — no-op where unsupported.
+ * correct: 50ms pulse
+ * wrong: double pulse (50–50–50ms)
+ */
+export function useHaptic() {
+  const correct = () => navigator.vibrate?.(50);
+  const wrong   = () => navigator.vibrate?.([50, 50, 50]);
+  return { correct, wrong };
+}


### PR DESCRIPTION
## Summary

When a player selects a wrong answer in any quiz game, three simultaneous feedback signals fire:
1. The wrong button shakes (CSS `animate-shake` already defined in globals.css)
2. Mobile device vibrates (double pulse via `navigator.vibrate`)
3. A random encouraging phrase is spoken via TTS ("כמעט!", "נסה שוב!", etc.)

## Changes

- **`hooks/shared/haptic/useHaptic.ts`** — new `useHaptic()` hook exposing `correct()` (50ms vibration) and `wrong()` (triple pulse) via `navigator.vibrate?.()`; no-op on desktop where vibration is unsupported.
- **`components/game/quiz/QuizAnswerGrid.tsx`** — on wrong answer detected (via `useEffect` watching `selected` from `useQuizGameStore`): calls `hapticWrong()`, speaks a random Hebrew encouragement phrase, and applies `animate-shake` CSS class to the wrong button for 600ms.

## Testing

- [ ] `npx tsc --noEmit` passes ✅
- [ ] Wrong answer button shakes visually
- [ ] TTS speaks an encouraging phrase on wrong answer
- [ ] Correct answer button does NOT shake
- [ ] Mobile device vibrates on wrong answer

Closes #990
Closes #1023
Closes #1035

🤖 Generated with [Claude Code](https://claude.com/claude-code)