### PR TITLE
feat(math-stories): add Hebrew math word problems quiz (closes #1229)

### DIFF
--- a/gamesformykids/app/games/[gameType]/gamePageConstants.ts
+++ b/gamesformykids/app/games/[gameType]/gamePageConstants.ts
@@ -64,6 +64,7 @@ export const SUPPORTED_GAMES = [
   'proverbs',
   'blessings',
   'number-slide',
+  'math-stories',
 ] as const;
 
 export type SupportedGameType = typeof SUPPORTED_GAMES[number];

--- a/gamesformykids/lib/constants/gameCategories.ts
+++ b/gamesformykids/lib/constants/gameCategories.ts
@@ -70,7 +70,7 @@ export const GAME_CATEGORIES: Record<string, GameCategory> = {
     icon: Calculator,
     color: "bg-indigo-500",
     gradient: "from-indigo-400 to-indigo-600",
-    gameIds: ["counting","math","shopping-money","coins-match","multiplication","fractions","sequences","arithmetic","ordinals","number-words","spatial-concepts","sorting","patterns","skip-counting","division","visual-addition","gematria","number-slide"],
+    gameIds: ["counting","math","shopping-money","coins-match","multiplication","fractions","sequences","arithmetic","ordinals","number-words","spatial-concepts","sorting","patterns","skip-counting","division","visual-addition","gematria","number-slide","math-stories"],
   },
   games: {
     title: "משחקים מיוחדים",

--- a/gamesformykids/lib/quiz/configs/math.tsx
+++ b/gamesformykids/lib/quiz/configs/math.tsx
@@ -5,6 +5,7 @@ import { GEMATRIA_QUESTIONS } from '@/lib/quiz/data/gematria';
 import { QUIZ_QUESTIONS, SHAPES_3D } from '@/lib/quiz/data/shapes-3d';
 import { SKIP_COUNTING_QUESTIONS } from '@/lib/quiz/data/skip-counting';
 import { VISUAL_ADDITION_QUESTIONS } from '@/lib/quiz/data/visual-addition';
+import { MATH_STORY_QUESTIONS } from '@/lib/quiz/data/math-stories';
 import FractionBar from '@/components/game/quiz/FractionBar';
 import { defineConfig } from './types';
 
@@ -116,4 +117,22 @@ export const shapes3dConfig = defineConfig({
         <p className="text-gray-700 text-lg font-medium">{q.question}</p></>
     );
   },
+});
+
+export const mathStoriesConfig = defineConfig({
+  gameType: 'math-stories', emoji: '📝', title: 'בעיות מילוליות',
+  description: 'פתור בעיות מתמטיות בעברית — מילים למספרים!', theme: 'blue',
+  buttonLabel: '📝 בואו נפתור!',
+  questions: MATH_STORY_QUESTIONS, questionsPerGame: QUESTIONS_PER_GAME,
+  getChoices: (q) => shuffle([q.answer, ...q.wrongOptions]),
+  isCorrect: (c, q) => c === q.answer,
+  getCorrectLabel: (q) => q.answer,
+  renderQuestion: (q) => (
+    <div className="w-full flex flex-col items-center gap-2">
+      <div className="text-5xl">{q.emoji}</div>
+      <p className="text-center text-gray-700 text-base font-semibold leading-relaxed" dir="rtl">
+        {q.question}
+      </p>
+    </div>
+  ),
 });

