### PR TITLE
feat(escape-room): Hebrew room-escape puzzle game (closes #1247)

### DIFF
--- a/gamesformykids/app/games/[gameType]/CustomGameRenderer.tsx
+++ b/gamesformykids/app/games/[gameType]/CustomGameRenderer.tsx
@@ -48,6 +48,7 @@ const GAME_CLIENTS: Record<string, ComponentType> = {
   'puppet-story':     dynamic(() => import('../puppet-story/PuppetClient'),                      { ssr: false }),
   'number-slide':     dynamic(() => import('../number-slide/NumberSlideClient'),                  { ssr: false }),
   'snakes-ladders':   dynamic(() => import('../snakes-ladders/SnakesLaddersClient'),              { ssr: false }),
+  'escape-room':      dynamic(() => import('../escape-room/EscapeRoomClient'),                    { ssr: false }),
 };
 
 interface Props { gameType: string; }

--- a/gamesformykids/app/games/[gameType]/gamePageConstants.ts
+++ b/gamesformykids/app/games/[gameType]/gamePageConstants.ts
@@ -66,6 +66,7 @@ export const SUPPORTED_GAMES = [
   'number-slide',
   'math-stories',
   'story-builder',
+  'escape-room',
 ] as const;
 
 export type SupportedGameType = typeof SUPPORTED_GAMES[number];
@@ -78,6 +79,7 @@ export const CUSTOM_GAME_TYPES = new Set([
   'puzzles', 'reflex', 'shesh-besh', 'simon', 'snake', 'space-defender',
   'stack', 'taki', 'tetris', 'true-false', 'tzedakah', 'whack-a-mole',
   'word-builder', 'word-scramble', 'maze', 'letter-defender', 'puppet-story', 'number-slide', 'snakes-ladders',
+  'escape-room',
 ]);
 
 // ─── מיפוי URL → GameType ──────────────────────────────────────────────────────

--- a/gamesformykids/app/games/escape-room/EscapeRoomClient.tsx
+++ b/gamesformykids/app/games/escape-room/EscapeRoomClient.tsx
@@ -1,0 +1,113 @@
+'use client';
+import { useEscapeRoom } from './useEscapeRoom';
+import RoomScene from './components/RoomScene';
+import PuzzleOverlay from './components/PuzzleOverlay';
+import DoorCodePanel from './components/DoorCodePanel';
+import GameResultCard from '@/components/game/shared/GameResultCard';
+
+export default function EscapeRoomClient() {
+  const {
+    phase, room, rooms, solvedIds, revealedDigits, activePuzzle,
+    funMessage, score, hintsUsed, puzzleCount,
+    handleStart, handleClickHotspot, handleAnswer, handleHint,
+    dismissOverlay, resetGame,
+  } = useEscapeRoom();
+
+  if (phase === 'menu') {
+    return (
+      <div className="min-h-screen bg-gradient-to-br from-purple-900 to-indigo-900 flex items-center justify-center p-4" dir="rtl">
+        <div className="bg-white rounded-3xl shadow-2xl p-8 max-w-md w-full flex flex-col items-center gap-6">
+          <div className="text-6xl">🔐</div>
+          <h1 className="text-3xl font-extrabold text-purple-800 text-center">בריחה מהחדר</h1>
+          <p className="text-center text-gray-600 leading-relaxed">
+            פתח חפצים, פתור חידות, גלה ספרות סודיות — ופרוץ את הדלת הנעולה!
+          </p>
+          <div className="flex flex-col gap-3 w-full">
+            <p className="text-sm font-bold text-gray-500 text-center">בחר חדר:</p>
+            {rooms.map(r => (
+              <button
+                key={r.id}
+                onClick={() => handleStart(r.id)}
+                className="w-full bg-gradient-to-r from-purple-500 to-indigo-600 hover:from-purple-600 hover:to-indigo-700 text-white font-bold text-lg rounded-2xl py-4 px-6 flex items-center gap-3 transition-all active:scale-95 shadow-md"
+              >
+                <span className="text-3xl">{r.emoji}</span>
+                <span>{r.title}</span>
+              </button>
+            ))}
+          </div>
+          <div className="text-xs text-gray-400 text-center" dir="rtl">
+            💡 לחץ על חפצים עם נקודה צהובה כדי לחשוף חידות
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  if (phase === 'result' && room) {
+    return (
+      <GameResultCard
+        emoji="🔓"
+        title={`פרצת את ${room.title}!`}
+        gradientClass="from-green-50 to-emerald-100"
+        buttonClass="from-purple-500 to-indigo-600"
+        onRestart={resetGame}
+        restartLabel="חדר נוסף"
+        score={score}
+        gameType="escape-room"
+        scorePercent={Math.round((revealedDigits.length / puzzleCount) * 100)}
+      >
+        <div className="flex flex-col items-center gap-2" dir="rtl">
+          <p className="text-gray-600 text-center">פתרת {puzzleCount} חידות וגילית את קוד הדלת!</p>
+          <p className="text-2xl font-bold text-purple-700">קוד: {revealedDigits.join('-')}</p>
+          <p className="text-gray-500 text-sm">ניקוד: {score} נקודות</p>
+        </div>
+      </GameResultCard>
+    );
+  }
+
+  if (!room) return null;
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-purple-900 to-indigo-900 flex flex-col items-center justify-center p-3 gap-3" dir="rtl">
+      {/* Header */}
+      <div className="flex items-center justify-between w-full max-w-2xl">
+        <button onClick={resetGame} className="text-white/70 hover:text-white text-sm font-bold px-3 py-1.5 rounded-xl bg-white/10 transition-all">
+          ← חזור
+        </button>
+        <h2 className="text-white font-extrabold text-xl">{room.emoji} {room.title}</h2>
+        <div className="text-white/80 text-sm font-bold">ניקוד: {score}</div>
+      </div>
+
+      {/* Room */}
+      <div className="w-full max-w-2xl">
+        <RoomScene room={room} solvedIds={solvedIds} onClickHotspot={handleClickHotspot} />
+      </div>
+
+      {/* Door code */}
+      <DoorCodePanel revealedDigits={revealedDigits} puzzleCount={puzzleCount} />
+
+      {/* Fun message */}
+      {funMessage && (
+        <div
+          className="bg-white/90 rounded-2xl px-5 py-3 text-gray-700 font-semibold text-sm shadow-lg max-w-sm text-center cursor-pointer"
+          onClick={dismissOverlay}
+        >
+          💬 {funMessage}
+          <p className="text-xs text-gray-400 mt-1">לחץ לסגירה</p>
+        </div>
+      )}
+
+      {/* Puzzle overlay */}
+      {activePuzzle && (
+        <PuzzleOverlay
+          hotspot={activePuzzle.hotspot}
+          puzzle={activePuzzle.puzzle}
+          hintsUsed={hintsUsed}
+          onAnswer={handleAnswer}
+          onHint={handleHint}
+          onDismiss={dismissOverlay}
+        />
+      )}
+    </div>
+  );
+}

--- a/gamesformykids/app/games/escape-room/components/DoorCodePanel.tsx
+++ b/gamesformykids/app/games/escape-room/components/DoorCodePanel.tsx
@@ -1,0 +1,41 @@
+'use client';
+
+type Props = {
+  revealedDigits: string[];
+  puzzleCount: number;
+};
+
+export default function DoorCodePanel({ revealedDigits, puzzleCount }: Props) {
+  const slots = Array.from({ length: puzzleCount }, (_, i) => revealedDigits[i] ?? null);
+  const allRevealed = revealedDigits.length >= puzzleCount;
+
+  return (
+    <div className="flex flex-col items-center gap-2 bg-white/90 rounded-2xl shadow-lg px-4 py-3 border-2 border-amber-300">
+      <p className="text-xs font-bold text-amber-700" dir="rtl">קוד הדלת</p>
+      <div className="flex gap-2 dir-ltr">
+        {slots.map((digit, i) => (
+          <div
+            key={i}
+            className={`w-10 h-12 rounded-xl border-2 flex items-center justify-center text-2xl font-bold transition-all duration-500 ${
+              digit
+                ? 'border-green-400 bg-green-100 text-green-700 scale-110'
+                : 'border-amber-300 bg-amber-50 text-amber-200'
+            }`}
+          >
+            {digit ?? '?'}
+          </div>
+        ))}
+      </div>
+      {allRevealed && (
+        <p className="text-xs text-green-600 font-semibold animate-pulse" dir="rtl">
+          🔓 הקוד מוכן!
+        </p>
+      )}
+      {!allRevealed && (
+        <p className="text-xs text-gray-500" dir="rtl">
+          {revealedDigits.length}/{puzzleCount} ספרות
+        </p>
+      )}
+    </div>
+  );
+}

--- a/gamesformykids/app/games/escape-room/components/PuzzleOverlay.tsx
+++ b/gamesformykids/app/games/escape-room/components/PuzzleOverlay.tsx
@@ -1,0 +1,85 @@
+'use client';
+import { useState, useCallback } from 'react';
+import type { Hotspot, Puzzle } from './puzzleData';
+
+type Props = {
+  hotspot: Hotspot;
+  puzzle: Puzzle;
+  hintsUsed: number;
+  onAnswer: (answer: string) => boolean;
+  onHint: () => string | null;
+  onDismiss: () => void;
+};
+
+export default function PuzzleOverlay({ hotspot, puzzle, hintsUsed, onAnswer, onHint, onDismiss }: Props) {
+  const [feedback, setFeedback] = useState<{ text: string; correct: boolean } | null>(null);
+  const [hint, setHint] = useState<string | null>(null);
+  const [answered, setAnswered] = useState(false);
+
+  const choices = [puzzle.answer, ...puzzle.wrongOptions].sort(() => Math.random() - 0.5);
+
+  const handleSelect = useCallback((choice: string) => {
+    if (answered) return;
+    const isCorrect = onAnswer(choice);
+    setFeedback({ text: isCorrect ? puzzle.successMessage : 'לא נכון — נסה שוב! 💪', correct: isCorrect });
+    if (isCorrect) {
+      setAnswered(true);
+      setTimeout(onDismiss, 2000);
+    }
+  }, [answered, onAnswer, onDismiss, puzzle.successMessage]);
+
+  const handleHint = useCallback(() => {
+    const h = onHint();
+    if (h) setHint(h);
+  }, [onHint]);
+
+  return (
+    <div className="fixed inset-0 bg-black/60 flex items-center justify-center z-50 p-4" onClick={onDismiss}>
+      <div
+        className="bg-white rounded-3xl shadow-2xl max-w-sm w-full p-6 flex flex-col gap-4"
+        onClick={e => e.stopPropagation()}
+        dir="rtl"
+      >
+        <div className="flex items-center justify-between">
+          <span className="text-3xl">{hotspot.emoji}</span>
+          <button onClick={onDismiss} className="text-gray-400 hover:text-gray-600 text-xl">✕</button>
+        </div>
+
+        <p className="text-center font-bold text-gray-800 text-lg leading-relaxed">{puzzle.question}</p>
+
+        {hint && (
+          <p className="text-center text-sm text-amber-600 bg-amber-50 rounded-xl p-2">💡 {hint}</p>
+        )}
+
+        {feedback && (
+          <p className={`text-center text-sm font-semibold rounded-xl p-2 ${feedback.correct ? 'bg-green-100 text-green-700' : 'bg-red-100 text-red-700'}`}>
+            {feedback.correct ? '✅' : '❌'} {feedback.text}
+          </p>
+        )}
+
+        {!answered && (
+          <div className="grid grid-cols-2 gap-2">
+            {choices.map((choice) => (
+              <button
+                key={choice}
+                onClick={() => handleSelect(choice)}
+                className="bg-indigo-50 hover:bg-indigo-100 active:bg-indigo-200 border-2 border-indigo-200 hover:border-indigo-400 rounded-2xl p-3 font-bold text-indigo-800 text-base transition-all"
+              >
+                {choice}
+              </button>
+            ))}
+          </div>
+        )}
+
+        {!answered && hintsUsed < 3 && (
+          <button
+            onClick={handleHint}
+            className="text-xs text-amber-600 underline text-center"
+          >
+            💡 רמז ({3 - hintsUsed} נותרו)
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/gamesformykids/app/games/escape-room/components/RoomScene.tsx
+++ b/gamesformykids/app/games/escape-room/components/RoomScene.tsx
@@ -1,0 +1,50 @@
+'use client';
+import type { Room } from './puzzleData';
+
+type Props = {
+  room: Room;
+  solvedIds: Set<string>;
+  onClickHotspot: (id: string) => void;
+};
+
+export default function RoomScene({ room, solvedIds, onClickHotspot }: Props) {
+  return (
+    <div className={`relative w-full aspect-[16/9] rounded-3xl bg-gradient-to-br ${room.bg} border-4 border-white/50 shadow-2xl overflow-hidden select-none`}>
+      {/* Floor line */}
+      <div className="absolute bottom-[28%] left-0 right-0 h-1 bg-white/20 rounded-full" />
+
+      {/* Hotspots */}
+      {room.hotspots.map((hotspot) => {
+        const isSolved = solvedIds.has(hotspot.id);
+        const hasPuzzle = hotspot.puzzle !== null;
+        return (
+          <button
+            key={hotspot.id}
+            onClick={() => onClickHotspot(hotspot.id)}
+            disabled={isSolved && hasPuzzle}
+            style={{ left: `${hotspot.x}%`, top: `${hotspot.y}%` }}
+            className={`absolute -translate-x-1/2 -translate-y-1/2 flex flex-col items-center gap-0.5 transition-all duration-200 ${
+              isSolved && hasPuzzle
+                ? 'opacity-60 cursor-default'
+                : 'hover:scale-125 active:scale-110 cursor-pointer'
+            }`}
+            title={hotspot.label}
+          >
+            <span className="text-3xl sm:text-4xl drop-shadow-md leading-none">
+              {hotspot.emoji}
+            </span>
+            {isSolved && hasPuzzle && (
+              <span className="text-base leading-none">✅</span>
+            )}
+            {hasPuzzle && !isSolved && (
+              <span className="w-2 h-2 rounded-full bg-yellow-400 animate-bounce" />
+            )}
+            <span className="text-xs font-bold text-gray-700 bg-white/70 rounded-full px-1.5 leading-tight" dir="rtl">
+              {hotspot.label}
+            </span>
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/gamesformykids/app/games/escape-room/components/puzzleData.ts
+++ b/gamesformykids/app/games/escape-room/components/puzzleData.ts
@@ -1,0 +1,220 @@
+export type Puzzle = {
+  question: string;
+  answer: string;
+  wrongOptions: [string, string, string];
+  digit: string;
+  successMessage: string;
+};
+
+export type Hotspot = {
+  id: string;
+  emoji: string;
+  label: string;
+  x: number; // % from left
+  y: number; // % from top
+  puzzle: Puzzle | null;
+  funMessage: string | null;
+};
+
+export type Room = {
+  id: string;
+  title: string;
+  emoji: string;
+  bg: string; // tailwind bg class
+  hotspots: Hotspot[];
+};
+
+export const ROOMS: Room[] = [
+  {
+    id: 'bedroom',
+    title: 'חדר השינה',
+    emoji: '🛏️',
+    bg: 'from-blue-100 to-indigo-200',
+    hotspots: [
+      {
+        id: 'bookshelf',
+        emoji: '📚',
+        label: 'ספרייה',
+        x: 12, y: 25,
+        puzzle: {
+          question: 'מה ההפך של "קצר"?',
+          answer: 'ארוך',
+          wrongOptions: ['גדול', 'רחב', 'חזק'],
+          digit: '7',
+          successMessage: 'כל הכבוד! הספרייה נפתחה — ספרה ראשונה: 7',
+        },
+        funMessage: null,
+      },
+      {
+        id: 'clock',
+        emoji: '🕐',
+        label: 'שעון',
+        x: 48, y: 12,
+        puzzle: {
+          question: 'כמה זה 6 + 4?',
+          answer: '10',
+          wrongOptions: ['8', '12', '9'],
+          digit: '4',
+          successMessage: 'מצוין! השעון מראה — ספרה שנייה: 4',
+        },
+        funMessage: null,
+      },
+      {
+        id: 'window',
+        emoji: '🪟',
+        label: 'חלון',
+        x: 78, y: 20,
+        puzzle: {
+          question: 'מה חי במים ויש לו קשקשים?',
+          answer: 'דג',
+          wrongOptions: ['כלב', 'ציפור', 'פרה'],
+          digit: '2',
+          successMessage: 'נכון! מבעד לחלון רואים — ספרה שלישית: 2',
+        },
+        funMessage: null,
+      },
+      {
+        id: 'wardrobe',
+        emoji: '🚪',
+        label: 'ארון',
+        x: 88, y: 55,
+        puzzle: {
+          question: 'כמה ימים יש בשבוע?',
+          answer: '7',
+          wrongOptions: ['5', '6', '8'],
+          digit: '9',
+          successMessage: 'יפה מאוד! בארון מוסתרת — ספרה רביעית: 9',
+        },
+        funMessage: null,
+      },
+      {
+        id: 'bed',
+        emoji: '🛏️',
+        label: 'מיטה',
+        x: 35, y: 68,
+        puzzle: null,
+        funMessage: 'זמן לשינה? לא עכשיו — יש חדר לפרוץ!',
+      },
+      {
+        id: 'doll',
+        emoji: '🪆',
+        label: 'בובה',
+        x: 60, y: 72,
+        puzzle: null,
+        funMessage: 'הבובה מחייכת ואומרת: "אתה תצליח!"',
+      },
+      {
+        id: 'lamp',
+        emoji: '🪔',
+        label: 'מנורה',
+        x: 10, y: 58,
+        puzzle: null,
+        funMessage: 'אוי — הנר דולק! אל תיכווה.',
+      },
+      {
+        id: 'rug',
+        emoji: '🎽',
+        label: 'שטיח',
+        x: 50, y: 85,
+        puzzle: null,
+        funMessage: 'שטיח רך ונעים מתחת לרגליים.',
+      },
+    ],
+  },
+  {
+    id: 'classroom',
+    title: 'הכיתה',
+    emoji: '🏫',
+    bg: 'from-green-100 to-emerald-200',
+    hotspots: [
+      {
+        id: 'blackboard',
+        emoji: '🖊️',
+        label: 'לוח',
+        x: 45, y: 10,
+        puzzle: {
+          question: 'מה ההפך של "גדול"?',
+          answer: 'קטן',
+          wrongOptions: ['שמח', 'מהיר', 'ארוך'],
+          digit: '3',
+          successMessage: 'מצוין! על הלוח כתוב — ספרה ראשונה: 3',
+        },
+        funMessage: null,
+      },
+      {
+        id: 'teacher-desk',
+        emoji: '🪑',
+        label: 'שולחן מורה',
+        x: 15, y: 60,
+        puzzle: {
+          question: 'כמה זה 8 - 3?',
+          answer: '5',
+          wrongOptions: ['4', '6', '3'],
+          digit: '8',
+          successMessage: 'כל הכבוד! במגירה הוסתר — ספרה שנייה: 8',
+        },
+        funMessage: null,
+      },
+      {
+        id: 'map',
+        emoji: '🗺️',
+        label: 'מפה',
+        x: 82, y: 25,
+        puzzle: {
+          question: 'מה בירת מדינת ישראל?',
+          answer: 'ירושלים',
+          wrongOptions: ['תל-אביב', 'חיפה', 'באר-שבע'],
+          digit: '1',
+          successMessage: 'נכון! על המפה מסומנת — ספרה שלישית: 1',
+        },
+        funMessage: null,
+      },
+      {
+        id: 'bookcase',
+        emoji: '📖',
+        label: 'ספריית כיתה',
+        x: 82, y: 70,
+        puzzle: {
+          question: 'כמה חודשים יש בשנה?',
+          answer: '12',
+          wrongOptions: ['10', '11', '13'],
+          digit: '6',
+          successMessage: 'יפה! בספר החבוי — ספרה רביעית: 6',
+        },
+        funMessage: null,
+      },
+      {
+        id: 'globe',
+        emoji: '🌍',
+        label: 'גלובוס',
+        x: 65, y: 18,
+        puzzle: null,
+        funMessage: 'העולם גדול ומרתק! יש בו יותר מ-190 מדינות.',
+      },
+      {
+        id: 'backpack',
+        emoji: '🎒',
+        label: 'תיק תלמיד',
+        x: 30, y: 80,
+        puzzle: null,
+        funMessage: 'תיק כבד... כנראה הרבה שיעורי בית בפנים.',
+      },
+      {
+        id: 'pencil',
+        emoji: '✏️',
+        label: 'עיפרון',
+        x: 60, y: 75,
+        puzzle: null,
+        funMessage: 'עיפרון חד ומוכן לכתיבה!',
+      },
+      {
+        id: 'window-class',
+        emoji: '🪟',
+        label: 'חלון כיתה',
+        x: 10, y: 22,
+        puzzle: null,
+        funMessage: 'מבחוץ נשמע קול ציפורים. איזה יום יפה!',
+      },
+    ],
+  },
+];

--- a/gamesformykids/app/games/escape-room/escapeRoomStore.ts
+++ b/gamesformykids/app/games/escape-room/escapeRoomStore.ts
@@ -20,7 +20,7 @@ interface Actions {
   clickHotspot: (hotspotId: string) => void;
   submitAnswer: (answer: string) => boolean; // returns isCorrect
   dismissOverlay: () => void;
-  useHint: () => string | null; // returns hint text or null if none left
+  applyHint: () => string | null; // returns hint text or null if none left
   resetGame: () => void;
 }
 
@@ -83,7 +83,7 @@ export const useEscapeRoomStore = create<State & Actions>((set, get) => ({
     set({ activePuzzle: null, funMessage: null });
   },
 
-  useHint: () => {
+  applyHint: () => {
     const { activePuzzle, hintsUsed } = get();
     if (!activePuzzle || hintsUsed >= 3) return null;
     set({ hintsUsed: hintsUsed + 1 });

--- a/gamesformykids/app/games/escape-room/escapeRoomStore.ts
+++ b/gamesformykids/app/games/escape-room/escapeRoomStore.ts
@@ -1,0 +1,98 @@
+'use client';
+import { create } from 'zustand';
+import { ROOMS, type Room, type Hotspot, type Puzzle } from './components/puzzleData';
+
+type Phase = 'menu' | 'playing' | 'result';
+
+interface State {
+  phase: Phase;
+  room: Room | null;
+  solvedIds: Set<string>;
+  revealedDigits: string[]; // digits in order revealed
+  activePuzzle: { hotspot: Hotspot; puzzle: Puzzle } | null;
+  funMessage: string | null;
+  score: number;
+  hintsUsed: number;
+}
+
+interface Actions {
+  startGame: (roomId: string) => void;
+  clickHotspot: (hotspotId: string) => void;
+  submitAnswer: (answer: string) => boolean; // returns isCorrect
+  dismissOverlay: () => void;
+  useHint: () => string | null; // returns hint text or null if none left
+  resetGame: () => void;
+}
+
+const INITIAL: State = {
+  phase: 'menu',
+  room: null,
+  solvedIds: new Set(),
+  revealedDigits: [],
+  activePuzzle: null,
+  funMessage: null,
+  score: 0,
+  hintsUsed: 0,
+};
+
+export const useEscapeRoomStore = create<State & Actions>((set, get) => ({
+  ...INITIAL,
+
+  startGame: (roomId) => {
+    const room = ROOMS.find(r => r.id === roomId) ?? ROOMS[0]!;
+    set({ phase: 'playing', room, solvedIds: new Set(), revealedDigits: [], activePuzzle: null, funMessage: null, score: 0, hintsUsed: 0 });
+  },
+
+  clickHotspot: (hotspotId) => {
+    const { room, solvedIds } = get();
+    if (!room) return;
+    const hotspot = room.hotspots.find(h => h.id === hotspotId);
+    if (!hotspot) return;
+    if (solvedIds.has(hotspotId)) return;
+
+    if (hotspot.puzzle) {
+      set({ activePuzzle: { hotspot, puzzle: hotspot.puzzle }, funMessage: null });
+    } else if (hotspot.funMessage) {
+      set({ funMessage: hotspot.funMessage, activePuzzle: null });
+    }
+  },
+
+  submitAnswer: (answer) => {
+    const { activePuzzle, solvedIds, revealedDigits, room, score } = get();
+    if (!activePuzzle || !room) return false;
+
+    const isCorrect = answer === activePuzzle.puzzle.answer;
+    if (isCorrect) {
+      const newSolved = new Set(solvedIds);
+      newSolved.add(activePuzzle.hotspot.id);
+      const newDigits = [...revealedDigits, activePuzzle.puzzle.digit];
+      const puzzleHotspots = room.hotspots.filter(h => h.puzzle !== null);
+      const allSolved = newSolved.size >= puzzleHotspots.length;
+      set({
+        solvedIds: newSolved,
+        revealedDigits: newDigits,
+        activePuzzle: null,
+        score: score + (100 - get().hintsUsed * 5),
+        phase: allSolved ? 'result' : 'playing',
+      });
+    }
+    return isCorrect;
+  },
+
+  dismissOverlay: () => {
+    set({ activePuzzle: null, funMessage: null });
+  },
+
+  useHint: () => {
+    const { activePuzzle, hintsUsed } = get();
+    if (!activePuzzle || hintsUsed >= 3) return null;
+    set({ hintsUsed: hintsUsed + 1 });
+    const wrong = activePuzzle.puzzle.wrongOptions;
+    const eliminated = wrong[Math.floor(Math.random() * wrong.length)]!;
+    return `הרמז: "${eliminated}" היא תשובה שגויה.`;
+  },
+
+  resetGame: () => {
+    set({ ...INITIAL, solvedIds: new Set() });
+  },
+}));

--- a/gamesformykids/app/games/escape-room/useEscapeRoom.ts
+++ b/gamesformykids/app/games/escape-room/useEscapeRoom.ts
@@ -1,0 +1,62 @@
+'use client';
+import { useCallback } from 'react';
+import { useEscapeRoomStore } from './escapeRoomStore';
+import { speakHebrew } from '@/lib/utils/speech/enhancedSpeechUtils';
+import { ROOMS } from './components/puzzleData';
+
+export function useEscapeRoom() {
+  const phase          = useEscapeRoomStore(s => s.phase);
+  const room           = useEscapeRoomStore(s => s.room);
+  const solvedIds      = useEscapeRoomStore(s => s.solvedIds);
+  const revealedDigits = useEscapeRoomStore(s => s.revealedDigits);
+  const activePuzzle   = useEscapeRoomStore(s => s.activePuzzle);
+  const funMessage     = useEscapeRoomStore(s => s.funMessage);
+  const score          = useEscapeRoomStore(s => s.score);
+  const hintsUsed      = useEscapeRoomStore(s => s.hintsUsed);
+  const { startGame, clickHotspot, submitAnswer, dismissOverlay, useHint, resetGame } = useEscapeRoomStore();
+
+  const handleStart = useCallback((roomId: string) => {
+    startGame(roomId);
+    speakHebrew('בואו נפרוץ את החדר!');
+  }, [startGame]);
+
+  const handleClickHotspot = useCallback((hotspotId: string) => {
+    clickHotspot(hotspotId);
+    const state = useEscapeRoomStore.getState();
+    if (state.activePuzzle) {
+      speakHebrew(state.activePuzzle.puzzle.question);
+    } else if (state.funMessage) {
+      speakHebrew(state.funMessage);
+    }
+  }, [clickHotspot]);
+
+  const handleAnswer = useCallback((answer: string) => {
+    const isCorrect = submitAnswer(answer);
+    const state = useEscapeRoomStore.getState();
+    if (isCorrect) {
+      const latestDigit = state.revealedDigits[state.revealedDigits.length - 1];
+      const msg = state.phase === 'result'
+        ? 'פרצת את החדר! כל הכבוד!'
+        : `נכון! ספרה ${latestDigit} התגלתה!`;
+      speakHebrew(msg);
+    } else {
+      speakHebrew('לא נכון — נסה שוב!');
+    }
+    return isCorrect;
+  }, [submitAnswer]);
+
+  const handleHint = useCallback(() => {
+    const hint = useHint();
+    if (hint) speakHebrew(hint);
+    return hint;
+  }, [useHint]);
+
+  const puzzleCount = room?.hotspots.filter(h => h.puzzle !== null).length ?? 0;
+
+  return {
+    phase, room, rooms: ROOMS, solvedIds, revealedDigits, activePuzzle,
+    funMessage, score, hintsUsed, puzzleCount,
+    handleStart, handleClickHotspot, handleAnswer, handleHint,
+    dismissOverlay, resetGame,
+  };
+}

--- a/gamesformykids/app/games/escape-room/useEscapeRoom.ts
+++ b/gamesformykids/app/games/escape-room/useEscapeRoom.ts
@@ -13,7 +13,7 @@ export function useEscapeRoom() {
   const funMessage     = useEscapeRoomStore(s => s.funMessage);
   const score          = useEscapeRoomStore(s => s.score);
   const hintsUsed      = useEscapeRoomStore(s => s.hintsUsed);
-  const { startGame, clickHotspot, submitAnswer, dismissOverlay, useHint, resetGame } = useEscapeRoomStore();
+  const { startGame, clickHotspot, submitAnswer, dismissOverlay, applyHint, resetGame } = useEscapeRoomStore();
 
   const handleStart = useCallback((roomId: string) => {
     startGame(roomId);
@@ -46,10 +46,10 @@ export function useEscapeRoom() {
   }, [submitAnswer]);
 
   const handleHint = useCallback(() => {
-    const hint = useHint();
+    const hint = applyHint();
     if (hint) speakHebrew(hint);
     return hint;
-  }, [useHint]);
+  }, [applyHint]);
 
   const puzzleCount = room?.hotspots.filter(h => h.puzzle !== null).length ?? 0;
 

--- a/gamesformykids/lib/constants/gameCategories.ts
+++ b/gamesformykids/lib/constants/gameCategories.ts
@@ -122,7 +122,7 @@ export const GAME_CATEGORIES: Record<string, GameCategory> = {
       "flappy-bird","snake","dino-runner","catch-fruit","space-defender",
       "whack-a-mole","brick-breaker","balloon-pop","pong","meteor-dodge",
       "frogger","stack","color-tap","jumper","simon",
-      "reflex","taki","checkers","chess","shesh-besh","maze","letter-defender","snakes-ladders",
+      "reflex","taki","checkers","chess","shesh-besh","maze","letter-defender","snakes-ladders","escape-room",
     ],
   },
   educational: {

--- a/gamesformykids/lib/registry/registryData/batch4.ts
+++ b/gamesformykids/lib/registry/registryData/batch4.ts
@@ -28,6 +28,7 @@ import {
   Type,
   AlignLeft,
   Calculator,
+  KeyRound,
 } from "lucide-react";
 import type { GameRegistration } from "@/lib/types/games/base";
 
@@ -584,5 +585,16 @@ export const gamesRegistryBatch4: GameRegistration[] = [
     href: "/games/story-builder",
     available: true,
     order: 174,
+  },
+  {
+    id: "escape-room",
+    title: "בריחה מהחדר",
+    description: "פתור חידות, גלה ספרות סודיות ופרוץ את הדלת הנעולה!",
+    icon: KeyRound,
+    emoji: "🔐",
+    color: "bg-purple-600 hover:bg-purple-700",
+    href: "/games/escape-room",
+    available: true,
+    order: 175,
   },
 ];

--- a/gamesformykids/lib/types/core/base.ts
+++ b/gamesformykids/lib/types/core/base.ts
@@ -202,4 +202,7 @@ export type GameType =
   // Board games
   | 'snakes-ladders'
   // Story & creative games
-  | 'story-builder';
+  | 'story-builder'
+  // Escape & adventure games
+  | 'escape-room';
+>>>>>>> 69f91cf7 (feat(escape-room): Hebrew room-escape puzzle game (closes #1247))

--- a/gamesformykids/lib/types/core/base.ts
+++ b/gamesformykids/lib/types/core/base.ts
@@ -205,4 +205,3 @@ export type GameType =
   | 'story-builder'
   // Escape & adventure games
   | 'escape-room';
->>>>>>> 69f91cf7 (feat(escape-room): Hebrew room-escape puzzle game (closes #1247))


### PR DESCRIPTION
## What
Adds a Hebrew escape-room game with two rooms (bedroom and classroom). Each room has 8 clickable hotspots — 4 puzzle hotspots and 4 fun-fact hotspots. Solving each puzzle reveals one digit of a 4-digit door code. Collecting all 4 digits wins the round.

## Features
- Two rooms: חדר שינה (bedroom) and הכיתה (classroom)
- 4 puzzle types per room: Hebrew opposites, arithmetic, riddles, geography
- 3-hint system (costs 5 points each)
- Door-code panel shows revealed digits in real time
- Fun-fact hotspots for non-puzzle objects (encourage exploration)
- TTS reads all puzzle text and feedback in Hebrew
- Result screen with score via GameResultCard

## Why
Closes #1247

## Test plan
- [ ] Visit `/games/escape-room` — menu shows two room buttons
- [ ] Click a room → room scene loads with emoji hotspots
- [ ] Click a yellow-dot hotspot → puzzle overlay appears with question + 4 choices
- [ ] Wrong answer → red feedback, stays on puzzle
- [ ] Correct answer → digit revealed in door panel, overlay closes automatically
- [ ] Click a fun hotspot → fun message appears, click to dismiss
- [ ] Collect all 4 digits → result screen with door code shown
- [ ] Hint button works (3 per game, eliminates a wrong answer)
- [ ] Appears in arcade category on home page
- [ ] Mobile touch works on all elements

🤖 Generated with [Claude Code](https://claude.com/claude-code)