### PR TITLE
fix(profile): prevent stale progress after game → profile navigation

### DIFF
--- a/gamesformykids/app/profile/ProfileClient.tsx
+++ b/gamesformykids/app/profile/ProfileClient.tsx
@@ -21,17 +21,23 @@ export default function ProfileClient() {
   const { refreshProgress } = useGameProgress();
   useAchievements();
 
-  // Fetch on mount (user change) and on tab re-focus so progress saved
-  // during a game session is visible when navigating back to this page.
+  // Fetch on mount and on tab re-focus.
+  // A delayed second fetch catches saves that were still in-flight when the
+  // user navigated here (game unmount fires an async Supabase write that may
+  // not have committed before the immediate fetch runs).
   useEffect(() => {
     if (!user) return;
     refreshProgress();
+    const delayed = setTimeout(refreshProgress, 1500);
 
     const onVisible = () => {
       if (document.visibilityState === 'visible') refreshProgress();
     };
     document.addEventListener('visibilitychange', onVisible);
-    return () => document.removeEventListener('visibilitychange', onVisible);
+    return () => {
+      clearTimeout(delayed);
+      document.removeEventListener('visibilitychange', onVisible);
+    };
   // refreshProgress is stable (useCallback), user drives re-runs
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [user]);

--- a/gamesformykids/lib/stores/gameProgressDataStore.ts
+++ b/gamesformykids/lib/stores/gameProgressDataStore.ts
@@ -36,8 +36,30 @@ const initialState: GameProgressDataState = {
 export const useGameProgressDataStore = makeStore<GameProgressDataState & GameProgressDataActions>('GameProgressDataStore', (set) => ({
       ...initialState,
 
-      setProgress: (progress) =>
-        set({ progress }, false, 'gameProgressData/setAll'),
+      setProgress: (incoming) =>
+        set(
+          (state) => {
+            // Merge DB data with in-memory data, keeping the more recent entry per
+            // game type. This prevents a concurrent profile refresh from overwriting
+            // an in-memory upsertProgressItem result that raced the DB read:
+            // if the profile fetch started before the game save committed, the fetch
+            // returns stale data — but the in-memory version is already correct.
+            const merged = [...incoming];
+            for (const mem of state.progress) {
+              const idx = merged.findIndex((p) => p.game_type === mem.game_type);
+              if (idx < 0) {
+                merged.push(mem); // in-memory has it, DB hasn't committed it yet
+              } else if (
+                new Date(mem.updated_at) > new Date(merged[idx]!.updated_at)
+              ) {
+                merged[idx] = mem; // in-memory is newer → prefer it
+              }
+            }
+            return { progress: merged };
+          },
+          false,
+          'gameProgressData/setAll',
+        ),
 
       upsertProgressItem: (item) =>
         set(


### PR DESCRIPTION
## Summary
- `gameProgressDataStore.setProgress` now **merges** incoming DB rows with in-memory rows (by `updated_at`), so a concurrent `setProgress(staleDbData)` call can no longer clobber a `upsertProgressItem` result that landed first
- `ProfileClient` fires a **delayed second refresh** (1.5 s) so that even if the immediate fetch wins the race against the DB write, the delayed fetch picks up the committed row

## Root cause
When a card game unmounts, the async Supabase upsert fires but is not awaited. If the user navigates home → profile before the upsert commits:
1. `refreshProgress()` reads the DB and gets stale data (race A)
2. `upsertProgressItem(freshData)` then writes the Zustand store with the correct value
3. If `setProgress(staleData)` resolves *after* step 2, it silently overwrites the correct value — nothing triggers a further update, so the profile is permanently stale

## Changes
- [`lib/stores/gameProgressDataStore.ts`](lib/stores/gameProgressDataStore.ts) — smart merge in `setProgress`
- [`app/profile/ProfileClient.tsx`](app/profile/ProfileClient.tsx) — `setTimeout(refreshProgress, 1500)` alongside the immediate call

## Test plan
- [ ] `npx tsc --noEmit` passes (zero errors)
- [ ] Play a card game (e.g. colors), navigate immediately to home → profile — stats show the new session within 2 s
- [ ] Play a quiz game to the result screen, navigate to profile — progress is visible
- [ ] Repeated profile visits continue to show correct (non-stale) data

Closes #1136

🤖 Generated with [Claude Code](https://claude.com/claude-code)