### PR TITLE
feat(ux): 3-step first-visit onboarding modal

### DIFF
--- a/gamesformykids/app/HomePageClient.tsx
+++ b/gamesformykids/app/HomePageClient.tsx
@@ -8,6 +8,7 @@ import SurpriseMeButton from "@/components/marketing/SurpriseMeButton";
 import CategorizedGamesGrid from "@/components/marketing/CategorizedGamesGrid";
 import LoadingScreen from "@/components/layout/LoadingScreen";
 import VocabularyOfTheDay from "@/components/marketing/VocabularyOfTheDay";
+import OnboardingModal from "@/components/marketing/OnboardingModal";
 import { useHomePage } from "./useHomePage";
 
 export default function HomePageClient() {
@@ -28,6 +29,7 @@ export default function HomePageClient() {
         <CategorizedGamesGrid />
       </main>
       <Footer />
+      <OnboardingModal />
     </div>
   );
 }

--- a/gamesformykids/components/marketing/OnboardingModal.tsx
+++ b/gamesformykids/components/marketing/OnboardingModal.tsx
@@ -1,0 +1,97 @@
+'use client';
+import { useState, useEffect } from 'react';
+
+const ONBOARDED_KEY = 'gfk_onboarded';
+
+const STEPS = [
+  {
+    emoji: '👋',
+    title: 'ברוכים הבאים!',
+    body: 'כאן תמצאו עשרות משחקים חינוכיים בעברית לילדים. בחרו קטגוריה ולחצו על משחק כדי להתחיל!',
+  },
+  {
+    emoji: '🎮',
+    title: 'איך משחקים?',
+    body: 'האפליקציה תאמר מילה בקול. הקשיבו טוב ולחצו על הכרטיס הנכון מבין האפשרויות.',
+  },
+  {
+    emoji: '🏆',
+    title: 'קבלו ניקוד!',
+    body: 'על כל תשובה נכונה תקבלו נקודות. נסו לשבור את השיא שלכם! שחקו כמה שתרצו — הכל בחינם.',
+  },
+];
+
+export default function OnboardingModal() {
+  const [step, setStep] = useState(0);
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    try {
+      if (!localStorage.getItem(ONBOARDED_KEY)) setVisible(true);
+    } catch {}
+  }, []);
+
+  const close = () => {
+    try { localStorage.setItem(ONBOARDED_KEY, '1'); } catch {}
+    setVisible(false);
+  };
+
+  const next = () => {
+    if (step < STEPS.length - 1) setStep(step + 1);
+    else close();
+  };
+
+  if (!visible) return null;
+
+  const current = STEPS[step]!;
+
+  return (
+    <div
+      className="fixed inset-0 z-[100] flex items-center justify-center p-4 bg-black/50 backdrop-blur-sm"
+      dir="rtl"
+      role="dialog"
+      aria-modal="true"
+      aria-label="ברוכים הבאים"
+    >
+      <div className="bg-white rounded-3xl shadow-2xl p-8 max-w-sm w-full text-center">
+        <div className="text-6xl mb-4">{current.emoji}</div>
+        <h2 className="text-2xl font-bold text-gray-800 mb-3">{current.title}</h2>
+        <p className="text-gray-600 leading-relaxed mb-6">{current.body}</p>
+
+        {/* Step dots */}
+        <div className="flex justify-center gap-2 mb-6">
+          {STEPS.map((_, i) => (
+            <div
+              key={i}
+              className={`w-2.5 h-2.5 rounded-full transition-colors ${i === step ? 'bg-purple-600' : 'bg-gray-200'}`}
+            />
+          ))}
+        </div>
+
+        <div className="flex gap-3">
+          {step > 0 && (
+            <button
+              onClick={() => setStep(step - 1)}
+              className="flex-1 py-3 rounded-2xl border-2 border-gray-200 text-gray-500 font-semibold hover:bg-gray-50 transition-colors"
+            >
+              ← אחורה
+            </button>
+          )}
+          <button
+            onClick={next}
+            className="flex-1 py-3 rounded-2xl bg-purple-600 text-white font-bold hover:bg-purple-700 active:scale-95 transition-[transform,background-color]"
+          >
+            {step < STEPS.length - 1 ? 'הבא ←' : '✓ בואו נשחק!'}
+          </button>
+        </div>
+
+        <button
+          onClick={close}
+          className="mt-3 text-sm text-gray-400 hover:text-gray-600 transition-colors"
+        >
+          דלג
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/gamesformykids/e2e/homepage.spec.ts
+++ b/gamesformykids/e2e/homepage.spec.ts
@@ -2,6 +2,11 @@ import { test, expect } from '@playwright/test';
 
 test.describe('Homepage', () => {
   test.beforeEach(async ({ page }) => {
+    // Suppress first-visit overlays (onboarding modal, PWA banner) that block clicks
+    await page.addInitScript(() => {
+      localStorage.setItem('gfk_onboarded', 'true');
+      localStorage.setItem('gfk_visit_count', '1');
+    });
     await page.goto('/');
   });
 


### PR DESCRIPTION
## Summary

Shows a 3-step welcome modal on the first home page visit. Each step covers a key concept (what the site is, how to play, scoring). The modal is dismissable via "דלג" and permanently hidden after completion via `localStorage` (`gfk_onboarded`).

## Changes

- `components/marketing/OnboardingModal.tsx` — new modal component with step dots, forward/back navigation, backdrop
- `app/HomePageClient.tsx` — renders `<OnboardingModal />` (positioned after Footer so z-index stacking is clean)

## Testing

- [ ] `npx tsc --noEmit` passes ✅
- [ ] Clear `gfk_onboarded` from localStorage and reload → modal appears
- [ ] Next/back navigation works; final step closes with "בואו נשחק!"
- [ ] "דלג" closes immediately and sets the flag
- [ ] Second visit: modal does not appear

Closes #998

🤖 Generated with [Claude Code](https://claude.com/claude-code)