### PR TITLE
feat(robot-coder): Hebrew Lightbot path-programming game (closes #1246)

### DIFF
--- a/gamesformykids/app/games/[gameType]/CustomGameRenderer.tsx
+++ b/gamesformykids/app/games/[gameType]/CustomGameRenderer.tsx
@@ -49,6 +49,7 @@ const GAME_CLIENTS: Record<string, ComponentType> = {
   'number-slide':     dynamic(() => import('../number-slide/NumberSlideClient'),                  { ssr: false }),
   'snakes-ladders':   dynamic(() => import('../snakes-ladders/SnakesLaddersClient'),              { ssr: false }),
   'escape-room':      dynamic(() => import('../escape-room/EscapeRoomClient'),                    { ssr: false }),
+  'robot-coder':      dynamic(() => import('../robot-coder/RobotCoderClient'),                    { ssr: false }),
 };
 
 interface Props { gameType: string; }

--- a/gamesformykids/app/games/[gameType]/gamePageConstants.ts
+++ b/gamesformykids/app/games/[gameType]/gamePageConstants.ts
@@ -67,6 +67,7 @@ export const SUPPORTED_GAMES = [
   'math-stories',
   'story-builder',
   'escape-room',
+  'robot-coder',
 ] as const;
 
 export type SupportedGameType = typeof SUPPORTED_GAMES[number];
@@ -79,7 +80,7 @@ export const CUSTOM_GAME_TYPES = new Set([
   'puzzles', 'reflex', 'shesh-besh', 'simon', 'snake', 'space-defender',
   'stack', 'taki', 'tetris', 'true-false', 'tzedakah', 'whack-a-mole',
   'word-builder', 'word-scramble', 'maze', 'letter-defender', 'puppet-story', 'number-slide', 'snakes-ladders',
-  'escape-room',
+  'escape-room', 'robot-coder',
 ]);
 
 // ─── מיפוי URL → GameType ──────────────────────────────────────────────────────

--- a/gamesformykids/app/games/robot-coder/RobotCoderClient.tsx
+++ b/gamesformykids/app/games/robot-coder/RobotCoderClient.tsx
@@ -1,0 +1,140 @@
+'use client';
+import { useRobotCoder } from './useRobotCoder';
+import RobotGrid from './components/RobotGrid';
+import CommandStrip from './components/CommandStrip';
+import GameResultCard from '@/components/game/shared/GameResultCard';
+
+export default function RobotCoderClient() {
+  const {
+    phase, levelIdx, level, commands, robotPos, collectedLetters, animStep, totalLevels,
+    startGame, nextLevel, addCommand, removeCommand, clearCommands, run, resetLevel, resetGame,
+  } = useRobotCoder();
+
+  const isRunning = phase === 'running';
+
+  if (phase === 'menu') {
+    return (
+      <div className="min-h-screen bg-gradient-to-br from-indigo-900 to-purple-900 flex items-center justify-center p-4" dir="rtl">
+        <div className="bg-white rounded-3xl shadow-2xl p-8 max-w-sm w-full flex flex-col items-center gap-6">
+          <div className="text-6xl">🤖</div>
+          <h1 className="text-3xl font-extrabold text-indigo-800 text-center">תכנת את הרובוט</h1>
+          <p className="text-center text-gray-600 leading-relaxed">
+            הכנס פקודות לרובוט, הרץ אותו — ואסוף אותיות עברית לפי הסדר!
+          </p>
+          <div className="bg-indigo-50 rounded-2xl p-4 text-sm text-indigo-700 text-right w-full">
+            <p>↑ ↓ ← → לתנועה</p>
+            <p>לחץ על חץ להוספה לפס הפקודות</p>
+            <p>לחץ על פקודה בפס להסרתה</p>
+            <p>לחץ &quot;הרץ!&quot; להפעלה</p>
+          </div>
+          <button
+            onClick={startGame}
+            className="w-full bg-gradient-to-r from-indigo-500 to-purple-600 hover:from-indigo-600 hover:to-purple-700 text-white font-extrabold text-xl rounded-2xl py-4 transition-all active:scale-95 shadow-md"
+          >
+            🤖 בואו נתכנת!
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  if (phase === 'success') {
+    const isLast = levelIdx >= totalLevels - 1;
+    return (
+      <GameResultCard
+        emoji="🤖"
+        title={`${level.targetWord}! מצוין!`}
+        gradientClass="from-indigo-50 to-purple-100"
+        buttonClass="from-indigo-500 to-purple-600"
+        onRestart={isLast ? resetGame : nextLevel}
+        restartLabel={isLast ? 'התחל מחדש' : `שלב ${levelIdx + 2} ←`}
+        score={(levelIdx + 1) * 100}
+        gameType="robot-coder"
+        scorePercent={Math.round(((levelIdx + 1) / totalLevels) * 100)}
+      >
+        <div className="flex flex-col items-center gap-2" dir="rtl">
+          <p className="text-gray-600">הרובוט איסף את המילה <strong>{level.targetWord}</strong>!</p>
+          <p className="text-gray-500 text-sm">שלב {levelIdx + 1} מתוך {totalLevels}</p>
+          {isLast && <p className="text-green-600 font-bold">השלמת את כל השלבים! 🏆</p>}
+        </div>
+      </GameResultCard>
+    );
+  }
+
+  if (phase === 'fail') {
+    return (
+      <div className="min-h-screen bg-gradient-to-br from-red-100 to-orange-100 flex items-center justify-center p-4" dir="rtl">
+        <div className="bg-white rounded-3xl shadow-xl p-8 max-w-sm w-full flex flex-col items-center gap-4">
+          <div className="text-5xl">😅</div>
+          <h2 className="text-2xl font-bold text-red-700">לא הצלחנו הפעם!</h2>
+          <p className="text-gray-600 text-center">
+            הרובוט לא אסף את <strong>{level.targetWord}</strong> בסדר הנכון.
+          </p>
+          <p className="text-sm text-amber-600 bg-amber-50 rounded-xl px-4 py-2">
+            💡 {level.hint}
+          </p>
+          <button
+            onClick={resetLevel}
+            className="w-full bg-gradient-to-r from-indigo-500 to-purple-600 text-white font-bold text-lg rounded-2xl py-3 transition-all active:scale-95"
+          >
+            נסה שוב
+          </button>
+          <button onClick={resetGame} className="text-sm text-gray-400 underline">
+            חזור לתפריט
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  // editing / running
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-indigo-900 to-purple-900 flex flex-col items-center justify-center p-3 gap-4" dir="rtl">
+      {/* Header */}
+      <div className="flex items-center justify-between w-full max-w-lg">
+        <button onClick={resetGame} className="text-white/70 hover:text-white text-sm font-bold px-3 py-1.5 rounded-xl bg-white/10">
+          ← חזור
+        </button>
+        <div className="text-white font-bold text-sm">שלב {levelIdx + 1}/{totalLevels}</div>
+      </div>
+
+      {/* Target word */}
+      <div className="bg-white/10 backdrop-blur-sm rounded-2xl px-6 py-3 text-center">
+        <p className="text-white/70 text-xs mb-1">אסוף את המילה:</p>
+        <div className="flex gap-2 justify-center">
+          {level.targetWord.split('').map((letter, i) => (
+            <span
+              key={i}
+              className={`w-10 h-10 rounded-xl border-2 flex items-center justify-center text-xl font-bold transition-all ${
+                i < collectedLetters.length
+                  ? 'border-green-400 bg-green-300 text-green-900'
+                  : 'border-white/30 text-white'
+              }`}
+            >
+              {letter}
+            </span>
+          ))}
+        </div>
+      </div>
+
+      {/* Grid */}
+      <div className="bg-white/10 backdrop-blur-sm rounded-3xl p-4">
+        <RobotGrid level={level} robotPos={robotPos} collectedLetters={collectedLetters} animStep={animStep} />
+      </div>
+
+      {/* Command strip */}
+      <div className="bg-white rounded-3xl shadow-xl p-4 w-full max-w-sm">
+        <CommandStrip
+          commands={commands}
+          maxCommands={level.maxCommands}
+          isRunning={isRunning}
+          animStep={animStep}
+          onAdd={addCommand}
+          onRemove={removeCommand}
+          onClear={clearCommands}
+          onRun={run}
+        />
+      </div>
+    </div>
+  );
+}

--- a/gamesformykids/app/games/robot-coder/components/CommandStrip.tsx
+++ b/gamesformykids/app/games/robot-coder/components/CommandStrip.tsx
@@ -1,0 +1,81 @@
+'use client';
+import type { Dir } from './LevelData';
+
+const DIRS: Dir[] = ['↑', '↓', '←', '→'];
+const DIR_LABELS: Record<Dir, string> = { '↑': 'למעלה', '↓': 'למטה', '←': 'שמאלה', '→': 'ימינה' };
+
+type Props = {
+  commands: Dir[];
+  maxCommands: number;
+  isRunning: boolean;
+  animStep: number;
+  onAdd: (dir: Dir) => void;
+  onRemove: (idx: number) => void;
+  onClear: () => void;
+  onRun: () => void;
+};
+
+export default function CommandStrip({ commands, maxCommands, isRunning, animStep, onAdd, onRemove, onClear, onRun }: Props) {
+  const slots = Array.from({ length: maxCommands }, (_, i) => commands[i] ?? null);
+
+  return (
+    <div className="flex flex-col gap-3 w-full items-center" dir="rtl">
+      {/* Direction palette */}
+      <div className="flex gap-2">
+        {DIRS.map(dir => (
+          <button
+            key={dir}
+            onClick={() => onAdd(dir)}
+            disabled={isRunning || commands.length >= maxCommands}
+            title={DIR_LABELS[dir]}
+            className="w-12 h-12 rounded-xl bg-indigo-100 hover:bg-indigo-200 active:bg-indigo-300 border-2 border-indigo-300 text-indigo-700 text-2xl font-bold transition-all disabled:opacity-40 disabled:cursor-not-allowed"
+          >
+            {dir}
+          </button>
+        ))}
+      </div>
+
+      {/* Command slots */}
+      <div className="flex flex-wrap gap-1.5 justify-center">
+        {slots.map((cmd, i) => (
+          <button
+            key={i}
+            onClick={() => cmd && !isRunning && onRemove(i)}
+            disabled={isRunning}
+            className={`w-10 h-10 rounded-xl border-2 text-xl font-bold transition-all ${
+              cmd
+                ? i === animStep - 1 && isRunning
+                  ? 'border-yellow-400 bg-yellow-200 text-yellow-800 scale-110'
+                  : 'border-indigo-400 bg-indigo-100 text-indigo-700 hover:bg-red-100 hover:border-red-400 hover:text-red-600'
+                : 'border-dashed border-gray-300 bg-gray-50 text-gray-300 cursor-default'
+            }`}
+          >
+            {cmd ?? '+'}
+          </button>
+        ))}
+      </div>
+
+      {/* Controls */}
+      <div className="flex gap-2">
+        <button
+          onClick={onClear}
+          disabled={isRunning || commands.length === 0}
+          className="px-4 py-2 rounded-xl bg-gray-200 hover:bg-gray-300 text-gray-700 font-bold text-sm transition-all disabled:opacity-40"
+        >
+          נקה
+        </button>
+        <button
+          onClick={onRun}
+          disabled={isRunning || commands.length === 0}
+          className="px-6 py-2 rounded-xl bg-green-500 hover:bg-green-600 active:bg-green-700 text-white font-extrabold text-base transition-all disabled:opacity-40 shadow-md"
+        >
+          {isRunning ? '⚙️ רץ...' : '▶ הרץ!'}
+        </button>
+      </div>
+
+      <p className="text-xs text-gray-400">
+        {commands.length}/{maxCommands} פקודות • לחץ על פקודה להסרה
+      </p>
+    </div>
+  );
+}

--- a/gamesformykids/app/games/robot-coder/components/LevelData.ts
+++ b/gamesformykids/app/games/robot-coder/components/LevelData.ts
@@ -1,0 +1,117 @@
+export type Dir = '→' | '←' | '↑' | '↓';
+
+export type LetterTile = {
+  row: number;
+  col: number;
+  letter: string;
+};
+
+export type Level = {
+  id: number;
+  gridSize: number;
+  start: { row: number; col: number };
+  letters: LetterTile[];
+  targetWord: string;
+  maxCommands: number;
+  hint: string;
+};
+
+export const LEVELS: Level[] = [
+  // Level 1-3: straight paths
+  {
+    id: 1, gridSize: 4, start: { row: 3, col: 0 },
+    letters: [{ row: 3, col: 1, letter: 'א' }, { row: 3, col: 2, letter: 'ב' }],
+    targetWord: 'אב', maxCommands: 4,
+    hint: 'לך ימינה פעמיים',
+  },
+  {
+    id: 2, gridSize: 4, start: { row: 0, col: 0 },
+    letters: [{ row: 0, col: 2, letter: 'ג' }, { row: 2, col: 2, letter: 'ד' }],
+    targetWord: 'גד', maxCommands: 6,
+    hint: 'לך ימינה ואז למטה',
+  },
+  {
+    id: 3, gridSize: 4, start: { row: 2, col: 0 },
+    letters: [
+      { row: 2, col: 1, letter: 'י' },
+      { row: 2, col: 2, letter: 'ל' },
+      { row: 2, col: 3, letter: 'ד' },
+    ],
+    targetWord: 'ילד', maxCommands: 4,
+    hint: 'לך ימינה שלוש פעמים',
+  },
+  // Level 4-6: L-shapes
+  {
+    id: 4, gridSize: 4, start: { row: 3, col: 0 },
+    letters: [
+      { row: 3, col: 2, letter: 'ש' },
+      { row: 1, col: 2, letter: 'מ' },
+      { row: 1, col: 3, letter: 'ש' },
+    ],
+    targetWord: 'שמש', maxCommands: 6,
+    hint: 'ימינה, למעלה, ימינה שוב',
+  },
+  {
+    id: 5, gridSize: 4, start: { row: 0, col: 3 },
+    letters: [
+      { row: 0, col: 1, letter: 'א' },
+      { row: 2, col: 1, letter: 'ר' },
+      { row: 2, col: 3, letter: 'י' },
+    ],
+    targetWord: 'ארי', maxCommands: 8,
+    hint: 'שמאלה, למטה, ימינה',
+  },
+  {
+    id: 6, gridSize: 5, start: { row: 4, col: 0 },
+    letters: [
+      { row: 4, col: 2, letter: 'ד' },
+      { row: 2, col: 2, letter: 'ב' },
+      { row: 2, col: 4, letter: 'ש' },
+    ],
+    targetWord: 'דבש', maxCommands: 8,
+    hint: 'ימינה, למעלה, ימינה שוב',
+  },
+  // Level 7-9: zigzag
+  {
+    id: 7, gridSize: 5, start: { row: 0, col: 4 },
+    letters: [
+      { row: 0, col: 2, letter: 'כ' },
+      { row: 2, col: 2, letter: 'ל' },
+      { row: 2, col: 0, letter: 'ב' },
+    ],
+    targetWord: 'כלב', maxCommands: 8,
+    hint: 'שמאלה, למטה, שמאלה',
+  },
+  {
+    id: 8, gridSize: 5, start: { row: 4, col: 4 },
+    letters: [
+      { row: 4, col: 1, letter: 'ס' },
+      { row: 1, col: 1, letter: 'פ' },
+      { row: 1, col: 4, letter: 'ר' },
+    ],
+    targetWord: 'ספר', maxCommands: 10,
+    hint: 'שמאלה, למעלה, ימינה',
+  },
+  {
+    id: 9, gridSize: 6, start: { row: 5, col: 0 },
+    letters: [
+      { row: 5, col: 3, letter: 'ח' },
+      { row: 2, col: 3, letter: 'ר' },
+      { row: 2, col: 5, letter: 'ב' },
+    ],
+    targetWord: 'חרב', maxCommands: 10,
+    hint: 'ימינה, למעלה, ימינה',
+  },
+  // Level 10: 4-letter word
+  {
+    id: 10, gridSize: 6, start: { row: 5, col: 0 },
+    letters: [
+      { row: 5, col: 2, letter: 'א' },
+      { row: 3, col: 2, letter: 'ה' },
+      { row: 3, col: 4, letter: 'ב' },
+      { row: 1, col: 4, letter: 'ה' },
+    ],
+    targetWord: 'אהבה', maxCommands: 10,
+    hint: 'ימינה, למעלה, ימינה, למעלה',
+  },
+];

--- a/gamesformykids/app/games/robot-coder/components/RobotGrid.tsx
+++ b/gamesformykids/app/games/robot-coder/components/RobotGrid.tsx
@@ -1,0 +1,73 @@
+'use client';
+import type { Level, LetterTile } from './LevelData';
+
+type Props = {
+  level: Level;
+  robotPos: { row: number; col: number };
+  collectedLetters: string[];
+  animStep: number;
+};
+
+export default function RobotGrid({ level, robotPos, collectedLetters }: Props) {
+  const { gridSize, letters, start } = level;
+
+  const isCollected = (tile: LetterTile) => {
+    const idx = letters.indexOf(tile);
+    return idx < collectedLetters.length;
+  };
+
+  const isStartTile = (row: number, col: number) =>
+    row === start.row && col === start.col;
+
+  const letterAt = (row: number, col: number): LetterTile | null =>
+    letters.find(t => t.row === row && t.col === col) ?? null;
+
+  const isRobot = (row: number, col: number) =>
+    robotPos.row === row && robotPos.col === col;
+
+  const cellSize = gridSize <= 4 ? 'w-14 h-14 sm:w-16 sm:h-16 text-xl' : gridSize === 5 ? 'w-11 h-11 sm:w-14 sm:h-14 text-lg' : 'w-10 h-10 sm:w-12 sm:h-12 text-base';
+
+  return (
+    <div className="flex flex-col gap-1 items-center">
+      {Array.from({ length: gridSize }, (_, row) => (
+        <div key={row} className="flex gap-1">
+          {Array.from({ length: gridSize }, (_, col) => {
+            const tile = letterAt(row, col);
+            const robot = isRobot(row, col);
+            const collected = tile ? isCollected(tile) : false;
+            const isStart = isStartTile(row, col) && !tile;
+
+            return (
+              <div
+                key={col}
+                className={`${cellSize} rounded-xl border-2 flex items-center justify-center font-bold relative transition-all duration-200 ${
+                  tile
+                    ? collected
+                      ? 'border-gray-300 bg-gray-100 text-gray-400'
+                      : 'border-amber-400 bg-amber-50 text-amber-700 shadow-md'
+                    : isStart
+                    ? 'border-dashed border-green-400 bg-green-50'
+                    : 'border-gray-200 bg-white/60'
+                }`}
+              >
+                {tile && (
+                  <span className={collected ? 'line-through opacity-40' : ''}>
+                    {tile.letter}
+                  </span>
+                )}
+                {robot && (
+                  <span
+                    className="absolute inset-0 flex items-center justify-center text-2xl animate-bounce"
+                    style={{ animationDuration: '0.6s' }}
+                  >
+                    🤖
+                  </span>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/gamesformykids/app/games/robot-coder/robotCoderStore.ts
+++ b/gamesformykids/app/games/robot-coder/robotCoderStore.ts
@@ -1,0 +1,116 @@
+'use client';
+import { create } from 'zustand';
+import { LEVELS, type Dir, type Level } from './components/LevelData';
+
+type Phase = 'menu' | 'editing' | 'running' | 'success' | 'fail';
+
+interface State {
+  phase: Phase;
+  levelIdx: number;
+  level: Level;
+  commands: Dir[];
+  robotPos: { row: number; col: number };
+  collectedLetters: string[];
+  animStep: number;
+}
+
+interface Actions {
+  startGame: () => void;
+  nextLevel: () => void;
+  addCommand: (dir: Dir) => void;
+  removeCommand: (idx: number) => void;
+  clearCommands: () => void;
+  run: () => void;
+  executeStep: () => void;
+  resetLevel: () => void;
+  resetGame: () => void;
+}
+
+const DELTA: Record<Dir, { dr: number; dc: number }> = {
+  '↑': { dr: -1, dc: 0 },
+  '↓': { dr: 1,  dc: 0 },
+  '←': { dr: 0,  dc: -1 },
+  '→': { dr: 0,  dc: 1 },
+};
+
+export const useRobotCoderStore = create<State & Actions>((set, get) => ({
+  phase: 'menu',
+  levelIdx: 0,
+  level: LEVELS[0]!,
+  commands: [],
+  robotPos: { ...LEVELS[0]!.start },
+  collectedLetters: [],
+  animStep: 0,
+
+  startGame: () => {
+    const level = LEVELS[0]!;
+    set({ phase: 'editing', levelIdx: 0, level, commands: [], robotPos: { ...level.start }, collectedLetters: [], animStep: 0 });
+  },
+
+  nextLevel: () => {
+    const { levelIdx } = get();
+    const nextIdx = levelIdx + 1;
+    if (nextIdx >= LEVELS.length) {
+      set({ phase: 'menu' });
+      return;
+    }
+    const level = LEVELS[nextIdx]!;
+    set({ phase: 'editing', levelIdx: nextIdx, level, commands: [], robotPos: { ...level.start }, collectedLetters: [], animStep: 0 });
+  },
+
+  addCommand: (dir) => {
+    const { commands, level } = get();
+    if (commands.length >= level.maxCommands) return;
+    set({ commands: [...commands, dir] });
+  },
+
+  removeCommand: (idx) => {
+    const { commands } = get();
+    set({ commands: commands.filter((_, i) => i !== idx) });
+  },
+
+  clearCommands: () => set({ commands: [] }),
+
+  run: () => {
+    const { commands, level } = get();
+    if (commands.length === 0) return;
+    set({ phase: 'running', robotPos: { ...level.start }, collectedLetters: [], animStep: 0 });
+  },
+
+  executeStep: () => {
+    const { animStep, commands, robotPos, collectedLetters, level } = get();
+    const dir = commands[animStep];
+    if (!dir) return;
+
+    const { dr, dc } = DELTA[dir];
+    const newRow = robotPos.row + dr;
+    const newCol = robotPos.col + dc;
+
+    if (newRow < 0 || newRow >= level.gridSize || newCol < 0 || newCol >= level.gridSize) {
+      set({ phase: 'fail' });
+      return;
+    }
+
+    const tile = level.letters.find(t => t.row === newRow && t.col === newCol);
+    const newCollected = tile ? [...collectedLetters, tile.letter] : collectedLetters;
+    const newStep = animStep + 1;
+
+    const isDone = newStep >= commands.length;
+    let newPhase: Phase = 'running';
+    if (isDone) {
+      newPhase = newCollected.join('') === level.targetWord ? 'success' : 'fail';
+    }
+
+    set({ robotPos: { row: newRow, col: newCol }, collectedLetters: newCollected, animStep: newStep, phase: newPhase });
+  },
+
+  resetLevel: () => {
+    const { level } = get();
+    set({ phase: 'editing', robotPos: { ...level.start }, collectedLetters: [], animStep: 0 });
+  },
+
+  resetGame: () => {
+    const level = LEVELS[0]!;
+    set({ phase: 'menu', levelIdx: 0, level, commands: [], robotPos: { ...level.start }, collectedLetters: [], animStep: 0 });
+  },
+}));

--- a/gamesformykids/app/games/robot-coder/useRobotCoder.ts
+++ b/gamesformykids/app/games/robot-coder/useRobotCoder.ts
@@ -1,0 +1,40 @@
+'use client';
+import { useEffect } from 'react';
+import { useRobotCoderStore } from './robotCoderStore';
+import { speakHebrew } from '@/lib/utils/speech/enhancedSpeechUtils';
+
+export function useRobotCoder() {
+  const phase          = useRobotCoderStore(s => s.phase);
+  const levelIdx       = useRobotCoderStore(s => s.levelIdx);
+  const level          = useRobotCoderStore(s => s.level);
+  const commands       = useRobotCoderStore(s => s.commands);
+  const robotPos       = useRobotCoderStore(s => s.robotPos);
+  const collectedLetters = useRobotCoderStore(s => s.collectedLetters);
+  const animStep       = useRobotCoderStore(s => s.animStep);
+  const { startGame, nextLevel, addCommand, removeCommand, clearCommands, run, executeStep, resetLevel, resetGame } = useRobotCoderStore();
+
+  // Drive step-by-step animation
+  useEffect(() => {
+    if (phase !== 'running') return;
+    if (animStep >= commands.length) return;
+    const timer = setTimeout(() => {
+      executeStep();
+    }, 450);
+    return () => clearTimeout(timer);
+  }, [phase, animStep, commands.length, executeStep]);
+
+  // Speak feedback on phase change
+  useEffect(() => {
+    if (phase === 'success') {
+      speakHebrew(`${level.targetWord}! כל הכבוד!`);
+    } else if (phase === 'fail') {
+      speakHebrew('לא הצלחנו — בוא ננסה שוב!');
+    }
+  }, [phase, level.targetWord]);
+
+  return {
+    phase, levelIdx, level, commands, robotPos, collectedLetters, animStep,
+    totalLevels: 10,
+    startGame, nextLevel, addCommand, removeCommand, clearCommands, run, resetLevel, resetGame,
+  };
+}

--- a/gamesformykids/lib/constants/gameCategories.ts
+++ b/gamesformykids/lib/constants/gameCategories.ts
@@ -131,6 +131,6 @@ export const GAME_CATEGORIES: Record<string, GameCategory> = {
     icon: Book,
     color: "bg-teal-500",
     gradient: "from-teal-400 to-cyan-600",
-    gameIds: ["true-false","emoji-math","math-race","number-bubbles","word-scramble","word-builder","word-chain","trivia","clock","spelling","opposites","world-languages","riddles","english-words","singular-plural","adjectives","verbs","visual-opposites","english-cards","proverbs","story-builder"],
+    gameIds: ["true-false","emoji-math","math-race","number-bubbles","word-scramble","word-builder","word-chain","trivia","clock","spelling","opposites","world-languages","riddles","english-words","singular-plural","adjectives","verbs","visual-opposites","english-cards","proverbs","story-builder","robot-coder"],
   },
 };

--- a/gamesformykids/lib/registry/registryData/batch4.ts
+++ b/gamesformykids/lib/registry/registryData/batch4.ts
@@ -597,4 +597,15 @@ export const gamesRegistryBatch4: GameRegistration[] = [
     available: true,
     order: 175,
   },
+  {
+    id: "robot-coder",
+    title: "תכנת את הרובוט",
+    description: "הכנס פקודות לרובוט ואסוף אותיות עברית — הכר תכנות!",
+    icon: Cpu,
+    emoji: "🤖",
+    color: "bg-indigo-600 hover:bg-indigo-700",
+    href: "/games/robot-coder",
+    available: true,
+    order: 176,
+  },
 ];

--- a/gamesformykids/lib/types/core/base.ts
+++ b/gamesformykids/lib/types/core/base.ts
@@ -204,4 +204,6 @@ export type GameType =
   // Story & creative games
   | 'story-builder'
   // Escape & adventure games
-  | 'escape-room';
+  | 'escape-room'
+  // Coding & logic games
+  | 'robot-coder';


### PR DESCRIPTION
## What
Adds a 10-level grid-based programming game where the player arranges directional arrow commands (↑↓←→) in a command strip, presses \"הרץ!\", and watches the robot walk step-by-step collecting Hebrew letters to spell a target word.

## Features
- 10 levels with increasing grid size (4×4 → 6×6) and path complexity (straight → L-shape → zigzag)
- Click-to-add from arrow palette; click-to-remove from command strip (works on mobile touch)
- Step-by-step animated robot movement (🤖) with 450ms delay per step
- Real-time letter progress indicator (collected vs. still needed)
- TTS reads success word and failure message in Hebrew
- Hint text shown on failure screen per level

## Why
Closes #1246

## Test plan
- [ ] Visit `/games/robot-coder` — menu screen loads
- [ ] Start game → level 1 shows 4×4 grid with letters א ב
- [ ] Click → → in palette → two slots fill in command strip
- [ ] Press הרץ! → robot animates right-right, collects both letters → success screen
- [ ] Wrong path (← for level 1) → fail screen with hint
- [ ] Continue button advances to level 2
- [ ] Level 10 (4-letter word "אהבה") works correctly
- [ ] Appears in educational category on home page
- [ ] Mobile touch works for adding/removing commands

🤖 Generated with [Claude Code](https://claude.com/claude-code)