### PR TITLE
fix(profile): score saves silently fail after first play + profile UX overhaul

### DIFF
--- a/gamesformykids/app/games/memory/useMemoryGameContent.ts
+++ b/gamesformykids/app/games/memory/useMemoryGameContent.ts
@@ -4,7 +4,7 @@ import { useEffect, useRef } from "react";
 import { useMemoryStore } from "./stores/useMemoryStore";
 import { MEMORY_GAME_CONSTANTS } from "@/lib/constants";
 import { playMemorySuccessSound } from "@/lib/utils/game/gameUtils";
-import { useGameProgress, useAchievements } from "@/hooks";
+import { useGameCompletion } from "@/hooks/shared/progress/useGameCompletion";
 import { useAuth } from "@/hooks/shared/auth/useAuth";
 
 export interface UseMemoryGameContentReturn {
@@ -90,35 +90,26 @@ export function useMemoryGameContent(): UseMemoryGameContentReturn {
   }, [timeLeft, phase, setPhase]);
 
   const { user } = useAuth();
-  const { updateScore, updateLevel, addPlayTime } = useGameProgress("memory");
-  const { checkScoreAchievements, checkLevelAchievements } = useAchievements("memory");
+  const { saveGameResultRef } = useGameCompletion("memory");
 
   useEffect(() => {
     if (phase !== 'won' || !user || gameStats.score <= 0) return;
 
-    updateScore("memory", gameStats.score);
-
     const levelMap: Record<string, number> = { EASY: 1, MEDIUM: 2, HARD: 3 };
     const currentLevel = levelMap[difficulty] ?? 1;
-    updateLevel("memory", currentLevel);
 
-    if (timer > 0) {
-      addPlayTime("memory", timer);
-    }
-
-    checkScoreAchievements("memory", gameStats.score);
-    checkLevelAchievements("memory", currentLevel);
+    saveGameResultRef.current({
+      score: gameStats.score,
+      level: currentLevel,
+      durationSeconds: timer,
+    });
   }, [
     phase,
     user,
     gameStats.score,
     timer,
     difficulty,
-    updateScore,
-    updateLevel,
-    addPlayTime,
-    checkScoreAchievements,
-    checkLevelAchievements,
+    saveGameResultRef,
   ]);
 
   return { phase };

--- a/gamesformykids/app/profile/components/AchievementsList.tsx
+++ b/gamesformykids/app/profile/components/AchievementsList.tsx
@@ -1,27 +1,41 @@
 import { useAchievements } from '@/hooks';
 
