### PR TITLE
feat(picture-dictionary): visual Hebrew dictionary browsing 1000+ words (closes #1225)

### DIFF
--- a/gamesformykids/app/games/[gameType]/CustomGameRenderer.tsx
+++ b/gamesformykids/app/games/[gameType]/CustomGameRenderer.tsx
@@ -53,6 +53,7 @@ const GAME_CLIENTS: Record<string, ComponentType> = {
   'find-in-scene':    dynamic(() => import('../find-in-scene/FindInSceneClient'),                  { ssr: false }),
   'hangman':           dynamic(() => import('../hangman/HangmanClient'),                             { ssr: false }),
   'choose-adventure':  dynamic(() => import('../choose-adventure/ChooseAdventureClient'),            { ssr: false }),
+  'picture-dictionary':  dynamic(() => import('../picture-dictionary/PictureDictionaryClient'),        { ssr: false }),
 };
 
 interface Props { gameType: string; }

--- a/gamesformykids/app/games/[gameType]/gamePageConstants.ts
+++ b/gamesformykids/app/games/[gameType]/gamePageConstants.ts
@@ -71,6 +71,7 @@ export const SUPPORTED_GAMES = [
   'find-in-scene',
   'hangman',
   'choose-adventure',
+  'picture-dictionary',
 ] as const;
 
 export type SupportedGameType = typeof SUPPORTED_GAMES[number];
@@ -83,7 +84,7 @@ export const CUSTOM_GAME_TYPES = new Set([
   'puzzles', 'reflex', 'shesh-besh', 'simon', 'snake', 'space-defender',
   'stack', 'taki', 'tetris', 'true-false', 'tzedakah', 'whack-a-mole',
   'word-builder', 'word-scramble', 'maze', 'letter-defender', 'puppet-story', 'number-slide', 'snakes-ladders',
-  'escape-room', 'robot-coder', 'find-in-scene', 'hangman', 'choose-adventure',
+  'escape-room', 'robot-coder', 'find-in-scene', 'hangman', 'choose-adventure', 'picture-dictionary',
 ]);
 
 // ─── מיפוי URL → GameType ──────────────────────────────────────────────────────

--- a/gamesformykids/app/games/picture-dictionary/PictureDictionaryClient.tsx
+++ b/gamesformykids/app/games/picture-dictionary/PictureDictionaryClient.tsx
@@ -1,0 +1,112 @@
+'use client';
+import { useEffect } from 'react';
+import { usePictureDictionaryStore } from './pictureDictionaryStore';
+import type { BrowseMode } from './pictureDictionaryStore';
+import DictionaryBrowse from './components/DictionaryBrowse';
+import DictionaryCard from './components/DictionaryCard';
+
+const TABS: { mode: BrowseMode; label: string; icon: string }[] = [
+  { mode: 'letter', label: 'לפי אות', icon: '🔤' },
+  { mode: 'category', label: 'לפי נושא', icon: '📂' },
+  { mode: 'search', label: 'חיפוש', icon: '🔍' },
+  { mode: 'collection', label: 'האוסף שלי', icon: '⭐' },
+];
+
+function CollectionTab() {
+  const { collection, expandItem } = usePictureDictionaryStore();
+
+  if (collection.length === 0) {
+    return (
+      <div className="flex flex-col items-center gap-4 py-16 text-center" dir="rtl">
+        <span className="text-6xl">⭐</span>
+        <p className="text-xl font-semibold text-gray-600">האוסף שלך ריק</p>
+        <p className="text-gray-400">לחץ על 💾 שמור בכרטיס מילה כדי להוסיף לאוסף</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="grid grid-cols-3 sm:grid-cols-4 md:grid-cols-5 gap-3" dir="rtl">
+      {collection.map((item, i) => (
+        <button
+          key={`${item.hebrew}-${i}`}
+          onClick={() => expandItem(item)}
+          className="flex flex-col items-center gap-2 p-3 bg-white rounded-2xl shadow hover:shadow-md hover:-translate-y-0.5 transition-all active:scale-95"
+        >
+          <div
+            className={`w-14 h-14 rounded-xl flex items-center justify-center text-4xl ${item.color ?? 'bg-gradient-to-br from-yellow-400 to-orange-500'}`}
+          >
+            {item.emoji}
+          </div>
+          <span className="text-sm font-semibold text-gray-700 text-center leading-tight">
+            {item.hebrew}
+          </span>
+        </button>
+      ))}
+    </div>
+  );
+}
+
+export default function PictureDictionaryClient() {
+  const { browseMode, setBrowseMode, expandedItem, searchQuery, setSearchQuery, initCollection } =
+    usePictureDictionaryStore();
+
+  useEffect(() => {
+    initCollection();
+  }, [initCollection]);
+
+  return (
+    <div
+      className="min-h-screen"
+      style={{ background: 'linear-gradient(135deg, #f0f4ff 0%, #fdf4ff 100%)' }}
+    >
+      {/* Header */}
+      <header className="bg-gradient-to-r from-purple-600 to-indigo-600 text-white px-4 py-5 text-center shadow-lg">
+        <h1 className="text-3xl font-bold">📖 מילון בתמונות</h1>
+        <p className="text-purple-200 mt-1 text-sm">גלה מילים עבריות עם תמונות וקול</p>
+      </header>
+
+      {/* Tabs */}
+      <div className="sticky top-0 z-10 bg-white/90 backdrop-blur-sm shadow-sm">
+        <div className="flex" dir="rtl">
+          {TABS.map(({ mode, label, icon }) => (
+            <button
+              key={mode}
+              onClick={() => setBrowseMode(mode)}
+              className={`flex-1 py-3 text-sm font-semibold flex flex-col items-center gap-0.5 transition-colors border-b-2 ${
+                browseMode === mode
+                  ? 'border-purple-600 text-purple-600'
+                  : 'border-transparent text-gray-500 hover:text-gray-700'
+              }`}
+            >
+              <span className="text-xl">{icon}</span>
+              <span>{label}</span>
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {/* Search input */}
+      {browseMode === 'search' && (
+        <div className="px-4 pt-4" dir="rtl">
+          <input
+            type="text"
+            value={searchQuery}
+            onChange={(e) => setSearchQuery(e.target.value)}
+            placeholder="חפש מילה בעברית או אנגלית..."
+            className="w-full px-4 py-3 rounded-2xl border-2 border-purple-200 focus:border-purple-400 outline-none text-lg font-semibold text-gray-700 bg-white shadow-sm"
+            autoFocus
+          />
+        </div>
+      )}
+
+      {/* Main content */}
+      <main className="px-4 py-5 max-w-2xl mx-auto">
+        {browseMode === 'collection' ? <CollectionTab /> : <DictionaryBrowse />}
+      </main>
+
+      {/* Expanded card overlay */}
+      {expandedItem && <DictionaryCard item={expandedItem} />}
+    </div>
+  );
+}

--- a/gamesformykids/app/games/picture-dictionary/components/DictionaryBrowse.tsx
+++ b/gamesformykids/app/games/picture-dictionary/components/DictionaryBrowse.tsx
@@ -1,0 +1,133 @@
+'use client';
+import { useMemo } from 'react';
+import {
+  usePictureDictionaryStore,
+  buildDictionary,
+  getFirstHebrewLetter,
+  HEBREW_ALPHABET,
+  CATEGORY_LABELS,
+} from '../pictureDictionaryStore';
+import type { DictionaryItem } from '../pictureDictionaryStore';
+
+function ItemTile({ item }: { item: DictionaryItem }) {
+  const { expandItem } = usePictureDictionaryStore();
+  return (
+    <button
+      onClick={() => expandItem(item)}
+      className="flex flex-col items-center gap-2 p-3 bg-white rounded-2xl shadow hover:shadow-md hover:-translate-y-0.5 transition-all active:scale-95 cursor-pointer"
+    >
+      <div
+        className={`w-14 h-14 rounded-xl flex items-center justify-center text-4xl ${item.color ?? 'bg-gradient-to-br from-blue-400 to-purple-500'}`}
+      >
+        {item.emoji}
+      </div>
+      <span className="text-sm font-semibold text-gray-700 text-center leading-tight" dir="rtl">
+        {item.hebrew}
+      </span>
+    </button>
+  );
+}
+
+export default function DictionaryBrowse() {
+  const {
+    browseMode, selectedLetter, selectedCategory,
+    searchQuery, selectLetter, selectCategory,
+  } = usePictureDictionaryStore();
+
+  const allItems = useMemo(() => buildDictionary(), []);
+
+  const displayedItems = useMemo((): DictionaryItem[] => {
+    if (browseMode === 'letter' && selectedLetter) {
+      return allItems.filter((item) => getFirstHebrewLetter(item.hebrew) === selectedLetter);
+    }
+    if (browseMode === 'category' && selectedCategory) {
+      return allItems.filter((item) => item.category === selectedCategory);
+    }
+    if (browseMode === 'search' && searchQuery.trim().length > 0) {
+      const q = searchQuery.trim();
+      return allItems.filter(
+        (item) => item.hebrew.includes(q) || item.english.toLowerCase().includes(q.toLowerCase())
+      );
+    }
+    return [];
+  }, [browseMode, selectedLetter, selectedCategory, searchQuery, allItems]);
+
+  const categoryKeys = useMemo(
+    () => Object.keys(CATEGORY_LABELS).filter((k) => allItems.some((i) => i.category === k)),
+    [allItems]
+  );
+
+  return (
+    <div className="flex flex-col gap-4" dir="rtl">
+      {/* Letter bar */}
+      {browseMode === 'letter' && (
+        <div className="flex flex-wrap gap-1.5 justify-start">
+          {HEBREW_ALPHABET.map((letter) => (
+            <button
+              key={letter}
+              onClick={() => selectLetter(letter)}
+              className={`w-10 h-10 rounded-xl font-bold text-lg transition-colors ${
+                selectedLetter === letter
+                  ? 'bg-purple-600 text-white shadow-md'
+                  : 'bg-white text-gray-700 hover:bg-purple-100 shadow'
+              }`}
+            >
+              {letter}
+            </button>
+          ))}
+        </div>
+      )}
+
+      {/* Category grid */}
+      {browseMode === 'category' && !selectedCategory && (
+        <div className="grid grid-cols-2 sm:grid-cols-3 gap-3">
+          {categoryKeys.map((key) => (
+            <button
+              key={key}
+              onClick={() => selectCategory(key)}
+              className="bg-white rounded-2xl shadow p-4 flex flex-col items-center gap-1 hover:shadow-md hover:-translate-y-0.5 transition-all"
+            >
+              <span className="text-3xl">
+                {allItems.find((i) => i.category === key)?.emoji ?? '📦'}
+              </span>
+              <span className="text-sm font-semibold text-gray-700 text-center">
+                {CATEGORY_LABELS[key]}
+              </span>
+              <span className="text-xs text-gray-400">
+                {allItems.filter((i) => i.category === key).length} פריטים
+              </span>
+            </button>
+          ))}
+        </div>
+      )}
+
+      {/* Back button when category selected */}
+      {browseMode === 'category' && selectedCategory && (
+        <button
+          onClick={() => selectCategory(null)}
+          className="self-start flex items-center gap-2 text-purple-600 hover:text-purple-800 font-semibold"
+        >
+          ← חזרה לקטגוריות
+        </button>
+      )}
+
+      {/* Item grid */}
+      {displayedItems.length > 0 && (
+        <div className="grid grid-cols-3 sm:grid-cols-4 md:grid-cols-5 gap-3">
+          {displayedItems.map((item, i) => (
+            <ItemTile key={`${item.hebrew}-${i}`} item={item} />
+          ))}
+        </div>
+      )}
+
+      {/* Empty state */}
+      {displayedItems.length === 0 && (browseMode !== 'category' || selectedCategory) && (
+        <div className="text-center text-gray-400 py-12 text-lg">
+          {browseMode === 'search' && searchQuery.length === 0
+            ? 'הקלד אותיות לחיפוש...'
+            : 'לא נמצאו פריטים'}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/gamesformykids/app/games/picture-dictionary/components/DictionaryCard.tsx
+++ b/gamesformykids/app/games/picture-dictionary/components/DictionaryCard.tsx
@@ -1,0 +1,77 @@
+'use client';
+import { useCallback } from 'react';
+import { speakHebrew } from '@/lib/utils/speech/enhancedSpeechUtils';
+import type { DictionaryItem } from '../pictureDictionaryStore';
+import { usePictureDictionaryStore } from '../pictureDictionaryStore';
+
+interface Props {
+  item: DictionaryItem;
+}
+
+export default function DictionaryCard({ item }: Props) {
+  const { closeExpanded, toggleCollection, collection } = usePictureDictionaryStore();
+  const isSaved = collection.some((c) => c.hebrew === item.hebrew);
+
+  const handleSpeak = useCallback(() => {
+    speakHebrew(item.hebrew);
+  }, [item.hebrew]);
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/50"
+      onClick={closeExpanded}
+    >
+      <div
+        className="bg-white rounded-3xl shadow-2xl max-w-sm w-full p-8 flex flex-col items-center gap-4 relative"
+        dir="rtl"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <button
+          onClick={closeExpanded}
+          className="absolute top-4 left-4 text-gray-400 hover:text-gray-600 text-2xl font-bold"
+          aria-label="סגור"
+        >
+          ✕
+        </button>
+
+        {/* Emoji */}
+        <div
+          className={`w-32 h-32 rounded-2xl flex items-center justify-center text-7xl ${item.color ?? 'bg-gradient-to-br from-blue-400 to-purple-500'}`}
+        >
+          {item.emoji}
+        </div>
+
+        {/* Hebrew name */}
+        <h2 className="text-4xl font-bold text-gray-800 text-center">{item.hebrew}</h2>
+
+        {/* English name */}
+        <p className="text-xl text-gray-500 text-center" dir="ltr">{item.english}</p>
+
+        {/* Category label */}
+        <span className="text-sm bg-purple-100 text-purple-700 px-3 py-1 rounded-full">
+          {item.categoryLabel}
+        </span>
+
+        {/* Action buttons */}
+        <div className="flex gap-3 w-full mt-2">
+          <button
+            onClick={handleSpeak}
+            className="flex-1 bg-blue-500 hover:bg-blue-600 text-white font-bold py-3 rounded-2xl text-lg transition-colors flex items-center justify-center gap-2"
+          >
+            🔊 הקשב
+          </button>
+          <button
+            onClick={() => toggleCollection(item)}
+            className={`flex-1 font-bold py-3 rounded-2xl text-lg transition-colors flex items-center justify-center gap-2 ${
+              isSaved
+                ? 'bg-yellow-400 hover:bg-yellow-500 text-white'
+                : 'bg-green-500 hover:bg-green-600 text-white'
+            }`}
+          >
+            {isSaved ? '⭐ נשמר' : '💾 שמור'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/gamesformykids/app/games/picture-dictionary/pictureDictionaryStore.ts
+++ b/gamesformykids/app/games/picture-dictionary/pictureDictionaryStore.ts
@@ -1,0 +1,151 @@
+'use client';
+import { create } from 'zustand';
+import { GAME_ITEMS_MAP } from '@/lib/constants/gameItemsMap';
+import type { BaseGameItem } from '@/lib/types/core/base';
+
+export interface DictionaryItem extends BaseGameItem {
+  category: string;
+  categoryLabel: string;
+}
+
+export const CATEGORY_LABELS: Record<string, string> = {
+  animals: 'חיות', fruits: 'פירות', vegetables: 'ירקות', clothing: 'בגדים',
+  weather: 'מזג אוויר', house: 'בית', instruments: 'כלי נגינה', professions: 'מקצועות',
+  emotions: 'רגשות', sports: 'ספורט', kitchen: 'מטבח', 'body-parts': 'חלקי גוף',
+  family: 'משפחה', dinosaurs: 'דינוזאורים', 'world-food': 'מזון עולמי',
+  recycling: 'מחזור', medicine: 'תרופות', 'nature-sounds': 'קולות טבע',
+  'seasons-holidays': 'עונות וחגים', 'shopping-money': 'קניות', 'road-safety': 'בטיחות',
+  'ocean-life': 'חיי ים', 'garden-plants': 'צמחי גן', 'magic-fairy-tales': 'אגדות',
+  'circus-show': 'קרקס', birds: 'ציפורים', 'bugs-insects': 'חרקים',
+  superheroes: 'גיבורי על', 'art-craft': 'אמנות', camping: 'טיול',
+  'fairy-tale-chars': 'דמויות אגדה', 'days-of-week': 'ימות השבוע',
+  'months-of-year': 'חודשי השנה', 'jewish-holidays': 'חגים יהודיים',
+  'new-professions': 'מקצועות חדשים', 'advanced-weather': 'מזג אוויר מתקדם',
+  'sound-imitation': 'קולות', 'body-movements': 'תנועות גוף',
+  'touch-senses': 'מגע וחושים', 'emotional-social': 'רגשות חברתיים',
+  'time-clock': 'זמן ושעות', 'climate-planet': 'אקלים', space: 'חלל',
+  'solar-system': 'מערכת השמש', vehicles: 'כלי רכב', tools: 'כלים',
+  transport: 'תחבורה', 'personal-safety': 'בטיחות אישית',
+};
+
+const SKIP_TYPES = new Set([
+  'letters', 'numbers', 'shapes', 'colored-shapes', 'math', 'counting',
+  'flags', 'car-brands', 'world-landmarks', 'famous-paintings', 'tech-logos',
+  'dog-breeds', 'cat-breeds', 'nba-teams', 'exotic-birds', 'butterflies',
+  'soccer-logos', 'geography-flags', 'geography-capitals', 'geography-continents',
+  'visual-opposites', 'english-cards', 'coins-match', 'ordinals',
+  'spatial-concepts', 'number-words', 'advanced-colors', 'logic-games',
+  'virtual-reality',
+]);
+
+const FINAL_TO_REGULAR: Record<string, string> = {
+  'ך': 'כ', 'ם': 'מ', 'ן': 'נ', 'ף': 'פ', 'ץ': 'צ',
+};
+
+export function getFirstHebrewLetter(hebrew: string): string {
+  const first = hebrew[0] ?? '';
+  return FINAL_TO_REGULAR[first] ?? first;
+}
+
+export const HEBREW_ALPHABET = [
+  'א','ב','ג','ד','ה','ו','ז','ח','ט','י','כ','ל','מ','נ','ס','ע','פ','צ','ק','ר','ש','ת'
+];
+
+let _cachedDictionary: DictionaryItem[] | null = null;
+
+export function buildDictionary(): DictionaryItem[] {
+  if (_cachedDictionary) return _cachedDictionary;
+  const items: DictionaryItem[] = [];
+  const seen = new Set<string>();
+
+  for (const [gameType, gameItems] of Object.entries(GAME_ITEMS_MAP)) {
+    if (!gameItems || SKIP_TYPES.has(gameType)) continue;
+    for (const item of gameItems) {
+      if (!item.hebrew || !item.emoji) continue;
+      const key = item.hebrew;
+      if (seen.has(key)) continue;
+      seen.add(key);
+      items.push({
+        ...item,
+        category: gameType,
+        categoryLabel: CATEGORY_LABELS[gameType] ?? gameType,
+      });
+    }
+  }
+
+  items.sort((a, b) => a.hebrew.localeCompare(b.hebrew, 'he'));
+  _cachedDictionary = items;
+  return items;
+}
+
+const COLLECTION_KEY = 'picture-dictionary-collection';
+
+function loadCollection(): DictionaryItem[] {
+  if (typeof window === 'undefined') return [];
+  try {
+    const raw = localStorage.getItem(COLLECTION_KEY);
+    return raw ? (JSON.parse(raw) as DictionaryItem[]) : [];
+  } catch {
+    return [];
+  }
+}
+
+function saveCollection(items: DictionaryItem[]): void {
+  try {
+    localStorage.setItem(COLLECTION_KEY, JSON.stringify(items));
+  } catch {
+    // ignore storage errors
+  }
+}
+
+export type BrowseMode = 'letter' | 'category' | 'search' | 'collection';
+
+interface State {
+  browseMode: BrowseMode;
+  selectedLetter: string | null;
+  selectedCategory: string | null;
+  searchQuery: string;
+  expandedItem: DictionaryItem | null;
+  collection: DictionaryItem[];
+}
+
+interface Actions {
+  setBrowseMode: (mode: BrowseMode) => void;
+  selectLetter: (letter: string | null) => void;
+  selectCategory: (category: string | null) => void;
+  setSearchQuery: (q: string) => void;
+  expandItem: (item: DictionaryItem) => void;
+  closeExpanded: () => void;
+  toggleCollection: (item: DictionaryItem) => void;
+  initCollection: () => void;
+}
+
+export const usePictureDictionaryStore = create<State & Actions>((set, get) => ({
+  browseMode: 'letter',
+  selectedLetter: 'א',
+  selectedCategory: null,
+  searchQuery: '',
+  expandedItem: null,
+  collection: [],
+
+  setBrowseMode: (mode) => set({ browseMode: mode, expandedItem: null }),
+  selectLetter: (letter) => set({ selectedLetter: letter }),
+  selectCategory: (category) => set({ selectedCategory: category }),
+  setSearchQuery: (q) => set({ searchQuery: q }),
+  expandItem: (item) => set({ expandedItem: item }),
+  closeExpanded: () => set({ expandedItem: null }),
+
+  toggleCollection: (item) => {
+    const { collection } = get();
+    const exists = collection.some((c) => c.hebrew === item.hebrew);
+    const next = exists
+      ? collection.filter((c) => c.hebrew !== item.hebrew)
+      : collection.length < 50 ? [...collection, item] : collection;
+    saveCollection(next);
+    set({ collection: next });
+  },
+
+  initCollection: () => {
+    set({ collection: loadCollection() });
+  },
+}));

--- a/gamesformykids/lib/constants/gameCategories.ts
+++ b/gamesformykids/lib/constants/gameCategories.ts
@@ -131,6 +131,6 @@ export const GAME_CATEGORIES: Record<string, GameCategory> = {
     icon: Book,
     color: "bg-teal-500",
     gradient: "from-teal-400 to-cyan-600",
-    gameIds: ["true-false","emoji-math","math-race","number-bubbles","word-scramble","word-builder","word-chain","trivia","clock","spelling","opposites","world-languages","riddles","english-words","singular-plural","adjectives","verbs","visual-opposites","english-cards","proverbs","story-builder","robot-coder","hangman","choose-adventure"],
+    gameIds: ["true-false","emoji-math","math-race","number-bubbles","word-scramble","word-builder","word-chain","trivia","clock","spelling","opposites","world-languages","riddles","english-words","singular-plural","adjectives","verbs","visual-opposites","english-cards","proverbs","story-builder","robot-coder","hangman","choose-adventure","picture-dictionary"],
   },
 };

--- a/gamesformykids/lib/registry/registryData/batch4.ts
+++ b/gamesformykids/lib/registry/registryData/batch4.ts
@@ -643,4 +643,15 @@ export const gamesRegistryBatch4: GameRegistration[] = [
     available: true,
     order: 179,
   },
+  {
+    id: "picture-dictionary",
+    title: "מילון בתמונות",
+    description: "גלה מילים עבריות לפי אות או נושא — 1000+ מילים עם תמונות וקול!",
+    icon: BookOpen,
+    emoji: "📖",
+    color: "bg-purple-500 hover:bg-purple-600",
+    href: "/games/picture-dictionary",
+    available: true,
+    order: 180,
+  },
 ];

--- a/gamesformykids/lib/types/core/base.ts
+++ b/gamesformykids/lib/types/core/base.ts
@@ -212,4 +212,6 @@ export type GameType =
   // Word puzzle games
   | 'hangman'
   // Interactive story games
-  | 'choose-adventure';
+  | 'choose-adventure'
+  // Visual dictionary
+  | 'picture-dictionary';


### PR DESCRIPTION
## What
Adds a visual Hebrew picture dictionary game that lets children browse over 1000 Hebrew vocabulary items already stored in `GAME_ITEMS_MAP`.

- **Browse by letter** — Hebrew alphabet bar (א–ת), tap a letter to see all words starting with that letter
- **Browse by category** — grid of 30+ topic categories (animals, food, clothing…), tap to drill in
- **Search** — type Hebrew or English text to filter
- **Personal collection** — save up to 50 favourite words to localStorage; persists between sessions
- **Expanded card** — large emoji, Hebrew word, English translation, TTS pronunciation button
- RTL layout throughout; works on mobile

No new content was created — all items come from existing `GAME_ITEMS_MAP` data.

## Why
Closes #1225

## Test plan
- [ ] Navigate to `/games/picture-dictionary`
- [ ] Tap letter 'א' → words starting with aleph appear
- [ ] Tap a word card → expanded overlay shows emoji, Hebrew, English, TTS and Save buttons
- [ ] TTS button speaks the Hebrew word
- [ ] Save a word → appears in ⭐ האוסף שלי tab; persists after page refresh
- [ ] Category tab → pick category → items appear; back button returns to category list
- [ ] Search tab → type 'כלב' → matching items appear
- [ ] Appears in educational category on home page

🤖 Generated with [Claude Code](https://claude.com/claude-code)