--- a/gamesformykids/lib/quiz/data/math-stories.ts
+++ b/gamesformykids/lib/quiz/data/math-stories.ts
@@ -1,0 +1,165 @@
+export type MathStoryQuestion = {
+  id: number;
+  question: string;
+  answer: string;
+  wrongOptions: [string, string, string];
+  emoji: string;
+  difficulty: 'easy' | 'medium' | 'hard';
+  operation: 'addition' | 'subtraction' | 'multiplication' | 'division' | 'mixed';
+};
+
+export const MATH_STORY_QUESTIONS: MathStoryQuestion[] = [
+  // EASY — single operation, small numbers
+  {
+    id: 1, emoji: '🍎', difficulty: 'easy', operation: 'subtraction',
+    question: 'לאורי יש 7 תפוחים. הוא אכל 3. כמה תפוחים נשארו?',
+    answer: '4',
+    wrongOptions: ['3', '5', '10'],
+  },
+  {
+    id: 2, emoji: '🐠', difficulty: 'easy', operation: 'addition',
+    question: 'באקווריום יש 5 דגים כתומים ו-3 דגים כחולים. כמה דגים יש בסך הכל?',
+    answer: '8',
+    wrongOptions: ['6', '9', '7'],
+  },
+  {
+    id: 3, emoji: '🌸', difficulty: 'easy', operation: 'addition',
+    question: 'אמא קנתה 4 ורדים אדומים ו-6 ורדים צהובים. כמה ורדים קנתה?',
+    answer: '10',
+    wrongOptions: ['8', '9', '11'],
+  },
+  {
+    id: 4, emoji: '🍪', difficulty: 'easy', operation: 'subtraction',
+    question: 'היו 12 עוגיות בקופסה. אכלנו 5. כמה עוגיות נשארו?',
+    answer: '7',
+    wrongOptions: ['6', '8', '17'],
+  },
+  {
+    id: 5, emoji: '✏️', difficulty: 'easy', operation: 'addition',
+    question: 'לדן יש 8 עפרונות. אביו קנה לו עוד 4. כמה עפרונות יש לו עכשיו?',
+    answer: '12',
+    wrongOptions: ['11', '13', '10'],
+  },
+  {
+    id: 6, emoji: '🐔', difficulty: 'easy', operation: 'subtraction',
+    question: 'בלול יש 15 תרנגולות. 6 ברחו. כמה תרנגולות נשארו?',
+    answer: '9',
+    wrongOptions: ['8', '10', '21'],
+  },
+  {
+    id: 7, emoji: '⚽', difficulty: 'easy', operation: 'addition',
+    question: 'קבוצת ילד כבשה 3 שערים בחצי הראשון ו-2 שערים בחצי השני. כמה שערים בסך הכל?',
+    answer: '5',
+    wrongOptions: ['4', '6', '7'],
+  },
+  {
+    id: 8, emoji: '🎈', difficulty: 'easy', operation: 'subtraction',
+    question: 'היו 20 בלונים במסיבה. 7 התפוצצו. כמה בלונים נשארו?',
+    answer: '13',
+    wrongOptions: ['12', '14', '27'],
+  },
+  // MEDIUM — two-step or larger numbers
+  {
+    id: 9, emoji: '📚', difficulty: 'medium', operation: 'division',
+    question: 'בכיתה יש 24 ילדים. חצי מהם ילדות. כמה ילדות יש?',
+    answer: '12',
+    wrongOptions: ['8', '16', '24'],
+  },
+  {
+    id: 10, emoji: '🍕', difficulty: 'medium', operation: 'multiplication',
+    question: 'קניתי 3 פיצות. כל פיצה חתוכה ל-8 חתיכות. כמה חתיכות יש בסך הכל?',
+    answer: '24',
+    wrongOptions: ['11', '16', '32'],
+  },
+  {
+    id: 11, emoji: '💰', difficulty: 'medium', operation: 'subtraction',
+    question: 'לשרה יש 30 שקלים. היא קנתה ספר ב-15 שקלים ועיפרון ב-4 שקלים. כמה כסף נשאר לה?',
+    answer: '11',
+    wrongOptions: ['15', '19', '9'],
+  },
+  {
+    id: 12, emoji: '🎠', difficulty: 'medium', operation: 'multiplication',
+    question: 'בגן יש 5 שולחנות. על כל שולחן יושבים 4 ילדים. כמה ילדים יש בגן?',
+    answer: '20',
+    wrongOptions: ['9', '15', '25'],
+  },
+  {
+    id: 13, emoji: '🚗', difficulty: 'medium', operation: 'division',
+    question: 'צריך להסיע 18 ילדים. כל מכונית מסיעה 3 ילדים. כמה מכוניות דרושות?',
+    answer: '6',
+    wrongOptions: ['5', '7', '9'],
+  },
+  {
+    id: 14, emoji: '🍊', difficulty: 'medium', operation: 'mixed',
+    question: 'אמא קנתה 4 חבילות של 5 תפוזים, ועוד 3 תפוזים בודדים. כמה תפוזים יש בסך הכל?',
+    answer: '23',
+    wrongOptions: ['20', '17', '25'],
+  },
+  {
+    id: 15, emoji: '📦', difficulty: 'medium', operation: 'multiplication',
+    question: 'קניתי 3 חבילות של 6 ביסקוויטים. כמה ביסקוויטים יש בסך הכל?',
+    answer: '18',
+    wrongOptions: ['9', '15', '24'],
+  },
+  {
+    id: 16, emoji: '🏀', difficulty: 'medium', operation: 'mixed',
+    question: 'בשחקן כדורסל היה 45 נקודות. בחצי שני הוא קבל 12 נקודות נוספות וקיבל קנס של 4. כמה נקודות יש לו?',
+    answer: '53',
+    wrongOptions: ['57', '49', '61'],
+  },
+  {
+    id: 17, emoji: '🐑', difficulty: 'medium', operation: 'division',
+    question: 'יש 35 כבשים. הרועה מחלק אותן ל-5 עדרים שווים. כמה כבשים בכל עדר?',
+    answer: '7',
+    wrongOptions: ['5', '6', '8'],
+  },
+  {
+    id: 18, emoji: '🎂', difficulty: 'medium', operation: 'mixed',
+    question: 'עוגת יום הולדת חתוכה ל-12 חתיכות. אכלנו 5 חתיכות ונשארו. כמה אחוז נשאר?',
+    answer: '7 חתיכות',
+    wrongOptions: ['5 חתיכות', '8 חתיכות', '6 חתיכות'],
+  },
+  // HARD — multi-step or requires choosing the right operation
+  {
+    id: 19, emoji: '🏫', difficulty: 'hard', operation: 'mixed',
+    question: 'בבית הספר יש 6 כיתות. בכל כיתה יש 28 תלמידים. כמה תלמידים יש בבית הספר?',
+    answer: '168',
+    wrongOptions: ['144', '180', '156'],
+  },
+  {
+    id: 20, emoji: '🌿', difficulty: 'hard', operation: 'mixed',
+    question: 'לגינה יש 4 שורות של עצים. בכל שורה 7 עצים. כל עץ נותן 15 תפוזים. כמה תפוזים יש בסך הכל?',
+    answer: '420',
+    wrongOptions: ['280', '105', '210'],
+  },
+  {
+    id: 21, emoji: '💼', difficulty: 'hard', operation: 'mixed',
+    question: 'קיוסק מרוויח 120 שקלים ביום. בשבוע עובד 6 ימים. כמה שקלים ירוויח בחודש של 4 שבועות?',
+    answer: '2880',
+    wrongOptions: ['2400', '720', '3600'],
+  },
+  {
+    id: 22, emoji: '🚌', difficulty: 'hard', operation: 'mixed',
+    question: 'אוטובוס יצא עם 48 נוסעים. ב-3 תחנות עלו 6 נוסעים בכל תחנה, וב-2 תחנות ירדו 8 נוסעים בכל תחנה. כמה נוסעים יש באוטובוס?',
+    answer: '46',
+    wrongOptions: ['50', '42', '54'],
+  },
+  {
+    id: 23, emoji: '🏊', difficulty: 'hard', operation: 'division',
+    question: 'שחיין שחה 500 מטר ב-10 דקות. כמה מטר שחה בדקה אחת?',
+    answer: '50',
+    wrongOptions: ['25', '100', '40'],
+  },
+  {
+    id: 24, emoji: '🍕', difficulty: 'hard', operation: 'mixed',
+    question: '5 חברים חולקים 3 פיצות שוות. כל פיצה ב-60 שקל. כמה ישלם כל אחד?',
+    answer: '36',
+    wrongOptions: ['30', '40', '45'],
+  },
+  {
+    id: 25, emoji: '🏗️', difficulty: 'hard', operation: 'mixed',
+    question: 'בנאי מניח 45 לבנים בשעה. כמה לבנים יניח ב-8 שעות עבודה?',
+    answer: '360',
+    wrongOptions: ['320', '400', '270'],
+  },
+];

