### PR TITLE
feat(content): long-press/hover vocabulary tooltip on answer cards (closes #1043)

### DIFF
--- a/gamesformykids/components/shared/cards/GameCardGrid.tsx
+++ b/gamesformykids/components/shared/cards/GameCardGrid.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useRef } from 'react';
 import { ComponentTypes } from "@/lib/types";
 import { useGridFillers } from "@/hooks";
 
@@ -26,6 +26,17 @@ export function GameCardGrid<T extends GameItemType>({
   );
 
   const [shakeKey, setShakeKey] = useState<string | null>(null);
+  const [tooltipKey, setTooltipKey] = useState<string | null>(null);
+  const longPressRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const hoverRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const getTooltipHandlers = useCallback((key: string) => ({
+    onMouseEnter: () => { hoverRef.current = setTimeout(() => setTooltipKey(key), 200); },
+    onMouseLeave: () => { if (hoverRef.current) clearTimeout(hoverRef.current); setTooltipKey(null); },
+    onTouchStart: () => { longPressRef.current = setTimeout(() => setTooltipKey(key), 500); },
+    onTouchEnd: () => { if (longPressRef.current) clearTimeout(longPressRef.current); setTooltipKey(null); },
+    onTouchMove: () => { if (longPressRef.current) clearTimeout(longPressRef.current); setTooltipKey(null); },
+  }), []);
 
   const handleItemClick = useCallback((item: T) => {
     if (!propOnItemClick) return;
@@ -69,11 +80,27 @@ export function GameCardGrid<T extends GameItemType>({
         const isCorrect = isCurrentItem(item, currentChallenge);
         const isFocused = typeof focusedIdx === 'number' && focusedIdx === idx;
 
+        const itemKey = getItemKey(item);
+        const itemObj = item as unknown as Record<string, unknown>;
+        const hasEnglish = typeof item === 'object' && item !== null && 'english' in item;
+        const englishLabel = hasEnglish ? String(itemObj.english) : null;
+        const funFact = hasEnglish && 'funFact' in item ? String(itemObj.funFact) : null;
+
         return (
           <div
-            key={getItemKey(item)}
-            className={isFocused ? 'ring-4 ring-blue-400 ring-offset-2 rounded-3xl' : ''}
+            key={itemKey}
+            className={`relative ${isFocused ? 'ring-4 ring-blue-400 ring-offset-2 rounded-3xl' : ''}`}
+            {...(englishLabel ? getTooltipHandlers(itemKey) : {})}
           >
+            {tooltipKey === itemKey && englishLabel && (
+              <div className="absolute bottom-full left-1/2 -translate-x-1/2 mb-2 z-20 pointer-events-none" dir="ltr">
+                <div className="bg-gray-900 text-white text-sm rounded-lg px-3 py-1.5 text-center shadow-lg whitespace-nowrap">
+                  <div className="font-semibold">{englishLabel}</div>
+                  {funFact && <div className="text-xs text-gray-300 mt-0.5">{funFact}</div>}
+                </div>
+                <div className="w-2 h-2 bg-gray-900 rotate-45 mx-auto -mt-1" />
+              </div>
+            )}
             {renderCustomCard ? (
               renderCustomCard(item, isCorrect)
             ) : (


### PR DESCRIPTION
## What
Add a hover (200ms delay) and long-press (500ms) vocabulary tooltip to every item in `GameCardGrid`. When triggered, a small dark tooltip appears above the card showing:
- The item's **English name** (always shown)
- A **fun fact** if `funFact` is present on the item

## Why
Children who are unsure of an answer can peek at the English word without being penalised. Turns uncertainty into a learning moment — passive vocabulary acquisition while deliberating.

Closes #1043

## Implementation details
- Tooltip state (`tooltipKey`) lives in `GameCardGrid` alongside the existing `shakeKey` animation state — same pattern, pure UI interaction state
- `onMouseEnter`/`onMouseLeave` for desktop with 200ms delay (prevents flicker on fast cursor swipes)
- `onTouchStart`/`onTouchEnd`/`onTouchMove` for mobile with 500ms long-press; `onTouchMove` cancels the timer so scrolling is unaffected
- Tooltip is `pointer-events-none` — does not block clicks on the card underneath
- `dir="ltr"` on tooltip so English text reads left-to-right even in the RTL layout

## Test plan
- [ ] Open any card game (e.g. `/games/animals`)
- [ ] **Desktop**: hover a card for 0.2s — tooltip shows English name above the card
- [ ] **Mobile**: long-press a card for 0.5s — tooltip shows; release → tooltip hides
- [ ] Normal tap still selects the answer — tooltip does not interfere
- [ ] Scrolling over cards does not trigger tooltip (touch-move cancels timer)
- [ ] RTL layout: tooltip appears centered above card correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)