+function formatEarnedAt(iso: string): string {
+  return new Date(iso).toLocaleDateString('he-IL', {
+    day: 'numeric',
+    month: 'short',
+    year: 'numeric',
+  });
+}
+
 export function AchievementsList() {
   const { achievements } = useAchievements();
   return (
     <div className="bg-white rounded-2xl shadow-lg p-6">
-      <h3 className="text-xl font-bold text-gray-800 mb-4">הישגים אחרונים</h3>
+      <h3 className="text-xl font-bold text-gray-800 mb-4">הישגים</h3>
       {achievements.length > 0 ? (
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
           {achievements.slice(0, 6).map((achievement) => (
             <div
               key={achievement.id}
-              className="flex items-center space-x-3 space-x-reverse p-3 bg-yellow-50 rounded-lg border border-yellow-200"
+              className="flex items-start gap-3 p-4 bg-linear-to-br from-yellow-50 to-amber-50 rounded-xl border border-amber-200 hover:border-amber-300 transition-colors"
             >
-              <div className="text-2xl">{achievement.icon}</div>
-              <div>
+              <div className="text-3xl shrink-0">{achievement.icon ?? '🏅'}</div>
+              <div className="min-w-0">
                 <h4 className="font-semibold text-gray-800">{achievement.achievement_name}</h4>
-                <p className="text-sm text-gray-600">{achievement.description}</p>
+                {achievement.description && (
+                  <p className="text-sm text-gray-600 mt-0.5">{achievement.description}</p>
+                )}
+                <p className="text-xs text-amber-500 mt-1">{formatEarnedAt(achievement.earned_at)}</p>
               </div>
             </div>
           ))}
         </div>
       ) : (
-        <p className="text-gray-500 text-center py-8">עדיין אין הישגים. שחק כדי לזכות בהישגים!</p>
+        <div className="text-center py-12">
+          <div className="text-5xl mb-3">🏅</div>
+          <p className="text-gray-500">עדיין אין הישגים. שחק כדי לזכות בהישגים!</p>
+        </div>
       )}
     </div>
   );

--- a/gamesformykids/app/profile/components/GameProgressList.tsx
+++ b/gamesformykids/app/profile/components/GameProgressList.tsx
@@ -1,30 +1,93 @@
+import Link from 'next/link';
 import { useGameProgress } from '@/hooks';
+import { GAMES_REGISTRY } from '@/lib/registry/gamesRegistryData';
+
+const GAME_INFO = Object.fromEntries(
+  GAMES_REGISTRY.map((g) => [g.id, { title: g.title, emoji: g.emoji }])
+);
+
+function formatLastPlayed(iso: string): string {
+  const diff = Date.now() - new Date(iso).getTime();
+  const days = Math.floor(diff / 86_400_000);
+  if (days === 0) return 'היום';
+  if (days === 1) return 'אתמול';
+  if (days < 7) return `לפני ${days} ימים`;
+  if (days < 30) return `לפני ${Math.floor(days / 7)} שבועות`;
+  return `לפני ${Math.floor(days / 30)} חודשים`;
+}
 
 export function GameProgressList() {
   const { progress } = useGameProgress();
+
+  const sorted = [...progress].sort(
+    (a, b) => new Date(b.last_played_at).getTime() - new Date(a.last_played_at).getTime()
+  );
+
+  const maxScore = sorted.reduce((m, p) => Math.max(m, p.best_score), 1);
+
   return (
     <div className="bg-white rounded-2xl shadow-lg p-6 mb-6">
       <h3 className="text-xl font-bold text-gray-800 mb-4">התקדמות במשחקים</h3>
-      {progress.length > 0 ? (
-        <div className="space-y-4">
-          {progress.map((gameProgress) => (
-            <div key={gameProgress.id} className="flex justify-between items-center p-4 bg-gray-50 rounded-lg">
-              <div>
-                <h4 className="font-semibold capitalize">{gameProgress.game_type}</h4>
-                <p className="text-sm text-gray-600">רמה {gameProgress.level}</p>
-              </div>
-              <div className="text-left">
-                <p className="font-bold text-purple-600">שיא: {gameProgress.best_score}</p>
-                {gameProgress.last_score > 0 && (
-                  <p className="text-sm text-blue-500">אחרון: {gameProgress.last_score}</p>
-                )}
-                <p className="text-sm text-gray-600">{Math.floor(gameProgress.total_play_time / 60)} דקות</p>
-              </div>
-            </div>
-          ))}
+      {sorted.length > 0 ? (
+        <div className="space-y-3">
+          {sorted.map((gp) => {
+            const info = GAME_INFO[gp.game_type];
+            const title = info?.title ?? gp.game_type;
+            const emoji = info?.emoji ?? '🎮';
+            const pct = Math.round((gp.best_score / maxScore) * 100);
+
+            return (
+              <Link
+                key={gp.id}
+                href={`/games/${gp.game_type}`}
+                className="flex items-center gap-4 p-4 bg-gray-50 rounded-xl hover:bg-purple-50 transition-colors group"
+              >
+                <span className="text-3xl shrink-0">{emoji}</span>
+
+                <div className="flex-1 min-w-0">
+                  <div className="flex items-center justify-between mb-1">
+                    <h4 className="font-semibold text-gray-800 truncate group-hover:text-purple-700">
+                      {title}
+                    </h4>
+                    <span className="text-xs text-gray-400 shrink-0 mr-2">
+                      {formatLastPlayed(gp.last_played_at)}
+                    </span>
+                  </div>
+
+                  {/* progress bar */}
+                  <div className="w-full bg-gray-200 rounded-full h-2 mb-2">
+                    <div
+                      className="bg-linear-to-r from-purple-400 to-purple-600 h-2 rounded-full transition-all"
+                      style={{ width: `${pct}%` }}
+                    />
+                  </div>
+
+                  <div className="flex gap-4 text-sm">
+                    <span className="font-bold text-purple-600">שיא: {gp.best_score}</span>
+                    {gp.last_score > 0 && (
+                      <span className="text-blue-500">אחרון: {gp.last_score}</span>
+                    )}
+                    <span className="text-gray-500">רמה {gp.level}</span>
+                    <span className="text-gray-400">
+                      {Math.floor(gp.total_play_time / 60)} דק׳
+                    </span>
+                  </div>
+                </div>
+              </Link>
+            );
+          })}
         </div>
       ) : (
-        <p className="text-gray-500 text-center py-8">עדיין לא שיחקת במשחקים! בוא נתחיל!</p>
+        <div className="text-center py-12">
+          <div className="text-5xl mb-3">🎮</div>
+          <p className="text-gray-500">עדיין לא שיחקת במשחקים! בוא נתחיל!</p>
+          <Link
+            href="/"
+            className="inline-block mt-4 bg-purple-500 text-white px-6 py-2 rounded-lg hover:bg-purple-600 transition-colors"
+          >
+            לדף המשחקים
+          </Link>
+        </div>
       )}
     </div>
   );

--- a/gamesformykids/app/profile/components/ProfileCard.tsx
+++ b/gamesformykids/app/profile/components/ProfileCard.tsx
@@ -4,6 +4,10 @@ import { useUserProfile } from '@/hooks';
 import { useProfileStore, getDisplayName, getAvatarSrc } from '../stores/useProfileStore';
 import { EditProfileForm } from './EditProfileForm';
 
+function formatMemberSince(iso: string): string {
+  return new Date(iso).toLocaleDateString('he-IL', { year: 'numeric', month: 'long' });
+}
+
 export function ProfileCard() {
   const { user } = useAuth();
   const { profile, uploadAvatar } = useUserProfile();
@@ -13,16 +17,20 @@ export function ProfileCard() {
 
   return (
     <div className="bg-white rounded-2xl shadow-lg p-6 mb-6">
-      <div className="flex items-center space-x-6 space-x-reverse">
-        <div className="relative">
+      <div className="flex items-center gap-6">
+        {/* avatar */}
+        <div className="relative shrink-0">
           <Image
             src={getAvatarSrc(profile, user)}
             alt="תמונת פרופיל"
-            width={100}
-            height={100}
-            className="w-24 h-24 rounded-full border-4 border-purple-300"
+            width={96}
+            height={96}
+            className="w-24 h-24 rounded-full border-4 border-purple-300 object-cover"
           />
-          <label className="absolute bottom-0 right-0 bg-purple-500 text-white p-2 rounded-full cursor-pointer hover:bg-purple-600">
+          <label
+            className="absolute bottom-0 right-0 bg-purple-500 text-white p-1.5 rounded-full cursor-pointer hover:bg-purple-600 transition-colors"
+            title="שנה תמונה"
+          >
             <input
               type="file"
               accept="image/*"
@@ -33,19 +41,30 @@ export function ProfileCard() {
               disabled={uploadingAvatar}
               className="hidden"
             />
-            {uploadingAvatar ? '⏳' : '📷'}
+            <span className="text-sm">{uploadingAvatar ? '⏳' : '📷'}</span>
           </label>
         </div>
 
-        <div className="flex-1">
+        {/* info */}
+        <div className="flex-1 min-w-0">
           {isEditing ? (
             <EditProfileForm />
           ) : (
             <div>
-              <h2 className="text-2xl font-bold text-gray-800">{getDisplayName(profile, user)}</h2>
-              <p className="text-gray-600">{user.email}</p>
-              <button onClick={startEdit} className="mt-2 text-purple-600 hover:text-purple-800">
-                ערוך פרופיל
+              <h2 className="text-2xl font-bold text-gray-800 truncate">
+                {getDisplayName(profile, user)}
+              </h2>
+              <p className="text-gray-500 text-sm truncate">{user.email}</p>
+              {profile?.created_at && (
+                <p className="text-xs text-gray-400 mt-0.5">
+                  חבר מאז {formatMemberSince(profile.created_at)}
+                </p>
+              )}
+              <button
+                onClick={startEdit}
+                className="mt-3 text-sm text-purple-600 hover:text-purple-800 font-medium transition-colors"
+              >
+                ✏️ ערוך פרופיל
               </button>
             </div>
           )}

--- a/gamesformykids/app/profile/components/ProfileLoadingScreen.tsx
+++ b/gamesformykids/app/profile/components/ProfileLoadingScreen.tsx
@@ -1,7 +1,54 @@
+function Skeleton({ className }: { className?: string }) {
+  return <div className={`animate-pulse bg-gray-200 rounded-xl ${className ?? ''}`} />;
+}
+
 export function ProfileLoadingScreen() {
   return (
-    <div className="min-h-screen bg-gradient-to-br from-purple-100 to-blue-100 flex items-center justify-center">
-      <div className="text-xl">טוען...</div>
+    <div className="min-h-screen bg-linear-to-br from-purple-100 to-blue-100 p-4">
+      <div className="max-w-4xl mx-auto">
+        {/* header */}
+        <div className="text-center mb-8 space-y-3">
+          <Skeleton className="h-4 w-36 mx-auto" />
+          <Skeleton className="h-10 w-56 mx-auto" />
+          <Skeleton className="h-4 w-44 mx-auto" />
+        </div>
+
+        {/* profile card */}
+        <div className="bg-white rounded-2xl shadow-lg p-6 mb-6 flex items-center gap-6">
+          <Skeleton className="w-24 h-24 rounded-full shrink-0" />
+          <div className="flex-1 space-y-3">
+            <Skeleton className="h-6 w-40" />
+            <Skeleton className="h-4 w-56" />
+            <Skeleton className="h-4 w-24" />
+          </div>
+        </div>
+
+        {/* stat cards */}
+        <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mb-6">
+          {[...Array(4)].map((_, i) => (
+            <div key={i} className="bg-white rounded-2xl shadow p-5 space-y-2">
+              <Skeleton className="h-8 w-8 mx-auto rounded-full" />
+              <Skeleton className="h-7 w-16 mx-auto" />
+              <Skeleton className="h-4 w-24 mx-auto" />
+            </div>
+          ))}
+        </div>
+
+        {/* progress list */}
+        <div className="bg-white rounded-2xl shadow-lg p-6 mb-6 space-y-4">
+          <Skeleton className="h-6 w-44 mb-2" />
+          {[...Array(3)].map((_, i) => (
+            <div key={i} className="flex items-center gap-4 p-4 bg-gray-50 rounded-xl">
+              <Skeleton className="w-10 h-10 rounded-full shrink-0" />
+              <div className="flex-1 space-y-2">
+                <Skeleton className="h-4 w-3/4" />
+                <Skeleton className="h-2 w-full" />
+                <Skeleton className="h-3 w-1/2" />
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
     </div>
   );
 }

--- a/gamesformykids/app/profile/components/ProfilePageHeader.tsx
+++ b/gamesformykids/app/profile/components/ProfilePageHeader.tsx
@@ -3,10 +3,15 @@ import Link from 'next/link';
 export function ProfilePageHeader() {
   return (
     <div className="text-center mb-8">
-      <Link href="/" className="inline-flex items-center text-purple-600 hover:text-purple-800 mb-4">
-        → חזור לדף הבית
+      <Link
+        href="/"
+        className="inline-flex items-center gap-1 text-purple-600 hover:text-purple-800 mb-6 transition-colors"
+      >
+        ← חזור לדף הבית
       </Link>
-      <h1 className="text-3xl font-bold text-purple-800">הפרופיל שלי</h1>
+      <div className="text-5xl mb-3">👤</div>
+      <h1 className="text-3xl font-bold text-purple-800">האזור האישי שלי</h1>
+      <p className="text-purple-500 mt-1">ניקוד, הישגים והתקדמות</p>
     </div>
   );
 }

--- a/gamesformykids/app/profile/components/ProfileStatCards.tsx
+++ b/gamesformykids/app/profile/components/ProfileStatCards.tsx
@@ -1,23 +1,34 @@
 import { useProfileComputedStats } from '../stores/useProfileStore';
 
+const STAT_STYLES = [
+  { from: 'from-purple-400', to: 'to-purple-600', text: 'text-purple-600', bg: 'bg-purple-50' },
+  { from: 'from-blue-400',   to: 'to-blue-600',   text: 'text-blue-600',   bg: 'bg-blue-50'   },
+  { from: 'from-amber-400',  to: 'to-amber-600',  text: 'text-amber-600',  bg: 'bg-amber-50'  },
+  { from: 'from-green-400',  to: 'to-green-600',  text: 'text-green-600',  bg: 'bg-green-50'  },
+];
+
 export function ProfileStatCards() {
-  const { totalScore, totalPlayTime, achievementsCount } = useProfileComputedStats();
+  const { totalScore, totalPlayTime, achievementsCount, gamesPlayed } = useProfileComputedStats();
 
   const stats = [
-    { emoji: '🏆', label: 'סך הניקוד', value: String(totalScore) },
-    { emoji: '⏰', label: 'זמן משחק', value: `${totalPlayTime} דקות` },
-    { emoji: '🎖️', label: 'הישגים', value: String(achievementsCount) },
+    { emoji: '🏆', label: 'סך הניקוד',   value: totalScore.toLocaleString('he-IL') },
+    { emoji: '⏰', label: 'זמן משחק',     value: `${totalPlayTime} דק׳` },
+    { emoji: '🎖️', label: 'הישגים',       value: String(achievementsCount) },
+    { emoji: '🎮', label: 'משחקים ששוחקו', value: String(gamesPlayed) },
   ];
 
   return (
-    <div className="grid grid-cols-1 md:grid-cols-3 gap-6 mb-6">
-      {stats.map(({ emoji, label, value }) => (
-        <div key={label} className="bg-white rounded-2xl shadow-lg p-6 text-center">
-          <div className="text-3xl mb-2">{emoji}</div>
-          <h3 className="text-lg font-semibold text-gray-700">{label}</h3>
-          <p className="text-2xl font-bold text-purple-600">{value}</p>
-        </div>
-      ))}
+    <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mb-6">
+      {stats.map(({ emoji, label, value }, i) => {
+        const style = STAT_STYLES[i] ?? STAT_STYLES[0]!;
+        return (
+          <div key={label} className={`${style.bg} rounded-2xl shadow p-5 text-center`}>
+            <div className="text-3xl mb-2">{emoji}</div>
+            <p className={`text-2xl font-bold ${style.text}`}>{value}</p>
+            <h3 className="text-sm font-medium text-gray-600 mt-1">{label}</h3>
+          </div>
+        );
+      })}
     </div>
   );
 }

--- a/gamesformykids/app/profile/stores/useProfileStore.ts
+++ b/gamesformykids/app/profile/stores/useProfileStore.ts
@@ -47,8 +47,9 @@ export function useProfileComputedStats() {
   const totalPlayTime = useGameProgressDataStore((s) =>
     Math.floor(s.progress.reduce((sum, p) => sum + p.total_play_time, 0) / 60)
   );
+  const gamesPlayed = useGameProgressDataStore((s) => s.progress.length);
   const achievementsCount = useAchievementsStore((s) => s.achievements.length);
-  return { totalScore, totalPlayTime, achievementsCount };
+  return { totalScore, totalPlayTime, achievementsCount, gamesPlayed };
 }
 
 // ── Store ─────────────────────────────────────────────────

--- a/gamesformykids/hooks/shared/game-state/useBaseGame.ts
+++ b/gamesformykids/hooks/shared/game-state/useBaseGame.ts
@@ -74,7 +74,9 @@ export function useBaseGame<T extends BaseGameItem = BaseGameItem>(config: UseBa
         save({ score: s, level: l, durationSeconds });
       }
     };
-  }, []); // empty deps — run cleanup only on unmount
+  // saveGameResultRef is a stable ref — intentionally omitted from deps
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
   
   const { getRandomChallenge, getOptionsForChallenge } = useGameOptions({
     allItems: items,

--- a/gamesformykids/hooks/shared/game-state/useBaseGame.ts
+++ b/gamesformykids/hooks/shared/game-state/useBaseGame.ts
@@ -7,7 +7,7 @@ import { useGameAudio } from "../audio/useGameAudio";
 import { useGameOptions } from "./useGameOptions";
 import { useGameHints } from "../ui/useGameHints";
 import { useSessionStats } from "../progress/useSessionStats";
-import { useGameProgress } from "../progress/useGameProgress";
+import { useGameCompletion } from "../progress/useGameCompletion";
 import { 
   delay, 
   speakItemName as speakItemNameUtil,
@@ -59,23 +59,19 @@ export function useBaseGame<T extends BaseGameItem = BaseGameItem>(config: UseBa
   // Progress tracking
   const progressHooks = useSessionStats(gameType);
 
-  // Supabase progress persistence
-  const { updateScore, updateLevel } = useGameProgress(gameType);
+  // Supabase progress persistence — single atomic upsert per session
+  const { saveGameResultRef } = useGameCompletion(gameType);
+  const sessionStartRef = useRef(Date.now());
 
-  // Keep a ref to always-fresh save functions (avoids stale closures in cleanup)
-  const saveProgressRef = useRef({ updateScore, updateLevel, gameType });
+  // Save on unmount (user navigates away mid-game)
   useEffect(() => {
-    saveProgressRef.current = { updateScore, updateLevel, gameType };
-  });
-
-  // Save progress to Supabase when the component unmounts (user navigates away)
-  useEffect(() => {
+    sessionStartRef.current = Date.now();
+    const save = saveGameResultRef.current;
     return () => {
       const { score: s, level: l, isGameActive } = useGameProgressStore.getState();
       if (isGameActive && (s > 0 || l > 1)) {
-        const { updateScore: save, updateLevel: saveLevel, gameType: gt } = saveProgressRef.current;
-        // Sequential to avoid race condition on the same upsert row
-        save(gt, s).then(() => saveLevel(gt, l));
+        const durationSeconds = Math.round((Date.now() - sessionStartRef.current) / 1000);
+        save({ score: s, level: l, durationSeconds });
       }
     };
   }, []); // empty deps — run cleanup only on unmount
@@ -194,12 +190,10 @@ export function useBaseGame<T extends BaseGameItem = BaseGameItem>(config: UseBa
     useGameProgressStore.getState().resetProgress();
     useGameSessionStore.getState().resetSession();
 
-    // Persist progress to Supabase (single upsert to avoid race condition)
+    // Persist progress to Supabase — single atomic upsert
     if (finalScore > 0 || finalLevel > 1) {
-      const currentProgress = saveProgressRef.current;
-      currentProgress.updateScore(gameType, finalScore).then(() =>
-        currentProgress.updateLevel(gameType, finalLevel)
-      );
+      const durationSeconds = Math.round((Date.now() - sessionStartRef.current) / 1000);
+      saveGameResultRef.current({ score: finalScore, level: finalLevel, durationSeconds });
     }
   };
 

--- a/gamesformykids/hooks/shared/progress/useGameCompletion.ts
+++ b/gamesformykids/hooks/shared/progress/useGameCompletion.ts
@@ -4,7 +4,7 @@ import { useCallback, useRef, useEffect } from 'react';
 import type { GameType } from '@/lib/types';
 import { useAuth } from '@/hooks/shared/auth/useAuth';
 import { useGameProgressDataStore } from '@/lib/stores/gameProgressDataStore';
-import { upsertGameProgress } from '@/lib/supabase/gameProgress';
+import { fetchGameProgress, upsertGameProgress } from '@/lib/supabase/gameProgress';
 import { useAchievements } from './useAchievements';
 
 export interface GameResult {
@@ -22,8 +22,20 @@ export function useGameCompletion(gameType: GameType) {
       if (!user) return;
 
       const gt = gameType as string;
-      const progress = useGameProgressDataStore.getState().progress;
-      const cur = progress.find((p) => p.game_type === gt);
+      let cur = useGameProgressDataStore.getState().progress.find((p) => p.game_type === gt);
+
+      // If not yet cached, fetch from DB so best_score / total_play_time are correct
+      if (!cur) {
+        try {
+          const rows = await fetchGameProgress(user.id, gt);
+          if (rows.length > 0) {
+            cur = rows[0];
+            useGameProgressDataStore.getState().upsertProgressItem(cur!);
+          }
+        } catch {
+          // non-fatal — proceed with 0 as baseline
+        }
+      }
 
       try {
         const data = await upsertGameProgress(user.id, {

--- a/gamesformykids/lib/supabase/gameProgress.ts
+++ b/gamesformykids/lib/supabase/gameProgress.ts
@@ -35,7 +35,10 @@ export async function upsertGameProgress(
 ): Promise<GameProgress> {
   const { data: row, error } = await supabase
     .from('game_progress')
-    .upsert({ user_id: userId, ...data })
+    .upsert(
+      { user_id: userId, ...data },
+      { onConflict: 'user_id,game_type' },
+    )
     .select()
     .single();
 


### PR DESCRIPTION
## Summary

- **Critical bug fix**: `upsertGameProgress` was missing `onConflict: 'user_id,game_type'` — after the first play session every score save silently failed (unique constraint error swallowed in `catch {}`)
- **Secondary bug fix**: `useGameCompletion` now fetches the current DB row before saving when the store is empty, preventing `best_score` / `total_play_time` from being overwritten with lower values
- **Refactor**: `useBaseGame` and `useMemoryGameContent` replaced two sequential Supabase calls (`updateScore` + `updateLevel`) with a single atomic `saveGameResult`
- **Profile UX overhaul**: Hebrew game names + emoji in progress list, progress bars, 4-stat cards, skeleton loading screen, member-since date, achievement dates

## Files changed

| File | Change |
|---|---|
| `lib/supabase/gameProgress.ts` | Add `onConflict` to `upsertGameProgress` |
| `hooks/shared/progress/useGameCompletion.ts` | Fetch DB row if not in store before saving |
| `hooks/shared/game-state/useBaseGame.ts` | Single `saveGameResult` instead of two calls |
| `app/games/memory/useMemoryGameContent.ts` | Single `saveGameResult` instead of three calls |
| `app/profile/components/*` | Full UX overhaul of personal area |
| `app/profile/stores/useProfileStore.ts` | Add `gamesPlayed` computed stat |

## Test plan

- [ ] Play any card game (Style A) multiple times — verify score increases in `/profile`
- [ ] Play a quiz game multiple times — verify score increases in `/profile`
- [ ] Play memory game multiple times — verify score increases
- [ ] Start a game without visiting `/profile` first — verify best_score is not reset
- [ ] Visit `/profile` — verify Hebrew game names, progress bars, 4 stat cards
- [ ] Verify loading skeleton animation appears before data loads
- [ ] Verify achievements show earned date

Closes #1057

🤖 Generated with [Claude Code](https://claude.com/claude-code)