### PR TITLE
feat(delight): staggered fade-in-up entrance animation for home page game cards

### DIFF
--- a/gamesformykids/app/globals.css
+++ b/gamesformykids/app/globals.css
@@ -404,3 +404,12 @@ body {
   outline-offset: 2px;
   border-radius: 4px;
 }
+
+@keyframes fade-in-up {
+  from { opacity: 0; transform: translateY(16px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+.animate-fade-in-up {
+  animation: fade-in-up 0.4s ease-out both;
+}

--- a/gamesformykids/components/game/AllGamesView.tsx
+++ b/gamesformykids/components/game/AllGamesView.tsx
@@ -33,8 +33,8 @@ export default function AllGamesView({ games: gamesProp, isFiltered = false }: P
           : `כל המשחקים (${games.length})`}
       </h2>
       <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-3 md:gap-4 lg:gap-6">
-        {games.map((game) => (
-          <GameCard key={game.id} game={game} />
+        {games.map((game, index) => (
+          <GameCard key={game.id} game={game} animationDelay={Math.min(index * 50, 600)} />
         ))}
         {Array.from({ length: fillerCount }).map((_, i) => (
           <div key={`filler-${i}`} aria-hidden="true" className="invisible" />

--- a/gamesformykids/components/game/CategoryGamesView.tsx
+++ b/gamesformykids/components/game/CategoryGamesView.tsx
@@ -47,8 +47,8 @@ export default function CategoryGamesView() {
       <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-3 md:gap-4 lg:gap-6">
         {categoryGames.length > 0 ? (
           <>
-            {categoryGames.map((game) => (
-              <GameCard key={game.id} game={game} />
+            {categoryGames.map((game, index) => (
+              <GameCard key={game.id} game={game} animationDelay={Math.min(index * 50, 600)} />
             ))}
             {Array.from({ length: fillerCount }).map((_, i) => (
               <div key={`filler-${i}`} aria-hidden="true" className="invisible" />

--- a/gamesformykids/components/game/GameCard.tsx
+++ b/gamesformykids/components/game/GameCard.tsx
@@ -5,13 +5,20 @@ import { Star } from "lucide-react";
 import { ComponentTypes } from "@/lib/types";
 import { useFavoritesStore } from "@/lib/stores";
 
-export default function GameCard({ game }: ComponentTypes.GameCardProps) {
+interface GameCardProps extends ComponentTypes.GameCardProps {
+  animationDelay?: number;
+}
+
+export default function GameCard({ game, animationDelay }: GameCardProps) {
   const toggleFavorite = useFavoritesStore((s) => s.toggleFavorite);
   const isFav = useFavoritesStore((s) => s.favoriteIds.includes(game.id));
 
   if (game.available) {
     return (
-      <div className="relative">
+      <div
+        className="relative motion-safe:animate-fade-in-up"
+        style={animationDelay ? { animationDelay: `${animationDelay}ms` } : undefined}
+      >
         <Link href={game.href} aria-label={game.title}>
           <div
             className={`


### PR DESCRIPTION
## Summary

Game cards on the home page now fade in from below in a staggered wave. Each card is delayed by 50ms * its index (capped at 600ms for large grids). The animation uses animation-fill-mode: both so cards start invisible and stay visible after the animation completes. Fully guarded by motion-safe: so users with prefers-reduced-motion see no animation.

## Changes

- app/globals.css - added @keyframes fade-in-up and .animate-fade-in-up utility class
- components/game/GameCard.tsx - added optional animationDelay prop, applies motion-safe:animate-fade-in-up
- components/game/AllGamesView.tsx - passes animationDelay capped at 600ms
- components/game/CategoryGamesView.tsx - same

## Testing

- [x] npx tsc --noEmit passes
- [ ] Home page cards appear in staggered wave on load
- [ ] Under prefers-reduced-motion: no animation, cards appear instantly
- [ ] No layout shift on 375px

Closes #1097

Generated with Claude Code