### PR TITLE
fix(ux): nav RTL order, memory win next-game, profile stats/gender, keyboard ring

### DIFF
--- a/gamesformykids/app/games/memory/components/GameWinMessage.tsx
+++ b/gamesformykids/app/games/memory/components/GameWinMessage.tsx
@@ -1,8 +1,10 @@
 'use client';
 
 import { useEffect } from 'react';
+import Link from 'next/link';
 import { useMemoryStore } from "../stores/useMemoryStore";
 import { useGameCompletion } from '@/hooks/shared/progress/useGameCompletion';
+import { useUniversalGameNavigation } from '@/components/game/universal/navigation/useUniversalGameNavigation';
 import WinStatsGrid from "./WinStatsGrid";
 import WinAchievements from "./WinAchievements";
 
@@ -14,6 +16,7 @@ export default function GameWinMessage() {
   const performance = getPerformanceLevel();
 
   const { saveGameResultRef } = useGameCompletion('memory');
+  const { navigation } = useUniversalGameNavigation({ showHomeButton: false });
 
   // Fires once on mount — this component only renders when the game is won.
   useEffect(() => {
@@ -56,6 +59,16 @@ export default function GameWinMessage() {
             >
               🎮 שחק שוב
             </button>
+            {navigation.next && (
+              <Link
+                href={navigation.next.href}
+                className="bg-gradient-to-r from-green-500 to-teal-500 hover:from-green-600 hover:to-teal-600 text-white font-bold py-3 px-8 rounded-full text-xl transition-all duration-300 transform hover:scale-105 shadow-lg flex items-center gap-2"
+              >
+                <span>משחק הבא</span>
+                <span>{navigation.next.title}</span>
+                <span>←</span>
+              </Link>
+            )}
             <button
               onClick={resetToMenu}
               className="bg-white/80 hover:bg-white text-gray-700 font-bold py-3 px-8 rounded-full text-xl transition-all duration-300 transform hover:scale-105 shadow-lg"

--- a/gamesformykids/app/profile/components/ProfileCard.tsx
+++ b/gamesformykids/app/profile/components/ProfileCard.tsx
@@ -8,12 +8,21 @@ function formatMemberSince(iso: string): string {
   return new Date(iso).toLocaleDateString('he-IL', { year: 'numeric', month: 'long' });
 }
 
+const GENDER_OPTIONS: { value: 'male' | 'female'; label: string; emoji: string }[] = [
+  { value: 'male',   label: 'זכר',  emoji: '👦' },
+  { value: 'female', label: 'נקבה', emoji: '👧' },
+];
+
 export function ProfileCard() {
   const { user } = useAuth();
-  const { profile, uploadAvatar } = useUserProfile();
+  const { profile, uploadAvatar, updateProfile } = useUserProfile();
   const { isEditing, uploadingAvatar, startEdit, handleAvatarUpload } = useProfileStore();
 
   if (!user) return null;
+
+  const handleGenderSelect = (gender: 'male' | 'female') => {
+    updateProfile({ gender: profile?.gender === gender ? null : gender });
+  };
 
   return (
     <div className="bg-white rounded-2xl shadow-lg p-6 mb-6">
@@ -60,6 +69,27 @@ export function ProfileCard() {
                   חבר מאז {formatMemberSince(profile.created_at)}
                 </p>
               )}
+
+              {/* gender selection */}
+              <div className="flex items-center gap-2 mt-3">
+                <span className="text-xs text-gray-500">אווטר:</span>
+                {GENDER_OPTIONS.map(({ value, label, emoji }) => (
+                  <button
+                    key={value}
+                    onClick={() => handleGenderSelect(value)}
+                    className={`flex items-center gap-1 px-3 py-1 rounded-full text-sm font-medium border-2 transition-all duration-200 ${
+                      profile?.gender === value
+                        ? 'border-purple-500 bg-purple-100 text-purple-700'
+                        : 'border-gray-200 bg-gray-50 text-gray-600 hover:border-purple-300'
+                    }`}
+                    title={`אווטר ${label}`}
+                  >
+                    <span>{emoji}</span>
+                    <span>{label}</span>
+                  </button>
+                ))}
+              </div>
+
               <button
                 onClick={startEdit}
                 className="mt-3 text-sm text-purple-600 hover:text-purple-800 font-medium transition-colors"

--- a/gamesformykids/app/profile/components/ProfileStatCards.tsx
+++ b/gamesformykids/app/profile/components/ProfileStatCards.tsx
@@ -1,20 +1,20 @@
 import { useProfileComputedStats } from '../stores/useProfileStore';
 
 const STAT_STYLES = [
-  { from: 'from-purple-400', to: 'to-purple-600', text: 'text-purple-600', bg: 'bg-purple-50' },
-  { from: 'from-blue-400',   to: 'to-blue-600',   text: 'text-blue-600',   bg: 'bg-blue-50'   },
-  { from: 'from-amber-400',  to: 'to-amber-600',  text: 'text-amber-600',  bg: 'bg-amber-50'  },
-  { from: 'from-green-400',  to: 'to-green-600',  text: 'text-green-600',  bg: 'bg-green-50'  },
+  { text: 'text-purple-600', bg: 'bg-purple-50' },
+  { text: 'text-blue-600',   bg: 'bg-blue-50'   },
+  { text: 'text-amber-600',  bg: 'bg-amber-50'  },
+  { text: 'text-green-600',  bg: 'bg-green-50'  },
 ];
 
 export function ProfileStatCards() {
-  const { totalScore, totalPlayTime, achievementsCount, gamesPlayed } = useProfileComputedStats();
+  const { totalScore, totalPlayTime, achievementsCount, gamesPlayed, isLoading } = useProfileComputedStats();
 
   const stats = [
-    { emoji: '🏆', label: 'סך הניקוד',   value: totalScore.toLocaleString('he-IL') },
-    { emoji: '⏰', label: 'זמן משחק',     value: `${totalPlayTime} דק׳` },
-    { emoji: '🎖️', label: 'הישגים',       value: String(achievementsCount) },
-    { emoji: '🎮', label: 'משחקים ששוחקו', value: String(gamesPlayed) },
+    { emoji: '🏆', label: 'סך הניקוד',    value: totalScore.toLocaleString('he-IL') },
+    { emoji: '⏰', label: 'זמן משחק',      value: `${totalPlayTime} דק׳` },
+    { emoji: '🎖️', label: 'הישגים',        value: String(achievementsCount) },
+    { emoji: '🎮', label: 'סוגי משחקים',   value: String(gamesPlayed) },
   ];
 
   return (
@@ -24,7 +24,11 @@ export function ProfileStatCards() {
         return (
           <div key={label} className={`${style.bg} rounded-2xl shadow p-5 text-center`}>
             <div className="text-3xl mb-2">{emoji}</div>
-            <p className={`text-2xl font-bold ${style.text}`}>{value}</p>
+            {isLoading ? (
+              <div className="h-8 w-16 bg-gray-200 rounded animate-pulse mx-auto mb-1" />
+            ) : (
+              <p className={`text-2xl font-bold ${style.text}`}>{value}</p>
+            )}
             <h3 className="text-sm font-medium text-gray-600 mt-1">{label}</h3>
           </div>
         );

--- a/gamesformykids/app/profile/stores/useProfileStore.ts
+++ b/gamesformykids/app/profile/stores/useProfileStore.ts
@@ -34,9 +34,16 @@ export interface ProfileActions {
 export const getDisplayName = (profile: UserProfile | null, user: User): string =>
   profile?.full_name ?? (user.user_metadata?.full_name as string | undefined) ?? 'משתמש';
 
-export const getAvatarSrc = (profile: UserProfile | null, user: User): string =>
-  profile?.avatar_url ??
-  `https://ui-avatars.com/api/?name=${encodeURIComponent(user.email ?? 'User')}&background=8b5cf6&color=fff`;
+const GENDER_AVATARS = {
+  male:   'https://api.dicebear.com/9.x/fun-emoji/svg?seed=boy&backgroundColor=b6e3f4',
+  female: 'https://api.dicebear.com/9.x/fun-emoji/svg?seed=girl&backgroundColor=ffd5dc',
+} as const;
+
+export const getAvatarSrc = (profile: UserProfile | null, user: User): string => {
+  if (profile?.avatar_url) return profile.avatar_url;
+  if (profile?.gender && GENDER_AVATARS[profile.gender]) return GENDER_AVATARS[profile.gender];
+  return `https://ui-avatars.com/api/?name=${encodeURIComponent(user.email ?? 'User')}&background=8b5cf6&color=fff`;
+};
 
 // ── Computed stats hook (subscribes to underlying stores) ─
 
@@ -47,9 +54,11 @@ export function useProfileComputedStats() {
   const totalPlayTime = useGameProgressDataStore((s) =>
     Math.floor(s.progress.reduce((sum, p) => sum + p.total_play_time, 0) / 60)
   );
+  // Distinct game types that have at least one session recorded
   const gamesPlayed = useGameProgressDataStore((s) => s.progress.length);
   const achievementsCount = useAchievementsStore((s) => s.achievements.length);
-  return { totalScore, totalPlayTime, achievementsCount, gamesPlayed };
+  const isLoading = useGameProgressDataStore((s) => s.loading);
+  return { totalScore, totalPlayTime, achievementsCount, gamesPlayed, isLoading };
 }
 
 // ── Store ─────────────────────────────────────────────────

--- a/gamesformykids/components/game/universal/navigation/UniversalGameNavigation.tsx
+++ b/gamesformykids/components/game/universal/navigation/UniversalGameNavigation.tsx
@@ -40,18 +40,20 @@ export default function UniversalGameNavigation({
       aria-label="ניווט בין משחקים"
       className="fixed top-4 inset-x-4 z-50 flex justify-between items-center pointer-events-none"
     >
-      {/* ימין — הבא (first in DOM = right side in RTL flex) */}
+      {/* ימין — קודם (first in DOM = right side in RTL flex) */}
       <div className="flex gap-2 pointer-events-auto">
-        {navigation.next && (
+        {navigation.previous && (
           <Link
-            href={navigation.next.href}
-            className="bg-green-500/90 backdrop-blur-sm hover:bg-green-600 text-white font-bold py-2 px-3 md:py-3 md:px-4 rounded-xl shadow-lg transition-[transform,colors] duration-200 hover:scale-105 active:scale-95 flex items-center gap-2 text-sm md:text-base border-2 border-green-400 hover:border-green-300"
-            title={`${navigation.next.title} (→)`}
-            aria-label={`משחק הבא: ${navigation.next.title}`}
+            href={navigation.previous.href}
+            className="bg-blue-500/90 backdrop-blur-sm hover:bg-blue-600 text-white font-bold py-2 px-3 md:py-3 md:px-4 rounded-xl shadow-lg transition-[transform,colors] duration-200 hover:scale-105 active:scale-95 flex items-center gap-2 text-sm md:text-base border-2 border-blue-400 hover:border-blue-300"
+            title={`${navigation.previous.title} (→)`}
+            aria-label={`משחק קודם: ${navigation.previous.title}`}
           >
-            <span className="hidden lg:inline">{navigation.next.title}</span>
-            {navigation.next.icon && renderIcon(navigation.next.icon)}
-            <ArrowLeft className="w-4 h-4 md:w-5 md:h-5" aria-hidden="true" />
+            <ArrowRight className="w-4 h-4 md:w-5 md:h-5" aria-hidden="true" />
+            {navigation.previous.icon && renderIcon(navigation.previous.icon)}
+            <span className="hidden lg:inline">
+              {navigation.previous.title}
+            </span>
           </Link>
         )}
       </div>
@@ -80,20 +82,18 @@ export default function UniversalGameNavigation({
         )}
       </div>
 
-      {/* שמאל — קודם (last in DOM = left side in RTL flex) */}
+      {/* שמאל — הבא (last in DOM = left side in RTL flex) */}
       <div className="flex gap-2 pointer-events-auto">
-        {navigation.previous && (
+        {navigation.next && (
           <Link
-            href={navigation.previous.href}
-            className="bg-blue-500/90 backdrop-blur-sm hover:bg-blue-600 text-white font-bold py-2 px-3 md:py-3 md:px-4 rounded-xl shadow-lg transition-[transform,colors] duration-200 hover:scale-105 active:scale-95 flex items-center gap-2 text-sm md:text-base border-2 border-blue-400 hover:border-blue-300"
-            title={`${navigation.previous.title} (←)`}
-            aria-label={`משחק קודם: ${navigation.previous.title}`}
+            href={navigation.next.href}
+            className="bg-green-500/90 backdrop-blur-sm hover:bg-green-600 text-white font-bold py-2 px-3 md:py-3 md:px-4 rounded-xl shadow-lg transition-[transform,colors] duration-200 hover:scale-105 active:scale-95 flex items-center gap-2 text-sm md:text-base border-2 border-green-400 hover:border-green-300"
+            title={`${navigation.next.title} (←)`}
+            aria-label={`משחק הבא: ${navigation.next.title}`}
           >
-            <ArrowRight className="w-4 h-4 md:w-5 md:h-5" aria-hidden="true" />
-            {navigation.previous.icon && renderIcon(navigation.previous.icon)}
-            <span className="hidden lg:inline">
-              {navigation.previous.title}
-            </span>
+            <ArrowLeft className="w-4 h-4 md:w-5 md:h-5" aria-hidden="true" />
+            {navigation.next.icon && renderIcon(navigation.next.icon)}
+            <span className="hidden lg:inline">{navigation.next.title}</span>
           </Link>
         )}
       </div>

--- a/gamesformykids/hooks/shared/useKeyboardAnswerSelect.ts
+++ b/gamesformykids/hooks/shared/useKeyboardAnswerSelect.ts
@@ -15,15 +15,16 @@ export function useKeyboardAnswerSelect(
   onSelect: (idx: number) => void,
   enabled: boolean,
 ) {
-  const [focusedIdx, setFocusedIdx] = useState(0);
-  const focusedRef = useRef(0);
+  // -1 = no keyboard focus yet; ring only appears after first arrow/number key press
+  const [focusedIdx, setFocusedIdx] = useState(-1);
+  const focusedRef = useRef(-1);
   const onSelectRef = useRef(onSelect);
   onSelectRef.current = onSelect;
 
   // Reset focus when a new set of choices arrives
   useEffect(() => {
-    setFocusedIdx(0);
-    focusedRef.current = 0;
+    setFocusedIdx(-1);
+    focusedRef.current = -1;
   }, [count]);
 
   useEffect(() => {
@@ -48,7 +49,7 @@ export function useKeyboardAnswerSelect(
       if (key === 'ArrowRight' || key === 'ArrowDown') {
         e.preventDefault();
         setFocusedIdx(prev => {
-          const next = (prev + 1) % count;
+          const next = prev < 0 ? 0 : (prev + 1) % count;
           focusedRef.current = next;
           return next;
         });
@@ -58,7 +59,7 @@ export function useKeyboardAnswerSelect(
       if (key === 'ArrowLeft' || key === 'ArrowUp') {
         e.preventDefault();
         setFocusedIdx(prev => {
-          const next = (prev - 1 + count) % count;
+          const next = prev < 0 ? count - 1 : (prev - 1 + count) % count;
           focusedRef.current = next;
           return next;
         });
@@ -67,7 +68,7 @@ export function useKeyboardAnswerSelect(
 
       if (key === 'Enter' || key === ' ') {
         e.preventDefault();
-        onSelectRef.current(focusedRef.current);
+        if (focusedRef.current >= 0) onSelectRef.current(focusedRef.current);
       }
     };
 

--- a/gamesformykids/hooks/shared/user/useUserProfile.ts
+++ b/gamesformykids/hooks/shared/user/useUserProfile.ts
@@ -29,6 +29,7 @@ export interface UserProfile {
   id: string
   full_name: string | null
   avatar_url: string | null
+  gender: 'male' | 'female' | null
   created_at: string
   updated_at: string
 }

--- a/gamesformykids/next.config.ts
+++ b/gamesformykids/next.config.ts
@@ -17,6 +17,21 @@ const nextConfig: NextConfig = {
         hostname: 'flagcdn.com',
         pathname: '/**',
       },
+      {
+        protocol: 'https',
+        hostname: 'ui-avatars.com',
+        pathname: '/**',
+      },
+      {
+        protocol: 'https',
+        hostname: 'api.dicebear.com',
+        pathname: '/**',
+      },
+      {
+        protocol: 'https',
+        hostname: '**.supabase.co',
+        pathname: '/**',
+      },
     ],
   },
   async headers() {


### PR DESCRIPTION
## Summary

Fixes five UX and bug issues reported by the user: navigation next/previous buttons were in the wrong order for RTL Hebrew, the memory game win screen had no way to go to the next game, profile statistics showed a misleading label with no loading state, the profile had no avatar/gender option, and the first card in card games showed a blue focus ring immediately before any keyboard interaction.

## Changes

| File | What changed |
|------|-------------|
| `components/game/universal/navigation/UniversalGameNavigation.tsx` | Swapped DOM order of next/previous divs — in RTL flex the first element is on the right, so **previous** (blue) is now first (→ right) and **next** (green) is last (→ left) |
| `app/games/memory/components/GameWinMessage.tsx` | Added green "משחק הבא ←" `<Link>` button using `useUniversalGameNavigation`; only renders when a next game exists |
| `app/profile/components/ProfileStatCards.tsx` | Renamed stat label `'משחקים ששוחקו'` → `'סוגי משחקים'`; added skeleton pulse animation while data loads |
| `app/profile/stores/useProfileStore.ts` | `useProfileComputedStats` now also exposes `isLoading`; added `GENDER_AVATARS` map for DiceBear fallback URLs |
| `app/profile/components/ProfileCard.tsx` | Added 👦 זכר / 👧 נקבה toggle buttons; clicking saves `gender` to `profiles` via `updateProfile`; avatar uses DiceBear per gender when no photo uploaded |
| `hooks/shared/user/useUserProfile.ts` | Added `gender: 'male' \| 'female' \| null` to `UserProfile` type |
| `hooks/shared/useKeyboardAnswerSelect.ts` | `focusedIdx` initialises to `-1` (was `0`); no card shows a focus ring until user presses an arrow or number key |
| `next.config.ts` | Added `ui-avatars.com`, `api.dicebear.com`, `**.supabase.co` to `images.remotePatterns` |

## ⚠️ Migration required

The gender avatar feature requires a new column in Supabase:
```sql
ALTER TABLE profiles ADD COLUMN IF NOT EXISTS gender TEXT CHECK (gender IN ('male','female')) DEFAULT NULL;
```
Without this column the gender save will fail silently (no app crash).

## Testing

- [x] `npx tsc --noEmit` — zero errors
- [ ] Nav: previous (כחול) is on the right, next (ירוק) on the left while playing any game
- [ ] Memory game: win screen shows green "משחק הבא" button
- [ ] Profile `/profile`: stats show skeleton while loading, label reads "סוגי משחקים"
- [ ] Profile: clicking 👦/👧 updates the avatar circle; clicking again deselects
- [ ] Card game (e.g. `/games/colors`): no card starts with a blue ring; ring appears only after pressing 1/2/3/4 or arrow keys

Closes #1133

🤖 Generated with [Claude Code](https://claude.com/claude-code)