### PR TITLE
feat(game): two-player pass-and-play mode for memory game

### DIFF
--- a/gamesformykids/app/games/memory/components/GameWinMessage.tsx
+++ b/gamesformykids/app/games/memory/components/GameWinMessage.tsx
@@ -7,11 +7,57 @@ import { useGameCompletion } from '@/hooks/shared/progress/useGameCompletion';
 import { useUniversalGameNavigation } from '@/components/game/universal/navigation/useUniversalGameNavigation';
 import WinStatsGrid from "./WinStatsGrid";
 import WinAchievements from "./WinAchievements";
+import type { DuoPlayer } from '../stores/memoryStoreTypes';
 
 const DIFFICULTY_LEVEL = { easy: 1, medium: 2, hard: 3 } as const;
 
+function DuoResult({ players, onRestart, onMenu }: {
+  players: [DuoPlayer, DuoPlayer];
+  onRestart: () => void;
+  onMenu: () => void;
+}) {
+  const [p0, p1] = players;
+  const isTie = p0.score === p1.score;
+  const winnerName = p0.score > p1.score ? p0.name : p1.name;
+  return (
+    <div className="min-h-screen bg-linear-to-br from-pink-100 via-purple-100 to-indigo-200 p-4 flex items-center justify-center">
+      <div className="max-w-sm w-full mx-auto">
+        <div className="text-center p-8 bg-linear-to-r from-yellow-200 via-orange-200 to-pink-200 rounded-3xl shadow-xl" dir="rtl">
+          <div className="text-5xl mb-2">{isTie ? '🤝' : '🏆'}</div>
+          <h2 className="text-3xl font-black text-orange-800 mb-1">
+            {isTie ? 'תיקו!' : `${winnerName} ניצח/ה!`}
+          </h2>
+          <div className="flex gap-3 justify-center my-5">
+            {players.map((p, i) => (
+              <div key={i} className={`flex-1 rounded-2xl p-4 shadow-md ${i === 0 ? 'bg-purple-100' : 'bg-pink-100'}`}>
+                <div className="text-2xl font-black text-gray-800">{p.score}</div>
+                <div className="text-xs text-gray-500">זוגות</div>
+                <div className="text-sm font-bold text-gray-700 mt-1">{p.name}</div>
+              </div>
+            ))}
+          </div>
+          <div className="flex gap-3 justify-center flex-wrap">
+            <button
+              onClick={onRestart}
+              className="bg-linear-to-r from-purple-500 to-pink-500 hover:from-purple-600 hover:to-pink-600 text-white font-bold py-3 px-6 rounded-full text-lg transition-all duration-300 hover:scale-105 shadow-lg"
+            >
+              🎮 שחק שוב
+            </button>
+            <button
+              onClick={onMenu}
+              className="bg-white/80 hover:bg-white text-gray-700 font-bold py-3 px-6 rounded-full text-lg transition-all duration-300 hover:scale-105 shadow-lg"
+            >
+              🏠 תפריט
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
 export default function GameWinMessage() {
-  const { gameStats, timer, difficulty, getDifficultyConfig, getPerformanceLevel, initializeGame, resetToMenu } = useMemoryStore();
+  const { gameStats, timer, difficulty, getDifficultyConfig, getPerformanceLevel, initializeGame, resetToMenu, mode, players } = useMemoryStore();
   const difficultyConfig = getDifficultyConfig();
   const performance = getPerformanceLevel();
 
@@ -28,10 +74,20 @@ export default function GameWinMessage() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
+  if (mode === 'duo') {
+    return (
+      <DuoResult
+        players={players}
+        onRestart={() => initializeGame(difficulty)}
+        onMenu={resetToMenu}
+      />
+    );
+  }
+
   return (
-    <div className="min-h-screen bg-gradient-to-br from-pink-100 via-purple-100 to-indigo-200 p-4 flex items-center justify-center">
+    <div className="min-h-screen bg-linear-to-br from-pink-100 via-purple-100 to-indigo-200 p-4 flex items-center justify-center">
       <div className="max-w-2xl w-full mx-auto">
-        <div className="text-center p-8 bg-gradient-to-r from-yellow-200 via-orange-200 to-pink-200 rounded-3xl shadow-xl animate-bounce-gentle">
+        <div className="text-center p-8 bg-linear-to-r from-yellow-200 via-orange-200 to-pink-200 rounded-3xl shadow-xl animate-bounce-gentle">
           <div className="mb-6">
             <h2 className="text-5xl font-bold text-orange-800 mb-2">🎉 {performance.level} 🎉</h2>
             <p className="text-2xl text-orange-700 mb-2">
@@ -55,14 +111,14 @@ export default function GameWinMessage() {
           <div className="flex gap-4 justify-center flex-wrap">
             <button
               onClick={() => initializeGame(difficulty)}
-              className="bg-gradient-to-r from-purple-500 to-pink-500 hover:from-purple-600 hover:to-pink-600 text-white font-bold py-3 px-8 rounded-full text-xl transition-all duration-300 transform hover:scale-105 shadow-lg"
+              className="bg-linear-to-r from-purple-500 to-pink-500 hover:from-purple-600 hover:to-pink-600 text-white font-bold py-3 px-8 rounded-full text-xl transition-all duration-300 transform hover:scale-105 shadow-lg"
             >
               🎮 שחק שוב
             </button>
             {navigation.next && (
               <Link
                 href={navigation.next.href}
-                className="bg-gradient-to-r from-green-500 to-teal-500 hover:from-green-600 hover:to-teal-600 text-white font-bold py-3 px-8 rounded-full text-xl transition-all duration-300 transform hover:scale-105 shadow-lg flex items-center gap-2"
+                className="bg-linear-to-r from-green-500 to-teal-500 hover:from-green-600 hover:to-teal-600 text-white font-bold py-3 px-8 rounded-full text-xl transition-all duration-300 transform hover:scale-105 shadow-lg flex items-center gap-2"
               >
                 <span>משחק הבא</span>
                 <span>{navigation.next.title}</span>

--- a/gamesformykids/app/games/memory/components/MemoryGameHeader.tsx
+++ b/gamesformykids/app/games/memory/components/MemoryGameHeader.tsx
@@ -2,8 +2,33 @@
 
 import { DifficultyPicker } from '@/components/game/shared/DifficultyPicker';
 import { useMemorySyncDifficulty } from '../useMemorySyncDifficulty';
+import { useMemoryStore } from '../stores/useMemoryStore';
 import GameStatsBar from './GameStatsBar';
 import GameControls from './GameControls';
+
+function DuoPlayerIndicator() {
+  const { mode, players, currentPlayer } = useMemoryStore();
+  if (mode !== 'duo') return null;
+
+  return (
+    <div className="flex gap-2 justify-center mb-3" dir="rtl">
+      {players.map((p, i) => (
+        <div
+          key={i}
+          className={`flex items-center gap-1 px-3 py-1.5 rounded-full text-sm font-bold transition-all duration-300 ${
+            currentPlayer === i
+              ? 'bg-white text-purple-700 shadow-lg scale-105'
+              : 'bg-white/20 text-white/70'
+          }`}
+        >
+          {currentPlayer === i && <span>🎮</span>}
+          <span>{p.name}</span>
+          <span className="text-xs opacity-80">{p.score} זוגות</span>
+        </div>
+      ))}
+    </div>
+  );
+}
 
 export default function MemoryGameHeader() {
   useMemorySyncDifficulty();
@@ -11,6 +36,7 @@ export default function MemoryGameHeader() {
   return (
     <div className="bg-gradient-to-r from-purple-600 via-pink-500 to-red-500 rounded-2xl p-6 shadow-2xl mb-6">
       <div className="bg-white bg-opacity-10 backdrop-blur-lg rounded-xl p-4">
+        <DuoPlayerIndicator />
         <DifficultyPicker />
         <GameStatsBar />
         <GameControls />

--- a/gamesformykids/app/games/memory/components/MemoryStartScreen.tsx
+++ b/gamesformykids/app/games/memory/components/MemoryStartScreen.tsx
@@ -1,26 +1,88 @@
 'use client';
 
-import { createDifficultyMenuScreen } from '@/components/game/shared/createDifficultyMenuScreen';
+import { useState } from 'react';
+import GameMenuCard from '@/components/game/shared/GameMenuCard';
+import { DifficultyPicker } from '@/components/game/shared/DifficultyPicker';
 import { useMemoryStore } from '../stores/useMemoryStore';
 import { useGameDifficulty } from '@/lib/stores/gameDifficultyStore';
 import { MEMORY_GAME_CONSTANTS } from '@/lib/constants/gameData/special';
-import type { DifficultyLevel } from '@/lib/types/games/base';
+import type { MemoryMode } from '../stores/memoryStoreTypes';
 
-function useMemoryStartGame() {
-  const { initializeGame } = useMemoryStore();
+export default function MemoryStartScreen() {
+  const { initializeGame, setMode, setPlayerNames, mode, players } = useMemoryStore();
   const { difficulty } = useGameDifficulty();
-  return {
-    startGame: () => initializeGame(difficulty),
-  };
-}
 
-export default createDifficultyMenuScreen(
-  {
-    emoji: '🧠',
-    title: 'משחק הזיכרון',
-    description: 'מצאו את הזוגות הזהים על הלוח!',
-    gradientClass: 'from-pink-100 via-purple-100 to-indigo-200',
-    hintFn: (d: DifficultyLevel) => `${MEMORY_GAME_CONSTANTS.DIFFICULTY_LEVELS[d].pairs} זוגות`,
-  },
-  useMemoryStartGame,
-);
+  const [p1, setP1] = useState(players[0].name);
+  const [p2, setP2] = useState(players[1].name);
+
+  const handleStart = () => {
+    if (mode === 'duo') {
+      setPlayerNames(p1, p2);
+    }
+    initializeGame(difficulty);
+  };
+
+  const handleModeChange = (m: MemoryMode) => setMode(m);
+
+  const hint = `${MEMORY_GAME_CONSTANTS.DIFFICULTY_LEVELS[difficulty].pairs} זוגות`;
+
+  return (
+    <GameMenuCard
+      emoji="🧠"
+      title="משחק הזיכרון"
+      description="מצאו את הזוגות הזהים על הלוח!"
+      gradientClass="from-pink-100 via-purple-100 to-indigo-200"
+      hint={hint}
+      onStart={handleStart}
+      startLabel="🧠 התחל!"
+    >
+      <DifficultyPicker />
+
+      {/* Mode toggle */}
+      <div className="flex rounded-xl overflow-hidden border border-gray-200 mb-4" dir="rtl">
+        <button
+          onClick={() => handleModeChange('solo')}
+          className={`flex-1 py-2 text-sm font-bold transition-colors ${
+            mode === 'solo'
+              ? 'bg-purple-500 text-white'
+              : 'bg-white text-gray-500 hover:bg-purple-50'
+          }`}
+        >
+          👤 יחיד
+        </button>
+        <button
+          onClick={() => handleModeChange('duo')}
+          className={`flex-1 py-2 text-sm font-bold transition-colors ${
+            mode === 'duo'
+              ? 'bg-pink-500 text-white'
+              : 'bg-white text-gray-500 hover:bg-pink-50'
+          }`}
+        >
+          👥 שני שחקנים
+        </button>
+      </div>
+
+      {/* Player name inputs (duo mode only) */}
+      {mode === 'duo' && (
+        <div className="space-y-2 mb-2" dir="rtl">
+          <input
+            type="text"
+            value={p1}
+            onChange={(e) => setP1(e.target.value)}
+            placeholder="שם שחקן 1"
+            maxLength={20}
+            className="w-full border border-purple-200 rounded-xl px-3 py-2 text-sm text-right focus:outline-none focus:ring-2 focus:ring-purple-400"
+          />
+          <input
+            type="text"
+            value={p2}
+            onChange={(e) => setP2(e.target.value)}
+            placeholder="שם שחקן 2"
+            maxLength={20}
+            className="w-full border border-pink-200 rounded-xl px-3 py-2 text-sm text-right focus:outline-none focus:ring-2 focus:ring-pink-400"
+          />
+        </div>
+      )}
+    </GameMenuCard>
+  );
+}

--- a/gamesformykids/app/games/memory/stores/memoryStoreTypes.ts
+++ b/gamesformykids/app/games/memory/stores/memoryStoreTypes.ts
@@ -16,6 +16,15 @@ export const initialGameStats: GameStats = {
 
 export type MemoryPhase = 'menu' | 'playing' | 'won' | 'timeout';
 
+// ─── Duo mode types ───────────────────────────────────────────────────────────
+
+export type MemoryMode = 'solo' | 'duo';
+
+export interface DuoPlayer {
+  name: string;
+  score: number;
+}
+
 // ─── State shape ──────────────────────────────────────────────────────────────
 
 export interface MemoryStoreState {
@@ -26,6 +35,11 @@ export interface MemoryStoreState {
   isGamePaused: boolean;
   difficulty: DifficultyLevel;
   gameStats: GameStats;
+
+  // Duo mode
+  mode: MemoryMode;
+  players: [DuoPlayer, DuoPlayer];
+  currentPlayer: 0 | 1;
 
   // Cards
   lastMatchWasSuccess: boolean;
@@ -50,6 +64,8 @@ export interface MemoryStoreActions {
   resetGame: () => void;
   resetToMenu: () => void;
   setDifficulty: (difficulty: DifficultyLevel) => void;
+  setMode: (mode: MemoryMode) => void;
+  setPlayerNames: (p1: string, p2: string) => void;
 
   // Called from timer useEffect in useMemoryGameContent
   incrementTimer: () => void;
@@ -98,4 +114,7 @@ export const initialState: MemoryStoreState = {
   matchedPairs: [],
   showHints: false,
   showDebug: false,
+  mode: 'solo',
+  players: [{ name: 'שחקן 1', score: 0 }, { name: 'שחקן 2', score: 0 }],
+  currentPlayer: 0,
 };

--- a/gamesformykids/app/games/memory/stores/useMemoryStore.ts
+++ b/gamesformykids/app/games/memory/stores/useMemoryStore.ts
@@ -14,11 +14,13 @@ import {
   initialState,
   initialGameStats,
   type MemoryPhase,
+  type MemoryMode,
+  type DuoPlayer,
 } from './memoryStoreTypes';
 import { formatTime, getTimeColor, getGridCols, getAnimationDelay } from './memoryPureHelpers';
 import { resolveCardMatch } from './memoryMatchLogic';
 
-export type { MemoryStoreState, MemoryStoreActions } from './memoryStoreTypes';
+export type { MemoryStoreState, MemoryStoreActions, MemoryMode, DuoPlayer } from './memoryStoreTypes';
 export type { DifficultyOption, PerformanceLevel, WinAchievement } from '../types/memoryDisplay';
 
 // ─── Store ────────────────────────────────────────────────────────────────────
@@ -133,6 +135,7 @@ export const useMemoryStore = makeStore<MemoryStoreState & MemoryStoreActions>(
         isMatched: card.isMatched,
       }));
 
+      const { players } = get();
       set(
         {
           ...(targetDifficulty ? { difficulty: currentDifficulty } : {}),
@@ -144,6 +147,8 @@ export const useMemoryStore = makeStore<MemoryStoreState & MemoryStoreActions>(
           flippedCards: [],
           matchedPairs: [],
           gameStats: initialGameStats,
+          currentPlayer: 0,
+          players: [{ ...players[0], score: 0 }, { ...players[1], score: 0 }],
         },
         false,
         'memory/initializeGame',
@@ -177,6 +182,19 @@ export const useMemoryStore = makeStore<MemoryStoreState & MemoryStoreActions>(
       const config = MEMORY_GAME_CONSTANTS.DIFFICULTY_LEVELS[s.difficulty];
       const outcome = resolveCardMatch(s, firstCardIndex, secondCardIndex, config.pairs);
 
+      // Duo mode: award pair to current player on match; switch on miss
+      let updatedPlayers = s.players;
+      let nextPlayer = s.currentPlayer;
+      if (s.mode === 'duo') {
+        if (outcome.isMatch) {
+          updatedPlayers = s.players.map((p, i) =>
+            i === s.currentPlayer ? { ...p, score: p.score + 1 } : p
+          ) as [DuoPlayer, DuoPlayer];
+        } else {
+          nextPlayer = (1 - s.currentPlayer) as 0 | 1;
+        }
+      }
+
       set(
         {
           cards: outcome.cards,
@@ -184,6 +202,8 @@ export const useMemoryStore = makeStore<MemoryStoreState & MemoryStoreActions>(
           flippedCards: outcome.flippedCards,
           gameStats: outcome.gameStats,
           lastMatchWasSuccess: outcome.isMatch,
+          players: updatedPlayers,
+          currentPlayer: nextPlayer,
         },
         false,
         outcome.isMatch ? 'memory/successMatch' : 'memory/failedMatch',
@@ -193,6 +213,20 @@ export const useMemoryStore = makeStore<MemoryStoreState & MemoryStoreActions>(
         set({ phase: 'won' as MemoryPhase }, false, 'memory/gameWon');
       }
     },
+
+    setMode: (mode: MemoryMode) => set({ mode }, false, 'memory/setMode'),
+
+    setPlayerNames: (p1: string, p2: string) =>
+      set(
+        (s) => ({
+          players: [
+            { ...s.players[0], name: p1 || 'שחקן 1' },
+            { ...s.players[1], name: p2 || 'שחקן 2' },
+          ] as [DuoPlayer, DuoPlayer],
+        }),
+        false,
+        'memory/setPlayerNames',
+      ),
 
     pauseGame: () => set({ isGamePaused: true }, false, 'memory/pause'),
     resumeGame: () => set({ isGamePaused: false }, false, 'memory/resume'),


### PR DESCRIPTION
﻿## Summary

Adds a two-player pass-and-play mode to the memory card game. Two players take turns on the same device. A matched pair lets the current player go again; a miss hands the turn to the other player. The player with more pairs when the board is cleared wins.

## Changes

- **`stores/memoryStoreTypes.ts`** - added `MemoryMode`, `DuoPlayer` types; extended state with `mode`, `players: [DuoPlayer, DuoPlayer]`, `currentPlayer: 0|1`; added `setMode` / `setPlayerNames` actions
- **`stores/useMemoryStore.ts`** - `resolveMatch` awards pair to current player on match (keeps turn) and switches player on miss; `initializeGame` resets both player scores
- **`components/MemoryStartScreen.tsx`** - replaced factory component with custom one; adds solo/duo toggle and player-name inputs in duo mode
- **`components/MemoryGameHeader.tsx`** - `DuoPlayerIndicator` shows both names + pair counts; active player highlighted with game controller emoji
- **`components/GameWinMessage.tsx`** - in duo mode renders `DuoResult` showing both scores + winner/tie; solo result unchanged

## Testing

- [x] `npx tsc --noEmit` passes
- [ ] Solo mode: unchanged single-player flow
- [ ] Duo mode: enter names, turn indicator shows, match keeps player, miss switches player, win screen shows scores + winner

Closes #1031

Generated with [Claude Code](https://claude.com/claude-code)
