### PR TITLE
feat(snakes-ladders): Hebrew board game with math quiz mechanic (closes #1249)

### DIFF
--- a/gamesformykids/app/games/[gameType]/CustomGameRenderer.tsx
+++ b/gamesformykids/app/games/[gameType]/CustomGameRenderer.tsx
@@ -47,6 +47,7 @@ const GAME_CLIENTS: Record<string, ComponentType> = {
   'letter-defender':  dynamic(() => import('../letter-defender/LetterDefenderClient'),           { ssr: false }),
   'puppet-story':     dynamic(() => import('../puppet-story/PuppetClient'),                      { ssr: false }),
   'number-slide':     dynamic(() => import('../number-slide/NumberSlideClient'),                  { ssr: false }),
+  'snakes-ladders':   dynamic(() => import('../snakes-ladders/SnakesLaddersClient'),              { ssr: false }),
 };
 
 interface Props { gameType: string; }

--- a/gamesformykids/app/games/[gameType]/gamePageConstants.ts
+++ b/gamesformykids/app/games/[gameType]/gamePageConstants.ts
@@ -32,7 +32,7 @@ export const SUPPORTED_GAMES = [
   'math-race', 'memory', 'meteor-dodge', 'multiplication', 'number-bubbles', 'pong',
   'puzzles', 'reflex', 'shesh-besh', 'simon', 'snake', 'space-defender',
   'stack', 'taki', 'tetris', 'true-false', 'tzedakah', 'whack-a-mole',
-  'word-builder', 'word-scramble',
+  'word-builder', 'word-scramble', 'snakes-ladders',
 
   // ── משחקי חידון (QuizGameRouter) ──────────────────────────────────────────
   'riddles', 'capitals', 'fractions', 'spelling',
@@ -76,7 +76,7 @@ export const CUSTOM_GAME_TYPES = new Set([
   'math-race', 'memory', 'meteor-dodge', 'multiplication', 'number-bubbles', 'pong',
   'puzzles', 'reflex', 'shesh-besh', 'simon', 'snake', 'space-defender',
   'stack', 'taki', 'tetris', 'true-false', 'tzedakah', 'whack-a-mole',
-  'word-builder', 'word-scramble', 'maze', 'letter-defender', 'puppet-story', 'number-slide',
+  'word-builder', 'word-scramble', 'maze', 'letter-defender', 'puppet-story', 'number-slide', 'snakes-ladders',
 ]);
 
 // ─── מיפוי URL → GameType ──────────────────────────────────────────────────────

--- a/gamesformykids/app/games/snakes-ladders/SnakesLaddersClient.tsx
+++ b/gamesformykids/app/games/snakes-ladders/SnakesLaddersClient.tsx
@@ -1,0 +1,133 @@
+'use client';
+import { useSnakesLadders } from './useSnakesLadders';
+import GameBoard from './components/GameBoard';
+import DiceRoller from './components/DiceRoller';
+import QuizPopup from './components/QuizPopup';
+
+export default function SnakesLaddersClient() {
+  const game = useSnakesLadders();
+  const {
+    phase, players, currentPlayer, diceValue,
+    pendingQuestion, pendingSquare, pendingSpecialType,
+    winner, lastMessage,
+    startGame, rollDice, answerQuestion, resetGame,
+  } = game;
+
+  if (phase === 'menu') {
+    return (
+      <div className="min-h-screen bg-gradient-to-br from-green-100 via-yellow-50 to-orange-100 flex items-center justify-center p-4">
+        <div className="bg-white rounded-3xl shadow-2xl max-w-md w-full p-8 flex flex-col items-center gap-6">
+          <div className="text-6xl">🐍</div>
+          <h1 className="text-3xl font-black text-center text-green-800">נחשים וסולמות</h1>
+          <p className="text-center text-gray-600 text-sm" dir="rtl">
+            הטל קוביה, התקדם בלוח וענה על שאלות מתמטיות — עלה בסולמות והימנע מהנחשים!
+          </p>
+          <div className="bg-green-50 rounded-2xl p-4 w-full text-sm" dir="rtl">
+            <p className="font-bold text-green-800 mb-2">איך משחקים?</p>
+            <p>🪜 נחת על סולם → ענה נכון → עלה!</p>
+            <p>🐍 נחת על נחש → ענה נכון → הישאר!</p>
+          </div>
+          <div className="flex flex-col gap-3 w-full">
+            <button
+              onClick={() => startGame('solo')}
+              className="w-full py-4 bg-green-600 hover:bg-green-700 text-white font-black text-lg rounded-2xl transition-colors"
+            >
+              🤖 נגד המחשב
+            </button>
+            <button
+              onClick={() => startGame('two-player')}
+              className="w-full py-4 bg-orange-500 hover:bg-orange-600 text-white font-black text-lg rounded-2xl transition-colors"
+            >
+              👥 שני שחקנים
+            </button>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  if (phase === 'result') {
+    const w = winner !== null ? players[winner] : null;
+    return (
+      <div className="min-h-screen bg-gradient-to-br from-yellow-100 to-orange-200 flex items-center justify-center p-4">
+        <div className="bg-white rounded-3xl shadow-2xl max-w-md w-full p-8 flex flex-col items-center gap-6 text-center">
+          <div className="text-6xl">🏆</div>
+          <h2 className="text-3xl font-black text-yellow-800">
+            {w ? `${w.emoji} ${w.name} ניצח!` : 'סיום!'}
+          </h2>
+          <div className="bg-gray-50 rounded-2xl p-4 w-full" dir="rtl">
+            {players.map((p, i) => (
+              <div key={i} className="flex justify-between items-center py-1">
+                <span className="font-bold">{p.emoji} {p.name}</span>
+                <span className="text-gray-600">ריבוע {p.position}</span>
+              </div>
+            ))}
+          </div>
+          <button
+            onClick={resetGame}
+            className="px-8 py-4 bg-green-600 hover:bg-green-700 text-white font-black text-lg rounded-2xl transition-colors"
+          >
+            🎲 משחק חדש
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  const current = players[currentPlayer];
+  const isHumanTurn = !current.isAI;
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-green-100 via-yellow-50 to-orange-100 p-2 sm:p-4">
+      <div className="max-w-2xl mx-auto flex flex-col gap-3">
+        {/* Header */}
+        <div className="flex justify-between items-center">
+          <button onClick={resetGame} className="text-xs text-gray-500 hover:text-gray-700 underline">
+            חזור לתפריט
+          </button>
+          <div className="flex gap-4">
+            {players.map((p, i) => (
+              <div key={i} className={`text-sm font-bold px-2 py-1 rounded-lg ${i === currentPlayer ? 'bg-indigo-100 text-indigo-800' : 'text-gray-500'}`}>
+                {p.emoji} {p.name}: {p.position}/100
+              </div>
+            ))}
+          </div>
+        </div>
+
+        {/* Message */}
+        {lastMessage && (
+          <div className="bg-white rounded-xl px-4 py-2 text-center text-sm font-bold text-gray-700 shadow-sm" dir="rtl">
+            {lastMessage}
+          </div>
+        )}
+
+        {/* Board */}
+        <GameBoard players={players} />
+
+        {/* Controls */}
+        <div className="bg-white rounded-2xl shadow p-4 flex flex-col items-center gap-3">
+          <DiceRoller
+            diceValue={diceValue}
+            canRoll={phase === 'rolling' && isHumanTurn}
+            onRoll={rollDice}
+            playerName={current.name}
+            playerEmoji={current.emoji}
+          />
+        </div>
+      </div>
+
+      {/* Quiz popup */}
+      {phase === 'quiz' && pendingQuestion && pendingSpecialType && (
+        <QuizPopup
+          question={pendingQuestion}
+          square={pendingSquare}
+          specialType={pendingSpecialType}
+          playerName={current.name}
+          playerEmoji={current.emoji}
+          isAI={current.isAI}
+          onAnswer={answerQuestion}
+        />
+      )}
+    </div>
+  );
+}

--- a/gamesformykids/app/games/snakes-ladders/components/DiceRoller.tsx
+++ b/gamesformykids/app/games/snakes-ladders/components/DiceRoller.tsx
@@ -1,0 +1,32 @@
+'use client';
+
+const DICE_FACES = ['', '⚀', '⚁', '⚂', '⚃', '⚄', '⚅'];
+
+interface Props {
+  diceValue: number;
+  canRoll: boolean;
+  onRoll: () => void;
+  playerName: string;
+  playerEmoji: string;
+}
+
+export default function DiceRoller({ diceValue, canRoll, onRoll, playerName, playerEmoji }: Props) {
+  return (
+    <div className="flex flex-col items-center gap-2">
+      <p className="text-sm font-bold text-gray-700" dir="rtl">
+        {playerEmoji} תור {playerName}
+      </p>
+      <div className="text-5xl">{diceValue > 0 ? DICE_FACES[diceValue] : '🎲'}</div>
+      {diceValue > 0 && (
+        <p className="text-xs text-gray-500">הטלת {diceValue}</p>
+      )}
+      <button
+        onClick={onRoll}
+        disabled={!canRoll}
+        className="px-5 py-2.5 bg-indigo-600 hover:bg-indigo-700 disabled:bg-gray-300 disabled:cursor-not-allowed text-white font-bold rounded-xl transition-colors text-sm"
+      >
+        {canRoll ? '🎲 הטל קוביה!' : '⏳ ממתין...'}
+      </button>
+    </div>
+  );
+}

--- a/gamesformykids/app/games/snakes-ladders/components/GameBoard.tsx
+++ b/gamesformykids/app/games/snakes-ladders/components/GameBoard.tsx
@@ -1,0 +1,62 @@
+'use client';
+import { LADDERS, SNAKES, type Player } from '../snakesLaddersStore';
+
+const BOARD: number[][] = (() => {
+  const board: number[][] = [];
+  for (let gridRow = 0; gridRow < 10; gridRow++) {
+    const boardRow = 9 - gridRow;
+    const start = boardRow * 10 + 1;
+    const row = Array.from({ length: 10 }, (_, i) => start + i);
+    if (boardRow % 2 === 1) row.reverse();
+    board.push(row);
+  }
+  return board;
+})();
+
+const LADDER_BOTTOMS = new Set(Object.keys(LADDERS).map(Number));
+const SNAKE_HEADS = new Set(Object.keys(SNAKES).map(Number));
+
+interface Props {
+  players: [Player, Player];
+}
+
+export default function GameBoard({ players }: Props) {
+  return (
+    <div className="w-full aspect-square border-2 border-gray-700 rounded-lg overflow-hidden">
+      <div className="grid grid-cols-10 h-full">
+        {BOARD.flatMap((row, rIdx) =>
+          row.map((sq, cIdx) => {
+            const isLadder = LADDER_BOTTOMS.has(sq);
+            const isSnake = SNAKE_HEADS.has(sq);
+            const isWin = sq === 100;
+            const tokensHere = players.filter(p => p.position === sq);
+
+            let bg = (rIdx + cIdx) % 2 === 0 ? 'bg-amber-50' : 'bg-white';
+            if (isLadder) bg = 'bg-green-200';
+            if (isSnake) bg = 'bg-red-200';
+            if (isWin) bg = 'bg-yellow-300';
+
+            return (
+              <div
+                key={sq}
+                className={`${bg} relative border border-gray-200 flex flex-col items-center justify-center`}
+              >
+                <span className="text-[7px] sm:text-[9px] font-bold text-gray-500 leading-none">{sq}</span>
+                {isLadder && <span className="text-[8px] sm:text-[10px] leading-none">🪜</span>}
+                {isSnake && <span className="text-[8px] sm:text-[10px] leading-none">🐍</span>}
+                {isWin && <span className="text-[8px] sm:text-[10px] leading-none">⭐</span>}
+                {tokensHere.length > 0 && (
+                  <div className="absolute bottom-0.5 flex gap-0.5">
+                    {tokensHere.map((p, i) => (
+                      <span key={i} className="text-[10px] sm:text-sm leading-none">{p.emoji}</span>
+                    ))}
+                  </div>
+                )}
+              </div>
+            );
+          })
+        )}
+      </div>
+    </div>
+  );
+}

--- a/gamesformykids/app/games/snakes-ladders/components/QuizPopup.tsx
+++ b/gamesformykids/app/games/snakes-ladders/components/QuizPopup.tsx
@@ -1,0 +1,59 @@
+'use client';
+import { useMemo } from 'react';
+import type { SNLQuestion } from '../data/questions';
+import { LADDERS, SNAKES } from '../snakesLaddersStore';
+
+interface Props {
+  question: SNLQuestion;
+  square: number;
+  specialType: 'ladder' | 'snake';
+  playerName: string;
+  playerEmoji: string;
+  isAI: boolean;
+  onAnswer: (answer: string) => void;
+}
+
+export default function QuizPopup({ question, square, specialType, playerName, playerEmoji, isAI, onAnswer }: Props) {
+  const choices = useMemo(() => {
+    const all = [question.answer, ...question.wrongOptions];
+    return all.sort(() => Math.random() - 0.5);
+  }, [question]);
+
+  const destination = specialType === 'ladder' ? LADDERS[square] : SNAKES[square];
+  const hint = specialType === 'ladder'
+    ? `ענה נכון ↑ עלה לריבוע ${destination}!`
+    : `ענה נכון ↓ הימנע מריבוע ${destination}!`;
+
+  return (
+    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
+      <div className="bg-white rounded-2xl shadow-2xl max-w-sm w-full p-6 flex flex-col items-center gap-4">
+        <div className="text-4xl">{specialType === 'ladder' ? '🪜' : '🐍'}</div>
+        <p className="text-xs text-center text-gray-500 font-medium" dir="rtl">{hint}</p>
+
+        <div className="bg-gray-50 rounded-xl p-4 w-full text-center">
+          <div className="text-3xl mb-2">{question.emoji}</div>
+          <p className="text-lg font-bold text-gray-800" dir="rtl">{question.question}</p>
+        </div>
+
+        {isAI ? (
+          <div className="text-center">
+            <div className="text-2xl mb-1">🤔</div>
+            <p className="text-sm text-gray-500">{playerEmoji} {playerName} חושב...</p>
+          </div>
+        ) : (
+          <div className="grid grid-cols-2 gap-2 w-full">
+            {choices.map((choice) => (
+              <button
+                key={choice}
+                onClick={() => onAnswer(choice)}
+                className="py-3 px-2 bg-indigo-100 hover:bg-indigo-200 active:bg-indigo-300 text-indigo-900 font-bold rounded-xl transition-colors text-base"
+              >
+                {choice}
+              </button>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/gamesformykids/app/games/snakes-ladders/data/questions.ts
+++ b/gamesformykids/app/games/snakes-ladders/data/questions.ts
@@ -1,0 +1,52 @@
+export type SNLQuestion = {
+  id: number;
+  question: string;
+  answer: string;
+  wrongOptions: [string, string, string];
+  emoji: string;
+  difficulty: 'easy' | 'medium' | 'hard';
+};
+
+export const SNL_QUESTIONS: SNLQuestion[] = [
+  // EASY (squares 1–33)
+  { id: 1,  emoji: '➕', difficulty: 'easy',   question: 'כמה זה 3 + 4?',          answer: '7',  wrongOptions: ['5', '8', '6'] },
+  { id: 2,  emoji: '➖', difficulty: 'easy',   question: 'כמה זה 9 - 3?',          answer: '6',  wrongOptions: ['5', '7', '4'] },
+  { id: 3,  emoji: '➕', difficulty: 'easy',   question: 'כמה זה 5 + 6?',          answer: '11', wrongOptions: ['9', '12', '10'] },
+  { id: 4,  emoji: '➖', difficulty: 'easy',   question: 'כמה זה 10 - 4?',         answer: '6',  wrongOptions: ['5', '7', '8'] },
+  { id: 5,  emoji: '➕', difficulty: 'easy',   question: 'כמה זה 4 + 8?',          answer: '12', wrongOptions: ['11', '13', '10'] },
+  { id: 6,  emoji: '➖', difficulty: 'easy',   question: 'כמה זה 15 - 7?',         answer: '8',  wrongOptions: ['7', '9', '6'] },
+  { id: 7,  emoji: '➕', difficulty: 'easy',   question: 'כמה זה 7 + 6?',          answer: '13', wrongOptions: ['12', '14', '11'] },
+  { id: 8,  emoji: '➖', difficulty: 'easy',   question: 'כמה זה 20 - 8?',         answer: '12', wrongOptions: ['10', '11', '13'] },
+  { id: 9,  emoji: '📅', difficulty: 'easy',   question: 'כמה ימים יש בשבוע?',     answer: '7',  wrongOptions: ['5', '6', '8'] },
+  { id: 10, emoji: '🗓️', difficulty: 'easy',   question: 'כמה חודשים יש בשנה?',   answer: '12', wrongOptions: ['10', '11', '13'] },
+  { id: 11, emoji: '➕', difficulty: 'easy',   question: 'כמה זה 6 + 9?',          answer: '15', wrongOptions: ['13', '14', '16'] },
+  // MEDIUM (squares 34–66)
+  { id: 12, emoji: '✖️', difficulty: 'medium', question: 'כמה זה 3 × 6?',          answer: '18', wrongOptions: ['15', '21', '9'] },
+  { id: 13, emoji: '✖️', difficulty: 'medium', question: 'כמה זה 4 × 7?',          answer: '28', wrongOptions: ['24', '32', '21'] },
+  { id: 14, emoji: '✖️', difficulty: 'medium', question: 'כמה זה 5 × 8?',          answer: '40', wrongOptions: ['35', '45', '30'] },
+  { id: 15, emoji: '✖️', difficulty: 'medium', question: 'כמה זה 7 × 7?',          answer: '49', wrongOptions: ['42', '56', '36'] },
+  { id: 16, emoji: '✖️', difficulty: 'medium', question: 'כמה זה 6 × 9?',          answer: '54', wrongOptions: ['48', '63', '45'] },
+  { id: 17, emoji: '➗', difficulty: 'medium', question: 'כמה זה 24 ÷ 4?',         answer: '6',  wrongOptions: ['5', '7', '8'] },
+  { id: 18, emoji: '➗', difficulty: 'medium', question: 'כמה זה 35 ÷ 5?',         answer: '7',  wrongOptions: ['6', '8', '5'] },
+  { id: 19, emoji: '➗', difficulty: 'medium', question: 'כמה זה 42 ÷ 6?',         answer: '7',  wrongOptions: ['6', '8', '9'] },
+  { id: 20, emoji: '➕', difficulty: 'medium', question: 'כמה זה 18 + 27?',        answer: '45', wrongOptions: ['43', '47', '35'] },
+  { id: 21, emoji: '➖', difficulty: 'medium', question: 'כמה זה 50 - 17?',        answer: '33', wrongOptions: ['31', '35', '37'] },
+  { id: 22, emoji: '✖️', difficulty: 'medium', question: 'כמה זה 8 × 4?',          answer: '32', wrongOptions: ['28', '36', '24'] },
+  // HARD (squares 67–100)
+  { id: 23, emoji: '✖️', difficulty: 'hard',   question: 'כמה זה 8 × 9?',          answer: '72', wrongOptions: ['63', '81', '64'] },
+  { id: 24, emoji: '✖️', difficulty: 'hard',   question: 'כמה זה 7 × 12?',         answer: '84', wrongOptions: ['77', '91', '72'] },
+  { id: 25, emoji: '➗', difficulty: 'hard',   question: 'כמה זה 81 ÷ 9?',         answer: '9',  wrongOptions: ['7', '8', '11'] },
+  { id: 26, emoji: '➗', difficulty: 'hard',   question: 'כמה זה 56 ÷ 7?',         answer: '8',  wrongOptions: ['7', '6', '9'] },
+  { id: 27, emoji: '➗', difficulty: 'hard',   question: 'כמה זה 72 ÷ 8?',         answer: '9',  wrongOptions: ['8', '7', '12'] },
+  { id: 28, emoji: '✖️', difficulty: 'hard',   question: 'כמה זה 9 × 11?',         answer: '99', wrongOptions: ['88', '108', '90'] },
+  { id: 29, emoji: '⏰', difficulty: 'hard',   question: 'כמה שניות יש בדקה?',    answer: '60', wrongOptions: ['30', '100', '45'] },
+  { id: 30, emoji: '🕐', difficulty: 'hard',   question: 'כמה דקות יש בשעה?',     answer: '60', wrongOptions: ['30', '100', '24'] },
+  { id: 31, emoji: '☀️', difficulty: 'hard',   question: 'כמה שעות יש ביממה?',   answer: '24', wrongOptions: ['12', '30', '48'] },
+  { id: 32, emoji: '➕', difficulty: 'hard',   question: 'כמה זה 67 + 35?',        answer: '102',wrongOptions: ['98', '95', '107'] },
+];
+
+export function getQuestionForSquare(square: number): SNLQuestion {
+  const difficulty = square <= 33 ? 'easy' : square <= 66 ? 'medium' : 'hard';
+  const pool = SNL_QUESTIONS.filter(q => q.difficulty === difficulty);
+  return pool[Math.floor(Math.random() * pool.length)] ?? SNL_QUESTIONS[0]!;
+}

--- a/gamesformykids/app/games/snakes-ladders/snakesLaddersStore.ts
+++ b/gamesformykids/app/games/snakes-ladders/snakesLaddersStore.ts
@@ -1,0 +1,159 @@
+'use client';
+import { create } from 'zustand';
+import { getQuestionForSquare, type SNLQuestion } from './data/questions';
+
+export const LADDERS: Record<number, number> = {
+  4: 14, 9: 31, 20: 38, 28: 84, 40: 59, 51: 67, 63: 81, 71: 91,
+};
+
+export const SNAKES: Record<number, number> = {
+  17: 7, 54: 34, 62: 19, 64: 60, 87: 24, 93: 73, 95: 75, 99: 78,
+};
+
+export interface Player {
+  name: string;
+  emoji: string;
+  position: number;
+  isAI: boolean;
+}
+
+type Phase = 'menu' | 'rolling' | 'quiz' | 'result';
+
+interface State {
+  mode: 'solo' | 'two-player';
+  phase: Phase;
+  players: [Player, Player];
+  currentPlayer: 0 | 1;
+  diceValue: number;
+  pendingQuestion: SNLQuestion | null;
+  pendingSquare: number;
+  pendingSpecialType: 'ladder' | 'snake' | null;
+  winner: 0 | 1 | null;
+  lastMessage: string;
+}
+
+interface Actions {
+  startGame: (mode: 'solo' | 'two-player') => void;
+  rollDice: () => void;
+  answerQuestion: (answer: string) => void;
+  resetGame: () => void;
+}
+
+const INITIAL_STATE: State = {
+  mode: 'solo',
+  phase: 'menu',
+  players: [
+    { name: 'שחקן 1', emoji: '🔵', position: 0, isAI: false },
+    { name: 'שחקן 2', emoji: '🔴', position: 0, isAI: true },
+  ],
+  currentPlayer: 0,
+  diceValue: 0,
+  pendingQuestion: null,
+  pendingSquare: 0,
+  pendingSpecialType: null,
+  winner: null,
+  lastMessage: '',
+};
+
+export const useSnakesLaddersStore = create<State & Actions>((set, get) => ({
+  ...INITIAL_STATE,
+
+  startGame: (mode) => {
+    set({
+      ...INITIAL_STATE,
+      mode,
+      phase: 'rolling',
+      players: [
+        { name: 'שחקן 1', emoji: '🔵', position: 0, isAI: false },
+        { name: mode === 'solo' ? 'מחשב' : 'שחקן 2', emoji: '🔴', position: 0, isAI: mode === 'solo' },
+      ],
+    });
+  },
+
+  rollDice: () => {
+    const { players, currentPlayer } = get();
+    const dice = Math.floor(Math.random() * 6) + 1;
+    const player = players[currentPlayer];
+    const newPos = Math.min(player.position + dice, 100);
+
+    set({ diceValue: dice });
+
+    if (newPos >= 100) {
+      const updated = [...players] as [Player, Player];
+      updated[currentPlayer] = { ...player, position: 100 };
+      set({ players: updated, phase: 'result', winner: currentPlayer });
+      return;
+    }
+
+    if (LADDERS[newPos] !== undefined || SNAKES[newPos] !== undefined) {
+      const updated = [...players] as [Player, Player];
+      updated[currentPlayer] = { ...player, position: newPos };
+      const specialType = LADDERS[newPos] !== undefined ? 'ladder' : 'snake';
+      set({
+        players: updated,
+        pendingSquare: newPos,
+        pendingQuestion: getQuestionForSquare(newPos),
+        pendingSpecialType: specialType,
+        phase: 'quiz',
+        lastMessage: '',
+      });
+    } else {
+      const updated = [...players] as [Player, Player];
+      updated[currentPlayer] = { ...player, position: newPos };
+      set({
+        players: updated,
+        phase: 'rolling',
+        currentPlayer: (currentPlayer === 0 ? 1 : 0) as 0 | 1,
+        lastMessage: '',
+      });
+    }
+  },
+
+  answerQuestion: (answer) => {
+    const { players, currentPlayer, pendingQuestion, pendingSquare, pendingSpecialType } = get();
+    if (!pendingQuestion) return;
+
+    const correct = answer === pendingQuestion.answer;
+    const player = players[currentPlayer];
+    let finalPos = pendingSquare;
+    let msg = '';
+
+    if (pendingSpecialType === 'ladder') {
+      if (correct) {
+        finalPos = LADDERS[pendingSquare] ?? pendingSquare;
+        msg = `🎉 נכון! ${player.emoji} ${player.name} עולה בסולם!`;
+      } else {
+        finalPos = pendingSquare;
+        msg = `😅 טעות... ${player.name} נשאר במקום!`;
+      }
+    } else {
+      if (correct) {
+        finalPos = pendingSquare;
+        msg = `🎉 נכון! ${player.emoji} ${player.name} נמלט מהנחש!`;
+      } else {
+        finalPos = SNAKES[pendingSquare] ?? pendingSquare;
+        msg = `🐍 טעות... ${player.name} יורד עם הנחש!`;
+      }
+    }
+
+    const updated = [...players] as [Player, Player];
+    updated[currentPlayer] = { ...player, position: finalPos };
+
+    if (finalPos >= 100) {
+      set({ players: updated, phase: 'result', winner: currentPlayer, lastMessage: msg });
+      return;
+    }
+
+    set({
+      players: updated,
+      pendingQuestion: null,
+      pendingSquare: 0,
+      pendingSpecialType: null,
+      phase: 'rolling',
+      currentPlayer: (currentPlayer === 0 ? 1 : 0) as 0 | 1,
+      lastMessage: msg,
+    });
+  },
+
+  resetGame: () => set({ ...INITIAL_STATE }),
+}));

--- a/gamesformykids/app/games/snakes-ladders/useSnakesLadders.ts
+++ b/gamesformykids/app/games/snakes-ladders/useSnakesLadders.ts
@@ -1,0 +1,30 @@
+'use client';
+import { useEffect } from 'react';
+import { useSnakesLaddersStore } from './snakesLaddersStore';
+
+export function useSnakesLadders() {
+  const store = useSnakesLaddersStore();
+  const { phase, players, currentPlayer, rollDice, answerQuestion } = store;
+
+  // Auto-play AI turn
+  useEffect(() => {
+    const current = players[currentPlayer];
+    if (!current?.isAI) return;
+
+    if (phase === 'rolling') {
+      const t = setTimeout(rollDice, 1200);
+      return () => clearTimeout(t);
+    }
+
+    if (phase === 'quiz') {
+      // AI always answers correctly
+      const t = setTimeout(() => {
+        const q = store.pendingQuestion;
+        if (q) answerQuestion(q.answer);
+      }, 1500);
+      return () => clearTimeout(t);
+    }
+  }, [phase, currentPlayer, players, rollDice, answerQuestion, store.pendingQuestion]);
+
+  return store;
+}

--- a/gamesformykids/lib/constants/gameCategories.ts
+++ b/gamesformykids/lib/constants/gameCategories.ts
@@ -122,7 +122,7 @@ export const GAME_CATEGORIES: Record<string, GameCategory> = {
       "flappy-bird","snake","dino-runner","catch-fruit","space-defender",
       "whack-a-mole","brick-breaker","balloon-pop","pong","meteor-dodge",
       "frogger","stack","color-tap","jumper","simon",
-      "reflex","taki","checkers","chess","shesh-besh","maze","letter-defender",
+      "reflex","taki","checkers","chess","shesh-besh","maze","letter-defender","snakes-ladders",
     ],
   },
   educational: {

--- a/gamesformykids/lib/registry/registryData/batch4.ts
+++ b/gamesformykids/lib/registry/registryData/batch4.ts
@@ -563,4 +563,15 @@ export const gamesRegistryBatch4: GameRegistration[] = [
     available: true,
     order: 172,
   },
+  {
+    id: "snakes-ladders",
+    title: "נחשים וסולמות",
+    description: "הטל קוביה, ענה על שאלות מתמטיות, עלה בסולמות והימנע מהנחשים!",
+    icon: Gamepad2,
+    emoji: "🐍",
+    color: "bg-green-600 hover:bg-green-700",
+    href: "/games/snakes-ladders",
+    available: true,
+    order: 173,
+  },
 ];

--- a/gamesformykids/lib/types/core/base.ts
+++ b/gamesformykids/lib/types/core/base.ts
@@ -198,4 +198,6 @@ export type GameType =
   // Number games
   | 'number-slide'
   // Math story problems
-  | 'math-stories';
+  | 'math-stories'
+  // Board games
+  | 'snakes-ladders';


### PR DESCRIPTION
﻿## What
Adds a Snakes and Ladders board game (Style D — Custom) with an integrated Hebrew math quiz mechanic. Classic 10×10 board (squares 1–100) with standard snake and ladder positions. When a player lands on a special square, a math question appears: answer correctly to climb a ladder or avoid a snake; answer wrong to miss the climb or slide down.

Features:
- Solo mode (player vs AI — AI always answers correctly for fairness)
- Two-player pass-and-play mode
- 32 math questions across 3 difficulty levels (easy/medium/hard, matched to board position)
- Turn-based dice rolling with visual feedback
- Quiz popup with 4-choice answers
- Win detection and result screen

## Why
Closes #1249

## Test plan
- [ ] Visit `/games/snakes-ladders` — menu appears with mode selection
- [ ] Start solo game — dice button appears, AI auto-rolls after delay
- [ ] Roll dice and land on a ladder square (4, 9, 20, 28, 40, 51, 63, 71) — quiz popup appears
- [ ] Answer correctly → player climbs; answer wrong → player stays
- [ ] Land on snake square (17, 54, 62, 64, 87, 93, 95, 99) — quiz popup appears
- [ ] Answer correctly → stays; wrong → slides down
- [ ] First to reach 100 sees win screen
- [ ] Two-player mode works with manual rolling for each player
- [ ] Game appears in 🕹️ ארקייד category on home page

🤖 Generated with [Claude Code](https://claude.com/claude-code)
