### PR TITLE
feat(gamification): show "שיא חדש!" banner when score beats personal best (#1020)

### DIFF
--- a/gamesformykids/app/games/math-race/components/MathRaceResultScreen.tsx
+++ b/gamesformykids/app/games/math-race/components/MathRaceResultScreen.tsx
@@ -16,6 +16,8 @@ export default function MathRaceResultScreen() {
       onRestart={startGame}
       restartLabel="🔄 שוב!"
       shareText={`🏁 קיבלתי ${score} נקודות במרוץ מתמטיקה!`}
+      score={score}
+      best={best}
     >
       <StatGrid>
         <StatCell label="ניקוד" value={score} bgClass="bg-blue-50" textClass="text-blue-600" labelClass="text-blue-400" />

--- a/gamesformykids/components/game/shared/CanvasGameOverOverlay.tsx
+++ b/gamesformykids/components/game/shared/CanvasGameOverOverlay.tsx
@@ -39,11 +39,19 @@ export default function CanvasGameOverOverlay({
   gridMb = 'mb-5',
   buttonSizeClass = 'py-4 text-xl',
 }: Props) {
+  const isNewRecord =
+    typeof score === 'number' && typeof best === 'number' && score > 0 && score === best;
+
   return (
     <div className={`absolute inset-0 flex items-center justify-center rounded-3xl ${backdropClass}`}>
       <div className={`bg-white rounded-3xl text-center shadow-2xl ${cardClass}`}>
         <div className="text-5xl mb-2">{emoji}</div>
         <h2 className="text-2xl font-black text-gray-800 mb-3">{title}</h2>
+        {isNewRecord && (
+          <div className="mb-3 px-3 py-1.5 rounded-2xl bg-linear-to-l from-yellow-400 to-amber-500 text-white font-black text-base animate-bounce shadow-md">
+            🏆 שיא חדש!
+          </div>
+        )}
         <div className={`grid grid-cols-2 gap-3 ${gridMb}`}>
           <div className={`${scoreBgClass} rounded-2xl p-3`}>
             <p className={`${scoreSize} font-black ${scoreTextClass}`}>{score}{scoreSuffix}</p>

--- a/gamesformykids/components/game/shared/GameResultCard.tsx
+++ b/gamesformykids/components/game/shared/GameResultCard.tsx
@@ -21,6 +21,9 @@ interface Props {
   animateEmoji?: boolean;
   /** Share text passed to Web Share API / clipboard. Omit to hide share button. */
   shareText?: string;
+  /** Pass score + best to surface a "🏆 שיא חדש!" banner when score equals best. */
+  score?: number;
+  best?: number;
   children: ReactNode;
 }
 
@@ -28,6 +31,7 @@ interface Props {
  * Shared shell for game result screens.
  * Provides the outer gradient background, white card, emoji, title, and restart button.
  * Pass game-specific metrics as `children`.
+ * When both `score` and `best` are provided, shows a "🏆 שיא חדש!" banner on new records.
  */
 export default function GameResultCard({
   emoji,
@@ -39,23 +43,32 @@ export default function GameResultCard({
   secondaryAction,
   animateEmoji = false,
   shareText,
+  score,
+  best,
   children,
 }: Props) {
   const { share, copied } = useShareScore();
+  const isNewRecord = score !== undefined && best !== undefined && score > 0 && score === best;
+
   return (
     <div
-      className={`min-h-screen bg-gradient-to-br ${gradientClass} flex items-center justify-center p-4`}
+      className={`min-h-screen bg-linear-to-br ${gradientClass} flex items-center justify-center p-4`}
       dir="rtl"
     >
       <GameCompletionCelebration />
       <div className="bg-white rounded-3xl shadow-2xl p-8 text-center max-w-sm w-full">
         <div className={`text-6xl mb-3 ${animateEmoji ? 'animate-bounce' : ''}`}>{emoji}</div>
         <h2 className="text-2xl font-bold text-gray-800 mb-4">{title}</h2>
+        {isNewRecord && (
+          <div className="mb-4 px-4 py-2 rounded-2xl bg-linear-to-l from-yellow-400 to-amber-500 text-white font-black text-lg animate-bounce shadow-md">
+            🏆 שיא חדש!
+          </div>
+        )}
         <div className="mb-6">{children}</div>
         <div className="flex gap-3">
           <button
             onClick={onRestart}
-            className={`flex-1 py-4 rounded-2xl bg-gradient-to-l ${buttonClass} text-white font-bold hover:opacity-90 active:scale-95 transition-[transform,opacity]`}
+            className={`flex-1 py-4 rounded-2xl bg-linear-to-l ${buttonClass} text-white font-bold hover:opacity-90 active:scale-95 transition-[transform,opacity]`}
           >
             {restartLabel}
           </button>

--- a/gamesformykids/components/game/shared/ScoreBestResultCard.tsx
+++ b/gamesformykids/components/game/shared/ScoreBestResultCard.tsx
@@ -25,6 +25,7 @@ interface Props {
 /**
  * Shared result screen for games that display only score + best.
  * Renders the standard 2-column grid inside GameResultCard.
+ * Shows a "🏆 שיא חדש!" banner when score equals best (new or tied record).
  * Use GameResultCard directly when you need a custom children layout.
  */
 export default function ScoreBestResultCard({
@@ -37,6 +38,9 @@ export default function ScoreBestResultCard({
   ...cardProps
 }: Props) {
   const [displayed, setDisplayed] = useState(0);
+  const [showBanner, setShowBanner] = useState(false);
+
+  const isNewRecord = score > 0 && score === best;
 
   useEffect(() => {
     if (score === 0) return;
@@ -48,15 +52,21 @@ export default function ScoreBestResultCard({
       if (current >= score) {
         setDisplayed(score);
         clearInterval(id);
+        if (isNewRecord) setShowBanner(true);
       } else {
         setDisplayed(Math.round(current));
       }
     }, 600 / steps);
     return () => clearInterval(id);
-  }, [score]);
+  }, [score, isNewRecord]);
 
   return (
     <GameResultCard {...cardProps}>
+      {showBanner && (
+        <div className="mb-4 px-4 py-2 rounded-2xl bg-linear-to-l from-yellow-400 to-amber-500 text-white font-black text-lg animate-bounce shadow-md">
+          🏆 שיא חדש!
+        </div>
+      )}
       <div className="grid grid-cols-2 gap-4">
         <div className={`${scoreBgClass} rounded-2xl p-3`}>
           <p className={`text-3xl font-black ${scoreTextClass} tabular-nums`}>{displayed}</p>


### PR DESCRIPTION
## What
Shows a 🏆 **שיא חדש!** animated banner on the result screen whenever the player's current score matches their all-time best (i.e., a new or tied record).

## Where it appears
- **`ScoreBestResultCard`** — banner fades in after the score-count animation finishes (Simon, canvas games, any game using `createScoreBestResultScreen`)
- **`GameResultCard`** — new optional `score` / `best` props; banner renders inline when both are provided (wired in `MathRaceResultScreen`)
- **`CanvasGameOverOverlay`** — same detection for arcade/canvas games rendered as in-game overlays

## Why
Competing against your own past self is highly motivating for kids. Showing a clear "new record!" signal on every improvement transforms replay into a personal challenge.

## Implementation notes
- Detection: `score > 0 && score === best` — works because stores update `best = max(prev, score)` before showing the result; so when score beats the old best, `best === score` at render time
- No store changes needed — the existing `best` value (localStorage/Supabase, already persisted by each game's store) is sufficient
- All new props are optional — zero breaking changes to existing callers

## Test plan
- [ ] Play Simon and beat your best — "🏆 שיא חדש!" banner appears after score count-up
- [ ] Play MathRace and beat your best — banner shows above the stats grid
- [ ] Play below your best — no banner shown
- [ ] First play ever (best = 0 → new score) — banner correctly appears

Closes #1020

🤖 Generated with [Claude Code](https://claude.com/claude-code)