### PR TITLE
feat(analytics): add game-level event tracking (game_start, game_complete, correct_answer, wrong_answer)

### DIFF
--- a/gamesformykids/hooks/shared/game-state/useBaseGame.ts
+++ b/gamesformykids/hooks/shared/game-state/useBaseGame.ts
@@ -18,6 +18,7 @@ import {
 import { GAME_CONSTANTS } from "@/lib/constants";
 import { useGameProgressStore, useGameStore } from "@/lib/stores";
 import { useGameSessionStore } from "@/lib/stores/gameSessionStore";
+import { trackEvent } from "@/lib/analytics/trackEvent";
 
 /**
  * Hook בסיסי לכל המשחקים הפשוטים
@@ -125,6 +126,7 @@ export function useBaseGame<T extends BaseGameItem = BaseGameItem>(config: UseBa
     progressStore.setGameActive(true);
     sessionStartRef.current = Date.now();
     useGameStore.getState().startGame(gameType);
+    trackEvent('game_start', { game_type: gameType });
 
     useGameSessionStore.getState().resetSession();
     progressHooks.startSession();
@@ -147,6 +149,7 @@ export function useBaseGame<T extends BaseGameItem = BaseGameItem>(config: UseBa
 
     if (selectedItem.name === currentChallenge.name) {
       // תשובה נכונה
+      trackEvent('correct_answer', { game_type: gameType });
       playSuccessSound();
       useGameSessionStore.getState().resetWrongAttempts();
 
@@ -178,6 +181,7 @@ export function useBaseGame<T extends BaseGameItem = BaseGameItem>(config: UseBa
       useGameStore.getState().updateProgress(updated.score, updated.level);
     } else {
       // תשובה שגויה
+      trackEvent('wrong_answer', { game_type: gameType });
       useGameSessionStore.getState().incrementWrongAttempts();
       progressHooks.recordMistake(currentChallenge, 1);
       
@@ -199,6 +203,8 @@ export function useBaseGame<T extends BaseGameItem = BaseGameItem>(config: UseBa
     useGameProgressStore.getState().setGameActive(false);
     useGameProgressStore.getState().resetProgress();
     useGameSessionStore.getState().resetSession();
+
+    trackEvent('game_complete', { game_type: gameType, score: finalScore });
 
     // Persist progress to Supabase — single atomic upsert
     if (finalScore > 0 || finalLevel > 1) {

--- a/gamesformykids/lib/analytics/trackEvent.ts
+++ b/gamesformykids/lib/analytics/trackEvent.ts
@@ -1,0 +1,13 @@
+type GameEventParams = {
+  game_type?: string;
+  score?: number;
+  total?: number;
+};
+
+// Safe wrapper around gtag — no-ops when gtag is not loaded (dev, no GA ID, SSR)
+export function trackEvent(name: string, params?: GameEventParams): void {
+  if (typeof window === 'undefined') return;
+  const g = (window as unknown as Record<string, unknown>).gtag;
+  if (typeof g !== 'function') return;
+  (g as (...args: unknown[]) => void)('event', name, params ?? {});
+}

--- a/gamesformykids/lib/stores/quizGameStore.ts
+++ b/gamesformykids/lib/stores/quizGameStore.ts
@@ -1,4 +1,5 @@
 import { makeStore } from './createStore';
+import { trackEvent } from '@/lib/analytics/trackEvent';
 
 export type QuizPhase = 'menu' | 'playing' | 'result';
 
@@ -37,14 +38,17 @@ const INITIAL_STATE: QuizGameState = {
 export const useQuizGameStore = makeStore<QuizGameState & QuizGameActions>('QuizGameStore', (set, get) => ({
       ...INITIAL_STATE,
 
-      startQuiz: (gameType, total) =>
+      startQuiz: (gameType, total) => {
         set(
           { phase: 'playing', gameType, index: 0, total, score: 0, streak: 0, bestStreak: 0, selected: null, isCorrect: null },
           false,
           'quiz/startQuiz',
-        ),
+        );
+        trackEvent('game_start', { game_type: gameType });
+      },
 
-      selectAnswer: (id, isCorrect) =>
+      selectAnswer: (id, isCorrect) => {
+        const gameType = get().gameType ?? undefined;
         set(
           (s) => {
             const newStreak = isCorrect ? s.streak + 1 : 0;
@@ -58,14 +62,17 @@ export const useQuizGameStore = makeStore<QuizGameState & QuizGameActions>('Quiz
           },
           false,
           'quiz/selectAnswer',
-        ),
+        );
+        if (gameType) trackEvent(isCorrect ? 'correct_answer' : 'wrong_answer', { game_type: gameType });
+      },
 
       nextQuestion: () => {
-        const { index, total } = get();
+        const { index, total, score, gameType } = get();
         if (index < total - 1) {
           set({ index: index + 1, selected: null, isCorrect: null }, false, 'quiz/nextQuestion');
         } else {
           set({ phase: 'result', selected: null, isCorrect: null }, false, 'quiz/endGame');
+          if (gameType) trackEvent('game_complete', { game_type: gameType, score, total });
         }
       },
 


### PR DESCRIPTION
## Summary

Creates a thin `trackEvent` wrapper around the existing `gtag` integration and wires four game-level custom events into both card games and quiz games. No PII is sent — only `game_type` and aggregate scores. The wrapper safely no-ops in development and on SSR, so the change is zero-risk in non-production environments.

## Changes

- `lib/analytics/trackEvent.ts` — new zero-dependency gtag wrapper; safe in dev/SSR/no-GA-ID environments
- `hooks/shared/game-state/useBaseGame.ts` — fires `game_start` on session begin, `correct_answer`/`wrong_answer` on each answer, `game_complete` on session end (card games)
- `lib/stores/quizGameStore.ts` — fires `game_start` in `startQuiz`, `correct_answer`/`wrong_answer` in `selectAnswer`, `game_complete` with score+total when `nextQuestion` transitions to result phase (quiz games)

## Testing

- [ ] `npx tsc --noEmit` passes
- [ ] In browser devtools Network tab, GA events fire on game start/answer/complete when `NEXT_PUBLIC_GA_ID` is set

Closes #1122

🤖 Generated with [Claude Code](https://claude.com/claude-code)