### PR TITLE
feat(ux): difficulty selector on card game start screen

### DIFF
--- a/gamesformykids/components/shared/screens/GenericStartScreen.tsx
+++ b/gamesformykids/components/shared/screens/GenericStartScreen.tsx
@@ -7,6 +7,7 @@ import { ButtonCheckAudio } from "@/components/shared";
 import { ComponentTypes } from "@/lib/types";
 import { useUniversalGame } from "@/hooks/shared/game-state/useUniversalGame";
 import { useGameStore } from "@/lib/stores/gameStore";
+import { DifficultyPicker } from "@/components/game/shared/DifficultyPicker";
 
 type GenericStartScreenProps<T> = ComponentTypes.GenericStartScreenProps<T>;
 
@@ -75,6 +76,9 @@ export default function GenericStartScreen<T>({
           showSteps={true}
           variant="detailed"
         />
+
+        {/* בחירת רמת קושי */}
+        <DifficultyPicker />
 
         {/* כפתור התחלה */}
         <SimpleGameStartButton

--- a/gamesformykids/hooks/games/useGenericGame.ts
+++ b/gamesformykids/hooks/games/useGenericGame.ts
@@ -2,8 +2,12 @@
 
 import { useBaseGame } from "@/hooks/shared/game-state/useBaseGame";
 import { BaseGameItem, GameType } from "@/lib/types/core/base";
+import { useGameDifficulty } from '@/lib/stores/gameDifficultyStore';
+
+const DIFFICULTY_BASE_COUNT: Record<string, number> = { easy: 3, medium: 4, hard: 6 };
 
 export function useGenericGame(items: BaseGameItem[], gameType: GameType) {
+  const { difficulty } = useGameDifficulty();
   const pronunciations = items.reduce<Record<string, string>>((acc, item) => {
     acc[item.name] = item.hebrew;
     return acc;
@@ -14,7 +18,7 @@ export function useGenericGame(items: BaseGameItem[], gameType: GameType) {
     items,
     pronunciations,
     gameConstants: {
-      BASE_COUNT: 4,
+      BASE_COUNT: DIFFICULTY_BASE_COUNT[difficulty] ?? 4,
       INCREMENT: 1,
       LEVEL_THRESHOLD: 3,
     },


### PR DESCRIPTION
## Summary

Adds the existing `DifficultyPicker` component (⭐/⭐⭐/⭐⭐⭐) to `GenericStartScreen` so players can choose their challenge level before starting any card game.

Difficulty now also meaningfully controls the number of choices shown in card games via `useGenericGame`:
- **קל (Easy ⭐)** — 3 choices
- **רגיל (Medium ⭐⭐)** — 4 choices (previous default)
- **קשה (Hard ⭐⭐⭐)** — 6 choices

The selection is persisted across sessions in localStorage (`gfk-difficulty`) and shared with all other games that already read from the same store.

## Changes

- `hooks/games/useGenericGame.ts` — reads `useGameDifficulty` and maps difficulty to `BASE_COUNT` (3/4/6)
- `components/shared/screens/GenericStartScreen.tsx` — renders `<DifficultyPicker />` above the start button

## Testing

- [ ] `npx tsc --noEmit` passes ✅
- [ ] Card game start screen shows ⭐/⭐⭐/⭐⭐⭐ buttons; selection persists on reload
- [ ] Easy → 3 choices shown per question; Hard → 6 choices shown

Closes #985

🤖 Generated with [Claude Code](https://claude.com/claude-code)