### PR TITLE
fix(a11y): guard all animate-bounce with motion-safe: prefix

### DIFF
--- a/gamesformykids/components/game/shared/CanvasGameOverOverlay.tsx
+++ b/gamesformykids/components/game/shared/CanvasGameOverOverlay.tsx
@@ -48,7 +48,7 @@ export default function CanvasGameOverOverlay({
         <div className="text-5xl mb-2">{emoji}</div>
         <h2 className="text-2xl font-black text-gray-800 mb-3">{title}</h2>
         {isNewRecord && (
-          <div className="mb-3 px-3 py-1.5 rounded-2xl bg-linear-to-l from-yellow-400 to-amber-500 text-white font-black text-base animate-bounce shadow-md">
+          <div className="mb-3 px-3 py-1.5 rounded-2xl bg-linear-to-l from-yellow-400 to-amber-500 text-white font-black text-base motion-safe:animate-bounce shadow-md">
             🏆 שיא חדש!
           </div>
         )}

--- a/gamesformykids/components/game/shared/GameResultCard.tsx
+++ b/gamesformykids/components/game/shared/GameResultCard.tsx
@@ -57,10 +57,10 @@ export default function GameResultCard({
     >
       <GameCompletionCelebration />
       <div className="bg-white rounded-3xl shadow-2xl p-8 text-center max-w-sm w-full">
-        <div className={`text-6xl mb-3 ${animateEmoji ? 'animate-bounce' : ''}`}>{emoji}</div>
+        <div className={`text-6xl mb-3 ${animateEmoji ? 'motion-safe:animate-bounce' : ''}`}>{emoji}</div>
         <h2 className="text-2xl font-bold text-gray-800 mb-4">{title}</h2>
         {isNewRecord && (
-          <div className="mb-4 px-4 py-2 rounded-2xl bg-linear-to-l from-yellow-400 to-amber-500 text-white font-black text-lg animate-bounce shadow-md">
+          <div className="mb-4 px-4 py-2 rounded-2xl bg-linear-to-l from-yellow-400 to-amber-500 text-white font-black text-lg motion-safe:animate-bounce shadow-md">
             🏆 שיא חדש!
           </div>
         )}

--- a/gamesformykids/components/game/shared/ScoreBestResultCard.tsx
+++ b/gamesformykids/components/game/shared/ScoreBestResultCard.tsx
@@ -63,7 +63,7 @@ export default function ScoreBestResultCard({
   return (
     <GameResultCard {...cardProps}>
       {showBanner && (
-        <div className="mb-4 px-4 py-2 rounded-2xl bg-linear-to-l from-yellow-400 to-amber-500 text-white font-black text-lg animate-bounce shadow-md">
+        <div className="mb-4 px-4 py-2 rounded-2xl bg-linear-to-l from-yellow-400 to-amber-500 text-white font-black text-lg motion-safe:animate-bounce shadow-md">
           🏆 שיא חדש!
         </div>
       )}

--- a/gamesformykids/components/layout/LoadingScreen.tsx
+++ b/gamesformykids/components/layout/LoadingScreen.tsx
@@ -10,7 +10,7 @@ const LoadingScreen = ({ onLoadingComplete }: LoadingScreenProps) => {
     <div className="fixed inset-0 bg-gradient-to-br from-purple-400 via-pink-400 to-blue-400 flex items-center justify-center z-50">
       <div className="text-center text-white">
         {/* Animated emoji */}
-        <div className="text-8xl mb-8 animate-bounce">
+        <div className="text-8xl mb-8 motion-safe:animate-bounce">
           {LOADING_EMOJIS[currentEmoji]}
         </div>
         

--- a/gamesformykids/components/shared/screens/GameLoadingScreen.tsx
+++ b/gamesformykids/components/shared/screens/GameLoadingScreen.tsx
@@ -9,7 +9,7 @@ export default function GameLoadingScreen({
   return (
     <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-blue-100 to-purple-100">
       <div className="text-center">
-        <div className="text-8xl mb-6 animate-bounce">🎮</div>
+        <div className="text-8xl mb-6 motion-safe:animate-bounce">🎮</div>
         <h2 className="text-3xl font-bold text-gray-700 mb-2">{message}</h2>
         <div className="w-20 h-2 bg-gray-200 rounded-full mx-auto">
           <div 


### PR DESCRIPTION
## Summary
Five components used `animate-bounce` without a `motion-safe:` guard. Children with vestibular disorders or motion sensitivity would see perpetual bouncing with no way to disable it. Applied `motion-safe:animate-bounce` to all five locations, matching the pattern already used in `GameCompletionCelebration`.

## Changes
- `components/game/shared/GameResultCard.tsx` — 2 occurrences (emoji bounce + "שיא חדש!" banner)
- `components/game/shared/ScoreBestResultCard.tsx` — "שיא חדש!" banner
- `components/game/shared/CanvasGameOverOverlay.tsx` — game-over badge
- `components/layout/LoadingScreen.tsx` — loading emoji
- `components/shared/screens/GameLoadingScreen.tsx` — 🎮 loading emoji

## Testing
- [x] `npx tsc --noEmit` passes
- [ ] Animations still play normally; disabled under `prefers-reduced-motion: reduce`

Closes #1062

🤖 Generated with [Claude Code](https://claude.com/claude-code)