--- a/gamesformykids/lib/quiz/quizGameConfigs.tsx
+++ b/gamesformykids/lib/quiz/quizGameConfigs.tsx
@@ -2,7 +2,7 @@ import type { GameType } from '@/lib/types/core/base';
 import { spellingConfig, oppositesConfig, englishWordsConfig, worldLanguagesConfig, rhymingConfig, adjectivesConfig, verbsConfig, genderConfig, finalLettersConfig, alphabetOrderConfig } from './configs/language';
 import { riddlesConfig, capitalsConfig, instrumentsConfig, sportsQuizConfig, continentsConfig, visualLogicConfig, proverbsConfig, blessingsConfig } from './configs/knowledge';
 import { emotionsConfig, familyConfig, healthyFoodConfig, singularPluralConfig, morningRoutineConfig } from './configs/social';
-import { fractionsConfig, gematriaConfig, shapes3dConfig, skipCountingConfig, visualAdditionConfig } from './configs/math';
+import { fractionsConfig, gematriaConfig, mathStoriesConfig, shapes3dConfig, skipCountingConfig, visualAdditionConfig } from './configs/math';
 
 export type { QuizGameConfig } from './configs/types';
 import type { QuizGameConfig } from './configs/types';
@@ -38,4 +38,5 @@ export const QUIZ_GAME_CONFIGS: Partial<Record<GameType, QuizGameConfig<unknown>
   'visual-logic': visualLogicConfig,
   'proverbs': proverbsConfig,
   'blessings': blessingsConfig,
