### PR TITLE
feat(ux): slow speech toggle and fullscreen toggle in card game HUD

### DIFF
--- a/gamesformykids/components/game/shared/FullscreenToggle.tsx
+++ b/gamesformykids/components/game/shared/FullscreenToggle.tsx
@@ -1,0 +1,41 @@
+'use client';
+
+import { useState, useEffect, useCallback } from 'react';
+
+export function FullscreenToggle() {
+  const [isFullscreen, setIsFullscreen] = useState(false);
+  const [supported, setSupported] = useState(false);
+
+  useEffect(() => {
+    setSupported('requestFullscreen' in document.documentElement);
+    const onChange = () => setIsFullscreen(!!document.fullscreenElement);
+    document.addEventListener('fullscreenchange', onChange);
+    return () => document.removeEventListener('fullscreenchange', onChange);
+  }, []);
+
+  const toggle = useCallback(async () => {
+    try {
+      if (document.fullscreenElement) {
+        await document.exitFullscreen();
+      } else {
+        await document.documentElement.requestFullscreen();
+      }
+    } catch {
+      // browser denied or not supported — ignore
+    }
+  }, []);
+
+  if (!supported) return null;
+
+  return (
+    <button
+      type="button"
+      onClick={toggle}
+      aria-label={isFullscreen ? 'יציאה ממסך מלא' : 'מסך מלא'}
+      title={isFullscreen ? 'יציאה ממסך מלא' : 'מסך מלא'}
+      className="px-2.5 py-2 rounded-lg shadow-lg text-sm font-bold bg-white/80 text-gray-600 hover:bg-white hover:scale-105 transition-[transform,background-color] duration-200"
+    >
+      {isFullscreen ? '⊠' : '⛶'}
+    </button>
+  );
+}

--- a/gamesformykids/components/game/shared/SlowSpeechToggle.tsx
+++ b/gamesformykids/components/game/shared/SlowSpeechToggle.tsx
@@ -1,0 +1,31 @@
+'use client';
+
+import { useAudioSettingsStore } from '@/lib/stores/audioSettingsStore';
+
+const NORMAL_RATE = 0.85;
+const SLOW_RATE = 0.5;
+
+export function SlowSpeechToggle() {
+  const speechRate = useAudioSettingsStore((s) => s.speechRate);
+  const updateSpeechRate = useAudioSettingsStore((s) => s.updateSpeechRate);
+
+  const isSlow = speechRate <= SLOW_RATE;
+
+  const toggle = () => updateSpeechRate(isSlow ? NORMAL_RATE : SLOW_RATE);
+
+  return (
+    <button
+      type="button"
+      onClick={toggle}
+      aria-label={isSlow ? 'עבור לדיבור רגיל' : 'עבור לדיבור איטי'}
+      title={isSlow ? '🏃 דיבור רגיל' : '🐢 דיבור איטי'}
+      className={`px-2.5 py-2 rounded-lg shadow-lg text-sm font-bold transition-[transform,background-color] duration-200 hover:scale-105 ${
+        isSlow
+          ? 'bg-amber-400 text-white'
+          : 'bg-white/80 text-gray-600 hover:bg-white'
+      }`}
+    >
+      {isSlow ? '🐢' : '🏃'}
+    </button>
+  );
+}

--- a/gamesformykids/components/game/universal/auto-game/AutoGameHeader.tsx
+++ b/gamesformykids/components/game/universal/auto-game/AutoGameHeader.tsx
@@ -4,6 +4,8 @@ import { useAutoGame } from "@/hooks";
 import { GameHeader } from "../../../shared";
 import { ChallengeBox } from "../../../shared";
 import { CelebrationBox } from "../../../shared";
+import { SlowSpeechToggle } from "@/components/game/shared/SlowSpeechToggle";
+import { FullscreenToggle } from "@/components/game/shared/FullscreenToggle";
 
 /**
  * AutoGameHeader - header section of AutoGamePage
@@ -23,18 +25,18 @@ export function AutoGameHeader() {
       <div className="flex justify-between items-center mb-4">
         <GameHeader />
 
-        {/* כפתור סטטיסטיקות */}
-        <button
-          onClick={() => setShowProgressModal(true)}
-          className="
-            px-3 py-2 bg-blue-500 text-white rounded-lg shadow-lg
-            hover:bg-blue-600 hover:scale-105
-            transition-[transform,colors] duration-200 text-sm font-bold
-          "
-          title="הצג סטטיסטיקות"
-        >
-          📊 {currentAccuracy || 0}%
-        </button>
+        {/* כפתורי שליטה */}
+        <div className="flex items-center gap-2">
+          <SlowSpeechToggle />
+          <FullscreenToggle />
+          <button
+            onClick={() => setShowProgressModal(true)}
+            className="px-3 py-2 bg-blue-500 text-white rounded-lg shadow-lg hover:bg-blue-600 hover:scale-105 transition-[transform,background-color] duration-200 text-sm font-bold"
+            title="הצג סטטיסטיקות"
+          >
+            📊 {currentAccuracy || 0}%
+          </button>
+        </div>
       </div>
 
       {/* Challenge Box */}


### PR DESCRIPTION
## Summary
Adds two toggle buttons to the card game HUD header row:
- **🐢 Slow speech toggle** (closes #992): switches TTS rate between normal (0.85) and slow (0.5) by writing to the existing persisted `audioSettingsStore.speechRate`. The `voiceSelector` already reads this value, so no changes to the speech pipeline are needed. Preference persists across sessions.
- **⛶ Fullscreen toggle** (closes #1024): calls `document.documentElement.requestFullscreen()` / `exitFullscreen()`. Only renders when the Fullscreen API is available (feature-detected), so it's invisible on iOS Safari.

## Changes
- `components/game/shared/SlowSpeechToggle.tsx` — new 🐢/🏃 toggle; reads/writes `audioSettingsStore.speechRate`
- `components/game/shared/FullscreenToggle.tsx` — new ⛶/⊠ toggle; uses Fullscreen API with feature detection and cleanup
- `components/game/universal/auto-game/AutoGameHeader.tsx` — renders both toggles alongside the stats button in the HUD header row

## Testing
- [x] `npx tsc --noEmit` passes
- [x] Slow speech toggle persists across sessions (via `makePersistStore`)
- [x] Fullscreen toggle hidden on unsupported browsers
- [x] Both toggles work on desktop Chrome/Edge

Closes #992
Closes #1024

🤖 Generated with [Claude Code](https://claude.com/claude-code)