### PR TITLE
feat(choose-adventure): interactive Hebrew branching story game (closes #1224)

### DIFF
--- a/gamesformykids/app/games/[gameType]/CustomGameRenderer.tsx
+++ b/gamesformykids/app/games/[gameType]/CustomGameRenderer.tsx
@@ -51,7 +51,8 @@ const GAME_CLIENTS: Record<string, ComponentType> = {
   'escape-room':      dynamic(() => import('../escape-room/EscapeRoomClient'),                    { ssr: false }),
   'robot-coder':      dynamic(() => import('../robot-coder/RobotCoderClient'),                    { ssr: false }),
   'find-in-scene':    dynamic(() => import('../find-in-scene/FindInSceneClient'),                  { ssr: false }),
-  'hangman':          dynamic(() => import('../hangman/HangmanClient'),                             { ssr: false }),
+  'hangman':           dynamic(() => import('../hangman/HangmanClient'),                             { ssr: false }),
+  'choose-adventure':  dynamic(() => import('../choose-adventure/ChooseAdventureClient'),            { ssr: false }),
 };
 
 interface Props { gameType: string; }

--- a/gamesformykids/app/games/[gameType]/gamePageConstants.ts
+++ b/gamesformykids/app/games/[gameType]/gamePageConstants.ts
@@ -70,6 +70,7 @@ export const SUPPORTED_GAMES = [
   'robot-coder',
   'find-in-scene',
   'hangman',
+  'choose-adventure',
 ] as const;
 
 export type SupportedGameType = typeof SUPPORTED_GAMES[number];
@@ -82,7 +83,7 @@ export const CUSTOM_GAME_TYPES = new Set([
   'puzzles', 'reflex', 'shesh-besh', 'simon', 'snake', 'space-defender',
   'stack', 'taki', 'tetris', 'true-false', 'tzedakah', 'whack-a-mole',
   'word-builder', 'word-scramble', 'maze', 'letter-defender', 'puppet-story', 'number-slide', 'snakes-ladders',
-  'escape-room', 'robot-coder', 'find-in-scene', 'hangman',
+  'escape-room', 'robot-coder', 'find-in-scene', 'hangman', 'choose-adventure',
 ]);
 
 // ─── מיפוי URL → GameType ──────────────────────────────────────────────────────

--- a/gamesformykids/app/games/choose-adventure/ChooseAdventureClient.tsx
+++ b/gamesformykids/app/games/choose-adventure/ChooseAdventureClient.tsx
@@ -1,0 +1,37 @@
+'use client';
+import { useChooseAdventure } from './useChooseAdventure';
+import StoryMenu from './components/StoryMenu';
+import StoryPage from './components/StoryPage';
+
+export default function ChooseAdventureClient() {
+  const {
+    phase, stories, currentStory, currentNode,
+    selectStory, makeChoice, returnToMenu, readAgain, getEndingsCount,
+  } = useChooseAdventure();
+
+  if ((phase === 'story' || phase === 'ending') && currentStory && currentNode) {
+    return (
+      <StoryPage
+        story={currentStory}
+        node={currentNode}
+        phase={phase}
+        onChoice={makeChoice}
+        onReadAgain={readAgain}
+        onMenu={returnToMenu}
+      />
+    );
+  }
+
+  return (
+    <div
+      className="min-h-screen"
+      style={{ background: 'linear-gradient(135deg, #eef2ff 0%, #fdf4ff 100%)' }}
+    >
+      <StoryMenu
+        stories={stories}
+        getEndingsCount={getEndingsCount}
+        onSelect={selectStory}
+      />
+    </div>
+  );
+}

--- a/gamesformykids/app/games/choose-adventure/components/StoryMenu.tsx
+++ b/gamesformykids/app/games/choose-adventure/components/StoryMenu.tsx
@@ -1,0 +1,54 @@
+'use client';
+import type { Story } from '@/lib/constants/stories/stories';
+
+interface Props {
+  stories: Story[];
+  getEndingsCount: (id: string) => number;
+  onSelect: (story: Story) => void;
+}
+
+const TOTAL_ENDINGS: Record<string, number> = {
+  cat: 4,
+  forest: 4,
+  space: 4,
+};
+
+export default function StoryMenu({ stories, getEndingsCount, onSelect }: Props) {
+  return (
+    <div className="flex flex-col items-center gap-6 px-4 py-8 max-w-md mx-auto" dir="rtl">
+      <div className="text-center">
+        <div className="text-6xl mb-3">📚</div>
+        <h1 className="text-3xl font-bold text-indigo-800">ספר הרפתקאות</h1>
+        <p className="text-gray-500 mt-1">בחר סיפור וגלה מה יקרה!</p>
+      </div>
+
+      <div className="flex flex-col gap-4 w-full">
+        {stories.map((story) => {
+          const found = getEndingsCount(story.id);
+          const total = TOTAL_ENDINGS[story.id] ?? 3;
+          return (
+            <button
+              key={story.id}
+              onClick={() => onSelect(story)}
+              className={`w-full bg-gradient-to-l ${story.color} text-white rounded-3xl p-5 text-right shadow-lg hover:scale-[1.02] active:scale-[0.98] transition-transform`}
+            >
+              <div className="flex items-center gap-3">
+                <span className="text-5xl">{story.emoji}</span>
+                <div className="flex-1">
+                  <h2 className="text-xl font-bold">{story.title}</h2>
+                  <p className="text-sm opacity-90 mt-0.5">{story.description}</p>
+                  {found > 0 && (
+                    <p className="text-xs mt-1 opacity-80">
+                      🔍 גילית {found}/{total} סיומים
+                    </p>
+                  )}
+                </div>
+                <span className="text-3xl">←</span>
+              </div>
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/gamesformykids/app/games/choose-adventure/components/StoryPage.tsx
+++ b/gamesformykids/app/games/choose-adventure/components/StoryPage.tsx
@@ -1,0 +1,103 @@
+'use client';
+import { useEffect, useRef } from 'react';
+import { speakHebrew } from '@/lib/utils/speech/enhancedSpeechUtils';
+import type { Story, StoryNode } from '@/lib/constants/stories/stories';
+
+interface Props {
+  story: Story;
+  node: StoryNode;
+  phase: 'story' | 'ending';
+  onChoice: (nextId: string) => void;
+  onReadAgain: () => void;
+  onMenu: () => void;
+}
+
+export default function StoryPage({ story, node, phase, onChoice, onReadAgain, onMenu }: Props) {
+  const spokenRef = useRef<string>('');
+
+  useEffect(() => {
+    // Auto-speak when node changes (avoid double-speak on re-render)
+    if (node.id !== spokenRef.current) {
+      spokenRef.current = node.id;
+      speakHebrew(node.text);
+    }
+  }, [node.id, node.text]);
+
+  return (
+    <div
+      className="min-h-screen flex flex-col"
+      style={{ background: 'linear-gradient(135deg, #eef2ff 0%, #fdf4ff 100%)' }}
+      dir="rtl"
+    >
+      {/* Top bar */}
+      <div className={`bg-gradient-to-l ${story.color} text-white px-4 py-3 flex items-center gap-3 shadow-md`}>
+        <button
+          onClick={onMenu}
+          className="text-white/80 hover:text-white text-sm font-semibold px-3 py-1.5 rounded-xl bg-white/20 hover:bg-white/30 transition-colors"
+        >
+          ← תפריט
+        </button>
+        <span className="text-2xl">{story.emoji}</span>
+        <h2 className="font-bold text-lg flex-1">{story.title}</h2>
+        <button
+          onClick={() => speakHebrew(node.text)}
+          className="text-white/80 hover:text-white text-xl"
+          aria-label="קרא שוב"
+        >
+          🔊
+        </button>
+      </div>
+
+      {/* Story card */}
+      <div className="flex-1 flex flex-col items-center justify-center p-6">
+        <div className="bg-white rounded-3xl shadow-xl max-w-sm w-full p-6 flex flex-col items-center gap-5">
+          {/* Emoji illustration */}
+          <div className="text-8xl">{node.emoji}</div>
+
+          {/* Text */}
+          <p className="text-xl text-gray-700 text-center leading-relaxed font-medium">
+            {node.text}
+          </p>
+
+          {/* Ending or choices */}
+          {phase === 'ending' ? (
+            <div className="flex flex-col items-center gap-4 w-full mt-2">
+              {node.endingEmoji && (
+                <div className="text-5xl animate-bounce">{node.endingEmoji}</div>
+              )}
+              <p className="text-purple-600 font-bold text-lg">🎉 סוף הסיפור!</p>
+              <div className="flex gap-3 w-full">
+                <button
+                  onClick={onReadAgain}
+                  className="flex-1 bg-indigo-500 hover:bg-indigo-600 text-white font-bold py-3 rounded-2xl transition-colors"
+                >
+                  📖 קרא שוב
+                </button>
+                <button
+                  onClick={onMenu}
+                  className="flex-1 bg-purple-500 hover:bg-purple-600 text-white font-bold py-3 rounded-2xl transition-colors"
+                >
+                  🏠 תפריט
+                </button>
+              </div>
+            </div>
+          ) : (
+            <div className="flex flex-col gap-3 w-full mt-2">
+              {node.choices?.map((choice) => (
+                <button
+                  key={choice.nextId}
+                  onClick={() => onChoice(choice.nextId)}
+                  className={`w-full bg-gradient-to-l ${story.color} text-white font-bold py-4 px-5 rounded-2xl text-lg text-right flex items-center gap-3 shadow hover:scale-[1.02] active:scale-[0.98] transition-transform`}
+                >
+                  <span className="text-3xl">{choice.emoji}</span>
+                  <span className="flex-1">{choice.label}</span>
+                  <span className="opacity-70">←</span>
+                </button>
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/gamesformykids/app/games/choose-adventure/useChooseAdventure.ts
+++ b/gamesformykids/app/games/choose-adventure/useChooseAdventure.ts
@@ -1,0 +1,64 @@
+'use client';
+import { useState, useCallback } from 'react';
+import { STORIES } from '@/lib/constants/stories/stories';
+import type { Story, StoryNode } from '@/lib/constants/stories/stories';
+
+export type AdventurePhase = 'menu' | 'story' | 'ending';
+
+export function useChooseAdventure() {
+  const [phase, setPhase] = useState<AdventurePhase>('menu');
+  const [currentStory, setCurrentStory] = useState<Story | null>(null);
+  const [currentNode, setCurrentNode] = useState<StoryNode | null>(null);
+  const [endingsFound, setEndingsFound] = useState<Record<string, Set<string>>>({});
+
+  const selectStory = useCallback((story: Story) => {
+    const startNode = story.nodes.find((n) => n.id === story.startId) ?? null;
+    setCurrentStory(story);
+    setCurrentNode(startNode);
+    setPhase('story');
+  }, []);
+
+  const makeChoice = useCallback((nextId: string) => {
+    if (!currentStory) return;
+    const next = currentStory.nodes.find((n) => n.id === nextId) ?? null;
+    if (!next) return;
+    if (next.isEnding) {
+      setEndingsFound((prev) => {
+        const storySet = new Set(prev[currentStory.id] ?? []);
+        storySet.add(next.id);
+        return { ...prev, [currentStory.id]: storySet };
+      });
+      setPhase('ending');
+    }
+    setCurrentNode(next);
+  }, [currentStory]);
+
+  const returnToMenu = useCallback(() => {
+    setPhase('menu');
+    setCurrentStory(null);
+    setCurrentNode(null);
+  }, []);
+
+  const readAgain = useCallback(() => {
+    if (!currentStory) return;
+    const startNode = currentStory.nodes.find((n) => n.id === currentStory.startId) ?? null;
+    setCurrentNode(startNode);
+    setPhase('story');
+  }, [currentStory]);
+
+  const getEndingsCount = useCallback((storyId: string) => {
+    return endingsFound[storyId]?.size ?? 0;
+  }, [endingsFound]);
+
+  return {
+    phase,
+    stories: STORIES,
+    currentStory,
+    currentNode,
+    selectStory,
+    makeChoice,
+    returnToMenu,
+    readAgain,
+    getEndingsCount,
+  };
+}

--- a/gamesformykids/lib/constants/gameCategories.ts
+++ b/gamesformykids/lib/constants/gameCategories.ts
@@ -131,6 +131,6 @@ export const GAME_CATEGORIES: Record<string, GameCategory> = {
     icon: Book,
     color: "bg-teal-500",
     gradient: "from-teal-400 to-cyan-600",
-    gameIds: ["true-false","emoji-math","math-race","number-bubbles","word-scramble","word-builder","word-chain","trivia","clock","spelling","opposites","world-languages","riddles","english-words","singular-plural","adjectives","verbs","visual-opposites","english-cards","proverbs","story-builder","robot-coder","hangman"],
+    gameIds: ["true-false","emoji-math","math-race","number-bubbles","word-scramble","word-builder","word-chain","trivia","clock","spelling","opposites","world-languages","riddles","english-words","singular-plural","adjectives","verbs","visual-opposites","english-cards","proverbs","story-builder","robot-coder","hangman","choose-adventure"],
   },
 };

--- a/gamesformykids/lib/constants/stories/stories.ts
+++ b/gamesformykids/lib/constants/stories/stories.ts
@@ -1,0 +1,246 @@
+export interface StoryChoice {
+  label: string;
+  emoji: string;
+  nextId: string;
+}
+
+export interface StoryNode {
+  id: string;
+  emoji: string;
+  text: string;
+  choices?: StoryChoice[];
+  isEnding?: true;
+  endingEmoji?: string;
+}
+
+export interface Story {
+  id: string;
+  title: string;
+  description: string;
+  emoji: string;
+  color: string;
+  startId: string;
+  nodes: StoryNode[];
+}
+
+export const STORIES: Story[] = [
+  {
+    id: 'cat',
+    title: 'יוסי והחתול',
+    description: 'מה יקרה כשיוסי מוצא חתול קטן בגינה?',
+    emoji: '🐱',
+    color: 'from-orange-400 to-yellow-500',
+    startId: 'start',
+    nodes: [
+      {
+        id: 'start',
+        emoji: '😺',
+        text: 'יוסי מצא חתול קטן בגינה. החתול מיאו בקול עצוב ורעד מקור. מה יעשה יוסי?',
+        choices: [
+          { label: 'תן לו אוכל', emoji: '🍖', nextId: 'fed' },
+          { label: 'קרא לאמא', emoji: '📢', nextId: 'called_mom' },
+          { label: 'בנה לו בית מקרטון', emoji: '📦', nextId: 'house' },
+        ],
+      },
+      {
+        id: 'fed',
+        emoji: '😋',
+        text: 'יוסי הביא אוכל לחתול. החתול אכל בשמחה ומירד את זנבו. יוסי שמח מאוד. האם יתן לו שם?',
+        choices: [
+          { label: 'כן! שם יפה', emoji: '🏷️', nextId: 'named' },
+          { label: 'לא, לשחרר אותו', emoji: '🐾', nextId: 'freed' },
+        ],
+      },
+      {
+        id: 'named',
+        emoji: '⭐',
+        text: 'יוסי קרא לחתול "כוכב". הם נהיו חברים הכי טובים בעולם. כוכב גר אצל יוסי הרבה שנים ואהב לישון על הספה!',
+        isEnding: true,
+        endingEmoji: '🐱⭐',
+      },
+      {
+        id: 'freed',
+        emoji: '🐱🐱',
+        text: 'יוסי שחרר את החתול. למחרת בבוקר, החתול חזר עם חבר! היו שני חתולים שמחים בגינה. יוסי צחק מרוב שמחה!',
+        isEnding: true,
+        endingEmoji: '🐱🐱',
+      },
+      {
+        id: 'called_mom',
+        emoji: '👩',
+        text: 'אמא של יוסי באה וראתה את החתול הקטן. היא אמרה: "הוא צריך בית חם". מה לעשות?',
+        choices: [
+          { label: 'לשמור אותו אצלנו', emoji: '🏠', nextId: 'keep' },
+          { label: 'למצוא לו משפחה', emoji: '❤️', nextId: 'adopt' },
+        ],
+      },
+      {
+        id: 'keep',
+        emoji: '🏠',
+        text: 'החתול נשאר בבית יוסי! הוא גדל והיה חתול גדול ושמן. כל הילדים מהשכונה אהבו לבוא לשחק איתו!',
+        isEnding: true,
+        endingEmoji: '🐈🏠',
+      },
+      {
+        id: 'adopt',
+        emoji: '❤️',
+        text: 'מצאו לחתול משפחה נהדרת. יוסי ביקר אותו כל שבוע. הם נשארו חברים לנצח וחתול תמיד ריץ אליו!',
+        isEnding: true,
+        endingEmoji: '❤️🐱',
+      },
+      {
+        id: 'house',
+        emoji: '📦',
+        text: 'יוסי בנה בית מקרטון עם שמיכה רכה. החתול נכנס ונרדם מיד. כשאבא חזר הביתה, הוא אמר: "איזה אדריכל גדול!"',
+        isEnding: true,
+        endingEmoji: '🏡🐱',
+      },
+    ],
+  },
+  {
+    id: 'forest',
+    title: 'הטיול ביער',
+    description: 'עדי מוצאת ילד אבוד ביער — מה היא תעשה?',
+    emoji: '🌲',
+    color: 'from-green-400 to-teal-500',
+    startId: 'start',
+    nodes: [
+      {
+        id: 'start',
+        emoji: '🌳',
+        text: 'עדי ואמה הלכו לטיול ביער. פתאום עדי ראתה ילד קטן בוכה לבד בין העצים. מה לעשות?',
+        choices: [
+          { label: 'גשי אליו בעצמך', emoji: '🤝', nextId: 'approach' },
+          { label: 'קראי לאמא לעזור', emoji: '👩', nextId: 'tell_mom' },
+          { label: 'הצחיקי אותו', emoji: '😄', nextId: 'cheer' },
+        ],
+      },
+      {
+        id: 'approach',
+        emoji: '🤗',
+        text: 'עדי גשה לילד. שמו היה אלי. הוא אמר שאיבד את ההורים שלו. איך לעזור?',
+        choices: [
+          { label: 'חפשו ביחד בקול רם', emoji: '📣', nextId: 'search' },
+          { label: 'תני לו אוכל ממה שיש', emoji: '🍎', nextId: 'give_food' },
+        ],
+      },
+      {
+        id: 'search',
+        emoji: '🌟',
+        text: 'עדי ואלי קראו בקול: "אמא! אבא!" אחרי עשר דקות — קול ענה! ההורים של אלי ריצו אליו ובכו מרוב שמחה. עדי קיבלה מדליית גיבורה!',
+        isEnding: true,
+        endingEmoji: '🦸🌟',
+      },
+      {
+        id: 'give_food',
+        emoji: '🍎',
+        text: 'אלי אכל את התפוח ושמח. אז הם ניסו לקרוא בקול יחד. מצאו את המשפחה! אמא של אלי אמרה: "תודה לך, גיבורה קטנה!"',
+        isEnding: true,
+        endingEmoji: '🍎🤝',
+      },
+      {
+        id: 'tell_mom',
+        emoji: '👩‍👧',
+        text: 'אמא של עדי הלכה לאלי, הרגיעה אותו והחזיקה בידו. ביחד, כולם הלכו לחפש את ההורים שלו ומצאו אותם ליד המעיין!',
+        choices: [
+          { label: 'מה אלי אמר?', emoji: '💬', nextId: 'grateful' },
+          { label: 'חגגו יחד', emoji: '🎉', nextId: 'celebrate' },
+        ],
+      },
+      {
+        id: 'grateful',
+        emoji: '💙',
+        text: 'אלי אמר: "לא אשכח אתכם לעולם!" הם החליפו מספרי טלפון ונהיו חברים. כל חופשה הם נפגשים ביער!',
+        isEnding: true,
+        endingEmoji: '💙🌲',
+      },
+      {
+        id: 'celebrate',
+        emoji: '🎊',
+        text: 'הם ישבו יחד ואכלו כריכים ושתו מיץ. ואז כולם שרו שיר יחד. זה היה הטיול הכי כיף שעדי אי פעם הייתה בו!',
+        isEnding: true,
+        endingEmoji: '🎊🌲',
+      },
+      {
+        id: 'cheer',
+        emoji: '😂',
+        text: 'עדי עשתה פרצופים מצחיקים ואלי פסק לבכות והתחיל לצחוק. "מי אתה?" שאלה. אחרי שמיצאו את ההורים, הוא אמר: "אתה כי מצחיקה לכל חיים!"',
+        isEnding: true,
+        endingEmoji: '😄🤝',
+      },
+    ],
+  },
+  {
+    id: 'space',
+    title: 'טיסה לחלל',
+    description: 'רון ומיה בחללית — הרפתקה בין הכוכבים!',
+    emoji: '🚀',
+    color: 'from-indigo-500 to-purple-600',
+    startId: 'start',
+    nodes: [
+      {
+        id: 'start',
+        emoji: '🚀',
+        text: 'רון ומיה היו בחללית מעל כדור הארץ. פתאום — בום! סלע חלל פגע בהם. מה לעשות?',
+        choices: [
+          { label: 'לחץ על הכפתור האדום', emoji: '🔴', nextId: 'red_button' },
+          { label: 'קרא למרכז הבקרה', emoji: '📡', nextId: 'control_center' },
+          { label: 'צא לתיקון בחלל', emoji: '🧑‍🚀', nextId: 'spacewalk' },
+        ],
+      },
+      {
+        id: 'red_button',
+        emoji: '🛡️',
+        text: 'הכפתור האדום הפעיל מגן אנרגיה! החללית הייתה בטוחה. אבל הם איבדו את הכיוון. לאן ללכת?',
+        choices: [
+          { label: 'לכוכב הירוק הקרוב', emoji: '🟢', nextId: 'green_star' },
+          { label: 'לחזור לכדור הארץ', emoji: '🌍', nextId: 'home' },
+        ],
+      },
+      {
+        id: 'green_star',
+        emoji: '👽',
+        text: 'הם נחתו על כוכב ירוק. מצאו שם חייזרים קטנים וחמודים שאמרו: "שלום!" בעברית! החייזרים עזרו להם לחזור הביתה ונשארו חברים!',
+        isEnding: true,
+        endingEmoji: '👽🌍',
+      },
+      {
+        id: 'home',
+        emoji: '🌍',
+        text: 'רון ומיה ניווטו לפי הכוכבים וחזרו לכדור הארץ בשלום! כשנחתו, כולם מחאו כפיים. הם הפכו לאסטרונאוטים הצעירים ביותר בעולם!',
+        isEnding: true,
+        endingEmoji: '🌍🏆',
+      },
+      {
+        id: 'control_center',
+        emoji: '📡',
+        text: 'מרכז הבקרה ענה: "אל תדאגו! שלחנו חללית הצלה!" אחרי כמה דקות ראו אורות כחולים. הגיעה העזרה!',
+        choices: [
+          { label: 'תספרו לכולם', emoji: '📺', nextId: 'tell_all' },
+          { label: 'שמרו את הסוד', emoji: '🤫', nextId: 'secret' },
+        ],
+      },
+      {
+        id: 'tell_all',
+        emoji: '📺',
+        text: 'רון ומיה הפכו לגיבורים. הם הופיעו בחדשות ובספרים. ילדים מכל העולם שאלו: "איך זה להיות בחלל?" והם סיפרו הכל!',
+        isEnding: true,
+        endingEmoji: '📺🌟',
+      },
+      {
+        id: 'secret',
+        emoji: '🌟',
+        text: 'הם החליטו לשמור את הסוד. רק הם שניים ידעו. ובלילה, כשהביטו בכוכבים, חייכו בסוד ואמרו: "אנחנו יודעים..."',
+        isEnding: true,
+        endingEmoji: '🌟🤫',
+      },
+      {
+        id: 'spacewalk',
+        emoji: '🧑‍🚀',
+        text: 'רון לבש חליפת חלל יצא לתקן. זה היה קר ושקט שם בחוץ. הוא ראת את כדור הארץ כולו — כחול ויפה! הוא תיקן הכל ושב. "הצלחתי!" הוא צעק!',
+        isEnding: true,
+        endingEmoji: '🧑‍🚀🔧',
+      },
+    ],
+  },
+];

--- a/gamesformykids/lib/registry/registryData/batch4.ts
+++ b/gamesformykids/lib/registry/registryData/batch4.ts
@@ -632,4 +632,15 @@ export const gamesRegistryBatch4: GameRegistration[] = [
     available: true,
     order: 178,
   },
+  {
+    id: "choose-adventure",
+    title: "ספר הרפתקאות",
+    description: "סיפורים אינטראקטיביים בעברית — בחר את הדרך וגלה סיומים שונים!",
+    icon: BookOpen,
+    emoji: "📚",
+    color: "bg-indigo-500 hover:bg-indigo-600",
+    href: "/games/choose-adventure",
+    available: true,
+    order: 179,
+  },
 ];

--- a/gamesformykids/lib/types/core/base.ts
+++ b/gamesformykids/lib/types/core/base.ts
@@ -210,4 +210,6 @@ export type GameType =
   // Hidden object games
   | 'find-in-scene'
   // Word puzzle games
-  | 'hangman';
+  | 'hangman'
+  // Interactive story games
+  | 'choose-adventure';


### PR DESCRIPTION
## What
Adds a choose-your-own-adventure story game in Hebrew with 3 complete branching stories:

- **יוסי והחתול** 🐱 — Cat story with 4 unique endings
- **הטיול ביער** 🌲 — Forest walk story with 4 unique endings
- **טיסה לחלל** 🚀 — Space adventure with 4 unique endings

**Features:**
- TTS auto-reads each page's Hebrew text on load; 🔊 button to replay
- 2–3 illustrated choice buttons per page (min 48px touch targets)
- Endings-found counter tracks per-story discovery progress across the session
- 'קרא שוב' restarts the current story; '🏠 תפריט' returns to story list
- Full RTL layout throughout; touch-friendly on mobile

## Why
Closes #1224

## Test plan
- [ ] Navigate to `/games/choose-adventure`
- [ ] All 3 story cards appear in menu with emoji and description
- [ ] Tap a story → opening page auto-plays TTS
- [ ] Make choices and reach an ending → ending screen with emoji + קרא שוב button
- [ ] קרא שוב → resets to story beginning
- [ ] Find multiple endings → counter updates on menu card
- [ ] Works on mobile touch

🤖 Generated with [Claude Code](https://claude.com/claude-code)