### PR TITLE
fix(ux): gate GameResultCard celebration on score > 0

### DIFF
--- a/gamesformykids/components/game/shared/GameResultCard.tsx
+++ b/gamesformykids/components/game/shared/GameResultCard.tsx
@@ -55,7 +55,7 @@ export default function GameResultCard({
       className={`min-h-screen bg-linear-to-br ${gradientClass} flex items-center justify-center p-4`}
       dir="rtl"
     >
-      <GameCompletionCelebration />
+      {(score === undefined || score > 0) && <GameCompletionCelebration />}
       <div className="bg-white rounded-3xl shadow-2xl p-8 text-center max-w-sm w-full">
         <div className={`text-6xl mb-3 ${animateEmoji ? 'animate-bounce' : ''}`}>{emoji}</div>
         <h2 className="text-2xl font-bold text-gray-800 mb-4">{title}</h2>


### PR DESCRIPTION
## Summary
`GameResultCard` was unconditionally rendering `<GameCompletionCelebration />`, triggering victory sounds and confetti even when the player scored 0. This made the celebration meaningless and confusing for children. Now the celebration only fires when `score > 0` (or when `score` is not provided, preserving backwards compatibility for callers that don't pass a score).

## Changes
- `components/game/shared/GameResultCard.tsx:58` — wrap `<GameCompletionCelebration />` in `{(score === undefined || score > 0) && ...}`

## Testing
- [x] `npx tsc --noEmit` passes
- [ ] Score of 0 → no confetti/sound
- [ ] Score > 0 → celebration still fires
- [ ] Callers that don't pass `score` prop → celebration still fires (backwards compatible)

Closes #1059

🤖 Generated with [Claude Code](https://claude.com/claude-code)