### PR TITLE
feat(gamification): daily login streak counter with 🔥 badge on home page

### DIFF
--- a/gamesformykids/app/HomePageClient.tsx
+++ b/gamesformykids/app/HomePageClient.tsx
@@ -8,6 +8,7 @@ import SurpriseMeButton from "@/components/marketing/SurpriseMeButton";
 import CategorizedGamesGrid from "@/components/marketing/CategorizedGamesGrid";
 import LoadingScreen from "@/components/layout/LoadingScreen";
 import VocabularyOfTheDay from "@/components/marketing/VocabularyOfTheDay";
+import DailyStreakBadge from "@/components/marketing/DailyStreakBadge";
 import { useHomePage } from "./useHomePage";
 
 export default function HomePageClient() {
@@ -22,6 +23,7 @@ export default function HomePageClient() {
       <VocabularyOfTheDay />
       <Header />
       <main>
+        <DailyStreakBadge />
         <FeaturedGame />
         <GameRecommendations />
         <SurpriseMeButton />

--- a/gamesformykids/components/marketing/DailyStreakBadge.tsx
+++ b/gamesformykids/components/marketing/DailyStreakBadge.tsx
@@ -1,0 +1,31 @@
+'use client';
+import { useState, useEffect } from 'react';
+import { getDailyLoginStreak } from '@/lib/utils/engagement/trackDailyLogin';
+
+export default function DailyStreakBadge() {
+  const [streak, setStreak] = useState(0);
+
+  useEffect(() => {
+    const { count } = getDailyLoginStreak();
+    setStreak(count);
+  }, []);
+
+  if (streak < 2) return null;
+
+  const fire = streak >= 30 ? '⚡🔥⚡' : streak >= 14 ? '🔥🔥🔥' : streak >= 7 ? '🔥🔥' : '🔥';
+  const label =
+    streak >= 30
+      ? `${streak} ימים ברצף! מדהים!`
+      : streak >= 7
+        ? `${streak} ימים ברצף! מהמם!`
+        : `${streak} ימים ברצף!`;
+
+  return (
+    <div className="flex justify-center my-3" dir="rtl">
+      <div className="inline-flex items-center gap-2 bg-orange-50 border border-orange-200 rounded-full px-4 py-1.5 text-sm font-bold text-orange-700 shadow-sm">
+        <span>{fire}</span>
+        <span>{label}</span>
+      </div>
+    </div>
+  );
+}

--- a/gamesformykids/lib/utils/engagement/trackDailyLogin.ts
+++ b/gamesformykids/lib/utils/engagement/trackDailyLogin.ts
@@ -1,0 +1,28 @@
+const STREAK_KEY = 'gfk_login_streak';
+const LAST_DATE_KEY = 'gfk_login_last_date';
+
+export interface LoginStreak {
+  count: number;
+  isNew: boolean;
+}
+
+/** Reads and updates the daily login streak in localStorage. Call once on home page mount. */
+export function getDailyLoginStreak(): LoginStreak {
+  if (typeof window === 'undefined') return { count: 0, isNew: false };
+  try {
+    const today = new Date().toISOString().slice(0, 10);
+    const lastDate = localStorage.getItem(LAST_DATE_KEY);
+    const streak = parseInt(localStorage.getItem(STREAK_KEY) ?? '0', 10);
+
+    if (lastDate === today) return { count: streak, isNew: false };
+
+    const yesterday = new Date(Date.now() - 86_400_000).toISOString().slice(0, 10);
+    const newStreak = lastDate === yesterday ? streak + 1 : 1;
+
+    localStorage.setItem(LAST_DATE_KEY, today);
+    localStorage.setItem(STREAK_KEY, String(newStreak));
+    return { count: newStreak, isNew: true };
+  } catch {
+    return { count: 0, isNew: false };
+  }
+}


### PR DESCRIPTION
## Summary

Tracks how many consecutive days the user visits the site and shows a motivational 🔥 badge ("N ימים ברצף!") on the home page. The badge only appears from day 2 onwards so it doesn't clutter the first visit. Fire icon escalates: 🔥 → 🔥🔥 at 7 days → 🔥🔥🔥 at 14 days → ⚡🔥⚡ at 30 days.

State is stored in `gfk_login_streak` + `gfk_login_last_date` localStorage keys. Compatible with the existing `gfk_today_count` engagement tracking in the codebase.

## Changes

- `lib/utils/engagement/trackDailyLogin.ts` — computes streak (yesterday = +1, gap = reset to 1) and persists to localStorage
- `components/marketing/DailyStreakBadge.tsx` — client component that calls the utility on mount and shows the pill badge
- `app/HomePageClient.tsx` — renders `<DailyStreakBadge />` at the top of `<main>`

## Testing

- [ ] `npx tsc --noEmit` passes ✅
- [ ] Set `gfk_login_last_date` to yesterday, `gfk_login_streak` to 3 → badge shows "🔥 4 ימים ברצף!"
- [ ] Same-day revisit: count stays at 4 (no double-increment)
- [ ] Gap of 2+ days resets to streak=1, badge hidden (< 2)

Closes #983

🤖 Generated with [Claude Code](https://claude.com/claude-code)