### PR TITLE
feat(delight): streak counter, haptic feedback, 4s perfect celebration

### DIFF
--- a/gamesformykids/components/game/quiz/QuizFeedback.tsx
+++ b/gamesformykids/components/game/quiz/QuizFeedback.tsx
@@ -1,7 +1,9 @@
 'use client';
 
+import { useEffect } from 'react';
 import { useQuizGameStore } from '@/lib/stores/quizGameStore';
 import { QUIZ_THEMES, type QuizTheme } from './quizTheme';
+import { vibrateCorrect, vibrateWrong } from '@/lib/utils/haptic';
 
 interface Props {
   correctLabel: string;
@@ -21,7 +23,13 @@ export function QuizFeedback({
   const isCorrect = useQuizGameStore(s => s.isCorrect);
   const index     = useQuizGameStore(s => s.index);
   const total     = useQuizGameStore(s => s.total);
+  const streak    = useQuizGameStore(s => s.streak);
   const next      = useQuizGameStore(s => s.nextQuestion);
+
+  useEffect(() => {
+    if (isCorrect === true) vibrateCorrect();
+    else if (isCorrect === false) vibrateWrong();
+  }, [isCorrect]);
 
   if (isCorrect === null) return null;
 
@@ -31,6 +39,15 @@ export function QuizFeedback({
 
   return (
     <div>
+      {isCorrect && streak >= 3 && (
+        <div
+          role="status"
+          aria-live="assertive"
+          className="text-center text-orange-500 font-black text-lg mb-2 motion-safe:animate-bounce"
+        >
+          🔥 רצף של {streak}!
+        </div>
+      )}
       <div
         role="status"
         aria-live="polite"

--- a/gamesformykids/components/game/quiz/QuizResultScreen.tsx
+++ b/gamesformykids/components/game/quiz/QuizResultScreen.tsx
@@ -32,7 +32,7 @@ export function QuizResultScreen({ onRestart, theme, title = 'כל הכבוד!',
       className={`min-h-screen bg-gradient-to-br ${t.gradient} flex flex-col items-center justify-center p-4`}
       dir="rtl"
     >
-      {pct >= 60 && <GameCompletionCelebration />}
+      {pct >= 60 && <GameCompletionCelebration isPerfect={pct === 100} />}
       <div className="bg-white rounded-3xl shadow-2xl p-8 max-w-md w-full text-center">
         {headerContent ?? <div className="text-8xl mb-4">{emoji}</div>}
         <h2 className={`text-2xl font-bold ${t.text} mb-2`}>{title}</h2>

--- a/gamesformykids/components/game/shared/GameCompletionCelebration.tsx
+++ b/gamesformykids/components/game/shared/GameCompletionCelebration.tsx
@@ -31,7 +31,11 @@ const KEYFRAMES = `
 }
 `;
 
-export function GameCompletionCelebration() {
+interface Props {
+  isPerfect?: boolean;
+}
+
+export function GameCompletionCelebration({ isPerfect = false }: Props) {
   const [visible, setVisible] = useState(true);
   const { playSuccessSound } = useGameAudio();
   const params = useParams();
@@ -54,7 +58,8 @@ export function GameCompletionCelebration() {
       setVisible(false);
       return;
     }
-    const id = setTimeout(() => setVisible(false), 2500);
+    const duration = isPerfect ? 4000 : 2500;
+    const id = setTimeout(() => setVisible(false), duration);
     return () => clearTimeout(id);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);

--- a/gamesformykids/lib/stores/quizGameStore.ts
+++ b/gamesformykids/lib/stores/quizGameStore.ts
@@ -8,6 +8,8 @@ export interface QuizGameState {
   index: number;
   total: number;
   score: number;
+  streak: number;
+  bestStreak: number;
   selected: string | null;
   isCorrect: boolean | null;
 }
@@ -26,6 +28,8 @@ const INITIAL_STATE: QuizGameState = {
   index: 0,
   total: 0,
   score: 0,
+  streak: 0,
+  bestStreak: 0,
   selected: null,
   isCorrect: null,
 };
@@ -35,14 +39,23 @@ export const useQuizGameStore = makeStore<QuizGameState & QuizGameActions>('Quiz
 
       startQuiz: (gameType, total) =>
         set(
-          { phase: 'playing', gameType, index: 0, total, score: 0, selected: null, isCorrect: null },
+          { phase: 'playing', gameType, index: 0, total, score: 0, streak: 0, bestStreak: 0, selected: null, isCorrect: null },
           false,
           'quiz/startQuiz',
         ),
 
       selectAnswer: (id, isCorrect) =>
         set(
-          (s) => ({ selected: id, isCorrect, score: isCorrect ? s.score + 1 : s.score }),
+          (s) => {
+            const newStreak = isCorrect ? s.streak + 1 : 0;
+            return {
+              selected: id,
+              isCorrect,
+              score: isCorrect ? s.score + 1 : s.score,
+              streak: newStreak,
+              bestStreak: Math.max(s.bestStreak, newStreak),
+            };
+          },
           false,
           'quiz/selectAnswer',
         ),
@@ -61,7 +74,7 @@ export const useQuizGameStore = makeStore<QuizGameState & QuizGameActions>('Quiz
 
       restartQuiz: () =>
         set(
-          { phase: 'playing', index: 0, score: 0, selected: null, isCorrect: null },
+          { phase: 'playing', index: 0, score: 0, streak: 0, bestStreak: 0, selected: null, isCorrect: null },
           false,
           'quiz/restartQuiz',
         ),

--- a/gamesformykids/lib/utils/haptic.ts
+++ b/gamesformykids/lib/utils/haptic.ts
@@ -1,0 +1,7 @@
+export function vibrateCorrect() {
+  navigator.vibrate?.(30);
+}
+
+export function vibrateWrong() {
+  navigator.vibrate?.([15, 10, 15]);
+}


### PR DESCRIPTION
## Summary

Three small delight enhancements to quiz games:

1. Streak counter after 3 consecutive correct answers (closes #1096) - adds streak/bestStreak to quizGameStore, shows fire emoji banner in QuizFeedback
2. Haptic feedback via navigator.vibrate (closes #1098) - new haptic.ts utility, called from QuizFeedback effect
3. Extended 4s celebration on perfect score (closes #1099) - GameCompletionCelebration accepts isPerfect prop, QuizResultScreen passes isPerfect when pct === 100

## Changes

- lib/utils/haptic.ts (new file)
- lib/stores/quizGameStore.ts - added streak, bestStreak fields
- components/game/quiz/QuizFeedback.tsx - haptic effect + streak banner
- components/game/shared/GameCompletionCelebration.tsx - isPerfect prop
- components/game/quiz/QuizResultScreen.tsx - passes isPerfect={pct === 100}

## Testing

- [x] npx tsc --noEmit passes
- [ ] 3+ correct in a row shows fire banner
- [ ] Wrong answer resets streak
- [ ] Perfect score celebration lasts 4s
- [ ] Non-perfect celebration lasts 2.5s

Closes #1096
Closes #1098
Closes #1099

Generated with Claude Code