+  'math-stories': mathStoriesConfig,
 };

--- a/gamesformykids/lib/quiz/registry/genericQuizGames.tsx
+++ b/gamesformykids/lib/quiz/registry/genericQuizGames.tsx
@@ -39,4 +39,5 @@ export const GENERIC_QUIZ_GAMES: Record<string, ComponentType> = {
   'visual-logic':          GenericQuizGame,
   'proverbs':              GenericQuizGame,
   'blessings':             GenericQuizGame,
+  'math-stories':          GenericQuizGame,
 };

--- a/gamesformykids/lib/registry/registryData/batch4.ts
+++ b/gamesformykids/lib/registry/registryData/batch4.ts
@@ -552,4 +552,15 @@ export const gamesRegistryBatch4: GameRegistration[] = [
     available: true,
     order: 171,
   },
+  {
+    id: "math-stories",
+    title: "בעיות מילוליות",
+    description: "פתור בעיות מתמטיות בעברית — מילים למספרים!",
+    icon: BookOpen,
+    emoji: "📝",
+    color: "bg-blue-500 hover:bg-blue-600",
+    href: "/games/math-stories",
+    available: true,
+    order: 172,
+  },
 ];

--- a/gamesformykids/lib/types/core/base.ts
+++ b/gamesformykids/lib/types/core/base.ts
@@ -196,4 +196,6 @@ export type GameType =
   // Jewish tradition
   | 'blessings'
   // Number games
-  | 'number-slide';
+  | 'number-slide'
+  // Math story problems
+  | 'math-stories';


### PR DESCRIPTION
﻿## What
Adds a Hebrew math word problems quiz game (Style B — GenericQuizGame). 25 questions across easy/medium/hard difficulties covering addition, subtraction, multiplication, division, and mixed operations. Questions are written in natural Hebrew prose, and the child must select the correct numeric answer from 4 choices.

## Why
Closes #1229

## Test plan
- [ ] Visit `/games/math-stories` — start screen appears with blue theme
- [ ] Play through several questions — word problem + emoji displayed, 4 answer choices shown
- [ ] Correct answer celebrated; wrong answer shown with correct value
- [ ] Game appears in the "מתמטיקה וחשיבה" category on the home page

🤖 Generated with [Claude Code](https://claude.com/claude-code)
