### PR TITLE
feat(ux): dark/light mode toggle in site header

### DIFF
--- a/gamesformykids/app/layout.tsx
+++ b/gamesformykids/app/layout.tsx
@@ -27,6 +27,12 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
       <head>
         <HeadLinks />
         <StructuredData />
+        {/* Prevent flash of wrong theme — runs before hydration */}
+        <script
+          dangerouslySetInnerHTML={{
+            __html: `try{var t=localStorage.getItem('gfk_theme');if(t==='dark'||(!t&&matchMedia('(prefers-color-scheme:dark)').matches))document.documentElement.classList.add('dark')}catch{}`,
+          }}
+        />
       </head>
       <body className={`${rubik.className} dark:bg-gray-900 dark:text-white`}>
         {process.env.NODE_ENV === 'production' && process.env.NEXT_PUBLIC_GA_ID && (

--- a/gamesformykids/components/layout/StaticHeader.tsx
+++ b/gamesformykids/components/layout/StaticHeader.tsx
@@ -2,6 +2,7 @@ import UserProfile from '../user/UserProfile';
 import { HeaderBackground } from './header/HeaderBackground';
 import { HeaderHero } from './header/HeaderHero';
 import { FeatureHighlights } from './header/FeatureHighlights';
+import { ThemeToggle } from '../ui/ThemeToggle';
 
 // Server Component - renders statically for better LCP
 export function StaticHeader() {
@@ -12,7 +13,8 @@ export function StaticHeader() {
       </div>
 
       <div className="relative z-10">
-        <div className="flex justify-end px-4 mb-2">
+        <div className="flex justify-end items-center gap-2 px-4 mb-2">
+          <ThemeToggle />
           <UserProfile />
         </div>
         <HeaderHero />

--- a/gamesformykids/components/ui/ThemeToggle.tsx
+++ b/gamesformykids/components/ui/ThemeToggle.tsx
@@ -1,0 +1,35 @@
+'use client';
+import { useState, useEffect } from 'react';
+
+const THEME_KEY = 'gfk_theme';
+
+export function ThemeToggle() {
+  const [isDark, setIsDark] = useState(false);
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+    setIsDark(document.documentElement.classList.contains('dark'));
+  }, []);
+
+  const toggle = () => {
+    const next = !isDark;
+    setIsDark(next);
+    document.documentElement.classList.toggle('dark', next);
+    try { localStorage.setItem(THEME_KEY, next ? 'dark' : 'light'); } catch {}
+  };
+
+  if (!mounted) return <div className="w-8 h-8" aria-hidden />;
+
+  return (
+    <button
+      type="button"
+      onClick={toggle}
+      aria-label={isDark ? 'עבור למצב בהיר' : 'עבור למצב כהה'}
+      title={isDark ? 'עבור למצב בהיר' : 'עבור למצב כהה'}
+      className="p-2 rounded-lg bg-white/20 hover:bg-white/40 dark:bg-white/10 dark:hover:bg-white/20 transition-colors text-lg leading-none"
+    >
+      {isDark ? '☀️' : '🌙'}
+    </button>
+  );
+}

--- a/gamesformykids/tailwind.config.js
+++ b/gamesformykids/tailwind.config.js
@@ -1,4 +1,5 @@
 module.exports = {
+  darkMode: 'class',
   content: [
     "./app/**/*.{js,ts,jsx,tsx}",
     "./pages/**/*.{js,ts,jsx,tsx}",


### PR DESCRIPTION
## Summary

Adds a 🌙/☀️ toggle button in the site header so any user (guest or logged-in) can switch between dark and light themes. Theme preference is persisted in `localStorage` (`gfk_theme`) and an inline `<script>` in `<head>` applies the class before React hydration to prevent flash-of-wrong-theme (FOUC).

Uses Tailwind's class-based dark mode (`darkMode: 'class'`), matching the `dark:` utilities already present in the codebase.

## Changes

- `tailwind.config.js` — adds `darkMode: 'class'`
- `components/ui/ThemeToggle.tsx` — new client component; reads/writes `dark` class on `<html>` and persists to localStorage; respects OS preference on first visit
- `app/layout.tsx` — adds FOUC-prevention inline script to `<head>`
- `components/layout/StaticHeader.tsx` — places `<ThemeToggle />` next to `<UserProfile />` in the top-right action row

## Testing

- [ ] `npx tsc --noEmit` passes ✅
- [ ] 🌙 button appears in header; clicking toggles dark mode on the entire page
- [ ] Refreshing preserves the chosen theme (no flash)
- [ ] OS dark preference is honoured on first visit with no saved setting

Closes #1010

🤖 Generated with [Claude Code](https://claude.com/claude-code)