### PR TITLE
fix(card-games): save score on replay and fix auth-race in cleanup

### DIFF
--- a/gamesformykids/hooks/shared/game-state/useBaseGame.ts
+++ b/gamesformykids/hooks/shared/game-state/useBaseGame.ts
@@ -63,18 +63,19 @@ export function useBaseGame<T extends BaseGameItem = BaseGameItem>(config: UseBa
   const { saveGameResultRef } = useGameCompletion(gameType);
   const sessionStartRef = useRef(Date.now());
 
-  // Save on unmount (user navigates away mid-game)
+  // Save on unmount (user navigates away mid-game).
+  // Read saveGameResultRef.current at cleanup time so we always call the
+  // latest version (auth may load after this effect mounts).
   useEffect(() => {
     sessionStartRef.current = Date.now();
-    const save = saveGameResultRef.current;
     return () => {
       const { score: s, level: l, isGameActive } = useGameProgressStore.getState();
       if (isGameActive && (s > 0 || l > 1)) {
         const durationSeconds = Math.round((Date.now() - sessionStartRef.current) / 1000);
-        save({ score: s, level: l, durationSeconds });
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+        saveGameResultRef.current({ score: s, level: l, durationSeconds });
       }
     };
-  // saveGameResultRef is a stable ref — intentionally omitted from deps
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
   
@@ -112,10 +113,17 @@ export function useBaseGame<T extends BaseGameItem = BaseGameItem>(config: UseBa
 
   // התחלת משחק
   const startGame = async () => {
-    // Reset Zustand stores
+    // Save previous session score before resetting (user may replay without navigating away)
     const progressStore = useGameProgressStore.getState();
+    const { score: prevScore, level: prevLevel, isGameActive } = progressStore;
+    if (isGameActive && (prevScore > 0 || prevLevel > 1)) {
+      const durationSeconds = Math.round((Date.now() - sessionStartRef.current) / 1000);
+      saveGameResultRef.current({ score: prevScore, level: prevLevel, durationSeconds });
+    }
+
     progressStore.resetProgress();
     progressStore.setGameActive(true);
+    sessionStartRef.current = Date.now();
     useGameStore.getState().startGame(gameType);
 
     useGameSessionStore.getState().resetSession();


### PR DESCRIPTION
## Problem

Card games (NBA, animals, colors, etc.) have no explicit game-over. Score was only saved via the unmount cleanup in \`useBaseGame\` — when the user navigates away entirely.

Two bugs prevented the save:

1. **Replay without navigation** — \`startGame()\` called \`resetProgress()\` immediately, discarding the previous session's score before it was saved. Playing NBA → clicking "Start" again → score gone silently.

2. **Auth race in cleanup** — The effect captured \`saveGameResultRef.current\` at **mount time**. The game page has no auth requirement, so \`user\` can be \`null\` at mount. After auth loads, \`saveGameResultRef.current\` points to the correct function — but the captured \`save\` variable still held the null-user version that early-returns.

## Fix

\`hooks/shared/game-state/useBaseGame.ts\`:
- At the top of \`startGame()\`: if a session is already active, call \`saveGameResultRef.current(...)\` with the current score/level/duration **before** \`resetProgress()\`
- In the unmount cleanup: read \`saveGameResultRef.current\` at cleanup time instead of capturing at mount time

## Test plan

- [ ] Play NBA (or any card game), get a score, then click "Start" again — verify the first score now appears in \`/profile\`
- [ ] Play NBA, navigate to the home page — verify the score appears in \`/profile\`
- [ ] Verify TypeScript and ESLint pass

Closes #1060

🤖 Generated with [Claude Code](https://claude.com/claude-code)