### PR TITLE
feat(ux): personalize spoken celebration messages with child's name

### DIFF
--- a/gamesformykids/lib/utils/game/feedbackUtils.ts
+++ b/gamesformykids/lib/utils/game/feedbackUtils.ts
@@ -5,6 +5,7 @@ import { FEEDBACK_MESSAGES, GAME_CONSTANTS } from '../../constants';
 import { speakHebrew, cancelSpeech, isSpeechEnabled } from '../speech/enhancedSpeechUtils';
 import { logError } from '../errorUtils';
 import { delay } from './gameUtils';
+import { getChildName } from './getChildName';
 
 /**
  * מחזיר הודעת משוב אקראית
@@ -14,6 +15,14 @@ export function getRandomFeedbackMessage(type: 'SUCCESS' | 'WRONG' | 'START'): s
   return messages[Math.floor(Math.random() * messages.length)]!;
 }
 
+/** Injects the child's name into a SUCCESS message when available. */
+function personalizeSuccessMessage(msg: string): string {
+  const name = getChildName();
+  if (!name) return msg;
+  // Messages ending with ! get the name prepended; others get it appended.
+  return msg.endsWith('!') ? `${name}, ${msg}` : `${msg}, ${name}!`;
+}
+
 /**
  * משמיע משוב קולי חיובי
  */
@@ -21,7 +30,7 @@ export async function speakPositiveFeedback(): Promise<void> {
   cancelSpeech();
   await delay(GAME_CONSTANTS.DELAYS.SUCCESS_SPEAK_DELAY);
   try {
-    await speakHebrew(getRandomFeedbackMessage('SUCCESS'));
+    await speakHebrew(personalizeSuccessMessage(getRandomFeedbackMessage('SUCCESS')));
   } catch (error) {
     logError('שגיאה בהשמעת משוב חיובי:', error);
   }

--- a/gamesformykids/lib/utils/game/getChildName.ts
+++ b/gamesformykids/lib/utils/game/getChildName.ts
@@ -1,0 +1,9 @@
+import { useUserProfileStore } from '@/lib/stores/userProfileStore';
+
+/** Returns the child's name from the logged-in profile, or the guest localStorage value, or null. */
+export function getChildName(): string | null {
+  if (typeof window === 'undefined') return null;
+  const name = useUserProfileStore.getState().profile?.full_name;
+  if (name) return name;
+  return localStorage.getItem('gfk_child_name');
+}


### PR DESCRIPTION
## Summary

When a child's name is known (logged-in profile `full_name`, or guest `gfk_child_name` in localStorage), success celebration messages spoken by TTS are personalized with that name.

Examples: "כל הכבוד" becomes "כל הכבוד, יוסי!" and "אתה פשוט מדהים!" becomes "יוסי, אתה פשוט מדהים!"

Guest parents can set `gfk_child_name` in localStorage to opt in without needing an account.

## Changes

- `lib/utils/game/getChildName.ts` — new utility: reads `profile.full_name` from `useUserProfileStore` (logged-in) or `gfk_child_name` from localStorage (guest)
- `lib/utils/game/feedbackUtils.ts` — `speakPositiveFeedback` now passes the SUCCESS message through `personalizeSuccessMessage()` which injects the name when available

## Testing

- [ ] `npx tsc --noEmit` passes ✅
- [ ] Logged-in user with `full_name` set: TTS says the name during correct answers
- [ ] Guest with no name: TTS behaviour unchanged

Closes #999

🤖 Generated with [Claude Code](https://claude.com/claude-code)