### PR TITLE
fix(ux): replace harsh ❌ with 💙 in HumanBodyQuestion wrong answer

### DIFF
--- a/gamesformykids/components/game/quiz/screens/HumanBodyQuestion.tsx
+++ b/gamesformykids/components/game/quiz/screens/HumanBodyQuestion.tsx
@@ -18,7 +18,7 @@ export default function HumanBodyQuestion({ currentQuestion, choices, onSelect }
       onSelect={onSelect}
       cols={1}
       correctMsg="✅ נכון!"
-      wrongMsg={`❌ התשובה: ${currentQuestion.function}`}
+      wrongMsg={`💙 התשובה: ${currentQuestion.function}`}
     >
       <div className="text-7xl mb-3">{currentQuestion.emoji}</div>
       <div className="inline-block px-3 py-1 rounded-full text-sm font-bold text-white bg-red-400 mb-3">{currentQuestion.category}</div>


### PR DESCRIPTION
## Summary
`HumanBodyQuestion` was the only quiz game using `❌` (red X) for wrong-answer feedback. Every other quiz game uses a friendly `💙` or `💜` heart. Replaced the single `❌` with `💙` to match the consistent, encouraging tone across all games.

## Changes
- `components/game/quiz/screens/HumanBodyQuestion.tsx:21` — changed `wrongMsg` from `❌ התשובה:` to `💙 התשובה:`

## Testing
- [x] `npx tsc --noEmit` passes
- [ ] Manually verified: wrong answer in Human Body game shows 💙, not ❌

Closes #1061

🤖 Generated with [Claude Code](https://claude.com/claude-code)