### PR TITLE
feat(kids-songs): add Hebrew children's songs karaoke game (closes #1238)

### DIFF
--- a/gamesformykids/app/games/[gameType]/CustomGameRenderer.tsx
+++ b/gamesformykids/app/games/[gameType]/CustomGameRenderer.tsx
@@ -56,7 +56,9 @@ const GAME_CLIENTS: Record<string, ComponentType> = {
   'picture-dictionary':  dynamic(() => import('../picture-dictionary/PictureDictionaryClient'),        { ssr: false }),
 
   'word-search':       dynamic(() => import('../word-search/WordSearchClient'),                      { ssr: false }),
+
   'israel-map':        dynamic(() => import('../israel-map/IsraelMapClient'),                        { ssr: false }),
+  'kids-songs':        dynamic(() => import('../kids-songs/KidsSongsClient'),                        { ssr: false }),
 };
 
 interface Props { gameType: string; }

--- a/gamesformykids/app/games/[gameType]/gamePageConstants.ts
+++ b/gamesformykids/app/games/[gameType]/gamePageConstants.ts
@@ -74,7 +74,9 @@ export const SUPPORTED_GAMES = [
   'picture-dictionary',
 
   'word-search',
+
   'israel-map',
+  'kids-songs',
 ] as const;
 
 export type SupportedGameType = typeof SUPPORTED_GAMES[number];
@@ -88,7 +90,9 @@ export const CUSTOM_GAME_TYPES = new Set([
   'stack', 'taki', 'tetris', 'true-false', 'tzedakah', 'whack-a-mole',
   'word-builder', 'word-scramble', 'maze', 'letter-defender', 'puppet-story', 'number-slide', 'snakes-ladders',
 
-  'escape-room', 'robot-coder', 'find-in-scene', 'hangman', 'choose-adventure', 'picture-dictionary', 'word-search', 'israel-map',
+
+  'escape-room', 'robot-coder', 'find-in-scene', 'hangman', 'choose-adventure', 'picture-dictionary', 'word-search', 'israel-map', 'kids-songs',
+  
   
 ]);
 

