### PR TITLE
fix(perf): replace transition-all with scoped transitions (closes #1063)

### DIFF
--- a/gamesformykids/components/game/AgeGroupCard.tsx
+++ b/gamesformykids/components/game/AgeGroupCard.tsx
@@ -9,7 +9,7 @@ export default function AgeGroupCard({ ageKey }: { ageKey: string }) {
 
   if (!ageGroup) return null;
   return (
-    <div className="bg-white rounded-2xl p-4 md:p-6 shadow-lg hover:shadow-xl transition-all duration-300">
+    <div className="bg-white rounded-2xl p-4 md:p-6 shadow-lg hover:shadow-xl transition-shadow duration-300">
       {/* Header — horizontal on mobile, centered on desktop */}
       <div className="flex items-center gap-3 sm:flex-col sm:items-center sm:text-center mb-3 md:mb-4">
         <div className="text-4xl sm:mb-1">{ageGroup.icon}</div>
@@ -23,7 +23,7 @@ export default function AgeGroupCard({ ageKey }: { ageKey: string }) {
         {ageGroup.recommendedGames.length > 0 ? (
           ageGroup.recommendedGames.map((game) => (
             <Link key={game.id} href={game.href} prefetch={false}>
-              <div className="flex items-center p-2.5 md:p-3 bg-gradient-to-r from-gray-50 to-gray-100/50 rounded-xl hover:from-purple-50 hover:to-blue-50 transition-all duration-300 cursor-pointer shadow-sm hover:shadow-md border border-gray-100">
+              <div className="flex items-center p-2.5 md:p-3 bg-gradient-to-r from-gray-50 to-gray-100/50 rounded-xl hover:from-purple-50 hover:to-blue-50 transition-shadow duration-300 cursor-pointer shadow-sm hover:shadow-md border border-gray-100">
                 <div className="flex-shrink-0 ms-3">
                   <div className="bg-gradient-to-br from-purple-100 to-blue-100 p-1.5 rounded-lg">
                     <game.icon className="w-6 h-6 md:w-7 md:h-7 text-purple-600" />

--- a/gamesformykids/components/game/FeaturedGameCallToAction.tsx
+++ b/gamesformykids/components/game/FeaturedGameCallToAction.tsx
@@ -10,7 +10,7 @@ export default function FeaturedGameCallToAction() {
 
   return (
     <Link href={featuredGame.href} className="mt-4 md:mt-8 block text-center cursor-pointer">
-      <div className="inline-block bg-gradient-to-r from-blue-500 via-purple-500 to-pink-500 text-white px-4 md:px-6 py-2 md:py-3 rounded-full font-bold text-sm md:text-base hover:from-blue-600 hover:via-purple-600 hover:to-pink-600 hover:shadow-xl transition-all duration-300 transform hover:scale-105 border border-white/20 shadow-lg backdrop-blur-sm">
+      <div className="inline-block bg-gradient-to-r from-blue-500 via-purple-500 to-pink-500 text-white px-4 md:px-6 py-2 md:py-3 rounded-full font-bold text-sm md:text-base hover:from-blue-600 hover:via-purple-600 hover:to-pink-600 hover:shadow-xl transition-[transform,box-shadow] duration-300 transform hover:scale-105 border border-white/20 shadow-lg backdrop-blur-sm">
         <span className="hidden sm:inline">💡 לא בטוחים איזה משחק לבחור? התחילו עם המשחק המומלץ!</span>
         <span className="sm:hidden">💡 התחילו עם המשחק המומלץ!</span>
       </div>

--- a/gamesformykids/components/game/quiz/FractionBar.tsx
+++ b/gamesformykids/components/game/quiz/FractionBar.tsx
@@ -12,7 +12,7 @@ export default function FractionBar({ numerator, denominator, color = '#7c3aed' 
       {Array.from({ length: denominator }).map((_, i) => (
         <div
           key={i}
-          className="h-10 rounded border-2 border-purple-400 transition-all"
+          className="h-10 rounded border-2 border-purple-400 transition-[width,background-color]"
           style={{
             width: `${Math.min(56 / denominator, 40)}px`,
             backgroundColor: i < numerator ? color : '#f3f4f6',

--- a/gamesformykids/components/game/quiz/screens/ClockMenuScreen.tsx
+++ b/gamesformykids/components/game/quiz/screens/ClockMenuScreen.tsx
@@ -13,7 +13,7 @@ export default function ClockMenuScreen({ onStart }: Props) {
         <h1 className="text-3xl font-bold text-indigo-800 mb-3">הכרת השעון</h1>
         <p className="text-indigo-600 mb-8">ראה את השעון — בחר את השעה הנכונה!</p>
         <button onClick={onStart}
-          className="w-full py-5 rounded-2xl text-white font-bold text-2xl bg-gradient-to-l from-violet-500 to-indigo-600 shadow-xl hover:opacity-90 active:scale-95 transition-all">
+          className="w-full py-5 rounded-2xl text-white font-bold text-2xl bg-gradient-to-l from-violet-500 to-indigo-600 shadow-xl hover:opacity-90 active:scale-95 transition-[transform,opacity]">
           🕐 התחל!
         </button>
       </div>

--- a/gamesformykids/components/game/quiz/screens/HumanBodyMenuScreen.tsx
+++ b/gamesformykids/components/game/quiz/screens/HumanBodyMenuScreen.tsx
@@ -17,7 +17,7 @@ export default function HumanBodyMenuScreen({ onStart }: Props) {
       title="גוף האדם"
       description="גלה את הפלאות של גוף האדם!"
       categories={BODY_CATEGORIES}
-      categoryClassName={cat => `py-3 px-4 rounded-xl font-bold text-white shadow-md active:scale-95 transition-all bg-gradient-to-r ${CATEGORY_GRADIENT_COLORS[cat] ?? 'from-gray-400 to-gray-600'} ${cat === 'הכל' ? 'col-span-2' : ''}`}
+      categoryClassName={cat => `py-3 px-4 rounded-xl font-bold text-white shadow-md active:scale-95 transition-transform bg-gradient-to-r ${CATEGORY_GRADIENT_COLORS[cat] ?? 'from-gray-400 to-gray-600'} ${cat === 'הכל' ? 'col-span-2' : ''}`}
       categoryLabel={cat => CATEGORY_LABELS[cat]}
       gridCols={2}
       onStart={onStart}

--- a/gamesformykids/components/game/quiz/screens/IsraelMenuScreen.tsx
+++ b/gamesformykids/components/game/quiz/screens/IsraelMenuScreen.tsx
@@ -16,7 +16,7 @@ export default function IsraelMenuScreen({ onStart }: Props) {
       title="ישראל שלי"
       description="בחר קטגוריה ובחן את הידע שלך!"
       categories={CATEGORIES}
-      categoryClassName={cat => `py-3 px-2 rounded-xl font-bold text-sm transition-all shadow hover:opacity-90 ${CATEGORY_COLORS[cat] ?? 'bg-gray-400 text-white'}`}
+      categoryClassName={cat => `py-3 px-2 rounded-xl font-bold text-sm transition-opacity shadow hover:opacity-90 ${CATEGORY_COLORS[cat] ?? 'bg-gray-400 text-white'}`}
       onStart={onStart}
     />
   );

--- a/gamesformykids/components/game/quiz/screens/LifeCyclesQuestion.tsx
+++ b/gamesformykids/components/game/quiz/screens/LifeCyclesQuestion.tsx
@@ -35,7 +35,7 @@ export default function LifeCyclesQuestion({ current, onComplete }: Props) {
               return (
                 <div
                   key={pos}
-                  className={`flex flex-col items-center gap-0.5 w-16 h-20 rounded-xl border-2 transition-all duration-300 ${
+                  className={`flex flex-col items-center gap-0.5 w-16 h-20 rounded-xl border-2 transition-colors duration-300 ${
                     stage
                       ? 'border-green-400 bg-green-50'
                       : 'border-dashed border-green-200 bg-gray-50'
@@ -69,7 +69,7 @@ export default function LifeCyclesQuestion({ current, onComplete }: Props) {
                   <button
                     key={stageIndex}
                     onClick={() => tapStage(stageIndex)}
-                    className={`p-3 rounded-xl border-2 flex flex-col items-center gap-1 transition-all duration-200 active:scale-95 ${
+                    className={`p-3 rounded-xl border-2 flex flex-col items-center gap-1 transition-[transform,background-color,border-color] duration-200 active:scale-95 ${
                       wrongIdx === stageIndex
                         ? 'border-red-400 bg-red-50 scale-95'
                         : 'border-gray-200 bg-gray-50 hover:bg-green-50 hover:border-green-300'

--- a/gamesformykids/components/game/quiz/screens/NatureMenuScreen.tsx
+++ b/gamesformykids/components/game/quiz/screens/NatureMenuScreen.tsx
@@ -16,7 +16,7 @@ export default function NatureMenuScreen({ onStart }: Props) {
       title="עולם הטבע"
       description="בחר קטגוריה ולמד על הטבע!"
       categories={CATEGORIES}
-      categoryClassName={cat => `py-3 rounded-xl font-bold text-sm transition-all shadow hover:opacity-90 ${CATEGORY_COLORS[cat] ?? 'bg-gray-400 text-white'}`}
+      categoryClassName={cat => `py-3 rounded-xl font-bold text-sm transition-opacity shadow hover:opacity-90 ${CATEGORY_COLORS[cat] ?? 'bg-gray-400 text-white'}`}
       onStart={onStart}
     />
   );

--- a/gamesformykids/components/game/quiz/screens/PhonicsQuestion.tsx
+++ b/gamesformykids/components/game/quiz/screens/PhonicsQuestion.tsx
@@ -19,7 +19,7 @@ export default function PhonicsQuestion({ current, choices, onSelect }: Props) {
 
         <button
           onClick={speak}
-          className="w-full py-5 mb-6 rounded-2xl bg-gradient-to-r from-violet-500 to-purple-600 text-white shadow-lg hover:opacity-90 active:scale-95 transition-all text-lg sm:text-2xl font-black"
+          className="w-full py-5 mb-6 rounded-2xl bg-gradient-to-r from-violet-500 to-purple-600 text-white shadow-lg hover:opacity-90 active:scale-95 transition-[transform,opacity] text-lg sm:text-2xl font-black"
           aria-label="לחץ לשמוע את הצליל"
         >
           🔊 שמע את הצליל
@@ -32,7 +32,7 @@ export default function PhonicsQuestion({ current, choices, onSelect }: Props) {
             <button
               key={letter}
               onClick={() => onSelect(letter)}
-              className="py-6 rounded-2xl bg-violet-50 border-2 border-violet-200 text-violet-800 font-black text-6xl hover:bg-violet-100 hover:border-violet-400 active:scale-95 transition-all"
+              className="py-6 rounded-2xl bg-violet-50 border-2 border-violet-200 text-violet-800 font-black text-6xl hover:bg-violet-100 hover:border-violet-400 active:scale-95 transition-[transform,background-color,border-color]"
             >
               {letter}
             </button>

--- a/gamesformykids/components/game/shared/TimedMathGame.tsx
+++ b/gamesformykids/components/game/shared/TimedMathGame.tsx
@@ -106,7 +106,7 @@ export default function TimedMathGame<Level, Q extends { answer: number; choices
             <span className={`font-bold ${config.accentText700}`}>⭐ {score}</span>
           </div>
           <div className="h-3 bg-gray-200 rounded-full mb-5 overflow-hidden">
-            <div className={`h-full rounded-full transition-all duration-1000 ${timerColor}`} style={{ width: `${timePct}%` }} />
+            <div className={`h-full rounded-full transition-[width,background-color] duration-1000 ${timerColor}`} style={{ width: `${timePct}%` }} />
           </div>
           <div className="bg-white rounded-3xl shadow-xl p-10 mb-6 text-center">
             <p className={`text-5xl font-black ${config.accentText700}`}>{config.renderEquation(question)}</p>
@@ -122,7 +122,7 @@ export default function TimedMathGame<Level, Q extends { answer: number; choices
               }
               return (
                 <button key={i} onClick={() => selectAnswer(choice)} disabled={selected !== null}
-                  className={`py-5 rounded-2xl text-3xl font-black transition-all active:scale-95 ${style}`}>
+                  className={`py-5 rounded-2xl text-3xl font-black transition-transform active:scale-95 ${style}`}>
                   {choice}
                 </button>
               );
@@ -133,7 +133,7 @@ export default function TimedMathGame<Level, Q extends { answer: number; choices
               <div className={`rounded-2xl p-3 mb-3 text-center font-bold text-lg ${isCorrect ? 'bg-green-100 text-green-700' : 'bg-red-100 text-red-700'}`}>
                 {config.renderFeedbackText(question, isCorrect ?? false)}
               </div>
-              <button onClick={advance} className={`w-full py-4 rounded-2xl text-white font-bold text-xl bg-gradient-to-l ${config.advanceBtn} shadow-lg hover:opacity-90 active:scale-95 transition-all`}>
+              <button onClick={advance} className={`w-full py-4 rounded-2xl text-white font-bold text-xl bg-gradient-to-l ${config.advanceBtn} shadow-lg hover:opacity-90 active:scale-95 transition-[transform,opacity]`}>
                 {questionNum < config.totalQuestions - 1 ? 'שאלה הבאה ←' : 'תוצאות! 🎉'}
               </button>
             </div>

--- a/gamesformykids/components/shared/GameMainContent.tsx
+++ b/gamesformykids/components/shared/GameMainContent.tsx
@@ -72,7 +72,7 @@ export default function GameMainContent() {
           className="
             px-6 py-3 bg-linear-to-r from-purple-500 to-pink-500 text-white rounded-xl shadow-lg
             hover:from-purple-600 hover:to-pink-600 transform hover:scale-105
-            transition-all duration-200 font-bold
+            transition-transform duration-200 font-bold
           "
         >
           📈 דיוק משחק: {Math.round(game.currentAccuracy)}%

--- a/gamesformykids/components/shared/buttons/ButtonCheckAudio.tsx
+++ b/gamesformykids/components/shared/buttons/ButtonCheckAudio.tsx
@@ -16,7 +16,7 @@ export default function ButtonCheckAudio() {
     <div className="mb-8">
       <button
         onClick={handleTestSpeech}
-        className="block w-full max-w-sm mx-auto px-8 py-4 cursor-pointer bg-blue-500 text-white rounded-full text-xl font-bold hover:bg-blue-600 transition-all duration-300 shadow-lg"
+        className="block w-full max-w-sm mx-auto px-8 py-4 cursor-pointer bg-blue-500 text-white rounded-full text-xl font-bold hover:bg-blue-600 transition-colors duration-300 shadow-lg"
       >
         🎤 בדיקת שמע
       </button>

--- a/gamesformykids/components/shared/cards/AdvancedCard.tsx
+++ b/gamesformykids/components/shared/cards/AdvancedCard.tsx
@@ -99,7 +99,7 @@ export function AdvancedCard({
         w-full
         ${aspectClasses[aspectRatio]}
         ${borderRadiusClasses[borderRadius] ?? "rounded-xl"}
-        cursor-pointer transition-all duration-300 transform
+        cursor-pointer transition-[transform,box-shadow] duration-300 transform
         ${hoverClasses[hoverEffect]}
         ${shadowClasses[shadow]} hover:shadow-2xl
         ${backgroundClass}

--- a/gamesformykids/components/shared/cards/ColoredShapeCard.tsx
+++ b/gamesformykids/components/shared/cards/ColoredShapeCard.tsx
@@ -30,7 +30,7 @@ export default function ColoredShapeCard({
       className={`
         relative group bg-white rounded-3xl p-8 shadow-xl 
         hover:shadow-2xl hover:scale-105 
-        transform transition-all duration-300 cursor-pointer 
+        transform transition-[transform,box-shadow] duration-300 cursor-pointer 
         border-2 border-gray-100 hover:border-gray-200
         ${className}
       `}

--- a/gamesformykids/components/shared/cards/FlagsGameCard.tsx
+++ b/gamesformykids/components/shared/cards/FlagsGameCard.tsx
@@ -42,7 +42,7 @@ export default function FlagsGameCard({ item, onClick, isSelected }: GameItemCar
     <button
       onClick={() => onClick(item)}
       className={`
-        w-full aspect-square rounded-3xl cursor-pointer transition-all duration-300
+        w-full aspect-square rounded-3xl cursor-pointer transition-[transform,box-shadow] duration-300
         transform hover:scale-110 shadow-xl hover:shadow-2xl
         bg-white flex flex-col items-center justify-center p-3 gap-2
         border-8 ${isSelected ? "border-green-400 ring-4 ring-green-400 ring-offset-4" : "border-white"}

--- a/gamesformykids/components/shared/cards/GeographyGameCard.tsx
+++ b/gamesformykids/components/shared/cards/GeographyGameCard.tsx
@@ -10,7 +10,7 @@ export default function GeographyGameCard({ item, onClick, isSelected }: GameIte
     <button
       onClick={() => onClick(item)}
       className={`
-        w-full aspect-square rounded-3xl cursor-pointer transition-all duration-300
+        w-full aspect-square rounded-3xl cursor-pointer transition-[transform,box-shadow] duration-300
         transform hover:scale-110 shadow-xl hover:shadow-2xl
         bg-white flex flex-col items-center justify-center p-3 gap-2
         border-8 ${isSelected ? "border-green-400 ring-4 ring-green-400 ring-offset-4" : "border-white"}

--- a/gamesformykids/components/shared/cards/GeographyTextCard.tsx
+++ b/gamesformykids/components/shared/cards/GeographyTextCard.tsx
@@ -6,7 +6,7 @@ export default function GeographyTextCard({ item, onClick, isSelected }: GameIte
     <button
       onClick={() => onClick(item)}
       className={`
-        w-full aspect-square rounded-3xl cursor-pointer transition-all duration-300
+        w-full aspect-square rounded-3xl cursor-pointer transition-[transform,box-shadow] duration-300
         transform hover:scale-110 shadow-xl hover:shadow-2xl
         bg-white flex items-center justify-center p-4
         border-8 ${isSelected ? "border-green-400 ring-4 ring-green-400 ring-offset-4" : "border-blue-200"}

--- a/gamesformykids/components/shared/cards/MathGameCard.tsx
+++ b/gamesformykids/components/shared/cards/MathGameCard.tsx
@@ -33,7 +33,7 @@ export default function MathGameCard({ item, onClick }: GameItemCardProps) {
         flex flex-col items-center justify-center gap-2
         shadow-lg hover:shadow-xl
         transform hover:scale-105 active:scale-95
-        transition-all duration-200 cursor-pointer
+        transition-[transform,box-shadow] duration-200 cursor-pointer
       `}
     >
       {/* Number */}

--- a/gamesformykids/components/shared/cards/PhotoGameCard.tsx
+++ b/gamesformykids/components/shared/cards/PhotoGameCard.tsx
@@ -25,7 +25,7 @@ function PhotoGameCard({ item, onClick, isSelected, config }: PhotoGameCardProps
     <button
       onClick={() => onClick(item)}
       className={`
-        w-full aspect-square rounded-3xl cursor-pointer transition-all duration-300
+        w-full aspect-square rounded-3xl cursor-pointer transition-[transform,box-shadow] duration-300
         transform hover:scale-110 shadow-xl hover:shadow-2xl
         ${cardBg} flex flex-col items-center justify-center overflow-hidden
         border-8 ${border}

--- a/gamesformykids/components/shared/cards/SimpleCard.tsx
+++ b/gamesformykids/components/shared/cards/SimpleCard.tsx
@@ -61,7 +61,7 @@ export function SimpleCard({
         ${sizeClasses[size]} ${shapeClasses[shape]}
         shadow-${shadow} ${color} ${textColor} border-${borderWidth} ${borderColor}
         transform ${hoverEffect === "scale" ? "hover:scale-110" : ""}
-        transition-all duration-300 cursor-pointer
+        transition-[transform,box-shadow] duration-300 cursor-pointer
         flex flex-col items-center justify-center p-2
         ${className}
       `}

--- a/gamesformykids/components/shared/displays/ContextProgressDisplay.tsx
+++ b/gamesformykids/components/shared/displays/ContextProgressDisplay.tsx
@@ -98,7 +98,7 @@ export function ContextProgressDisplay() {
         <div className="mt-6 text-center">
           <button
             onClick={() => setShowProgressModal(false)}
-            className="px-8 py-3 bg-gradient-to-r from-blue-500 to-purple-500 text-white rounded-lg hover:from-blue-600 hover:to-purple-600 transition-all duration-200 transform hover:scale-105 font-bold"
+            className="px-8 py-3 bg-gradient-to-r from-blue-500 to-purple-500 text-white rounded-lg hover:from-blue-600 hover:to-purple-600 transition-transform duration-200 transform hover:scale-105 font-bold"
           >
             סגור
           </button>

--- a/gamesformykids/components/shared/feedback/ChallengeBox.tsx
+++ b/gamesformykids/components/shared/feedback/ChallengeBox.tsx
@@ -57,7 +57,7 @@ export default function ChallengeBox({
       <button
         onClick={handleSpeak}
         aria-label="שמע שוב"
-        className={`inline-flex items-center gap-2 px-4 py-3 min-h-11 rounded-xl font-bold text-base transition-all duration-150 select-none
+        className={`inline-flex items-center gap-2 px-4 py-3 min-h-11 rounded-xl font-bold text-base transition-[transform,background-color] duration-150 select-none
           bg-blue-100 hover:bg-blue-200 text-blue-700 border-2 border-blue-300
           ${speaking ? 'scale-90 bg-blue-300' : 'active:scale-90'}`}
       >

--- a/gamesformykids/components/shared/headers/UnifiedHeader.tsx
+++ b/gamesformykids/components/shared/headers/UnifiedHeader.tsx
@@ -30,7 +30,7 @@ export default function UnifiedHeader({
               type="button"
               onClick={onBack}
               aria-label="חזור לעמוד הקודם"
-              className="flex items-center gap-1 px-4 py-2 bg-purple-500 text-white rounded-lg hover:bg-purple-600 active:scale-95 transition-all duration-200 font-bold text-sm md:text-base shadow-md"
+              className="flex items-center gap-1 px-4 py-2 bg-purple-500 text-white rounded-lg hover:bg-purple-600 active:scale-95 transition-[transform,background-color] duration-200 font-bold text-sm md:text-base shadow-md"
             >
               חזור ←
             </button>

--- a/gamesformykids/components/shared/screens/GameErrorScreen.tsx
+++ b/gamesformykids/components/shared/screens/GameErrorScreen.tsx
@@ -23,7 +23,7 @@ export default function GameErrorScreen({
         )}
         <button
           onClick={onRetry}
-          className="px-8 py-3 bg-gradient-to-r from-purple-500 to-pink-500 hover:from-purple-600 hover:to-pink-600 text-white rounded-lg font-bold transition-all duration-200 transform hover:scale-105 focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-purple-500"
+          className="px-8 py-3 bg-gradient-to-r from-purple-500 to-pink-500 hover:from-purple-600 hover:to-pink-600 text-white rounded-lg font-bold transition-transform duration-200 transform hover:scale-105 focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-purple-500"
         >
           🔄 נסה שוב
         </button>


### PR DESCRIPTION
## What
Replace all 28 occurrences of `transition-all` across 24 shared and game components with minimal, property-scoped transition classes (`transition-[transform,box-shadow]`, `transition-colors`, `transition-transform`, `transition-opacity`, etc.).

## Why
`transition-all` transitions every CSS property including layout-affecting ones (width, height, padding, margin). On mid-range Android devices this triggers unnecessary style recalculations on every frame, causing visible jank when children tap answers. Scoping transitions to only the properties that actually change eliminates the unnecessary work.

Closes #1063

## Test plan
- [ ] Visit any card game (animals, colors, flags) and tap cards — no jank on button press
- [ ] Visit a quiz game (clock, human body, life cycles) and tap answers — shake animation smooth
- [ ] Hover over `AgeGroupCard` and `FeaturedGameCallToAction` — shadow/scale animations intact
- [ ] Verify progress bars in `TimedMathGame` and `FractionBar` animate width + color changes correctly
- [ ] `npx tsc --noEmit` — zero errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)