### PR TITLE
refactor(math): move inline MATH_ITEMS out of useMathGame hook to gameData/math.ts

### DIFF
--- a/gamesformykids/app/games/math/hooks/useMathGame.ts
+++ b/gamesformykids/app/games/math/hooks/useMathGame.ts
@@ -8,19 +8,7 @@ import { delay, getRandomItem } from "@/lib/utils/game/gameUtils";
 import { MATH_GAME_CONSTANTS } from "@/lib/constants";
 import { useMathChallengeStore } from "@/lib/stores/mathChallengeStore";
 import { useNumericQuizRuntime } from "@/hooks/games/useNumericQuizRuntime";
-
-// ---------------------------------------------------------------------------
-// Items
-// ---------------------------------------------------------------------------
-
-const MATH_ITEMS = [
-  { emoji: "🍎", name: "תפוח", plural: "תפוחים" },
-  { emoji: "🌟", name: "כוכב", plural: "כוכבים" },
-  { emoji: "🐶", name: "כלב", plural: "כלבים" },
-  { emoji: "🎈", name: "בלון", plural: "בלונים" },
-  { emoji: "🍭", name: "סוכריה", plural: "סוכריות" },
-  { emoji: "🦋", name: "פרפר", plural: "פרפרים" },
-];
+import { MATH_ITEMS } from "@/lib/constants/gameData/math";
 
 // ---------------------------------------------------------------------------
 // Pure helpers (defined outside hook — stable references, no closures)

--- a/gamesformykids/lib/constants/gameData/math.ts
+++ b/gamesformykids/lib/constants/gameData/math.ts
@@ -1,0 +1,14 @@
+export type MathItem = {
+  emoji: string;
+  name: string;
+  plural: string;
+};
+
+export const MATH_ITEMS: MathItem[] = [
+  { emoji: "🍎", name: "תפוח",   plural: "תפוחים" },
+  { emoji: "🌟", name: "כוכב",   plural: "כוכבים" },
+  { emoji: "🐶", name: "כלב",    plural: "כלבים"  },
+  { emoji: "🎈", name: "בלון",   plural: "בלונים" },
+  { emoji: "🍭", name: "סוכריה", plural: "סוכריות" },
+  { emoji: "🦋", name: "פרפר",   plural: "פרפרים" },
+];


### PR DESCRIPTION
## Summary
Extracts the MATH_ITEMS constant from the top of useMathGame.ts (where it was mixed in with game logic) to a standalone lib/constants/gameData/math.ts file. The hook now imports MATH_ITEMS from the canonical data location, consistent with how all other games source their item data.

## Changes
- lib/constants/gameData/math.ts — new file; exports MathItem type and MATH_ITEMS array of 6 countable Hebrew nouns (emoji, name, plural)
- pp/games/math/hooks/useMathGame.ts — removed inline MATH_ITEMS definition; added import from @/lib/constants/gameData/math

## Testing
- [x] `npx tsc --noEmit` passes
- [ ] Manually verify math game still generates challenges at `http://localhost:3000/games/math`

Closes #1174

🤖 Generated with [Claude Code](https://claude.com/claude-code)