### PR TITLE
feat: per-game mastery stars on game cards

### DIFF
--- a/gamesformykids/components/game/GameCard.tsx
+++ b/gamesformykids/components/game/GameCard.tsx
@@ -1,9 +1,11 @@
 "use client";
 
 import Link from "next/link";
+import { useState, useEffect } from "react";
 import { Star } from "lucide-react";
 import { ComponentTypes } from "@/lib/types";
 import { useFavoritesStore } from "@/lib/stores";
+import { getMasteryStars } from "@/lib/utils/engagement/masteryStars";
 
 interface GameCardProps extends ComponentTypes.GameCardProps {
   animationDelay?: number;
@@ -12,6 +14,11 @@ interface GameCardProps extends ComponentTypes.GameCardProps {
 export default function GameCard({ game, animationDelay }: GameCardProps) {
   const toggleFavorite = useFavoritesStore((s) => s.toggleFavorite);
   const isFav = useFavoritesStore((s) => s.favoriteIds.includes(game.id));
+  const [masteryStars, setMasteryStars] = useState(0);
+
+  useEffect(() => {
+    setMasteryStars(getMasteryStars(game.id));
+  }, [game.id]);
 
   if (game.available) {
     return (
@@ -58,6 +65,15 @@ export default function GameCard({ game, animationDelay }: GameCardProps) {
                 isFav ? 'text-yellow-300 fill-current' : 'text-white'
               }`} />
             </button>
+            {/* כוכבי שליטה */}
+            {masteryStars > 0 && (
+              <div
+                className="absolute bottom-1 inset-e-1 md:bottom-2 md:inset-e-2 flex gap-0.5 leading-none"
+                aria-label={`${masteryStars} כוכבי שליטה`}
+              >
+                {'⭐'.repeat(masteryStars)}
+              </div>
+            )}
           </div>
         </Link>
       </div>

--- a/gamesformykids/hooks/shared/progress/useSessionStats.ts
+++ b/gamesformykids/hooks/shared/progress/useSessionStats.ts
@@ -9,6 +9,7 @@ import { useState, useCallback } from 'react';
 import { BaseGameItem, GameType } from '@/lib/types/core/base';
 import { GameSession } from '@/lib/types/hooks/progress';
 import { useProgressTrackingStore } from '@/lib/stores/progressTrackingStore';
+import { recordGameSession } from '@/lib/utils/engagement/masteryStars';
 
 export function useSessionStats(gameType: GameType) {
   const { addSession } = useProgressTrackingStore();
@@ -77,9 +78,13 @@ export function useSessionStats(gameType: GameType) {
         endTime: new Date(),
       };
       addSession(completedSession);
+      const accuracy = completedSession.totalAnswers > 0
+        ? Math.round((completedSession.correctAnswers / completedSession.totalAnswers) * 100)
+        : 0;
+      recordGameSession(String(gameType), accuracy);
       setCurrentSession(null);
     }
-  }, [currentSession, addSession]);
+  }, [currentSession, addSession, gameType]);
 
   // Get accuracy rate for current session
   const getCurrentAccuracy = useCallback(() => {

--- a/gamesformykids/lib/utils/engagement/masteryStars.ts
+++ b/gamesformykids/lib/utils/engagement/masteryStars.ts
@@ -1,0 +1,40 @@
+interface MasteryData {
+  plays: number;
+  accuracies: number[];
+}
+
+function key(gameId: string): string {
+  return `gfk_stars_${gameId}`;
+}
+
+/** Record the accuracy of a completed game session and increment play count. */
+export function recordGameSession(gameId: string, accuracy: number): void {
+  if (typeof window === 'undefined') return;
+  try {
+    const raw = localStorage.getItem(key(gameId));
+    const data: MasteryData = raw ? (JSON.parse(raw) as MasteryData) : { plays: 0, accuracies: [] };
+    data.plays++;
+    data.accuracies = [...data.accuracies.slice(-9), accuracy];
+    localStorage.setItem(key(gameId), JSON.stringify(data));
+  } catch {}
+}
+
+/** Returns 0–3 mastery stars based on play count + average accuracy. */
+export function getMasteryStars(gameId: string): number {
+  if (typeof window === 'undefined') return 0;
+  try {
+    const raw = localStorage.getItem(key(gameId));
+    if (!raw) return 0;
+    const data = JSON.parse(raw) as MasteryData;
+    const avg =
+      data.accuracies.length > 0
+        ? data.accuracies.reduce((a, b) => a + b, 0) / data.accuracies.length
+        : 0;
+    if (data.plays >= 5 && avg >= 90) return 3;
+    if (data.plays >= 3 && avg >= 70) return 2;
+    if (data.plays >= 1) return 1;
+    return 0;
+  } catch {
+    return 0;
+  }
+}


### PR DESCRIPTION
## Summary

Adds a lightweight mastery-stars system that tracks how many times each game has been played and the player's average accuracy, then displays 1–3 stars on the game card so children can see their progress at a glance.

## Changes

- **`lib/utils/engagement/masteryStars.ts`** (new) — `recordGameSession(gameId, accuracy)` persists play count + rolling accuracy in `localStorage`; `getMasteryStars(gameId)` returns 0–3 based on thresholds (⭐ = any play, ⭐⭐ = 3+ plays & 70%+ avg, ⭐⭐⭐ = 5+ plays & 90%+ avg)
- **`hooks/shared/progress/useSessionStats.ts`** — `endSession()` now calls `recordGameSession()` so every card-game session is automatically tracked
- **`components/game/GameCard.tsx`** — reads mastery stars via `getMasteryStars` on mount; renders a small star row in the bottom-end corner when stars > 0

## Testing

- [x] `npx tsc --noEmit` passes
- [ ] Play a card game 1×, 3×, 5× and verify 1, 2, 3 stars appear on the home-page card

Closes #1004

🤖 Generated with [Claude Code](https://claude.com/claude-code)