### PR TITLE
feat(coins-match): add Israeli coin recognition card game (closes #1227)

### DIFF
--- a/gamesformykids/app/games/[gameType]/gamePageConstants.ts
+++ b/gamesformykids/app/games/[gameType]/gamePageConstants.ts
@@ -23,6 +23,7 @@ export const SUPPORTED_GAMES = [
   'ordinals',
   'spatial-concepts', 'number-words',
   'visual-opposites', 'english-cards',
+  'coins-match',
 
   // ── משחקים מותאמים (CustomGameRenderer) ──────────────────────────────────
   'arithmetic', 'balloon-pop', 'brick-breaker', 'bubbles', 'building',

--- a/gamesformykids/lib/constants/gameCategories.ts
+++ b/gamesformykids/lib/constants/gameCategories.ts
@@ -70,7 +70,7 @@ export const GAME_CATEGORIES: Record<string, GameCategory> = {
     icon: Calculator,
     color: "bg-indigo-500",
     gradient: "from-indigo-400 to-indigo-600",
-    gameIds: ["counting","math","shopping-money","multiplication","fractions","sequences","arithmetic","ordinals","number-words","spatial-concepts","sorting","patterns","skip-counting","division","visual-addition","gematria"],
+    gameIds: ["counting","math","shopping-money","coins-match","multiplication","fractions","sequences","arithmetic","ordinals","number-words","spatial-concepts","sorting","patterns","skip-counting","division","visual-addition","gematria"],
   },
   games: {
     title: "משחקים מיוחדים",

--- a/gamesformykids/lib/constants/gameData/coins.ts
+++ b/gamesformykids/lib/constants/gameData/coins.ts
@@ -1,0 +1,61 @@
+import type { BaseGameItem } from '@/lib/types/core/base';
+
+export const ISRAELI_COINS: BaseGameItem[] = [
+  {
+    name: 'coin-10ag',
+    hebrew: 'עשרה אגורות',
+    english: '10 Agorot',
+    emoji: '🪙',
+    color: 'bg-gradient-to-br from-gray-300 to-gray-500',
+    funFact: 'המטבע הקטן ביותר בישראל',
+  },
+  {
+    name: 'coin-50ag',
+    hebrew: 'חמישים אגורות',
+    english: '50 Agorot',
+    emoji: '🪙',
+    color: 'bg-gradient-to-br from-gray-400 to-gray-600',
+    funFact: 'חצי שקל — בדיוק',
+  },
+  {
+    name: 'coin-1nis',
+    hebrew: 'שקל אחד',
+    english: '1 Shekel',
+    emoji: '💰',
+    color: 'bg-gradient-to-br from-yellow-300 to-yellow-500',
+    funFact: 'המטבע הבסיסי של ישראל',
+  },
+  {
+    name: 'coin-2nis',
+    hebrew: 'שני שקלים',
+    english: '2 Shekels',
+    emoji: '💰',
+    color: 'bg-gradient-to-br from-yellow-400 to-amber-500',
+    funFact: 'מטבע כספי עם לב זהב במרכז',
+  },
+  {
+    name: 'coin-5nis',
+    hebrew: 'חמישה שקלים',
+    english: '5 Shekels',
+    emoji: '💰',
+    color: 'bg-gradient-to-br from-amber-400 to-orange-500',
+    funFact: 'מטבע גדול עם ציון לרבית',
+  },
+  {
+    name: 'coin-10nis',
+    hebrew: 'עשרה שקלים',
+    english: '10 Shekels',
+    emoji: '💎',
+    color: 'bg-gradient-to-br from-amber-500 to-yellow-700',
+    funFact: 'המטבע הגדול ביותר בישראל',
+  },
+];
+
+export const COINS_PRONUNCIATIONS: Record<string, string> = {
+  'coin-10ag': 'עֲשָׂרָה אֲגוֹרוֹת',
+  'coin-50ag': 'חֲמִישִׁים אֲגוֹרוֹת',
+  'coin-1nis': 'שֶׁקֶל אֶחָד',
+  'coin-2nis': 'שְׁנֵי שְׁקָלִים',
+  'coin-5nis': 'חֲמִישָׁה שְׁקָלִים',
+  'coin-10nis': 'עֲשָׂרָה שְׁקָלִים',
+};

--- a/gamesformykids/lib/constants/gameItemsMap.ts
+++ b/gamesformykids/lib/constants/gameItemsMap.ts
@@ -65,6 +65,7 @@ import { NBA_TEAMS_ITEMS } from "@/lib/constants/gameData/nbaTeams";
 import { EXOTIC_BIRDS_ITEMS } from "@/lib/constants/gameData/exoticBirds";
 import { BUTTERFLIES_ITEMS } from "@/lib/constants/gameData/butterflies";
 import { ALL_PERSONAL_SAFETY } from "@/lib/constants/gameData/personalSafety";
+import { ISRAELI_COINS } from "@/lib/constants/gameData/coins";
 
 import { GameType, BaseGameItem } from "@/lib/types/core/base";
 
@@ -167,4 +168,5 @@ export const GAME_ITEMS_MAP: Partial<Record<GameType, BaseGameItem[]>> = {
   "visual-opposites": OPPOSITES_ITEMS, // ✅ משחק ניגודים ויזואלי
   "english-cards": ENGLISH_FIRST_ITEMS, // ✅ משחק אנגלית ראשונה
   "personal-safety": ALL_PERSONAL_SAFETY, // ✅ משחק בטיחות אישית
+  "coins-match": ISRAELI_COINS, // ✅ משחק מטבעות ישראליים
 } as const;

--- a/gamesformykids/lib/constants/ui/homeLifeConfigData/timeLearning.ts
+++ b/gamesformykids/lib/constants/ui/homeLifeConfigData/timeLearning.ts
@@ -30,6 +30,39 @@ export const timeLearningConfigs: Partial<Record<string, GameUIConfig>> = {
     tipDescription: "לחץ על הסמל למעלה כדי לשמוע שוב, או על העונות והחגים למטה לשמוע עליהם",
   },
 
+  "coins-match": {
+    title: "🪙 מטבעות ישראליים 💰",
+    subTitle: "למד לזהות את מטבעות ישראל!",
+    itemsTitle: "המטבעות שנלמד:",
+    itemsDescription: "לחץ על מטבע כדי לשמוע את ערכו!",
+    steps: [
+      { icon: "👀", title: "1. תראה", description: "איזה מטבע אני מבקש" },
+      { icon: "🎤", title: "2. תשמע", description: "את שם המטבע" },
+      { icon: "👆", title: "3. תלחץ", description: "על המטבע הנכון" },
+    ],
+    colors: {
+      background: "linear-gradient(135deg, #f6d365 0%, #fda085 50%, #f093fb 100%)",
+      header: "text-yellow-900",
+      subHeader: "text-yellow-800",
+      itemsDescription: "text-yellow-800",
+      button: { from: "yellow", to: "amber" },
+      stepsBg: "bg-yellow-100 bg-opacity-90",
+    },
+    grid: {
+      className: "flex flex-wrap justify-center gap-4",
+    },
+    challengeTitle: "איזה מטבע שמעת?",
+    challengeIcon: "🪙💰💎",
+    challengeDescription: "בחר את המטבע הנכון!",
+    itemLabel: "מטבע",
+    tip: "💡 טיפ: תשמע את שם המטבע!",
+    tipDescription: "לחץ על הסמל למעלה כדי לשמוע שוב",
+    metadata: {
+      keywords: "מטבעות ישראל שקל אגורה כסף כלכלה",
+      description: "למד לזהות מטבעות ישראליים — עשרה אגורות, חמישים אגורות, שקל, שני שקלים, חמישה שקלים, עשרה שקלים",
+    },
+  },
+
   "shopping-money": {
     title: "🛒 משחק קניות וכסף 💰",
     subTitle: "למד על קניות וחשבון כסף!",

--- a/gamesformykids/lib/registry/registryData/batch4.ts
+++ b/gamesformykids/lib/registry/registryData/batch4.ts
@@ -497,6 +497,17 @@ export const gamesRegistryBatch4: GameRegistration[] = [
     order: 166,
   },
   {
+    id: "coins-match",
+    title: "מטבעות ישראליים",
+    description: "למד לזהות מטבעות ישראל — מעשרה אגורות ועד עשרה שקלים!",
+    icon: Calculator,
+    emoji: "🪙",
+    color: "bg-yellow-500 hover:bg-yellow-600",
+    href: "/games/coins-match",
+    available: true,
+    order: 170,
+  },
+  {
     id: "puppet-story",
     title: "תיאטרון בובות",
     description: "בחר דמויות ומיקום, צפה בסיפור עברי ועני על שאלות הבנה!",

--- a/gamesformykids/lib/types/core/base.ts
+++ b/gamesformykids/lib/types/core/base.ts
@@ -190,4 +190,6 @@ export type GameType =
   // Story games
   | 'puppet-story'
   // Language & wisdom
-  | 'proverbs';
+  | 'proverbs'
+  // Money & economy
+  | 'coins-match';


### PR DESCRIPTION
﻿## What
Style A card game: 6 Israeli coins (10 agorot, 50 agorot, 1, 2, 5, 10 shekels) as BaseGameItem entries. The TTS engine pronounces the coin name; the player taps the correct coin from 4 options. Uses the existing UltimateGamePage challenge engine — no custom components needed.

- New data file: `lib/constants/gameData/coins.ts` (6 coins with nikud-correct pronunciations)
- UI config in `homeLifeConfigData/timeLearning.ts` (amber/gold theme alongside shopping-money)
- Registered in `gameItemsMap`, `base.ts`, `SUPPORTED_GAMES`, `batch4`, and `math` category

## Why
Closes #1227

## Test plan
- [ ] Navigate to `/games/coins-match` -- see gold-themed start screen
- [ ] Start game -- TTS reads a coin name, 4 coin cards appear as choices
- [ ] Correct/wrong feedback works as usual
- [ ] Game appears in home page math category (alongside shopping-money)

Generated with Claude Code
