### PR TITLE
feat(blessings): add Hebrew brachot quiz game (closes #1228)

### DIFF
--- a/gamesformykids/app/games/[gameType]/gamePageConstants.ts
+++ b/gamesformykids/app/games/[gameType]/gamePageConstants.ts
@@ -62,6 +62,7 @@ export const SUPPORTED_GAMES = [
   'visual-logic',
   'puppet-story',
   'proverbs',
+  'blessings',
 ] as const;
 
 export type SupportedGameType = typeof SUPPORTED_GAMES[number];

--- a/gamesformykids/lib/constants/gameCategories.ts
+++ b/gamesformykids/lib/constants/gameCategories.ts
@@ -102,7 +102,7 @@ export const GAME_CATEGORIES: Record<string, GameCategory> = {
     icon: Calendar,
     color: "bg-yellow-500",
     gradient: "from-yellow-400 to-yellow-600",
-    gameIds: ["seasons-holidays","jewish-holidays","time-clock","tzadikim","holidays","days-of-week","months-of-year"],
+    gameIds: ["seasons-holidays","jewish-holidays","time-clock","tzadikim","holidays","days-of-week","months-of-year","blessings"],
   },
   innovative: {
     title: "משחקים חדשניים",

--- a/gamesformykids/lib/quiz/configs/knowledge.tsx
+++ b/gamesformykids/lib/quiz/configs/knowledge.tsx
@@ -7,6 +7,7 @@ import { SPORTS_QUESTIONS } from '@/lib/quiz/data/sports-quiz';
 import { CONTINENT_QUESTIONS } from '@/lib/quiz/data/continents';
 import { VISUAL_LOGIC_QUESTIONS } from '@/lib/quiz/data/visual-logic';
 import { PROVERB_QUESTIONS } from '@/lib/quiz/data/proverbs';
+import { BLESSING_QUESTIONS } from '@/lib/quiz/data/blessings';
 import { defineConfig } from './types';
 
 const FAMILY_BADGE: Record<string, string> = {
@@ -168,6 +169,34 @@ export const proverbsConfig = defineConfig({
       <p className="text-center text-gray-500 text-sm font-medium" dir="rtl">השלם את הפתגם:</p>
       <p className="text-center text-xl font-bold text-amber-800 leading-relaxed" dir="rtl">
         {q.firstHalf} <span className="text-amber-400">___</span>
+      </p>
+    </div>
+  ),
+});
+
+export const blessingsConfig = defineConfig({
+  gameType: 'blessings', emoji: '🙏', title: 'ברכות יהודיות',
+  description: 'איזו ברכה אומרים? — ברכות על אוכל, טבע ומועדים!', theme: 'violet',
+  buttonLabel: '🙏 בואו נברך!',
+  preview: (
+    <div className="text-right" dir="rtl">
+      <p className="text-violet-800 font-semibold text-sm mb-1">דוגמה:</p>
+      <p className="text-gray-700 text-sm">לפני שאוכלים לחם 🍞</p>
+      <p className="text-violet-600 font-bold text-sm">המוציא לחם מן הארץ</p>
+    </div>
+  ),
+  questions: BLESSING_QUESTIONS, questionsPerGame: QUESTIONS_PER_GAME,
+  getChoices: (q) => shuffle([q.answer, ...q.wrongOptions]),
+  isCorrect: (c, q) => c === q.answer,
+  getCorrectLabel: (q) => q.answer,
+  correctMsg: '🙏 כל הכבוד! ברכת נכון!',
+  wrongMsg: (q) => `💡 הברכה הנכונה: ${q.answer}`,
+  renderQuestion: (q) => (
+    <div className="w-full flex flex-col items-center gap-2">
+      <div className="text-5xl">{q.emoji}</div>
+      <p className="text-center text-gray-500 text-sm font-medium" dir="rtl">מה הברכה המתאימה?</p>
+      <p className="text-center text-lg font-bold text-violet-800 leading-relaxed" dir="rtl">
+        {q.situation}
       </p>
     </div>
   ),

--- a/gamesformykids/lib/quiz/data/blessings.ts
+++ b/gamesformykids/lib/quiz/data/blessings.ts
@@ -1,0 +1,155 @@
+export type BlessingQuestion = {
+  id: number;
+  situation: string;
+  answer: string;
+  wrongOptions: [string, string, string];
+  emoji: string;
+  category: 'food' | 'nature' | 'shabbat-holidays' | 'special';
+};
+
+export const BLESSING_QUESTIONS: BlessingQuestion[] = [
+  {
+    id: 1, emoji: '🍞', category: 'food',
+    situation: 'לפני שאוכלים לחם',
+    answer: 'המוציא לחם מן הארץ',
+    wrongOptions: ['בורא פרי האדמה', 'שהכל נהיה בדברו', 'בורא פרי הגפן'],
+  },
+  {
+    id: 2, emoji: '🍎', category: 'food',
+    situation: 'לפני שאוכלים תפוח (פרי עץ)',
+    answer: 'בורא פרי העץ',
+    wrongOptions: ['המוציא לחם מן הארץ', 'בורא פרי האדמה', 'שהכל נהיה בדברו'],
+  },
+  {
+    id: 3, emoji: '🥕', category: 'food',
+    situation: 'לפני שאוכלים גזר (ירק)',
+    answer: 'בורא פרי האדמה',
+    wrongOptions: ['בורא פרי העץ', 'המוציא לחם מן הארץ', 'בורא מיני מזונות'],
+  },
+  {
+    id: 4, emoji: '🧃', category: 'food',
+    situation: 'לפני שותים מיץ תפוזים',
+    answer: 'שהכל נהיה בדברו',
+    wrongOptions: ['בורא פרי הגפן', 'בורא פרי העץ', 'המוציא לחם מן הארץ'],
+  },
+  {
+    id: 5, emoji: '🍇', category: 'food',
+    situation: 'לפני שותים יין',
+    answer: 'בורא פרי הגפן',
+    wrongOptions: ['שהכל נהיה בדברו', 'בורא פרי העץ', 'בורא פרי האדמה'],
+  },
+  {
+    id: 6, emoji: '🍰', category: 'food',
+    situation: 'לפני שאוכלים עוגה (מזונות)',
+    answer: 'בורא מיני מזונות',
+    wrongOptions: ['המוציא לחם מן הארץ', 'שהכל נהיה בדברו', 'בורא פרי האדמה'],
+  },
+  {
+    id: 7, emoji: '🕯️', category: 'shabbat-holidays',
+    situation: 'לפני שמדליקים נרות שבת',
+    answer: 'להדליק נר של שבת',
+    wrongOptions: ['להדליק נר של חנוכה', 'להדליק נר של יום טוב', 'על מצוות הדלקת הנר'],
+  },
+  {
+    id: 8, emoji: '🕎', category: 'shabbat-holidays',
+    situation: 'לפני שמדליקים נרות חנוכה',
+    answer: 'להדליק נר של חנוכה',
+    wrongOptions: ['להדליק נר של שבת', 'להדליק נר של יום טוב', 'לראות את הנר'],
+  },
+  {
+    id: 9, emoji: '⚡', category: 'nature',
+    situation: 'כשרואים ברק',
+    answer: 'שעושה מעשה בראשית',
+    wrongOptions: ['זוכר הברית', 'שכוחו וגבורתו מלא עולם', 'הטוב והמטיב'],
+  },
+  {
+    id: 10, emoji: '🌈', category: 'nature',
+    situation: 'כשרואים קשת בענן',
+    answer: 'זוכר הברית',
+    wrongOptions: ['שעושה מעשה בראשית', 'שכוחו וגבורתו מלא עולם', 'הטוב והמטיב'],
+  },
+  {
+    id: 11, emoji: '🌊', category: 'nature',
+    situation: 'כשרואים את הים הגדול',
+    answer: 'שעשה את הים הגדול',
+    wrongOptions: ['שעושה מעשה בראשית', 'זוכר הברית', 'בורא העולם'],
+  },
+  {
+    id: 12, emoji: '⛈️', category: 'nature',
+    situation: 'כשרואים רעם',
+    answer: 'שכוחו וגבורתו מלא עולם',
+    wrongOptions: ['שעושה מעשה בראשית', 'זוכר הברית', 'הטוב והמטיב'],
+  },
+  {
+    id: 13, emoji: '🌸', category: 'nature',
+    situation: 'ראשית ראיית עצי פרחים באביב',
+    answer: 'שלא חיסר בעולמו כלום',
+    wrongOptions: ['שעושה מעשה בראשית', 'זוכר הברית', 'בורא פרי העץ'],
+  },
+  {
+    id: 14, emoji: '👤', category: 'special',
+    situation: 'כשרואים חכם גדול בתורה',
+    answer: 'שחלק מחכמתו ליראיו',
+    wrongOptions: ['שחלק מכבודו לבשר ודם', 'שנתן מחכמתו לבשר ודם', 'ברוך המקום'],
+  },
+  {
+    id: 15, emoji: '👑', category: 'special',
+    situation: 'כשרואים מלך',
+    answer: 'שחלק מכבודו לבשר ודם',
+    wrongOptions: ['שחלק מחכמתו ליראיו', 'שנתן מחכמתו לבשר ודם', 'ברוך המקום'],
+  },
+  {
+    id: 16, emoji: '🌟', category: 'special',
+    situation: 'כשרואים מקום שנעשה בו נס לישראל',
+    answer: 'שעשה נסים לאבותינו',
+    wrongOptions: ['הטוב והמטיב', 'שחיינו וקיימנו', 'זוכר הברית'],
+  },
+  {
+    id: 17, emoji: '🎉', category: 'special',
+    situation: 'בהגיעה לזמן מיוחד לראשונה בשנה',
+    answer: 'שהחיינו וקיימנו והגיענו לזמן הזה',
+    wrongOptions: ['הטוב והמטיב', 'שעשה נסים לאבותינו', 'ברוך המקום'],
+  },
+  {
+    id: 18, emoji: '🕍', category: 'shabbat-holidays',
+    situation: 'לפני קידוש שבת',
+    answer: 'בורא פרי הגפן',
+    wrongOptions: ['שהחיינו וקיימנו', 'המוציא לחם מן הארץ', 'אשר קדשנו'],
+  },
+  {
+    id: 19, emoji: '🍫', category: 'food',
+    situation: 'לפני שאוכלים שוקולד',
+    answer: 'שהכל נהיה בדברו',
+    wrongOptions: ['בורא מיני מזונות', 'בורא פרי העץ', 'בורא פרי האדמה'],
+  },
+  {
+    id: 20, emoji: '🌿', category: 'shabbat-holidays',
+    situation: 'לפני נטילת ארבעת המינים בסוכות',
+    answer: 'על נטילת לולב',
+    wrongOptions: ['לישב בסוכה', 'להניח תפילין', 'להדליק נר של יום טוב'],
+  },
+  {
+    id: 21, emoji: '🏠', category: 'shabbat-holidays',
+    situation: 'לפני ישיבה בסוכה',
+    answer: 'לישב בסוכה',
+    wrongOptions: ['על נטילת לולב', 'שהחיינו וקיימנו', 'להדליק נר של יום טוב'],
+  },
+  {
+    id: 22, emoji: '🍷', category: 'shabbat-holidays',
+    situation: 'בהבדלה במוצאי שבת',
+    answer: 'בורא פרי הגפן',
+    wrongOptions: ['בורא מיני בשמים', 'בורא מאורי האש', 'המבדיל בין קודש לחול'],
+  },
+  {
+    id: 23, emoji: '💧', category: 'food',
+    situation: 'לפני שותים מים',
+    answer: 'שהכל נהיה בדברו',
+    wrongOptions: ['בורא פרי הגפן', 'בורא פרי האדמה', 'בורא פרי העץ'],
+  },
+  {
+    id: 24, emoji: '🥜', category: 'food',
+    situation: 'לפני שאוכלים בוטנים',
+    answer: 'שהכל נהיה בדברו',
+    wrongOptions: ['בורא פרי האדמה', 'בורא פרי העץ', 'בורא מיני מזונות'],
+  },
+];

--- a/gamesformykids/lib/quiz/quizGameConfigs.tsx
+++ b/gamesformykids/lib/quiz/quizGameConfigs.tsx
@@ -1,6 +1,6 @@
 import type { GameType } from '@/lib/types/core/base';
 import { spellingConfig, oppositesConfig, englishWordsConfig, worldLanguagesConfig, rhymingConfig, adjectivesConfig, verbsConfig, genderConfig, finalLettersConfig, alphabetOrderConfig } from './configs/language';
-import { riddlesConfig, capitalsConfig, instrumentsConfig, sportsQuizConfig, continentsConfig, visualLogicConfig, proverbsConfig } from './configs/knowledge';
+import { riddlesConfig, capitalsConfig, instrumentsConfig, sportsQuizConfig, continentsConfig, visualLogicConfig, proverbsConfig, blessingsConfig } from './configs/knowledge';
 import { emotionsConfig, familyConfig, healthyFoodConfig, singularPluralConfig, morningRoutineConfig } from './configs/social';
 import { fractionsConfig, gematriaConfig, shapes3dConfig, skipCountingConfig, visualAdditionConfig } from './configs/math';
 
@@ -37,4 +37,5 @@ export const QUIZ_GAME_CONFIGS: Partial<Record<GameType, QuizGameConfig<unknown>
   'gematria': gematriaConfig,
   'visual-logic': visualLogicConfig,
   'proverbs': proverbsConfig,
+  'blessings': blessingsConfig,
 };

--- a/gamesformykids/lib/quiz/registry/genericQuizGames.tsx
+++ b/gamesformykids/lib/quiz/registry/genericQuizGames.tsx
@@ -38,4 +38,5 @@ export const GENERIC_QUIZ_GAMES: Record<string, ComponentType> = {
   'gematria':              GenericQuizGame,
   'visual-logic':          GenericQuizGame,
   'proverbs':              GenericQuizGame,
+  'blessings':             GenericQuizGame,
 };

--- a/gamesformykids/lib/registry/registryData/batch4.ts
+++ b/gamesformykids/lib/registry/registryData/batch4.ts
@@ -529,4 +529,15 @@ export const gamesRegistryBatch4: GameRegistration[] = [
     available: true,
     order: 169,
   },
+  {
+    id: "blessings",
+    title: "ברכות יהודיות",
+    description: "למד איזו ברכה אומרים — על לחם, יין, פירות, ברק וקשת!",
+    icon: BookOpen,
+    emoji: "🙏",
+    color: "bg-violet-500 hover:bg-violet-600",
+    href: "/games/blessings",
+    available: true,
+    order: 171,
+  },
 ];

--- a/gamesformykids/lib/types/core/base.ts
+++ b/gamesformykids/lib/types/core/base.ts
@@ -192,4 +192,6 @@ export type GameType =
   // Language & wisdom
   | 'proverbs'
   // Money & economy
-  | 'coins-match';
+  | 'coins-match'
+  // Jewish tradition
+  | 'blessings';


### PR DESCRIPTION
﻿## What
Style B GenericQuiz game: 24 Hebrew brachot (blessings) questions covering food (bread, fruit, vegetables, wine, drinks), nature events (lightning, thunder, rainbow, ocean, spring blossoms), and holiday candle-lighting (Shabbat, Hanukkah, Sukkot). The player sees a situation emoji + description and chooses the correct blessing from 4 options.

- New data file: `lib/quiz/data/blessings.ts` (24 questions across 4 categories)
- Config in `lib/quiz/configs/knowledge.tsx` using violet theme
- Registered in `genericQuizGames`, `quizGameConfigs`, `batch4`, GameType, SUPPORTED_GAMES, and `holidays` category

## Why
Closes #1228

## Test plan
- [ ] Navigate to `/games/blessings` -- see violet-themed start screen
- [ ] Start game -- situation shown with emoji, 4 blessing choices appear
- [ ] Correct answer shows celebration; wrong answer shows the correct blessing
- [ ] Game appears in home page holidays category (alongside jewish-holidays)

Generated with Claude Code
