### PR TITLE
feat(letter-defender): Hebrew tower defense spelling game (closes #1243)

### DIFF
--- a/gamesformykids/app/games/[gameType]/CustomGameRenderer.tsx
+++ b/gamesformykids/app/games/[gameType]/CustomGameRenderer.tsx
@@ -43,7 +43,8 @@ const GAME_CLIENTS: Record<string, ComponentType> = {
   'whack-a-mole':    dynamic(() => import('../whack-a-mole/WhackAMoleClient'),               { ssr: false }),
   'word-builder':    dynamic(() => import('../word-builder/WordBuilderGameClient')),
   'word-scramble':   dynamic(() => import('../word-scramble/WordScrambleClient')),
-  'maze':            dynamic(() => import('../maze/MazeClient'),                                  { ssr: false }),
+  'maze':             dynamic(() => import('../maze/MazeClient'),                                 { ssr: false }),
+  'letter-defender':  dynamic(() => import('../letter-defender/LetterDefenderClient'),           { ssr: false }),
 };
 
 interface Props { gameType: string; }

--- a/gamesformykids/app/games/[gameType]/gamePageConstants.ts
+++ b/gamesformykids/app/games/[gameType]/gamePageConstants.ts
@@ -57,6 +57,7 @@ export const SUPPORTED_GAMES = [
   'visual-addition',
   'gematria',
   'word-chain',
+  'letter-defender',
 ] as const;
 
 export type SupportedGameType = typeof SUPPORTED_GAMES[number];
@@ -68,7 +69,7 @@ export const CUSTOM_GAME_TYPES = new Set([
   'math-race', 'memory', 'meteor-dodge', 'multiplication', 'number-bubbles', 'pong',
   'puzzles', 'reflex', 'shesh-besh', 'simon', 'snake', 'space-defender',
   'stack', 'taki', 'tetris', 'true-false', 'tzedakah', 'whack-a-mole',
-  'word-builder', 'word-scramble', 'maze',
+  'word-builder', 'word-scramble', 'maze', 'letter-defender',
 ]);
 
 // ─── מיפוי URL → GameType ──────────────────────────────────────────────────────

--- a/gamesformykids/app/games/letter-defender/LetterDefenderClient.tsx
+++ b/gamesformykids/app/games/letter-defender/LetterDefenderClient.tsx
@@ -1,0 +1,102 @@
+'use client';
+
+import { useLetterDefender } from './useLetterDefender';
+import DefenderGrid from './components/DefenderGrid';
+import { WAVE_DATA } from './letterDefenderStore';
+
+export default function LetterDefenderClient() {
+  const {
+    phase, wave, lives, score, enemies, towers, targetWord,
+    enemiesToSpawn, startGame, restartGame, toggleTower,
+  } = useLetterDefender();
+
+  const totalWaves = WAVE_DATA.length;
+  const livesArr = Array.from({ length: 3 });
+
+  if (phase === 'idle') {
+    return (
+      <div className="min-h-screen bg-linear-to-br from-emerald-50 to-teal-100 flex flex-col items-center justify-center p-6" dir="rtl">
+        <div className="bg-white rounded-3xl shadow-2xl p-8 max-w-sm w-full text-center">
+          <div className="text-6xl mb-4">🏰</div>
+          <h1 className="text-2xl font-black text-emerald-800 mb-2">מגן האותיות</h1>
+          <p className="text-gray-600 text-sm mb-6">הצב מגדלים כדי לעצור את המילים השגויות — הגן על המילה הנכונה!</p>
+          <div className="text-sm text-gray-500 mb-6 space-y-1 text-right">
+            <p>🏰 לחץ על תא ריק להצבת מגדל</p>
+            <p>🔴 עצור את המילים השגויות</p>
+            <p>💔 3 חיים — אל תתן להן לעבור!</p>
+          </div>
+          <button
+            onClick={startGame}
+            className="w-full py-4 rounded-2xl bg-emerald-600 hover:bg-emerald-700 text-white font-black text-xl active:scale-95 transition-[transform,background-color]"
+          >
+            🏰 התחל לשמור!
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  if (phase === 'gameOver') {
+    const won = wave >= totalWaves - 1 && lives > 0;
+    return (
+      <div className="min-h-screen bg-linear-to-br from-emerald-50 to-teal-100 flex flex-col items-center justify-center p-6" dir="rtl">
+        <div className="bg-white rounded-3xl shadow-2xl p-8 max-w-sm w-full text-center">
+          <div className="text-7xl mb-4">{won ? '🏆' : '💔'}</div>
+          <h2 className="text-2xl font-black text-emerald-800 mb-2">
+            {won ? 'ניצחון!' : 'המשחק נגמר'}
+          </h2>
+          <p className="text-gray-600 mb-2">גל: {wave + 1} / {totalWaves}</p>
+          <div className="text-4xl font-black text-emerald-600 mb-1">{score}</div>
+          <p className="text-gray-400 mb-6">נקודות</p>
+          <button
+            onClick={restartGame}
+            className="w-full py-3 rounded-2xl bg-emerald-600 hover:bg-emerald-700 text-white font-bold text-lg active:scale-95 transition-[transform,background-color]"
+          >
+            שחק שוב
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-linear-to-br from-emerald-50 to-teal-100 flex flex-col items-center p-3" dir="rtl">
+      {/* HUD */}
+      <div className="w-full max-w-2xl flex items-center justify-between mb-3 px-1">
+        <div className="flex items-center gap-1">
+          {livesArr.map((_, i) => (
+            <span key={i} className={`text-2xl transition-opacity ${i < lives ? 'opacity-100' : 'opacity-20'}`}>❤️</span>
+          ))}
+        </div>
+        <div className="text-center">
+          <div className="text-xs text-emerald-600 font-semibold">גל {wave + 1} / {totalWaves}</div>
+          <div className="text-sm font-black text-emerald-800">הגן על: <span className="text-red-600">{targetWord}</span></div>
+        </div>
+        <div className="text-right">
+          <div className="text-xs text-gray-400">ניקוד</div>
+          <div className="text-xl font-black text-emerald-700">{score}</div>
+        </div>
+      </div>
+
+      {/* Grid */}
+      <div className="overflow-auto max-w-full">
+        <DefenderGrid
+          enemies={enemies}
+          towers={towers}
+          onCellClick={toggleTower}
+        />
+      </div>
+
+      {/* Wave status */}
+      <div className="mt-3 text-center text-sm text-gray-500">
+        {enemiesToSpawn.length > 0
+          ? `${enemiesToSpawn.length} אויבים ממתינים`
+          : enemies.some(e => !e.dying)
+            ? 'עצור אותם!'
+            : '⏳ מתחיל גל הבא...'}
+      </div>
+
+      <p className="mt-2 text-xs text-gray-400">לחץ על תא ריק להצבת מגדל 🏰 / לחץ שוב להסרה</p>
+    </div>
+  );
+}

--- a/gamesformykids/app/games/letter-defender/components/DefenderGrid.tsx
+++ b/gamesformykids/app/games/letter-defender/components/DefenderGrid.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { PATH, PATH_SET, GRID_ROWS, GRID_COLS, CELL_PX, isOnPath } from '../letterDefenderStore';
+import { PATH, GRID_ROWS, GRID_COLS, CELL_PX, isOnPath } from '../letterDefenderStore';
 import type { Enemy, Tower } from '../letterDefenderStore';
 
 interface Props {
@@ -9,18 +9,6 @@ interface Props {
   onCellClick: (row: number, col: number) => void;
 }
 
-function pathDirectionClass(index: number): string {
-  const cur = PATH[index];
-  const nxt = PATH[index + 1];
-  if (!cur || !nxt) return '';
-  const dr = nxt[0] - cur[0];
-  const dc = nxt[1] - cur[1];
-  if (dr > 0) return 'after:content-["↓"]';
-  if (dr < 0) return 'after:content-["↑"]';
-  if (dc > 0) return 'after:content-["→"]';
-  if (dc < 0) return 'after:content-["←"]';
-  return '';
-}
 
 export default function DefenderGrid({ enemies, towers, onCellClick }: Props) {
   const w = GRID_COLS * CELL_PX;

--- a/gamesformykids/app/games/letter-defender/components/DefenderGrid.tsx
+++ b/gamesformykids/app/games/letter-defender/components/DefenderGrid.tsx
@@ -1,0 +1,94 @@
+'use client';
+
+import { PATH, PATH_SET, GRID_ROWS, GRID_COLS, CELL_PX, isOnPath } from '../letterDefenderStore';
+import type { Enemy, Tower } from '../letterDefenderStore';
+
+interface Props {
+  enemies: Enemy[];
+  towers: Tower[];
+  onCellClick: (row: number, col: number) => void;
+}
+
+function pathDirectionClass(index: number): string {
+  const cur = PATH[index];
+  const nxt = PATH[index + 1];
+  if (!cur || !nxt) return '';
+  const dr = nxt[0] - cur[0];
+  const dc = nxt[1] - cur[1];
+  if (dr > 0) return 'after:content-["↓"]';
+  if (dr < 0) return 'after:content-["↑"]';
+  if (dc > 0) return 'after:content-["→"]';
+  if (dc < 0) return 'after:content-["←"]';
+  return '';
+}
+
+export default function DefenderGrid({ enemies, towers, onCellClick }: Props) {
+  const w = GRID_COLS * CELL_PX;
+  const h = GRID_ROWS * CELL_PX;
+
+  return (
+    <div
+      className="relative rounded-2xl overflow-hidden border-2 border-gray-300 shadow-inner"
+      style={{ width: w, height: h, background: '#e8f4e8' }}
+    >
+      {/* Path cells */}
+      {PATH.map(([r, c], i) => (
+        <div
+          key={`p${r}-${c}`}
+          className="absolute bg-amber-100 border border-amber-300 flex items-center justify-center text-xs text-amber-400 select-none"
+          style={{ top: r * CELL_PX, left: c * CELL_PX, width: CELL_PX, height: CELL_PX }}
+        >
+          {i === 0 && <span className="text-green-600 font-bold text-sm">▶</span>}
+          {i === PATH.length - 1 && <span className="text-red-500 font-bold text-sm">🏁</span>}
+        </div>
+      ))}
+
+      {/* Non-path cells — clickable for tower placement */}
+      {Array.from({ length: GRID_ROWS }, (_, r) =>
+        Array.from({ length: GRID_COLS }, (_, c) => {
+          if (isOnPath(r, c)) return null;
+          const hasTower = towers.some(t => t.row === r && t.col === c);
+          return (
+            <div
+              key={`c${r}-${c}`}
+              onClick={() => onCellClick(r, c)}
+              className={`absolute border border-gray-200 flex items-center justify-center cursor-pointer select-none transition-colors duration-150 ${hasTower ? 'bg-blue-100 border-blue-300' : 'bg-green-50 hover:bg-green-100'}`}
+              style={{ top: r * CELL_PX, left: c * CELL_PX, width: CELL_PX, height: CELL_PX }}
+            >
+              {hasTower && <span className="text-2xl">🏰</span>}
+            </div>
+          );
+        })
+      )}
+
+      {/* Enemies */}
+      {enemies.map(enemy => {
+        const idx = Math.min(enemy.pathIndex, PATH.length - 1);
+        const pos = PATH[idx];
+        if (!pos) return null;
+        const [r, c] = pos;
+        return (
+          <div
+            key={enemy.id}
+            className="absolute flex items-center justify-center rounded-lg border-2 font-bold text-xs select-none"
+            style={{
+              top: r * CELL_PX + 5,
+              left: c * CELL_PX + 5,
+              width: CELL_PX - 10,
+              height: CELL_PX - 10,
+              transition: 'top 0.8s ease, left 0.8s ease, opacity 0.5s, transform 0.5s',
+              opacity: enemy.dying ? 0 : 1,
+              transform: enemy.dying ? 'scale(0) rotate(90deg)' : 'scale(1)',
+              background: 'linear-gradient(135deg, #fee2e2, #fecaca)',
+              borderColor: '#f87171',
+              color: '#b91c1c',
+              zIndex: 10,
+            }}
+          >
+            {enemy.label}
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/gamesformykids/app/games/letter-defender/letterDefenderStore.ts
+++ b/gamesformykids/app/games/letter-defender/letterDefenderStore.ts
@@ -1,0 +1,175 @@
+'use client';
+import { create } from 'zustand';
+
+// ─── Grid geometry ────────────────────────────────────────────────────────────
+export const GRID_ROWS = 5;
+export const GRID_COLS = 10;
+export const CELL_PX   = 54; // pixels per cell
+
+// S-curve path through the 10×5 grid (row, col)
+export const PATH: [number, number][] = [
+  [0,0],[0,1],[0,2],[0,3],[0,4],
+  [1,4],[2,4],[3,4],
+  [3,3],[3,2],[3,1],[3,0],
+  [4,0],[4,1],[4,2],[4,3],[4,4],[4,5],[4,6],[4,7],[4,8],[4,9],
+];
+export const PATH_SET = new Set(PATH.map(([r, c]) => `${r},${c}`));
+export function isOnPath(row: number, col: number) {
+  return PATH_SET.has(`${row},${col}`);
+}
+
+// ─── Wave data ────────────────────────────────────────────────────────────────
+export const WAVE_DATA = [
+  { targetWord: 'בית',  enemyWords: ['בין','ביד','בות','דית','ביץ'] },
+  { targetWord: 'שמש',  enemyWords: ['שמן','שמג','שמך','שמס','שמם'] },
+  { targetWord: 'ילד',  enemyWords: ['ילם','ילב','ילג','ילן','ילה'] },
+  { targetWord: 'כלב',  enemyWords: ['כלם','כלג','כלה','כמב','כלף'] },
+  { targetWord: 'אמא',  enemyWords: ['אמה','אמב','אמן','אמג','אמם'] },
+];
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+export interface Enemy {
+  id: number;
+  pathIndex: number;
+  label: string;
+  dying: boolean;
+}
+export interface Tower {
+  row: number;
+  col: number;
+}
+
+interface State {
+  phase: 'idle' | 'playing' | 'gameOver';
+  wave: number;
+  lives: number;
+  score: number;
+  enemies: Enemy[];
+  towers: Tower[];
+  targetWord: string;
+  enemiesToSpawn: string[];
+}
+interface Actions {
+  startGame: () => void;
+  restartGame: () => void;
+  toggleTower: (row: number, col: number) => void;
+  spawnNext: () => void;
+  tick: () => void;
+  advanceWave: () => void;
+}
+
+let nextId = 0;
+
+const INITIAL: State = {
+  phase: 'idle',
+  wave: 0,
+  lives: 3,
+  score: 0,
+  enemies: [],
+  towers: [],
+  targetWord: WAVE_DATA[0]?.targetWord ?? '',
+  enemiesToSpawn: [],
+};
+
+function buildInitialWave(waveIndex: number): Partial<State> {
+  const data = WAVE_DATA[waveIndex];
+  if (!data) return {};
+  return {
+    targetWord: data.targetWord,
+    enemiesToSpawn: [...data.enemyWords],
+    enemies: [],
+  };
+}
+
+export const useLetterDefenderStore = create<State & Actions>((set, get) => ({
+  ...INITIAL,
+
+  startGame: () => {
+    nextId = 0;
+    set({
+      ...INITIAL,
+      phase: 'playing',
+      ...buildInitialWave(0),
+      wave: 0,
+      towers: [],
+    });
+  },
+
+  restartGame: () => {
+    nextId = 0;
+    set({
+      ...INITIAL,
+      phase: 'playing',
+      ...buildInitialWave(0),
+      wave: 0,
+      towers: [],
+    });
+  },
+
+  toggleTower: (row, col) => {
+    if (isOnPath(row, col)) return;
+    const towers = get().towers;
+    const exists = towers.some(t => t.row === row && t.col === col);
+    set({ towers: exists ? towers.filter(t => !(t.row === row && t.col === col)) : [...towers, { row, col }] });
+  },
+
+  spawnNext: () => {
+    const { enemiesToSpawn, enemies } = get();
+    if (enemiesToSpawn.length === 0) return;
+    const [label, ...rest] = enemiesToSpawn;
+    if (!label) return;
+    set({
+      enemies: [...enemies, { id: nextId++, pathIndex: 0, label, dying: false }],
+      enemiesToSpawn: rest,
+    });
+  },
+
+  tick: () => {
+    const state = get();
+    if (state.phase !== 'playing') return;
+
+    const active = state.enemies.filter(e => !e.dying);
+    const moved  = active.map(e => ({ ...e, pathIndex: e.pathIndex + 1 }));
+
+    const reached  = moved.filter(e => e.pathIndex >= PATH.length);
+    const still    = moved.filter(e => e.pathIndex < PATH.length);
+    let   lives    = state.lives - reached.length;
+    let   score    = state.score;
+
+    const shot = new Set<number>();
+    for (const tower of state.towers) {
+      for (const enemy of still) {
+        if (shot.has(enemy.id)) continue;
+        const pos = PATH[enemy.pathIndex];
+        if (!pos) continue;
+        const dist = Math.abs(pos[0] - tower.row) + Math.abs(pos[1] - tower.col);
+        if (dist <= 2) { shot.add(enemy.id); score += 10; }
+      }
+    }
+
+    const surviving = still.map(e => shot.has(e.id) ? { ...e, dying: true } : e);
+
+    if (lives <= 0) {
+      set({ phase: 'gameOver', lives: 0, score, enemies: surviving });
+      return;
+    }
+
+    set({ lives, score, enemies: surviving });
+
+    if (shot.size > 0) {
+      setTimeout(() => {
+        set(s => ({ enemies: s.enemies.filter(e => !e.dying) }));
+      }, 600);
+    }
+  },
+
+  advanceWave: () => {
+    const { wave } = get();
+    const next = wave + 1;
+    if (next >= WAVE_DATA.length) {
+      set({ phase: 'gameOver' });
+      return;
+    }
+    set({ wave: next, ...buildInitialWave(next) });
+  },
+}));

--- a/gamesformykids/app/games/letter-defender/letterDefenderStore.ts
+++ b/gamesformykids/app/games/letter-defender/letterDefenderStore.ts
@@ -133,7 +133,7 @@ export const useLetterDefenderStore = create<State & Actions>((set, get) => ({
 
     const reached  = moved.filter(e => e.pathIndex >= PATH.length);
     const still    = moved.filter(e => e.pathIndex < PATH.length);
-    let   lives    = state.lives - reached.length;
+    const lives    = state.lives - reached.length;
     let   score    = state.score;
 
     const shot = new Set<number>();

--- a/gamesformykids/app/games/letter-defender/useLetterDefender.ts
+++ b/gamesformykids/app/games/letter-defender/useLetterDefender.ts
@@ -1,0 +1,51 @@
+'use client';
+import { useEffect } from 'react';
+import { useLetterDefenderStore } from './letterDefenderStore';
+import { speak } from '@/lib/utils/speech/enhancedSpeechUtils';
+
+const TICK_MS  = 900;   // ms between each enemy step
+const SPAWN_MS = 1800;  // ms between enemy spawns
+
+export function useLetterDefender() {
+  const phase          = useLetterDefenderStore(s => s.phase);
+  const wave           = useLetterDefenderStore(s => s.wave);
+  const targetWord     = useLetterDefenderStore(s => s.targetWord);
+  const enemies        = useLetterDefenderStore(s => s.enemies);
+  const enemiesToSpawn = useLetterDefenderStore(s => s.enemiesToSpawn);
+  const { tick, spawnNext, advanceWave } = useLetterDefenderStore();
+
+  // TTS: announce target word at start of each wave
+  useEffect(() => {
+    if (phase === 'playing' && targetWord) {
+      speak(`הגן על המילה ${targetWord}!`);
+    }
+  }, [wave, phase, targetWord]);
+
+  // Game tick — advance enemies one step
+  useEffect(() => {
+    if (phase !== 'playing') return;
+    const id = setInterval(tick, TICK_MS);
+    return () => clearInterval(id);
+  }, [phase, tick]);
+
+  // Enemy spawner
+  useEffect(() => {
+    if (phase !== 'playing') return;
+    const id = setInterval(() => {
+      if (enemiesToSpawn.length > 0) spawnNext();
+    }, SPAWN_MS);
+    return () => clearInterval(id);
+  }, [phase, enemiesToSpawn, spawnNext]);
+
+  // Wave completion: all enemies dead and none left to spawn
+  useEffect(() => {
+    if (phase !== 'playing') return;
+    if (enemiesToSpawn.length > 0) return;
+    if (enemies.some(e => !e.dying)) return;
+    // Delay slightly so last enemy death animation plays
+    const id = setTimeout(advanceWave, 800);
+    return () => clearTimeout(id);
+  }, [phase, enemies, enemiesToSpawn, advanceWave]);
+
+  return useLetterDefenderStore();
+}

--- a/gamesformykids/lib/constants/gameCategories.ts
+++ b/gamesformykids/lib/constants/gameCategories.ts
@@ -122,7 +122,7 @@ export const GAME_CATEGORIES: Record<string, GameCategory> = {
       "flappy-bird","snake","dino-runner","catch-fruit","space-defender",
       "whack-a-mole","brick-breaker","balloon-pop","pong","meteor-dodge",
       "frogger","stack","color-tap","jumper","simon",
-      "reflex","taki","checkers","chess","shesh-besh","maze",
+      "reflex","taki","checkers","chess","shesh-besh","maze","letter-defender",
     ],
   },
   educational: {

--- a/gamesformykids/lib/registry/registryData/batch4.ts
+++ b/gamesformykids/lib/registry/registryData/batch4.ts
@@ -474,4 +474,15 @@ export const gamesRegistryBatch4: GameRegistration[] = [
     available: true,
     order: 164,
   },
+  {
+    id: "letter-defender",
+    title: "מגן האותיות",
+    description: "הצב מגדלים כדי לעצור מילים שגויות — הגן על האיות הנכון!",
+    icon: Layers,
+    emoji: "🏰",
+    color: "bg-emerald-600 hover:bg-emerald-700",
+    href: "/games/letter-defender",
+    available: true,
+    order: 165,
+  },
 ];

--- a/gamesformykids/lib/types/core/base.ts
+++ b/gamesformykids/lib/types/core/base.ts
@@ -184,6 +184,6 @@ export type GameType =
   // Word games
   | 'word-builder' | 'word-scramble' | 'word-chain'
   // Special games
-  | 'hebrew-letters' | 'tzedakah'
+  | 'hebrew-letters' | 'tzedakah' | 'letter-defender'
   // Logic & patterns
   | 'sorting' | 'patterns';


### PR DESCRIPTION
﻿## What
Adds letter-defender (מגן האותיות) — a Hebrew spelling tower defense game.

**Mechanics:**
- 10x5 grid with a pre-defined S-curve path (22 cells)
- Enemies (wrong spellings of the wave target word) walk along the path via CSS transitions
- setInterval advances each enemy one step per 900ms
- Player taps/clicks free grid cells to place or remove castle towers
- Towers auto-fire at enemies within Manhattan distance 2 (+10 pts each)
- 5 waves of 5 enemies each (target words: בית, שמש, ילד, כלב, אמא)
- TTS announces the target word at the start of each wave
- 3 lives — lost when an enemy reaches the path end
- Win by surviving all 5 waves

**Files:**
- letterDefenderStore.ts — Zustand store: path geometry, wave data, enemy/tower state, tick logic
- useLetterDefender.ts — setInterval game loop + TTS + wave advancement
- components/DefenderGrid.tsx — grid rendering, CSS-animated enemies, tower placement
- LetterDefenderClient.tsx — entry with idle/playing/gameOver screens and HUD

## Why
Closes #1243

## Test plan
- [ ] Visit /games/letter-defender — idle screen shows instructions
- [ ] Start game — TTS says target word for wave 1
- [ ] Enemies (wrong spellings) appear at path start and walk toward the end
- [ ] Click free grid cell → castle tower placed
- [ ] Tower destroys nearby enemies (they fade/shrink)
- [ ] Enemy reaching path end → lose a life (heart goes dark)
- [ ] After wave 5 complete → win screen
- [ ] 3 lives lost → game over screen
- [ ] Score increments on each destroyed enemy
- [ ] npx tsc --noEmit passes (verified)

Generated with Claude Code
