### PR TITLE
refactor(checkers): replace DamkaResultScreen with shared GameResultCard

### DIFF
--- a/gamesformykids/app/games/checkers/components/DamkaResultScreen.tsx
+++ b/gamesformykids/app/games/checkers/components/DamkaResultScreen.tsx
@@ -1,26 +1,24 @@
 'use client';
 
 import { useDamkaGame } from '../useDamkaGame';
+import GameResultCard from '@/components/game/shared/GameResultCard';
 
 export default function DamkaResultScreen() {
   const { phase, playerScore, computerScore, startGame } = useDamkaGame();
 
   return (
-    <div className="flex flex-col items-center gap-6 text-center">
-      <div className="text-8xl">{phase === 'won' ? '🎉' : '😢'}</div>
-      <h2 className="text-4xl font-extrabold text-white">
-        {phase === 'won' ? 'ניצחת!' : 'המחשב ניצח!'}
-      </h2>
-      <div className="flex gap-6 text-white text-xl font-semibold">
+    <GameResultCard
+      emoji={phase === 'won' ? '🎉' : '😢'}
+      title={phase === 'won' ? 'ניצחת!' : 'המחשב ניצח!'}
+      gradientClass="from-amber-50 to-yellow-100"
+      buttonClass="from-amber-400 to-orange-500"
+      onRestart={startGame}
+      restartLabel="🔄 שחק שוב"
+    >
+      <div className="flex gap-6 text-gray-700 text-xl font-semibold justify-center">
         <span>🔴 אתה: {playerScore}</span>
         <span>⚪ מחשב: {computerScore}</span>
       </div>
-      <button
-        onClick={startGame}
-        className="bg-amber-400 hover:bg-amber-300 text-gray-900 font-extrabold text-xl px-10 py-4 rounded-2xl shadow-xl transition-transform hover:scale-105 active:scale-95"
-      >
-        🔄 שחק שוב
-      </button>
-    </div>
+    </GameResultCard>
   );
 }


### PR DESCRIPTION
## Summary
Replaces the hand-rolled result markup in DamkaResultScreen.tsx with the shared GameResultCard component, which is already used by taki, reflex, word-scramble, and other games. The custom screen had identical structure (emoji, title, scores, restart button) but without the new-record banner, share button, rating buttons, or next-game link that GameResultCard provides.

## Changes
- pp/games/checkers/components/DamkaResultScreen.tsx — replaced 25-line manual markup with GameResultCard using amber/orange palette; scores rendered as children

## Testing
- [x] `npx tsc --noEmit` passes
- [ ] Manually verify win/lose result screen at `http://localhost:3000/games/checkers`

Closes #1171

🤖 Generated with [Claude Code](https://claude.com/claude-code)