### PR TITLE
refactor(ui-logic): extract audio side-effects out of shared components

### DIFF
--- a/gamesformykids/components/game/quiz/QuizAnswerGrid.tsx
+++ b/gamesformykids/components/game/quiz/QuizAnswerGrid.tsx
@@ -1,14 +1,11 @@
 'use client';
 
-import { useState, useEffect, type ReactNode } from 'react';
+import { type ReactNode } from 'react';
 import { useQuizGameStore } from '@/lib/stores/quizGameStore';
 import { QUIZ_THEMES, type QuizTheme } from './quizTheme';
 import { answerButtonClass } from '@/lib/quiz/answerButtonClass';
 import { useKeyboardAnswerSelect } from '@/hooks/shared/useKeyboardAnswerSelect';
-import { useHaptic } from '@/hooks/shared/haptic/useHaptic';
-import { speakHebrew } from '@/lib/utils/speech/speaker';
-
-const WRONG_PHRASES = ['כמעט!', 'נסה שוב!', 'לא נורא, תנסה שוב!'] as const;
+import { useWrongAnswerFeedback } from '@/hooks/shared/audio/useWrongAnswerFeedback';
 
 interface Props {
   choices: string[];
@@ -30,26 +27,13 @@ export function QuizAnswerGrid({
   const selected = useQuizGameStore(s => s.selected);
   const t = QUIZ_THEMES[theme];
   const enabled = selected === null;
-  const { wrong: hapticWrong } = useHaptic();
-  const [shakingChoice, setShakingChoice] = useState<string | null>(null);
+  const { shakingChoice } = useWrongAnswerFeedback(selected, correctValue);
 
   const { focusedIdx } = useKeyboardAnswerSelect(
     choices.length,
     (idx) => onSelect(choices[idx]!),
     enabled,
   );
-
-  useEffect(() => {
-    if (selected !== null && selected !== correctValue) {
-      hapticWrong();
-      const phrase = WRONG_PHRASES[Math.floor(Math.random() * WRONG_PHRASES.length)]!;
-      void speakHebrew(phrase);
-      setShakingChoice(selected);
-      const id = setTimeout(() => setShakingChoice(null), 600);
-      return () => clearTimeout(id);
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [selected]);
 
   const gridClass = cols === 1
     ? 'grid grid-cols-1 gap-3 mb-4'

--- a/gamesformykids/components/ui/SoundToggleButton.tsx
+++ b/gamesformykids/components/ui/SoundToggleButton.tsx
@@ -1,43 +1,18 @@
 'use client';
 
-import { useEffect, useState } from 'react';
-import { setUserMuted } from '@/lib/utils/speech/enhancedSpeechUtils';
-
-const STORAGE_KEY = 'sound_muted';
+import { useSoundToggle } from '@/hooks/shared/audio/useSoundToggle';
 
 export default function SoundToggleButton() {
-  const [mounted, setMounted] = useState(false);
-  const [muted, setMuted] = useState(false);
+  const { mounted, muted, toggle } = useSoundToggle();
 
-  useEffect(() => {
-    setMounted(true);
-    const saved = localStorage.getItem(STORAGE_KEY) === 'true';
-    if (saved) {
-      setMuted(true);
-      setUserMuted(true);
-    }
-  }, []);
-
-  // Render nothing on the server and on first paint to avoid hydration mismatch
-  // (mute state can only be read from localStorage after mount).
   if (!mounted) return null;
-
-  const toggle = () => {
-    const newMuted = !muted;
-    setMuted(newMuted);
-    setUserMuted(newMuted);
-    localStorage.setItem(STORAGE_KEY, String(newMuted));
-    if (newMuted && typeof window !== 'undefined' && 'speechSynthesis' in window) {
-      window.speechSynthesis.cancel();
-    }
-  };
 
   return (
     <button
       onClick={toggle}
       aria-label={muted ? 'הפעל קול' : 'השתק'}
       title={muted ? 'הפעל קול' : 'השתק'}
-      className="fixed bottom-4 start-4 z-50 flex items-center justify-center min-h-[44px] min-w-[44px] rounded-full bg-white/90 dark:bg-gray-800/90 shadow-lg border border-gray-200 dark:border-gray-700 hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors backdrop-blur-sm"
+      className="fixed bottom-4 inset-s-4 z-50 flex items-center justify-center min-h-11 min-w-11 rounded-full bg-white/90 dark:bg-gray-800/90 shadow-lg border border-gray-200 dark:border-gray-700 hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors backdrop-blur-sm"
     >
       {muted ? (
         <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="w-5 h-5 text-gray-400" aria-hidden>

--- a/gamesformykids/hooks/shared/audio/index.ts
+++ b/gamesformykids/hooks/shared/audio/index.ts
@@ -1,1 +1,3 @@
 export { useGameAudio } from './useGameAudio';
+export { useSoundToggle } from './useSoundToggle';
+export { useWrongAnswerFeedback } from './useWrongAnswerFeedback';

--- a/gamesformykids/hooks/shared/audio/useSoundToggle.ts
+++ b/gamesformykids/hooks/shared/audio/useSoundToggle.ts
@@ -1,0 +1,32 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { setUserMuted } from '@/lib/utils/speech/enhancedSpeechUtils';
+
+const STORAGE_KEY = 'sound_muted';
+
+export function useSoundToggle() {
+  const [mounted, setMounted] = useState(false);
+  const [muted, setMuted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+    const saved = localStorage.getItem(STORAGE_KEY) === 'true';
+    if (saved) {
+      setMuted(true);
+      setUserMuted(true);
+    }
+  }, []);
+
+  const toggle = () => {
+    const newMuted = !muted;
+    setMuted(newMuted);
+    setUserMuted(newMuted);
+    localStorage.setItem(STORAGE_KEY, String(newMuted));
+    if (newMuted && typeof window !== 'undefined' && 'speechSynthesis' in window) {
+      window.speechSynthesis.cancel();
+    }
+  };
+
+  return { mounted, muted, toggle };
+}

--- a/gamesformykids/hooks/shared/audio/useWrongAnswerFeedback.ts
+++ b/gamesformykids/hooks/shared/audio/useWrongAnswerFeedback.ts
@@ -1,0 +1,29 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { useHaptic } from '@/hooks/shared/haptic/useHaptic';
+import { speakHebrew } from '@/lib/utils/speech/speaker';
+
+const WRONG_PHRASES = ['כמעט!', 'נסה שוב!', 'לא נורא, תנסה שוב!'] as const;
+
+export function useWrongAnswerFeedback(
+  selected: string | null,
+  correctValue: string,
+) {
+  const [shakingChoice, setShakingChoice] = useState<string | null>(null);
+  const { wrong: hapticWrong } = useHaptic();
+
+  useEffect(() => {
+    if (selected !== null && selected !== correctValue) {
+      hapticWrong();
+      const phrase = WRONG_PHRASES[Math.floor(Math.random() * WRONG_PHRASES.length)]!;
+      void speakHebrew(phrase);
+      setShakingChoice(selected);
+      const id = setTimeout(() => setShakingChoice(null), 600);
+      return () => clearTimeout(id);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [selected]);
+
+  return { shakingChoice };
+}


### PR DESCRIPTION
## What

Extracts business logic (audio triggers, state, side-effects) out of two shared UI components and into dedicated hooks in `hooks/shared/audio/`:

- **`useSoundToggle`** — owns `muted` state, `localStorage` persistence, `setUserMuted()` call, and `speechSynthesis.cancel()` on mute. `SoundToggleButton` is now a pure renderer.
- **`useWrongAnswerFeedback`** — owns `shakingChoice` animation state, haptic trigger, random wrong-phrase TTS (`speakHebrew`), and the 600ms shake timeout. `QuizAnswerGrid` is now a pure renderer.

Both hooks are exported from `hooks/shared/audio/index.ts`.

## Why

`SoundToggleButton` and `QuizAnswerGrid` were mixing rendering with audio/haptic business logic, making the logic harder to test or reuse. This is a clean separation of concerns — no behaviour changes.

## Test plan
- [ ] Mute/unmute button still persists across page reloads
- [ ] Wrong quiz answers still trigger haptic + Hebrew TTS phrase + shake animation
- [ ] `npx tsc --noEmit` — zero errors (verified before opening)

🤖 Generated with [Claude Code](https://claude.com/claude-code)