### PR TITLE
feat(gamification): in-session streak badge in card game HUD

### DIFF
--- a/gamesformykids/components/game/shared/StreakBadge.tsx
+++ b/gamesformykids/components/game/shared/StreakBadge.tsx
@@ -1,0 +1,24 @@
+'use client';
+
+import { useGameProgressStore } from '@/lib/stores/gameProgressStore';
+
+export function StreakBadge() {
+  const streak = useGameProgressStore((s) => s.streakCount);
+
+  if (streak < 3) return null;
+
+  const fire = streak >= 20 ? '⚡' : streak >= 10 ? '🔥🔥🔥' : streak >= 5 ? '🔥🔥' : '🔥';
+  const bonus = streak >= 20 ? '+20 נקודות בונוס!' : streak >= 10 ? '+10 נקודות בונוס!' : streak >= 5 ? '+5 נקודות בונוס!' : null;
+
+  return (
+    <div
+      dir="rtl"
+      className="flex items-center gap-1.5 bg-orange-50 border border-orange-200 rounded-full px-3 py-1 text-sm font-bold text-orange-700 motion-safe:animate-pulse"
+      aria-live="polite"
+    >
+      <span>{fire}</span>
+      <span>{streak} ברצף!</span>
+      {bonus && <span className="text-xs font-semibold text-orange-500">({bonus})</span>}
+    </div>
+  );
+}

--- a/gamesformykids/components/game/universal/auto-game/AutoGameHeader.tsx
+++ b/gamesformykids/components/game/universal/auto-game/AutoGameHeader.tsx
@@ -4,6 +4,7 @@ import { useAutoGame } from "@/hooks";
 import { GameHeader } from "../../../shared";
 import { ChallengeBox } from "../../../shared";
 import { CelebrationBox } from "../../../shared";
+import { StreakBadge } from "@/components/game/shared/StreakBadge";
 
 /**
  * AutoGameHeader - header section of AutoGamePage
@@ -36,6 +37,13 @@ export function AutoGameHeader() {
           📊 {currentAccuracy || 0}%
         </button>
       </div>
+
+      {/* Streak badge */}
+      {gameState && !showCelebration && (
+        <div className="flex justify-center mb-2">
+          <StreakBadge />
+        </div>
+      )}
 
       {/* Challenge Box */}
       {gameState && currentChallenge && !showCelebration && (


### PR DESCRIPTION
## Summary
Adds a visible streak counter badge to the card game HUD. The badge reads `streakCount` directly from the existing `gameProgressStore` (no new state) and renders a 🔥/🔥🔥/🔥🔥🔥/⚡ badge when the player answers 3+ consecutive questions correctly. The badge disappears on any wrong answer and reappears when the streak rebuilds.

## Changes
- `components/game/shared/StreakBadge.tsx` — new component: shows streak badge with escalating fire emoji + bonus-points note at streaks of 5, 10, 20
- `components/game/universal/auto-game/AutoGameHeader.tsx` — renders `<StreakBadge />` between the HUD row and the challenge box when the game is active

## Testing
- [x] `npx tsc --noEmit` passes
- [x] Badge appears after 3 correct answers in any card game
- [x] Escalates visually at 5, 10, 20 streak
- [x] Disappears on wrong answer
- [x] `aria-live="polite"` for accessibility

Closes #993

🤖 Generated with [Claude Code](https://claude.com/claude-code)