### PR TITLE
feat(melody-maker): Hebrew xylophone with recording and song learning (closes #1223)

### DIFF
--- a/gamesformykids/app/games/[gameType]/CustomGameRenderer.tsx
+++ b/gamesformykids/app/games/[gameType]/CustomGameRenderer.tsx
@@ -58,7 +58,9 @@ const GAME_CLIENTS: Record<string, ComponentType> = {
   'word-search':       dynamic(() => import('../word-search/WordSearchClient'),                      { ssr: false }),
 
   'israel-map':        dynamic(() => import('../israel-map/IsraelMapClient'),                        { ssr: false }),
+
   'kids-songs':        dynamic(() => import('../kids-songs/KidsSongsClient'),                        { ssr: false }),
+  'melody-maker':        dynamic(() => import('../melody-maker/MelodyMakerClient'),                    { ssr: false }),
 };
 
 interface Props { gameType: string; }

--- a/gamesformykids/app/games/[gameType]/gamePageConstants.ts
+++ b/gamesformykids/app/games/[gameType]/gamePageConstants.ts
@@ -76,7 +76,9 @@ export const SUPPORTED_GAMES = [
   'word-search',
 
   'israel-map',
+
   'kids-songs',
+  'melody-maker',
 ] as const;
 
 export type SupportedGameType = typeof SUPPORTED_GAMES[number];
@@ -91,7 +93,9 @@ export const CUSTOM_GAME_TYPES = new Set([
   'word-builder', 'word-scramble', 'maze', 'letter-defender', 'puppet-story', 'number-slide', 'snakes-ladders',
 
 
-  'escape-room', 'robot-coder', 'find-in-scene', 'hangman', 'choose-adventure', 'picture-dictionary', 'word-search', 'israel-map', 'kids-songs',
+
+  'escape-room', 'robot-coder', 'find-in-scene', 'hangman', 'choose-adventure', 'picture-dictionary', 'word-search', 'israel-map', 'kids-songs', 'melody-maker',
+  
   
   
 ]);

--- a/gamesformykids/app/games/melody-maker/MelodyMakerClient.tsx
+++ b/gamesformykids/app/games/melody-maker/MelodyMakerClient.tsx
@@ -1,0 +1,119 @@
+'use client';
+import { MELODY_MAKER_SONGS } from '@/lib/constants/melodyMakerSongs';
+import { useMelodyMaker, NOTE_NAMES_HE } from './useMelodyMaker';
+import XylophoneKeys from './components/XylophoneKeys';
+import SongGuide from './components/SongGuide';
+
+export default function MelodyMakerClient() {
+  const {
+    mode, recording, isRecording, isPlayingBack,
+    selectedSong, songProgress, songComplete, flashingKey,
+    setMode, startRecording, stopRecording,
+    selectSong, clearSelectedSong, resetSong,
+    tapKey, playbackRecording, previewSong,
+  } = useMelodyMaker();
+
+  const songNotes = selectedSong !== null ? (MELODY_MAKER_SONGS[selectedSong]?.notes ?? null) : null;
+  const highlightKey =
+    mode === 'learning' && songNotes !== null && !songComplete
+      ? (songNotes[songProgress] ?? null)
+      : null;
+
+  return (
+    <div className="min-h-screen bg-linear-to-br from-purple-100 via-pink-50 to-yellow-100 flex flex-col items-center py-6 px-4 gap-6" dir="rtl">
+      <div className="text-center">
+        <h1 className="text-3xl font-extrabold text-purple-800">🎼 יוצר מנגינות</h1>
+        <p className="text-purple-500 text-sm mt-1">נגן, הקלט ולמד שירים עבריים!</p>
+      </div>
+
+      <div className="flex gap-2">
+        <button
+          onClick={() => setMode('free')}
+          className={[
+            'px-4 py-2 rounded-full font-bold text-sm transition-all',
+            mode === 'free'
+              ? 'bg-purple-600 text-white shadow-md'
+              : 'bg-white text-purple-600 border-2 border-purple-300 hover:bg-purple-50',
+          ].join(' ')}
+        >
+          🎵 נגינה חופשית
+        </button>
+        <button
+          onClick={() => setMode('learning')}
+          className={[
+            'px-4 py-2 rounded-full font-bold text-sm transition-all',
+            mode === 'learning'
+              ? 'bg-purple-600 text-white shadow-md'
+              : 'bg-white text-purple-600 border-2 border-purple-300 hover:bg-purple-50',
+          ].join(' ')}
+        >
+          📖 לומד שיר
+        </button>
+      </div>
+
+      <div className="w-full max-w-lg bg-white bg-opacity-70 rounded-2xl p-4 shadow-lg">
+        <XylophoneKeys
+          onTap={tapKey}
+          flashingKey={flashingKey}
+          highlightKey={highlightKey}
+        />
+      </div>
+
+      {mode === 'free' ? (
+        <div className="flex flex-col items-center gap-3 w-full max-w-lg">
+          <div className="flex gap-3">
+            {!isRecording ? (
+              <button
+                onClick={startRecording}
+                className="bg-red-500 text-white rounded-xl px-5 py-3 font-bold hover:bg-red-600 shadow flex items-center gap-2"
+              >
+                🔴 הקלט
+              </button>
+            ) : (
+              <button
+                onClick={stopRecording}
+                className="bg-gray-700 text-white rounded-xl px-5 py-3 font-bold hover:bg-gray-800 shadow flex items-center gap-2 animate-pulse"
+              >
+                ⏹ עצור
+              </button>
+            )}
+            <button
+              onClick={playbackRecording}
+              disabled={recording.length === 0 || isPlayingBack}
+              className="bg-green-500 text-white rounded-xl px-5 py-3 font-bold hover:bg-green-600 shadow disabled:opacity-40 flex items-center gap-2"
+            >
+              ▶️ נגן
+            </button>
+          </div>
+
+          {isRecording && (
+            <p className="text-red-500 font-bold text-sm animate-pulse">● מקליט...</p>
+          )}
+
+          {recording.length > 0 && (
+            <div className="flex flex-wrap gap-1 justify-center bg-white bg-opacity-80 rounded-xl p-3 w-full">
+              {recording.map((noteIdx, i) => (
+                <span key={i} className="bg-purple-100 text-purple-700 text-xs font-bold px-2 py-1 rounded-full">
+                  {NOTE_NAMES_HE[noteIdx] ?? ''}
+                </span>
+              ))}
+            </div>
+          )}
+        </div>
+      ) : (
+        <div className="w-full max-w-lg bg-white bg-opacity-70 rounded-2xl p-4 shadow-lg">
+          <SongGuide
+            selectedSong={selectedSong}
+            songProgress={songProgress}
+            songComplete={songComplete}
+            onSelectSong={selectSong}
+            onPreview={previewSong}
+            onResetSong={resetSong}
+            onBackToSongList={clearSelectedSong}
+            onExitLearning={() => setMode('free')}
+          />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/gamesformykids/app/games/melody-maker/components/SongGuide.tsx
+++ b/gamesformykids/app/games/melody-maker/components/SongGuide.tsx
@@ -1,0 +1,122 @@
+'use client';
+import { MELODY_MAKER_SONGS } from '@/lib/constants/melodyMakerSongs';
+import { NOTE_NAMES_HE } from '../useMelodyMaker';
+
+interface Props {
+  selectedSong: number | null;
+  songProgress: number;
+  songComplete: boolean;
+  onSelectSong: (index: number) => void;
+  onPreview: (index: number) => void;
+  onResetSong: () => void;
+  onBackToSongList: () => void;
+  onExitLearning: () => void;
+}
+
+export default function SongGuide({
+  selectedSong,
+  songProgress,
+  songComplete,
+  onSelectSong,
+  onPreview,
+  onResetSong,
+  onBackToSongList,
+  onExitLearning,
+}: Props) {
+  if (selectedSong === null) {
+    return (
+      <div className="flex flex-col items-center gap-3 w-full" dir="rtl">
+        <p className="text-purple-700 font-bold text-lg">🎼 בחר שיר ללמידה</p>
+        <div className="flex flex-wrap gap-3 justify-center">
+          {MELODY_MAKER_SONGS.map((song, i) => (
+            <button
+              key={song.id}
+              onClick={() => onSelectSong(i)}
+              className="flex flex-col items-center gap-1 bg-white border-2 border-purple-300 rounded-xl px-4 py-3 hover:bg-purple-50 hover:border-purple-500 transition-all shadow"
+            >
+              <span className="text-3xl">{song.emoji}</span>
+              <span className="font-bold text-purple-800 text-sm">{song.title}</span>
+              <span className="text-purple-400 text-xs">{song.notes.length} תווים</span>
+            </button>
+          ))}
+        </div>
+        <button
+          onClick={onExitLearning}
+          className="text-sm text-gray-500 underline mt-1 hover:text-gray-700"
+        >
+          ← חזור לנגינה חופשית
+        </button>
+      </div>
+    );
+  }
+
+  const song = MELODY_MAKER_SONGS[selectedSong];
+  if (!song) return null;
+
+  const nextNote = song.notes[songProgress];
+
+  return (
+    <div className="flex flex-col items-center gap-3 w-full" dir="rtl">
+      <div className="flex items-center gap-2">
+        <span className="text-2xl">{song.emoji}</span>
+        <span className="font-bold text-purple-800 text-lg">{song.title}</span>
+        <button
+          onClick={() => onPreview(selectedSong)}
+          className="text-xs bg-purple-100 text-purple-700 rounded-full px-3 py-1 hover:bg-purple-200"
+        >
+          🔊 האזן
+        </button>
+      </div>
+
+      {songComplete ? (
+        <div className="flex flex-col items-center gap-2 bg-green-50 border-2 border-green-400 rounded-xl px-6 py-3">
+          <span className="text-3xl">🎉</span>
+          <p className="font-bold text-green-700">כל הכבוד! ניגנת את השיר!</p>
+          <div className="flex gap-2 mt-1">
+            <button
+              onClick={onResetSong}
+              className="bg-green-500 text-white rounded-lg px-4 py-2 text-sm hover:bg-green-600"
+            >
+              🔄 שוב
+            </button>
+            <button
+              onClick={onBackToSongList}
+              className="bg-purple-500 text-white rounded-lg px-4 py-2 text-sm hover:bg-purple-600"
+            >
+              🎵 שיר אחר
+            </button>
+          </div>
+        </div>
+      ) : (
+        <>
+          <div className="flex gap-1 flex-wrap justify-center">
+            {song.notes.map((noteIdx, i) => (
+              <span
+                key={i}
+                className={[
+                  'text-xs font-bold px-2 py-1 rounded-full',
+                  i < songProgress ? 'bg-green-400 text-white' :
+                  i === songProgress ? 'bg-purple-500 text-white ring-2 ring-purple-300 scale-110' :
+                  'bg-gray-200 text-gray-500',
+                ].join(' ')}
+              >
+                {NOTE_NAMES_HE[noteIdx] ?? ''}
+              </span>
+            ))}
+          </div>
+          {nextNote !== undefined && (
+            <p className="text-purple-700 font-bold text-sm">
+              לחץ על: <span className="text-purple-900 text-lg">{NOTE_NAMES_HE[nextNote] ?? ''}</span>
+            </p>
+          )}
+        </>
+      )}
+      <button
+        onClick={onBackToSongList}
+        className="text-xs text-gray-400 underline hover:text-gray-600 mt-1"
+      >
+        ← שנה שיר
+      </button>
+    </div>
+  );
+}

--- a/gamesformykids/app/games/melody-maker/components/XylophoneKeys.tsx
+++ b/gamesformykids/app/games/melody-maker/components/XylophoneKeys.tsx
@@ -1,0 +1,40 @@
+'use client';
+import { NOTE_COLORS, NOTE_NAMES_HE } from '../useMelodyMaker';
+
+interface Props {
+  onTap: (noteIndex: number) => void;
+  flashingKey: number | null;
+  highlightKey: number | null;
+}
+
+export default function XylophoneKeys({ onTap, flashingKey, highlightKey }: Props) {
+  return (
+    <div className="flex gap-2 justify-center items-end w-full px-2 select-none" dir="ltr">
+      {NOTE_COLORS.map((color, i) => {
+        const isFlashing = flashingKey === i;
+        const isHighlighted = highlightKey === i;
+        const heightClass = [
+          'h-40', 'h-36', 'h-32', 'h-28', 'h-36', 'h-32', 'h-28', 'h-40',
+        ][i] ?? 'h-32';
+        return (
+          <button
+            key={i}
+            onPointerDown={() => onTap(i)}
+            className={[
+              'flex-1 rounded-b-xl rounded-t-sm text-white font-bold text-xs sm:text-sm',
+              'transition-all duration-75 touch-none',
+              'shadow-md flex flex-col items-center justify-end pb-3 gap-1',
+              color,
+              heightClass,
+              isFlashing || isHighlighted ? 'brightness-150 scale-105 ring-4 ring-white' : '',
+            ].join(' ')}
+            aria-label={NOTE_NAMES_HE[i]}
+          >
+            <span className="text-lg leading-none">{['♩','♪','♫','♬','♩','♪','♫','♬'][i]}</span>
+            <span className="font-bold leading-none">{NOTE_NAMES_HE[i]}</span>
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/gamesformykids/app/games/melody-maker/melodyMakerStore.ts
+++ b/gamesformykids/app/games/melody-maker/melodyMakerStore.ts
@@ -1,0 +1,52 @@
+'use client';
+import { create } from 'zustand';
+
+export type GameMode = 'free' | 'learning';
+
+interface State {
+  mode: GameMode;
+  recording: number[];
+  isRecording: boolean;
+  isPlayingBack: boolean;
+  selectedSong: number | null;
+  songProgress: number;
+  songComplete: boolean;
+  flashingKey: number | null;
+}
+
+interface Actions {
+  setMode: (mode: GameMode) => void;
+  startRecording: () => void;
+  stopRecording: () => void;
+  addToRecording: (noteIndex: number) => void;
+  setPlayingBack: (v: boolean) => void;
+  selectSong: (index: number) => void;
+  clearSelectedSong: () => void;
+  advanceSong: () => void;
+  setSongComplete: (v: boolean) => void;
+  setFlashingKey: (key: number | null) => void;
+  resetSong: () => void;
+}
+
+export const useMelodyMakerStore = create<State & Actions>((set) => ({
+  mode: 'free',
+  recording: [],
+  isRecording: false,
+  isPlayingBack: false,
+  selectedSong: null,
+  songProgress: 0,
+  songComplete: false,
+  flashingKey: null,
+
+  setMode: (mode) => set({ mode }),
+  startRecording: () => set({ isRecording: true, recording: [] }),
+  stopRecording: () => set({ isRecording: false }),
+  addToRecording: (noteIndex) => set((s) => ({ recording: [...s.recording, noteIndex] })),
+  setPlayingBack: (v) => set({ isPlayingBack: v }),
+  selectSong: (index) => set({ selectedSong: index, songProgress: 0, songComplete: false, flashingKey: null }),
+  advanceSong: () => set((s) => ({ songProgress: s.songProgress + 1 })),
+  setSongComplete: (v) => set({ songComplete: v }),
+  setFlashingKey: (key) => set({ flashingKey: key }),
+  resetSong: () => set({ songProgress: 0, songComplete: false, flashingKey: null }),
+  clearSelectedSong: () => set({ selectedSong: null, songProgress: 0, songComplete: false, flashingKey: null }),
+}));

--- a/gamesformykids/app/games/melody-maker/useMelodyMaker.ts
+++ b/gamesformykids/app/games/melody-maker/useMelodyMaker.ts
@@ -1,0 +1,104 @@
+'use client';
+import { useCallback, useRef } from 'react';
+import { useMelodyMakerStore } from './melodyMakerStore';
+import { MELODY_MAKER_SONGS } from '@/lib/constants/melodyMakerSongs';
+import { speakHebrew } from '@/lib/utils/speech/enhancedSpeechUtils';
+
+export const NOTE_FREQUENCIES: number[] = [261.63, 293.66, 329.63, 349.23, 392.00, 440.00, 493.88, 523.25];
+export const NOTE_NAMES_HE: string[] = ['דּוֹ', 'רֵה', 'מִי', 'פָּה', 'סוֹל', 'לָה', 'סִי', 'דּוֹ'];
+export const NOTE_COLORS: string[] = [
+  'bg-red-500 hover:bg-red-400 active:bg-red-600',
+  'bg-orange-500 hover:bg-orange-400 active:bg-orange-600',
+  'bg-yellow-500 hover:bg-yellow-400 active:bg-yellow-600',
+  'bg-green-500 hover:bg-green-400 active:bg-green-600',
+  'bg-teal-500 hover:bg-teal-400 active:bg-teal-600',
+  'bg-blue-500 hover:bg-blue-400 active:bg-blue-600',
+  'bg-indigo-500 hover:bg-indigo-400 active:bg-indigo-600',
+  'bg-pink-500 hover:bg-pink-400 active:bg-pink-600',
+];
+
+function playOscillator(ctx: AudioContext, freq: number, startTime: number, duration: number) {
+  const osc = ctx.createOscillator();
+  const gain = ctx.createGain();
+  osc.type = 'triangle';
+  osc.frequency.setValueAtTime(freq, startTime);
+  gain.gain.setValueAtTime(0.5, startTime);
+  gain.gain.exponentialRampToValueAtTime(0.001, startTime + duration);
+  osc.connect(gain);
+  gain.connect(ctx.destination);
+  osc.start(startTime);
+  osc.stop(startTime + duration + 0.01);
+}
+
+export function useMelodyMaker() {
+  const store = useMelodyMakerStore();
+  const audioCtxRef = useRef<AudioContext | null>(null);
+
+  const getCtx = useCallback((): AudioContext => {
+    if (!audioCtxRef.current) {
+      audioCtxRef.current = new AudioContext();
+    }
+    const ctx = audioCtxRef.current;
+    if (ctx.state === 'suspended') {
+      void ctx.resume();
+    }
+    return ctx;
+  }, []);
+
+  const tapKey = useCallback((noteIndex: number) => {
+    const ctx = getCtx();
+    const freq = NOTE_FREQUENCIES[noteIndex] ?? 261.63;
+    playOscillator(ctx, freq, ctx.currentTime, 0.5);
+    speakHebrew(NOTE_NAMES_HE[noteIndex] ?? '');
+
+    const { isRecording, addToRecording, mode, selectedSong, songProgress, advanceSong, setSongComplete } =
+      useMelodyMakerStore.getState();
+
+    if (isRecording) {
+      addToRecording(noteIndex);
+    }
+
+    if (mode === 'learning' && selectedSong !== null) {
+      const song = MELODY_MAKER_SONGS[selectedSong];
+      if (!song) return;
+      const expected = song.notes[songProgress];
+      if (noteIndex === expected) {
+        const next = songProgress + 1;
+        if (next >= song.notes.length) {
+          setSongComplete(true);
+        } else {
+          advanceSong();
+        }
+      }
+    }
+  }, [getCtx]);
+
+  const playbackRecording = useCallback(() => {
+    const { recording, isPlayingBack, setPlayingBack } = useMelodyMakerStore.getState();
+    if (recording.length === 0 || isPlayingBack) return;
+    setPlayingBack(true);
+    const ctx = getCtx();
+    const now = ctx.currentTime;
+    recording.forEach((noteIndex, i) => {
+      const freq = NOTE_FREQUENCIES[noteIndex] ?? 261.63;
+      playOscillator(ctx, freq, now + i * 0.6, 0.5);
+    });
+    setTimeout(() => setPlayingBack(false), recording.length * 600 + 200);
+  }, [getCtx]);
+
+  const previewSong = useCallback((songIndex: number) => {
+    const song = MELODY_MAKER_SONGS[songIndex];
+    if (!song) return;
+    const { setFlashingKey } = useMelodyMakerStore.getState();
+    const ctx = getCtx();
+    const now = ctx.currentTime;
+    song.notes.forEach((noteIndex, i) => {
+      const freq = NOTE_FREQUENCIES[noteIndex] ?? 261.63;
+      playOscillator(ctx, freq, now + i * 0.65, 0.5);
+      setTimeout(() => setFlashingKey(noteIndex), i * 650);
+    });
+    setTimeout(() => setFlashingKey(null), song.notes.length * 650 + 200);
+  }, [getCtx]);
+
+  return { ...store, tapKey, playbackRecording, previewSong };
+}

--- a/gamesformykids/lib/constants/gameCategories.ts
+++ b/gamesformykids/lib/constants/gameCategories.ts
@@ -38,7 +38,7 @@ export const GAME_CATEGORIES: Record<string, GameCategory> = {
     icon: Palette,
     color: "bg-purple-500",
     gradient: "from-purple-400 to-purple-600",
-    gameIds: ["instruments","puzzles","drawing","building","tetris","magic-fairy-tales","circus-show","logic-games","art-craft","superheroes","fairy-tale-chars","famous-paintings","tech-logos","color-mix","puppet-story"],
+    gameIds: ["instruments","puzzles","drawing","building","tetris","magic-fairy-tales","circus-show","logic-games","art-craft","superheroes","fairy-tale-chars","famous-paintings","tech-logos","color-mix","puppet-story","melody-maker"],
   },
   nature: {
     title: "טבע ואוכל",

--- a/gamesformykids/lib/constants/melodyMakerSongs.ts
+++ b/gamesformykids/lib/constants/melodyMakerSongs.ts
@@ -1,0 +1,28 @@
+export interface MelodyMakerSong {
+  id: string;
+  title: string;
+  emoji: string;
+  notes: number[];
+}
+
+// Note indices: 0=C4(דו), 1=D4(רה), 2=E4(מי), 3=F4(פה), 4=G4(סול), 5=A4(לה), 6=B4(סי), 7=C5(דו)
+export const MELODY_MAKER_SONGS: MelodyMakerSong[] = [
+  {
+    id: 'yeled-katan',
+    title: 'ילד קטן',
+    emoji: '👦',
+    notes: [0, 0, 4, 4, 5, 5, 4, 3, 3, 2, 2, 1, 1, 0],
+  },
+  {
+    id: 'nikolai',
+    title: 'ניקולאי',
+    emoji: '🎵',
+    notes: [2, 1, 0, 1, 2, 2, 2, 1, 1, 1, 2, 4, 4],
+  },
+  {
+    id: 'roshi-roshi',
+    title: 'ראשי ראשי',
+    emoji: '🎶',
+    notes: [0, 0, 0, 1, 2, 2, 1, 2, 3, 4],
+  },
+];

--- a/gamesformykids/lib/registry/registryData/batch4.ts
+++ b/gamesformykids/lib/registry/registryData/batch4.ts
@@ -688,4 +688,15 @@ export const gamesRegistryBatch4: GameRegistration[] = [
     available: true,
     order: 183,
   },
+  {
+    id: "melody-maker",
+    title: "יוצר מנגינות",
+    description: "נגן על קסילופון צבעוני, הקלט מנגינות ולמד שירי ילדים עבריים!",
+    icon: Music,
+    emoji: "🎼",
+    color: "bg-purple-600 hover:bg-purple-700",
+    href: "/games/melody-maker",
+    available: true,
+    order: 184,
+  },
 ];

--- a/gamesformykids/lib/types/core/base.ts
+++ b/gamesformykids/lib/types/core/base.ts
@@ -221,5 +221,8 @@ export type GameType =
 
   // Interactive map
   | 'israel-map'
+
   // Music & songs
-  | 'kids-songs';
+  | 'kids-songs'
+  // Music & creativity
+  | 'melody-maker';


### PR DESCRIPTION
## What
Adds a colourful Hebrew xylophone game — 8 keys (C4–C5) using Web Audio API oscillators, no audio files required.

**Free mode:** tap rainbow keys → hears the note + TTS says Hebrew note name (דו/רה/מי/פה/סול/לה/סי/דו). Record button captures a sequence; Play button plays it back.

**Learning mode:** choose one of 3 Hebrew children's songs (ילד קטן, ניקולאי, ראשי ראשי) → the correct key to tap next is highlighted in pulsing purple → tap it to advance → completion celebration when the full song is played correctly. "Listen" button plays a preview with flashing keys.

iOS Safari handled via `AudioContext.resume()` on every user gesture.

## Why
Closes #1223

## Test plan
- [ ] Tap all 8 keys — each plays a distinct note and TTS says the Hebrew name
- [ ] Record a sequence and play it back
- [ ] Enter learning mode, select a song, tap keys in order until completion
- [ ] Use "Listen" button to hear the song preview with flashing keys
- [ ] RTL layout correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)