### PR TITLE
fix(rtl): correct prev/next button order and use logical inset-x-4 in UniversalGameNavigation

### DIFF
--- a/gamesformykids/components/game/universal/navigation/UniversalGameNavigation.tsx
+++ b/gamesformykids/components/game/universal/navigation/UniversalGameNavigation.tsx
@@ -38,22 +38,20 @@ export default function UniversalGameNavigation({
   return (
     <nav
       aria-label="ניווט בין משחקים"
-      className="fixed top-4 left-4 right-4 z-50 flex justify-between items-center pointer-events-none"
+      className="fixed top-4 inset-x-4 z-50 flex justify-between items-center pointer-events-none"
     >
-      {/* שמאל — קודם */}
+      {/* ימין — הבא (first in DOM = right side in RTL flex) */}
       <div className="flex gap-2 pointer-events-auto">
-        {navigation.previous && (
+        {navigation.next && (
           <Link
-            href={navigation.previous.href}
-            className="bg-blue-500/90 backdrop-blur-sm hover:bg-blue-600 text-white font-bold py-2 px-3 md:py-3 md:px-4 rounded-xl shadow-lg transition-[transform,colors] duration-200 hover:scale-105 active:scale-95 flex items-center gap-2 text-sm md:text-base border-2 border-blue-400 hover:border-blue-300"
-            title={`${navigation.previous.title} (←)`}
-            aria-label={`משחק קודם: ${navigation.previous.title}`}
+            href={navigation.next.href}
+            className="bg-green-500/90 backdrop-blur-sm hover:bg-green-600 text-white font-bold py-2 px-3 md:py-3 md:px-4 rounded-xl shadow-lg transition-[transform,colors] duration-200 hover:scale-105 active:scale-95 flex items-center gap-2 text-sm md:text-base border-2 border-green-400 hover:border-green-300"
+            title={`${navigation.next.title} (→)`}
+            aria-label={`משחק הבא: ${navigation.next.title}`}
           >
-            <ArrowRight className="w-4 h-4 md:w-5 md:h-5" aria-hidden="true" />
-            {navigation.previous.icon && renderIcon(navigation.previous.icon)}
-            <span className="hidden lg:inline">
-              {navigation.previous.title}
-            </span>
+            <span className="hidden lg:inline">{navigation.next.title}</span>
+            {navigation.next.icon && renderIcon(navigation.next.icon)}
+            <ArrowLeft className="w-4 h-4 md:w-5 md:h-5" aria-hidden="true" />
           </Link>
         )}
       </div>
@@ -82,18 +80,20 @@ export default function UniversalGameNavigation({
         )}
       </div>
 
-      {/* ימין — הבא */}
+      {/* שמאל — קודם (last in DOM = left side in RTL flex) */}
       <div className="flex gap-2 pointer-events-auto">
-        {navigation.next && (
+        {navigation.previous && (
           <Link
-            href={navigation.next.href}
-            className="bg-green-500/90 backdrop-blur-sm hover:bg-green-600 text-white font-bold py-2 px-3 md:py-3 md:px-4 rounded-xl shadow-lg transition-[transform,colors] duration-200 hover:scale-105 active:scale-95 flex items-center gap-2 text-sm md:text-base border-2 border-green-400 hover:border-green-300"
-            title={`${navigation.next.title} (→)`}
-            aria-label={`משחק הבא: ${navigation.next.title}`}
+            href={navigation.previous.href}
+            className="bg-blue-500/90 backdrop-blur-sm hover:bg-blue-600 text-white font-bold py-2 px-3 md:py-3 md:px-4 rounded-xl shadow-lg transition-[transform,colors] duration-200 hover:scale-105 active:scale-95 flex items-center gap-2 text-sm md:text-base border-2 border-blue-400 hover:border-blue-300"
+            title={`${navigation.previous.title} (←)`}
+            aria-label={`משחק קודם: ${navigation.previous.title}`}
           >
-            <span className="hidden lg:inline">{navigation.next.title}</span>
-            {navigation.next.icon && renderIcon(navigation.next.icon)}
-            <ArrowLeft className="w-4 h-4 md:w-5 md:h-5" aria-hidden="true" />
+            <ArrowRight className="w-4 h-4 md:w-5 md:h-5" aria-hidden="true" />
+            {navigation.previous.icon && renderIcon(navigation.previous.icon)}
+            <span className="hidden lg:inline">
+              {navigation.previous.title}
+            </span>
           </Link>
         )}
       </div>


### PR DESCRIPTION
## Summary
`UniversalGameNavigation` had two RTL issues: physical `left-4 right-4` positioning and LTR-conventional button order. With the document's `dir="rtl"`, flex items flow right→left, so the first DOM element occupies the visual right edge. Swapping "next" to first and "previous" to last now places Next (green) on the right and Previous (blue) on the left — the RTL-correct layout for Hebrew navigation. Also replaced physical `left-4 right-4` with the logical `inset-x-4`.

## Changes
- `components/game/universal/navigation/UniversalGameNavigation.tsx:41` — `left-4 right-4` → `inset-x-4`
- Same file — moved "next game" div before the center div, "previous game" div after: Next appears on the visual right (RTL inline-start), Previous appears on the visual left (RTL inline-end)

## Testing
- [x] `npx tsc --noEmit` passes
- [ ] "Next game" button appears on right side of screen in RTL
- [ ] "Previous game" button appears on left side of screen in RTL
- [ ] Navigation still works correctly (keyboard shortcut, links)

Closes #1067

🤖 Generated with [Claude Code](https://claude.com/claude-code)