### PR TITLE
feat(game): visual addition quiz for ages 3-5

### DIFF
--- a/gamesformykids/app/games/[gameType]/gamePageConstants.ts
+++ b/gamesformykids/app/games/[gameType]/gamePageConstants.ts
@@ -54,6 +54,7 @@ export const SUPPORTED_GAMES = [
   // New language & safety games
   'gender', 'final-letters', 'alphabet-order',
   'personal-safety',
+  'visual-addition',
 ] as const;
 
 export type SupportedGameType = typeof SUPPORTED_GAMES[number];

--- a/gamesformykids/lib/constants/gameCategories.ts
+++ b/gamesformykids/lib/constants/gameCategories.ts
@@ -70,7 +70,7 @@ export const GAME_CATEGORIES: Record<string, GameCategory> = {
     icon: Calculator,
     color: "bg-indigo-500",
     gradient: "from-indigo-400 to-indigo-600",
-    gameIds: ["counting","math","shopping-money","multiplication","fractions","sequences","arithmetic","ordinals","number-words","spatial-concepts","sorting","patterns","skip-counting","division"],
+    gameIds: ["counting","math","shopping-money","multiplication","fractions","sequences","arithmetic","ordinals","number-words","spatial-concepts","sorting","patterns","skip-counting","division","visual-addition"],
   },
   games: {
     title: "משחקים מיוחדים",

--- a/gamesformykids/lib/quiz/configs/math.tsx
+++ b/gamesformykids/lib/quiz/configs/math.tsx
@@ -3,8 +3,31 @@ import { QUESTIONS_PER_GAME } from '@/lib/quiz/constants';
 import { FRACTION_QUESTIONS } from '@/lib/quiz/data/fractions';
 import { QUIZ_QUESTIONS, SHAPES_3D } from '@/lib/quiz/data/shapes-3d';
 import { SKIP_COUNTING_QUESTIONS } from '@/lib/quiz/data/skip-counting';
+import { VISUAL_ADDITION_QUESTIONS } from '@/lib/quiz/data/visual-addition';
 import FractionBar from '@/components/game/quiz/FractionBar';
 import { defineConfig } from './types';
+
+export const visualAdditionConfig = defineConfig({
+  gameType: 'visual-addition', emoji: '➕', title: 'חיבור חזותי',
+  description: 'ספור את האובייקטים וחבר אותם!', theme: 'green',
+  preview: (
+    <div className="grid grid-cols-2 gap-2">
+      {['🐸 + 🐸🐸 = 3', '⭐⭐ + ⭐⭐ = 4', '🍎🍎🍎 + 🍎 = 4', '🎈🎈🎈 + 🎈🎈🎈 = 6'].map(s => (
+        <div key={s} className="bg-green-50 rounded-xl px-2 py-1.5 text-xs font-medium text-green-700 text-center">{s}</div>
+      ))}
+    </div>
+  ),
+  buttonLabel: '➕ בואו נספור!',
+  questions: VISUAL_ADDITION_QUESTIONS, questionsPerGame: QUESTIONS_PER_GAME,
+  getChoices: (q) => shuffle([q.answer, ...q.wrongOptions]),
+  isCorrect: (c, q) => c === q.answer,
+  getCorrectLabel: (q) => q.answer,
+  renderQuestion: (q) => (
+    <><div className="text-4xl mb-3">{q.emoji}</div>
+      <p className="text-gray-600 text-sm mb-2">כמה סה"כ?</p>
+      <p className="text-3xl font-black text-green-700 tracking-widest">{q.question}</p></>
+  ),
+});
 
 export const skipCountingConfig = defineConfig({
   gameType: 'skip-counting', emoji: '🔢', title: 'ספירה לפי קפיצות',

--- a/gamesformykids/lib/quiz/configs/math.tsx
+++ b/gamesformykids/lib/quiz/configs/math.tsx
@@ -24,7 +24,7 @@ export const visualAdditionConfig = defineConfig({
   getCorrectLabel: (q) => q.answer,
   renderQuestion: (q) => (
     <><div className="text-4xl mb-3">{q.emoji}</div>
-      <p className="text-gray-600 text-sm mb-2">כמה סה"כ?</p>
+      <p className="text-gray-600 text-sm mb-2">{'כמה סה"כ?'}</p>
       <p className="text-3xl font-black text-green-700 tracking-widest">{q.question}</p></>
   ),
 });

--- a/gamesformykids/lib/quiz/data/visual-addition.ts
+++ b/gamesformykids/lib/quiz/data/visual-addition.ts
@@ -1,0 +1,34 @@
+export type VisualAdditionQuestion = {
+  id: number;
+  question: string;
+  answer: string;
+  emoji: string;
+  wrongOptions: [string, string, string];
+};
+
+export const VISUAL_ADDITION_QUESTIONS: VisualAdditionQuestion[] = [
+  { id: 1,  question: "🐸 + 🐸 = ?",                        answer: "2",  emoji: "🐸", wrongOptions: ["1",  "3",  "4"]  },
+  { id: 2,  question: "🍎🍎 + 🍎 = ?",                      answer: "3",  emoji: "🍎", wrongOptions: ["2",  "4",  "5"]  },
+  { id: 3,  question: "⭐⭐ + ⭐⭐ = ?",                     answer: "4",  emoji: "⭐", wrongOptions: ["3",  "5",  "6"]  },
+  { id: 4,  question: "🐶🐶🐶 + 🐶🐶 = ?",                  answer: "5",  emoji: "🐶", wrongOptions: ["4",  "6",  "7"]  },
+  { id: 5,  question: "🎈🎈🎈 + 🎈🎈🎈 = ?",               answer: "6",  emoji: "🎈", wrongOptions: ["5",  "7",  "8"]  },
+  { id: 6,  question: "🌟🌟🌟🌟 + 🌟🌟🌟 = ?",             answer: "7",  emoji: "🌟", wrongOptions: ["6",  "8",  "9"]  },
+  { id: 7,  question: "🐱🐱🐱🐱 + 🐱🐱🐱🐱 = ?",          answer: "8",  emoji: "🐱", wrongOptions: ["7",  "9",  "6"]  },
+  { id: 8,  question: "🍌🍌🍌🍌🍌 + 🍌🍌🍌🍌 = ?",         answer: "9",  emoji: "🍌", wrongOptions: ["8",  "10", "7"]  },
+  { id: 9,  question: "🦋🦋🦋🦋🦋 + 🦋🦋🦋🦋🦋 = ?",      answer: "10", emoji: "🦋", wrongOptions: ["9",  "8",  "11"] },
+  { id: 10, question: "🌸 + 🌸🌸 = ?",                      answer: "3",  emoji: "🌸", wrongOptions: ["2",  "4",  "5"]  },
+  { id: 11, question: "🏀🏀 + 🏀🏀🏀 = ?",                 answer: "5",  emoji: "🏀", wrongOptions: ["4",  "6",  "7"]  },
+  { id: 12, question: "🦊🦊🦊 + 🦊 = ?",                   answer: "4",  emoji: "🦊", wrongOptions: ["3",  "5",  "6"]  },
+  { id: 13, question: "🍕 + 🍕🍕🍕 = ?",                   answer: "4",  emoji: "🍕", wrongOptions: ["3",  "5",  "2"]  },
+  { id: 14, question: "🌈🌈 + 🌈🌈🌈🌈 = ?",               answer: "6",  emoji: "🌈", wrongOptions: ["5",  "7",  "8"]  },
+  { id: 15, question: "🐘🐘🐘🐘 + 🐘🐘 = ?",               answer: "6",  emoji: "🐘", wrongOptions: ["5",  "7",  "8"]  },
+  { id: 16, question: "🎵🎵 + 🎵🎵🎵🎵🎵 = ?",             answer: "7",  emoji: "🎵", wrongOptions: ["6",  "8",  "5"]  },
+  { id: 17, question: "🍦🍦🍦🍦🍦 + 🍦🍦🍦 = ?",           answer: "8",  emoji: "🍦", wrongOptions: ["7",  "9",  "6"]  },
+  { id: 18, question: "🐟🐟🐟🐟 + 🐟🐟🐟🐟🐟 = ?",         answer: "9",  emoji: "🐟", wrongOptions: ["8",  "10", "7"]  },
+  { id: 19, question: "🌻🌻🌻🌻🌻🌻 + 🌻🌻🌻🌻 = ?",        answer: "10", emoji: "🌻", wrongOptions: ["9",  "8",  "11"] },
+  { id: 20, question: "🍇🍇🍇 + 🍇🍇🍇🍇 = ?",             answer: "7",  emoji: "🍇", wrongOptions: ["6",  "8",  "5"]  },
+  { id: 21, question: "🎯 + 🎯🎯🎯🎯 = ?",                 answer: "5",  emoji: "🎯", wrongOptions: ["4",  "6",  "3"]  },
+  { id: 22, question: "🐢🐢 + 🐢🐢🐢🐢🐢🐢 = ?",           answer: "8",  emoji: "🐢", wrongOptions: ["7",  "9",  "10"] },
+  { id: 23, question: "🦁🦁🦁🦁🦁🦁🦁 + 🦁🦁🦁 = ?",      answer: "10", emoji: "🦁", wrongOptions: ["9",  "8",  "11"] },
+  { id: 24, question: "🍩🍩 + 🍩 = ?",                     answer: "3",  emoji: "🍩", wrongOptions: ["2",  "4",  "5"]  },
+];

--- a/gamesformykids/lib/quiz/quizGameConfigs.tsx
+++ b/gamesformykids/lib/quiz/quizGameConfigs.tsx
@@ -2,7 +2,7 @@ import type { GameType } from '@/lib/types/core/base';
 import { spellingConfig, oppositesConfig, englishWordsConfig, worldLanguagesConfig, rhymingConfig, adjectivesConfig, verbsConfig, genderConfig, finalLettersConfig, alphabetOrderConfig } from './configs/language';
 import { riddlesConfig, capitalsConfig, instrumentsConfig, sportsQuizConfig, continentsConfig } from './configs/knowledge';
 import { emotionsConfig, familyConfig, healthyFoodConfig, singularPluralConfig, morningRoutineConfig } from './configs/social';
-import { fractionsConfig, shapes3dConfig, skipCountingConfig } from './configs/math';
+import { fractionsConfig, shapes3dConfig, skipCountingConfig, visualAdditionConfig } from './configs/math';
 
 export type { QuizGameConfig } from './configs/types';
 import type { QuizGameConfig } from './configs/types';
@@ -33,4 +33,5 @@ export const QUIZ_GAME_CONFIGS: Partial<Record<GameType, QuizGameConfig<unknown>
   'gender': genderConfig,
   'final-letters': finalLettersConfig,
   'alphabet-order': alphabetOrderConfig,
+  'visual-addition': visualAdditionConfig,
 };

--- a/gamesformykids/lib/quiz/registry/genericQuizGames.tsx
+++ b/gamesformykids/lib/quiz/registry/genericQuizGames.tsx
@@ -34,4 +34,5 @@ export const GENERIC_QUIZ_GAMES: Record<string, ComponentType> = {
   'gender':                GenericQuizGame,
   'final-letters':         GenericQuizGame,
   'alphabet-order':        GenericQuizGame,
+  'visual-addition':       GenericQuizGame,
 };

--- a/gamesformykids/lib/registry/registryData/batch4.ts
+++ b/gamesformykids/lib/registry/registryData/batch4.ts
@@ -440,4 +440,15 @@ export const gamesRegistryBatch4: GameRegistration[] = [
     available: true,
     order: 161,
   },
+  {
+    id: "visual-addition",
+    title: "חיבור חזותי",
+    description: "ספור את האובייקטים וחבר אותם — מתאים לגילאי 3-5!",
+    icon: Hash,
+    emoji: "➕",
+    color: "bg-green-500 hover:bg-green-600",
+    href: "/games/visual-addition",
+    available: true,
+    order: 162,
+  },
 ];

--- a/gamesformykids/lib/types/core/base.ts
+++ b/gamesformykids/lib/types/core/base.ts
@@ -170,6 +170,7 @@ export type GameType =
   | 'visual-opposites' | 'english-cards'
   | 'gender' | 'final-letters' | 'alphabet-order'
   | 'personal-safety'
+  | 'visual-addition'
   // Arcade & action games
   | 'maze'
   | 'true-false' | 'flappy-bird' | 'snake' | 'pong' | 'frogger'


### PR DESCRIPTION
## Summary

Adds a Style B quiz game teaching early addition through visual emoji groups. Children ages 3-5 see two groups of objects (e.g. 🐸🐸🐸 + 🐸🐸) and pick the correct total from 4 number tiles. All sums are capped at 10 to match early curriculum. No written arithmetic notation — purely visual counting.

## Changes

- lib/quiz/data/visual-addition.ts (new) — 24 questions, sums 2-10, emoji groups as question text
- lib/quiz/configs/math.tsx — added visualAdditionConfig
- lib/quiz/quizGameConfigs.tsx — registered visual-addition config
- lib/quiz/registry/genericQuizGames.tsx — registered under GenericQuizGame
- lib/types/core/base.ts — added 'visual-addition' to GameType union
- app/games/[gameType]/gamePageConstants.ts — added to SUPPORTED_GAMES
- lib/registry/registryData/batch4.ts — registry entry (order 162)
- lib/constants/gameCategories.ts — added to math category

## Testing

- [x] npx tsc --noEmit passes
- [ ] Game appears at /games/visual-addition
- [ ] Questions show emoji groups with + sign
- [ ] 4 number answer tiles visible
- [ ] Game appears in math category on home page

Closes #1082

Generated with Claude Code