### PR TITLE
feat(ux): add sticky category jump bar to home page

### DIFF
--- a/gamesformykids/app/HomePageClient.tsx
+++ b/gamesformykids/app/HomePageClient.tsx
@@ -8,6 +8,7 @@ import SurpriseMeButton from "@/components/marketing/SurpriseMeButton";
 import CategorizedGamesGrid from "@/components/marketing/CategorizedGamesGrid";
 import LoadingScreen from "@/components/layout/LoadingScreen";
 import VocabularyOfTheDay from "@/components/marketing/VocabularyOfTheDay";
+import CategoryJumpBar from "@/components/marketing/CategoryJumpBar";
 import { useHomePage } from "./useHomePage";
 
 export default function HomePageClient() {
@@ -21,6 +22,7 @@ export default function HomePageClient() {
     <div className="min-h-screen bg-linear-to-br from-blue-100 via-purple-100 to-pink-100 dark:from-gray-900 dark:via-gray-800 dark:to-gray-900">
       <VocabularyOfTheDay />
       <Header />
+      <CategoryJumpBar />
       <main>
         <FeaturedGame />
         <GameRecommendations />

--- a/gamesformykids/components/game/CategoriesView.tsx
+++ b/gamesformykids/components/game/CategoriesView.tsx
@@ -26,12 +26,13 @@ export default function CategoriesView() {
           ).length;
 
           return (
-            <CategoryCard
-              key={key}
-              category={category}
-              gamesCount={gamesCount}
-              onClick={() => selectCategory(key)}
-            />
+            <div key={key} id={`category-${key}`}>
+              <CategoryCard
+                category={category}
+                gamesCount={gamesCount}
+                onClick={() => selectCategory(key)}
+              />
+            </div>
           );
         })}
         {Array.from({ length: fillerCount }).map((_, i) => (

--- a/gamesformykids/components/marketing/CategoryJumpBar.tsx
+++ b/gamesformykids/components/marketing/CategoryJumpBar.tsx
@@ -1,0 +1,48 @@
+'use client';
+
+import { useCallback } from 'react';
+import { GAME_CATEGORIES } from '@/lib/constants/gameCategories';
+import { useHomePageStore } from '@/lib/stores';
+
+export default function CategoryJumpBar() {
+  const showCategoriesView = useHomePageStore((s) => s.showCategoriesView);
+
+  const handleClick = useCallback((key: string) => {
+    showCategoriesView();
+    // Let the view render before scrolling
+    setTimeout(() => {
+      const el = document.getElementById(`category-${key}`);
+      el?.scrollIntoView({ behavior: 'smooth', block: 'center' });
+    }, 50);
+  }, [showCategoriesView]);
+
+  return (
+    <div
+      dir="rtl"
+      className="sticky top-16 z-30 bg-white/80 dark:bg-gray-900/80 backdrop-blur-sm border-b border-gray-200 dark:border-gray-700 shadow-sm"
+    >
+      <div className="overflow-x-auto scrollbar-hide">
+        <div className="flex gap-1 px-3 py-2 min-w-max">
+          {Object.entries(GAME_CATEGORIES).map(([key, category]) => {
+            const Icon = category.icon;
+            return (
+              <button
+                key={key}
+                onClick={() => handleClick(key)}
+                aria-label={category.title}
+                className="flex flex-col items-center gap-0.5 px-3 py-1.5 rounded-xl hover:bg-purple-50 dark:hover:bg-gray-700 transition-colors group shrink-0"
+              >
+                <div className={`w-8 h-8 rounded-lg bg-gradient-to-br ${category.gradient} flex items-center justify-center shadow-sm group-hover:scale-110 transition-transform`}>
+                  <Icon className="w-4 h-4 text-white" />
+                </div>
+                <span className="text-xs text-gray-600 dark:text-gray-300 font-medium leading-tight max-w-[60px] text-center line-clamp-1">
+                  {category.title.replace('📚 ', '').replace('🕹️ ', '')}
+                </span>
+              </button>
+            );
+          })}
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
Adds a horizontally-scrollable sticky bar beneath the site header containing icon + label buttons for all 13 game categories. Clicking a button scrolls smoothly to that category card in the grid (or switches back to the categories view if the user is in a drill-down view). Fully RTL-aware.

## Changes
- `components/marketing/CategoryJumpBar.tsx`: new sticky bar component reading from `GAME_CATEGORIES`; each button calls `showCategoriesView()` and then smooth-scrolls to `#category-{key}`
- `components/game/CategoriesView.tsx`: wrap each `CategoryCard` in `<div id="category-{key}">` for anchor targeting
- `app/HomePageClient.tsx`: render `<CategoryJumpBar />` immediately after `<Header />`

## Testing
- [x] `npx tsc --noEmit` passes
- [x] All 13 categories shown in horizontal scrollable bar
- [x] Clicking scrolls to correct category section
- [x] Sticky `top-16` positions below the site header (64px)
- [x] RTL layout (scrolls from right in Hebrew)

Closes #982

🤖 Generated with [Claude Code](https://claude.com/claude-code)