### PR TITLE
feat(ux): skeleton shimmer loading state for game card grid

### DIFF
--- a/gamesformykids/components/game/AllGamesView.tsx
+++ b/gamesformykids/components/game/AllGamesView.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { useMemo } from "react";
+import { useMemo, useState, useEffect } from "react";
 import GameCard from "./GameCard";
+import { GameCardSkeletonGrid } from "./GameCardSkeleton";
 import { GamesRegistry, GameRegistration } from "@/lib/registry/gamesRegistry";
 import { useGridFillers } from "@/hooks";
 
@@ -14,6 +15,9 @@ export default function AllGamesView({ games: gamesProp, isFiltered = false }: P
   const allGameRegistrations = useMemo(() => GamesRegistry.getAllGameRegistrations(), []);
   const games = gamesProp ?? allGameRegistrations;
   const fillerCount = useGridFillers(games.length);
+  const [hydrated, setHydrated] = useState(false);
+
+  useEffect(() => { setHydrated(true); }, []);
 
   if (isFiltered && games.length === 0) {
     return (
@@ -21,6 +25,15 @@ export default function AllGamesView({ games: gamesProp, isFiltered = false }: P
         <div className="text-5xl mb-4">🔍</div>
         <p className="text-xl font-bold text-gray-600 mb-2">לא נמצאו משחקים</p>
         <p className="text-gray-400 text-sm">נסה מילות חיפוש שונות או קטגוריה אחרת</p>
+      </div>
+    );
+  }
+
+  if (!hydrated) {
+    return (
+      <div>
+        <div className="h-9 w-48 bg-gray-200 animate-pulse rounded-xl mx-auto mb-6" />
+        <GameCardSkeletonGrid count={12} />
       </div>
     );
   }

--- a/gamesformykids/components/game/GameCardSkeleton.tsx
+++ b/gamesformykids/components/game/GameCardSkeleton.tsx
@@ -1,0 +1,23 @@
+'use client';
+
+export function GameCardSkeleton() {
+  return (
+    <div
+      aria-hidden="true"
+      className="rounded-2xl md:rounded-3xl shadow-lg overflow-hidden bg-gray-200 animate-pulse"
+      style={{ minHeight: '140px' }}
+    >
+      <div className="h-full w-full bg-gradient-to-br from-gray-200 to-gray-300" />
+    </div>
+  );
+}
+
+export function GameCardSkeletonGrid({ count = 12 }: { count?: number }) {
+  return (
+    <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-3 md:gap-4 lg:gap-6">
+      {Array.from({ length: count }).map((_, i) => (
+        <GameCardSkeleton key={i} />
+      ))}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
Adds animated skeleton placeholder cards to the "all games" grid view so the page shows a structured layout immediately on first render (before client-side hydration completes) rather than a blank area.

## Changes
- `components/game/GameCardSkeleton.tsx` — new `GameCardSkeleton` (single card) and `GameCardSkeletonGrid` (N-card grid) components using Tailwind `animate-pulse`
- `components/game/AllGamesView.tsx` — `useState(false)` + `useEffect(() => setHydrated(true))` pattern; shows skeleton grid with a shimmer header placeholder before hydration, real cards after

## Testing
- [x] `npx tsc --noEmit` passes
- [x] Skeleton grid renders before JS hydration (visible in SSR/slow-network conditions)
- [x] Real cards replace skeletons without flicker
- [x] Skeleton card dimensions match real `GameCard` layout

Closes #1029

🤖 Generated with [Claude Code](https://claude.com/claude-code)