### PR TITLE
refactor(hebrew-letters): replace raw speechSynthesis in audioSlice with shared speak util

### DIFF
--- a/gamesformykids/app/games/hebrew-letters/store/slices/audioSlice.ts
+++ b/gamesformykids/app/games/hebrew-letters/store/slices/audioSlice.ts
@@ -1,8 +1,8 @@
 import type { StateCreator } from 'zustand';
 import type { HebrewLettersStore } from '../types';
 import { makeToggle, makeSetter } from '@/lib/stores/utils/sliceUtils';
+import { speak } from '@/lib/utils/speech/enhancedSpeechUtils';
 import {
-  DEFAULT_AUDIO_STATE,
   ENCOURAGEMENT_MESSAGES,
   STEP_MESSAGES,
 } from '../../constants/hebrewLettersConstants';
@@ -26,13 +26,8 @@ export const createAudioSlice: StateCreator<HebrewLettersStore, [['zustand/devto
 
   speakText: (text, settings) => {
     const { isAudioEnabled } = get();
-    if (!isAudioEnabled || !('speechSynthesis' in window)) return;
-    const utterance = new SpeechSynthesisUtterance(text);
-    utterance.lang = settings?.lang ?? 'he-IL';
-    utterance.rate = settings?.rate ?? DEFAULT_AUDIO_STATE.speechRate;
-    utterance.pitch = settings?.pitch ?? DEFAULT_AUDIO_STATE.speechPitch;
-    utterance.volume = settings?.volume ?? DEFAULT_AUDIO_STATE.volume;
-    speechSynthesis.speak(utterance);
+    if (!isAudioEnabled) return;
+    speak(text, settings);
   },
 
   playLetterSound: (letter) => {


### PR DESCRIPTION
## Summary
Removes the inline SpeechSynthesisUtterance construction from udioSlice.ts and replaces it with a call to the shared speak() utility from @/lib/utils/speech/enhancedSpeechUtils. The new implementation respects the same settings parameter shape (rate, pitch, volume, lang) via SpeechOptions, so callers like LetterTracingStep that pass { rate: 0.8 } continue to work correctly. Also removes the now-unused DEFAULT_AUDIO_STATE import.

## Changes
- pp/games/hebrew-letters/store/slices/audioSlice.ts — replaced direct SpeechSynthesisUtterance construction with speak(text, settings) from shared util; removed DEFAULT_AUDIO_STATE import

## Testing
- [x] `npx tsc --noEmit` passes
- [ ] Manually verify letter TTS fires in hebrew-letters game at `http://localhost:3000/games/hebrew-letters`

Closes #1170

🤖 Generated with [Claude Code](https://claude.com/claude-code)