--- a/gamesformykids/app/games/kids-songs/KidsSongsClient.tsx
+++ b/gamesformykids/app/games/kids-songs/KidsSongsClient.tsx
@@ -1,0 +1,68 @@
+'use client';
+import { useKidsSongsStore } from './kidsSongsStore';
+import SongPicker from './components/SongPicker';
+import LyricsDisplay from './components/LyricsDisplay';
+import SongQuiz from './components/SongQuiz';
+import GameResultCard from '@/components/game/shared/GameResultCard';
+
+export default function KidsSongsClient() {
+  const {
+    phase,
+    currentSong,
+    currentQuestionIdx,
+    score,
+    selectSong,
+    startQuiz,
+    answerQuestion,
+    nextQuestion,
+    resetGame,
+  } = useKidsSongsStore();
+
+  if (phase === 'menu' || !currentSong) {
+    return <SongPicker onSelect={selectSong} />;
+  }
+
+  if (phase === 'lyrics') {
+    return (
+      <LyricsDisplay
+        key={currentSong.id}
+        song={currentSong}
+        onFinish={startQuiz}
+        onBack={resetGame}
+      />
+    );
+  }
+
+  if (phase === 'quiz') {
+    return (
+      <SongQuiz
+        song={currentSong}
+        question={currentSong.questions[currentQuestionIdx as 0 | 1]}
+        questionNum={currentQuestionIdx + 1}
+        onAnswer={(idx) => {
+          answerQuestion(idx);
+          nextQuestion();
+        }}
+      />
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-purple-100 to-pink-100 flex items-center justify-center p-6">
+      <GameResultCard
+        emoji={currentSong.emoji}
+        title={`${currentSong.title} — סיימת!`}
+        gradientClass="from-purple-500 to-pink-600"
+        buttonClass="bg-purple-600 hover:bg-purple-700"
+        onRestart={resetGame}
+        restartLabel="שיר נוסף"
+        score={score}
+        scorePercent={(score / 2) * 100}
+      >
+        <p className="text-center text-purple-700 font-medium mt-2">
+          ענית נכון על {score} מתוך 2 שאלות
+        </p>
+      </GameResultCard>
+    </div>
+  );
+}

--- a/gamesformykids/app/games/kids-songs/components/LyricsDisplay.tsx
+++ b/gamesformykids/app/games/kids-songs/components/LyricsDisplay.tsx
@@ -1,0 +1,171 @@
+'use client';
+import { useState, useEffect, useCallback, useRef } from 'react';
+import type { SongData } from '../data/songs';
+
+interface Props {
+  song: SongData;
+  onFinish: () => void;
+  onBack: () => void;
+}
+
+export default function LyricsDisplay({ song, onFinish, onBack }: Props) {
+  const [lineIdx, setLineIdx] = useState(0);
+  const [wordIdx, setWordIdx] = useState(-1);
+  const [playing, setPlaying] = useState(false);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const onFinishRef = useRef(onFinish);
+  onFinishRef.current = onFinish;
+
+  const cancel = useCallback(() => {
+    window.speechSynthesis.cancel();
+    if (timerRef.current) clearTimeout(timerRef.current);
+  }, []);
+
+  const advance = useCallback((idx: number) => {
+    cancel();
+    if (idx >= song.lines.length) {
+      onFinishRef.current();
+      return;
+    }
+    setLineIdx(idx);
+    setWordIdx(-1);
+    setPlaying(true);
+
+    const line = song.lines[idx] ?? '';
+    const words = line.split(' ');
+
+    // Precompute char offsets for word-boundary highlighting
+    const wordStarts: number[] = [];
+    let pos = 0;
+    for (const word of words) {
+      wordStarts.push(pos);
+      pos += word.length + 1;
+    }
+
+    const utter = new SpeechSynthesisUtterance(line);
+    utter.lang = 'he-IL';
+    utter.rate = 0.85;
+
+    utter.onboundary = (e: SpeechSynthesisEvent) => {
+      if (e.name !== 'word') return;
+      let found = 0;
+      for (let i = wordStarts.length - 1; i >= 0; i--) {
+        if ((wordStarts[i] ?? 0) <= e.charIndex) { found = i; break; }
+      }
+      setWordIdx(found);
+    };
+
+    utter.onend = () => {
+      setWordIdx(-1);
+      setPlaying(false);
+      timerRef.current = setTimeout(() => advance(idx + 1), 1000);
+    };
+
+    utter.onerror = () => setPlaying(false);
+    window.speechSynthesis.speak(utter);
+  }, [song, cancel]);
+
+  useEffect(() => {
+    advance(0);
+    return cancel;
+  }, [advance, cancel]);
+
+  const handleReplay = () => {
+    if (timerRef.current) clearTimeout(timerRef.current);
+    advance(lineIdx);
+  };
+
+  const handleNext = () => {
+    cancel();
+    if (lineIdx + 1 >= song.lines.length) {
+      onFinishRef.current();
+    } else {
+      advance(lineIdx + 1);
+    }
+  };
+
+  const handleBack = () => {
+    cancel();
+    onBack();
+  };
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-indigo-50 to-purple-100 flex flex-col items-center p-6">
+      <div className="w-full max-w-lg">
+        {/* Header */}
+        <div className="flex items-center mb-6 mt-2">
+          <button onClick={handleBack} className="text-purple-500 hover:text-purple-700 text-2xl ml-3">→</button>
+          <div className="text-4xl mx-3">{song.emoji}</div>
+          <h2 className="text-2xl font-bold text-purple-800">{song.title}</h2>
+        </div>
+
+        {/* Lyrics card */}
+        <div className="bg-white rounded-2xl shadow-lg p-6 mb-6" dir="rtl">
+          {song.lines.map((line, li) => {
+            const isCurrent = li === lineIdx;
+            const words = line.split(' ');
+            return (
+              <div
+                key={li}
+                className={`text-center py-3 px-4 rounded-xl mb-2 transition-all duration-300 ${
+                  isCurrent
+                    ? 'bg-purple-100 scale-105'
+                    : li < lineIdx
+                    ? 'opacity-40'
+                    : 'opacity-25'
+                }`}
+              >
+                {isCurrent ? (
+                  <span className={`text-xl font-bold text-purple-900 ${playing ? '' : ''}`}>
+                    {words.map((word, wi) => (
+                      <span
+                        key={wi}
+                        className={`inline-block mx-1 transition-all duration-150 rounded px-1 ${
+                          wi === wordIdx
+                            ? 'bg-yellow-300 text-yellow-900 scale-110'
+                            : 'text-purple-900'
+                        }`}
+                      >
+                        {word}
+                      </span>
+                    ))}
+                  </span>
+                ) : (
+                  <span className="text-base text-gray-600">{line}</span>
+                )}
+              </div>
+            );
+          })}
+        </div>
+
+        {/* Progress dots */}
+        <div className="flex justify-center gap-2 mb-6">
+          {song.lines.map((_, i) => (
+            <div
+              key={i}
+              className={`w-3 h-3 rounded-full transition-all ${
+                i < lineIdx ? 'bg-purple-500' : i === lineIdx ? 'bg-yellow-400 scale-125' : 'bg-gray-200'
+              }`}
+            />
+          ))}
+        </div>
+
+        {/* Controls */}
+        <div className="flex gap-3 justify-center">
+          <button
+            onClick={handleReplay}
+            className="bg-white border-2 border-purple-400 text-purple-700 px-5 py-2 rounded-xl font-medium hover:bg-purple-50 transition-colors"
+          >
+            🔄 שוב
+          </button>
+          <button
+            onClick={handleNext}
+            className="bg-purple-600 text-white px-6 py-2 rounded-xl font-bold hover:bg-purple-700 shadow transition-colors"
+          >
+            {lineIdx + 1 >= song.lines.length ? '✅ לשאלות' : 'הבא ←'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/gamesformykids/app/games/kids-songs/components/SongPicker.tsx
+++ b/gamesformykids/app/games/kids-songs/components/SongPicker.tsx
@@ -1,0 +1,27 @@
+'use client';
+import { SONGS, type SongData } from '../data/songs';
+
+interface Props {
+  onSelect: (song: SongData) => void;
+}
+
+export default function SongPicker({ onSelect }: Props) {
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-purple-100 to-pink-100 flex flex-col items-center p-6">
+      <h1 className="text-3xl font-bold text-purple-800 mb-2 mt-6">🎵 שירי ילדים</h1>
+      <p className="text-purple-600 mb-8 text-center">בחר שיר, האזן ולמד!</p>
+      <div className="grid grid-cols-2 gap-4 w-full max-w-lg">
+        {SONGS.map((song) => (
+          <button
+            key={song.id}
+            onClick={() => onSelect(song)}
+            className={`bg-gradient-to-br ${song.color} text-white rounded-2xl p-5 shadow-lg hover:scale-105 active:scale-95 transition-transform text-center`}
+          >
+            <div className="text-4xl mb-2">{song.emoji}</div>
+            <div className="text-lg font-bold">{song.title}</div>
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/gamesformykids/app/games/kids-songs/components/SongQuiz.tsx
+++ b/gamesformykids/app/games/kids-songs/components/SongQuiz.tsx
@@ -1,0 +1,86 @@
+'use client';
+import { useState } from 'react';
+import type { SongData, ComprehensionQuestion } from '../data/songs';
+
+interface Props {
+  song: SongData;
+  question: ComprehensionQuestion;
+  questionNum: number;
+  onAnswer: (idx: number) => void;
+}
+
+export default function SongQuiz({ song, question, questionNum, onAnswer }: Props) {
+  const [selected, setSelected] = useState<number | null>(null);
+  const [submitted, setSubmitted] = useState(false);
+
+  const handleSubmit = () => {
+    if (selected === null) return;
+    setSubmitted(true);
+    setTimeout(() => onAnswer(selected), 1500);
+  };
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-purple-100 to-pink-100 flex flex-col items-center p-6" dir="rtl">
+      <div className="w-full max-w-md mt-6">
+        <div className="text-center mb-6">
+          <div className="text-5xl mb-2">{song.emoji}</div>
+          <h2 className="text-xl font-bold text-purple-700">{song.title}</h2>
+          <p className="text-purple-500 mt-1">שאלה {questionNum} מתוך 2</p>
+        </div>
+
+        <div className="bg-white rounded-2xl shadow-lg p-6 mb-6">
+          <p className="text-xl font-bold text-center text-purple-800 mb-6">{question.question}</p>
+          <div className="grid grid-cols-2 gap-3">
+            {question.options.map((option, idx) => {
+              let cls =
+                'p-4 rounded-xl border-2 font-semibold text-center transition-all text-base cursor-pointer ';
+              if (!submitted) {
+                cls +=
+                  selected === idx
+                    ? 'border-purple-500 bg-purple-100 text-purple-800'
+                    : 'border-gray-200 bg-white text-gray-700 hover:border-purple-300 hover:bg-purple-50';
+              } else {
+                if (idx === question.correctIndex) {
+                  cls += 'border-green-500 bg-green-100 text-green-800';
+                } else if (idx === selected && idx !== question.correctIndex) {
+                  cls += 'border-red-400 bg-red-100 text-red-700';
+                } else {
+                  cls += 'border-gray-100 bg-white text-gray-400';
+                }
+              }
+              return (
+                <button
+                  key={idx}
+                  className={cls}
+                  onClick={() => !submitted && setSelected(idx)}
+                >
+                  {option}
+                </button>
+              );
+            })}
+          </div>
+        </div>
+
+        {!submitted ? (
+          <button
+            onClick={handleSubmit}
+            disabled={selected === null}
+            className="w-full bg-purple-600 text-white py-3 rounded-xl font-bold text-lg shadow hover:bg-purple-700 disabled:opacity-40 transition-colors"
+          >
+            אישור
+          </button>
+        ) : (
+          <div
+            className={`text-center text-2xl font-bold ${
+              selected === question.correctIndex ? 'text-green-600' : 'text-red-500'
+            }`}
+          >
+            {selected === question.correctIndex
+              ? '✅ כל הכבוד!'
+              : `❌ הנכון: ${question.options[question.correctIndex]}`}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/gamesformykids/app/games/kids-songs/data/songs.ts
+++ b/gamesformykids/app/games/kids-songs/data/songs.ts
@@ -1,0 +1,227 @@
+'use client';
+
+export type ComprehensionQuestion = {
+  question: string;
+  options: [string, string, string, string];
+  correctIndex: 0 | 1 | 2 | 3;
+};
+
+export type SongData = {
+  id: string;
+  title: string;
+  emoji: string;
+  color: string;
+  lines: string[];
+  questions: [ComprehensionQuestion, ComprehensionQuestion];
+};
+
+export const SONGS: SongData[] = [
+  {
+    id: 'kochav-katan',
+    title: 'כוכב קטן',
+    emoji: '⭐',
+    color: 'from-indigo-400 to-purple-600',
+    lines: [
+      'כוכב כוכב קטן',
+      'מה אתה שם שם בחשכן',
+      'מעלה מעלה באוויר',
+      'כמו יהלום שמבהיר',
+      'כוכב כוכב קטן',
+      'מה אתה שם שם בחשכן',
+    ],
+    questions: [
+      {
+        question: 'למה מדמים את הכוכב בשיר?',
+        options: ['ליהלום', 'לתפוח', 'לשמש', 'לירח'],
+        correctIndex: 0,
+      },
+      {
+        question: 'איפה נמצא הכוכב?',
+        options: ['בשמים', 'בים', 'בהר', 'בבית'],
+        correctIndex: 0,
+      },
+    ],
+  },
+  {
+    id: 'geshem',
+    title: 'שיר הגשם',
+    emoji: '🌧️',
+    color: 'from-blue-400 to-cyan-600',
+    lines: [
+      'יורד הגשם יורד',
+      'על הגג על הגג',
+      'גשם גשם גשמי ברכה',
+      'תן לנו ולכל ברכה',
+      'יורד הגשם יורד',
+      'על הגג על הגג',
+    ],
+    questions: [
+      {
+        question: 'מה יורד בשיר?',
+        options: ['גשם', 'שלג', 'ברד', 'טל'],
+        correctIndex: 0,
+      },
+      {
+        question: 'על מה יורד הגשם בשיר?',
+        options: ['על הגג', 'על השדה', 'על הים', 'על ההר'],
+        correctIndex: 0,
+      },
+    ],
+  },
+  {
+    id: 'rosh-hashana',
+    title: 'ראש השנה',
+    emoji: '🍎',
+    color: 'from-red-400 to-orange-500',
+    lines: [
+      'ראש השנה בא',
+      'ראש השנה בא',
+      'תפוח בדבש נאכל',
+      'שנה טובה נקבל',
+      'שנה טובה ומתוקה',
+      'שנה טובה ומתוקה',
+    ],
+    questions: [
+      {
+        question: 'מה אוכלים בראש השנה לפי השיר?',
+        options: ['תפוח בדבש', 'עוגה', 'לחם', 'שוקולד'],
+        correctIndex: 0,
+      },
+      {
+        question: 'מה מאחלים בסוף השיר?',
+        options: ['שנה טובה', 'חג שמח', 'בוקר טוב', 'ערב טוב'],
+        correctIndex: 0,
+      },
+    ],
+  },
+  {
+    id: 'haver',
+    title: 'יש לי חבר',
+    emoji: '🤝',
+    color: 'from-green-400 to-teal-600',
+    lines: [
+      'יש לי חבר',
+      'חבר טוב יש לי',
+      'כשאני עצוב הוא משמח אותי',
+      'כשאני בוכה הוא מנחם אותי',
+      'יש לי חבר',
+      'חבר טוב יש לי',
+    ],
+    questions: [
+      {
+        question: 'מה עושה החבר כשהילד עצוב?',
+        options: ['משמח אותו', 'בוכה איתו', 'הולך הביתה', 'ישן'],
+        correctIndex: 0,
+      },
+      {
+        question: 'מה עושה החבר כשהילד בוכה?',
+        options: ['מנחם אותו', 'צוחק', 'הולך הביתה', 'אוכל'],
+        correctIndex: 0,
+      },
+    ],
+  },
+  {
+    id: 'ima',
+    title: 'אמא אמא',
+    emoji: '💕',
+    color: 'from-pink-400 to-rose-600',
+    lines: [
+      'אמא אמא',
+      'כמה אני אוהב אותך',
+      'אמא אמא',
+      'אין כמוך בעולם',
+      'חיבוק ונשיקה',
+      'אמא שלי הכי טובה',
+    ],
+    questions: [
+      {
+        question: 'את מי אוהב הילד בשיר?',
+        options: ['את אמא', 'את אבא', 'את הסבתא', 'את האח'],
+        correctIndex: 0,
+      },
+      {
+        question: 'מה נותן הילד לאמא?',
+        options: ['חיבוק ונשיקה', 'ממתק', 'פרח', 'ציור'],
+        correctIndex: 0,
+      },
+    ],
+  },
+  {
+    id: 'shabbat',
+    title: 'שבת שלום',
+    emoji: '🕯️',
+    color: 'from-yellow-400 to-amber-600',
+    lines: [
+      'שבת שלום שבת שלום',
+      'שבת שלום ומבורך',
+      'נרות של שבת דולקים',
+      'לב שמח לנו מביאים',
+      'שבת שלום שבת שלום',
+      'שבת שלום ומבורך',
+    ],
+    questions: [
+      {
+        question: 'מה דולקים בשבת לפי השיר?',
+        options: ['נרות', 'מנגל', 'פנס', 'מדורה'],
+        correctIndex: 0,
+      },
+      {
+        question: 'מה מביאים נרות השבת?',
+        options: ['לב שמח', 'אוכל טוב', 'ממתקים', 'שירים'],
+        correctIndex: 0,
+      },
+    ],
+  },
+  {
+    id: 'chanukah',
+    title: 'חנוכה',
+    emoji: '🕎',
+    color: 'from-blue-500 to-indigo-700',
+    lines: [
+      'חנוכה חנוכה',
+      'חג יפה כל כך',
+      'אור חביב סביב',
+      'סביבון סוב סוב סוב',
+      'חנוכה חנוכה',
+      'חג יפה כל כך',
+    ],
+    questions: [
+      {
+        question: 'מה סובב בחנוכה לפי השיר?',
+        options: ['סביבון', 'כדור', 'גלגל', 'חישוק'],
+        correctIndex: 0,
+      },
+      {
+        question: 'איזה חג מתואר בשיר?',
+        options: ['חנוכה', 'פסח', 'סוכות', 'ראש השנה'],
+        correctIndex: 0,
+      },
+    ],
+  },
+  {
+    id: 'boker-tov',
+    title: 'בוקר טוב',
+    emoji: '☀️',
+    color: 'from-orange-300 to-yellow-500',
+    lines: [
+      'בוקר טוב בוקר טוב',
+      'יום חדש עלה',
+      'השמש זורחת בשמים',
+      'ואנחנו שמחים',
+      'בוקר טוב בוקר טוב',
+      'יום חדש עלה',
+    ],
+    questions: [
+      {
+        question: 'מה עלה בבוקר לפי השיר?',
+        options: ['יום חדש', 'ירח', 'כוכב', 'עב'],
+        correctIndex: 0,
+      },
+      {
+        question: 'מה זורחת בשמים?',
+        options: ['השמש', 'הירח', 'הכוכב', 'הברק'],
+        correctIndex: 0,
+      },
+    ],
+  },
+];

--- a/gamesformykids/app/games/kids-songs/kidsSongsStore.ts
+++ b/gamesformykids/app/games/kids-songs/kidsSongsStore.ts
@@ -1,0 +1,56 @@
+'use client';
+import { create } from 'zustand';
+import type { SongData } from './data/songs';
+
+export type Phase = 'menu' | 'lyrics' | 'quiz' | 'result';
+
+interface State {
+  phase: Phase;
+  currentSong: SongData | null;
+  currentQuestionIdx: number;
+  answers: (number | null)[];
+  score: number;
+}
+
+interface Actions {
+  selectSong: (song: SongData) => void;
+  startQuiz: () => void;
+  answerQuestion: (optIdx: number) => void;
+  nextQuestion: () => void;
+  resetGame: () => void;
+}
+
+export const useKidsSongsStore = create<State & Actions>((set, get) => ({
+  phase: 'menu',
+  currentSong: null,
+  currentQuestionIdx: 0,
+  answers: [null, null],
+  score: 0,
+
+  selectSong: (song) =>
+    set({ currentSong: song, phase: 'lyrics', currentQuestionIdx: 0, answers: [null, null], score: 0 }),
+
+  startQuiz: () => set({ phase: 'quiz', currentQuestionIdx: 0 }),
+
+  answerQuestion: (optIdx) => {
+    const { currentSong, currentQuestionIdx, score } = get();
+    if (!currentSong) return;
+    const q = currentSong.questions[currentQuestionIdx as 0 | 1];
+    const isCorrect = q !== undefined && optIdx === q.correctIndex;
+    const newAnswers = [null, null] as (number | null)[];
+    newAnswers[currentQuestionIdx] = optIdx;
+    set({ answers: newAnswers, score: isCorrect ? score + 1 : score });
+  },
+
+  nextQuestion: () => {
+    const { currentQuestionIdx } = get();
+    if (currentQuestionIdx < 1) {
+      set({ currentQuestionIdx: 1 });
+    } else {
+      set({ phase: 'result' });
+    }
+  },
+
+  resetGame: () =>
+    set({ phase: 'menu', currentSong: null, currentQuestionIdx: 0, answers: [null, null], score: 0 }),
+}));

--- a/gamesformykids/lib/constants/gameCategories.ts
+++ b/gamesformykids/lib/constants/gameCategories.ts
@@ -131,6 +131,7 @@ export const GAME_CATEGORIES: Record<string, GameCategory> = {
     icon: Book,
     color: "bg-teal-500",
     gradient: "from-teal-400 to-cyan-600",
-    gameIds: ["true-false","emoji-math","math-race","number-bubbles","word-scramble","word-builder","word-chain","trivia","clock","spelling","opposites","world-languages","riddles","english-words","singular-plural","adjectives","verbs","visual-opposites","english-cards","proverbs","story-builder","robot-coder","hangman","choose-adventure","picture-dictionary","word-search"],
+
+    gameIds: ["true-false","emoji-math","math-race","number-bubbles","word-scramble","word-builder","word-chain","trivia","clock","spelling","opposites","world-languages","riddles","english-words","singular-plural","adjectives","verbs","visual-opposites","english-cards","proverbs","story-builder","robot-coder","hangman","choose-adventure","picture-dictionary","word-search","kids-songs"],
   },
 };

--- a/gamesformykids/lib/registry/registryData/batch4.ts
+++ b/gamesformykids/lib/registry/registryData/batch4.ts
@@ -677,4 +677,15 @@ export const gamesRegistryBatch4: GameRegistration[] = [
     available: true,
     order: 182,
   },
+  {
+    id: "kids-songs",
+    title: "שירי ילדים",
+    description: "האזן לשירי ילדים עבריים, עקוב אחר המילים ובדוק הבנה — 8 שירים!",
+    icon: Music,
+    emoji: "🎵",
+    color: "bg-purple-500 hover:bg-purple-600",
+    href: "/games/kids-songs",
+    available: true,
+    order: 183,
+  },
 ];

--- a/gamesformykids/lib/types/core/base.ts
+++ b/gamesformykids/lib/types/core/base.ts
@@ -218,5 +218,8 @@ export type GameType =
 
   // Word search games
   | 'word-search'
+
   // Interactive map
-  | 'israel-map';
+  | 'israel-map'
+  // Music & songs
+  | 'kids-songs';


### PR DESCRIPTION
## What
Adds a Hebrew children's songs karaoke game with 8 classic songs.

Each song is displayed line-by-line. TTS reads each line aloud and highlights individual words in real time via SpeechSynthesis `boundary` events (word-level karaoke). After all lines play, 2 comprehension questions test the child's understanding with 4-choice answers.

**Songs included:** כוכב קטן, שיר הגשם, ראש השנה, יש לי חבר, אמא אמא, שבת שלום, חנוכה, בוקר טוב.

## Implementation
- Style D (Custom Game): Zustand store + client component
- Word-level karaoke via `SpeechSynthesisUtterance.onboundary` with char offset mapping
- Line-by-line auto-advance with 1 s pause between lines
- Manual "הבא" skip button + "שוב" replay
- 2 comprehension questions per song (SongQuiz component)
- Result screen via GameResultCard

## Why
Closes #1238

## Test plan
- [ ] Visit `/games/kids-songs` — 8 song picker tiles appear
- [ ] Select a song — lyrics appear and TTS starts automatically
- [ ] Current line is highlighted; current word highlights in yellow (where browser supports boundary events)
- [ ] Song auto-advances through all lines then shows comprehension questions
- [ ] Manual "הבא" button skips to next line
- [ ] Manual "שוב" button replays current line
- [ ] Answering both questions leads to result screen with score
- [ ] Result screen shows "שיר נוסף" restart button
- [ ] Game appears in educational category on home page

🤖 Generated with [Claude Code](https://claude.com/claude-code)