### PR TITLE
feat(ux): dim gradient backgrounds in dark mode (closes #1066)

### DIFF
--- a/gamesformykids/app/globals.css
+++ b/gamesformykids/app/globals.css
@@ -187,6 +187,13 @@ body {
     --background: #0a0a0a;
     --foreground: #ededed;
   }
+
+  /* Dim game screen backgrounds for comfortable night-time play.
+     Targets both Tailwind bg-gradient-to-* classes and inline linear-gradient styles. */
+  [class*="bg-gradient-to-"],
+  [style*="linear-gradient"] {
+    filter: brightness(0.85) saturate(0.9);
+  }
 }
 
 body {


### PR DESCRIPTION
## What
Add a single `@media (prefers-color-scheme: dark)` CSS rule in `globals.css` that applies `filter: brightness(0.85) saturate(0.9)` to all elements using Tailwind `bg-gradient-to-*` classes or inline `linear-gradient` styles.

## Why
Game screens (quiz, card games, canvas games) used hardcoded light gradients with zero dark-mode support. On iOS/Android in dark mode, game screens rendered blinding light backgrounds while the OS chrome was dark — jarring for children playing at night.

The two-selector rule covers:
- `[class*="bg-gradient-to-"]` → all shared quiz screens (`QuizQuestionShell`, `QuizMenuScreen`, `QuizResultScreen`, category screens, etc.)
- `[style*="linear-gradient"]` → card-game start screens (`UltimateStartScreen`), chess, shesh-besh, bubbles, etc.

Closes #1066

## Test plan
- [ ] Set OS/browser to dark mode, visit `/games/animals` — card game start screen visibly dimmed
- [ ] Visit `/games/riddles` — quiz menu, question, result screens all dimmed
- [ ] Visit `/games/clock` — clock quiz screen dimmed
- [ ] Light mode unchanged — no visual regression
- [ ] Sound toggle button (fixed in root layout) not affected
- [ ] Text remains readable throughout

🤖 Generated with [Claude Code](https://claude.com/claude-code)