### PR TITLE
feat(age-calculator): add Hebrew birthday age calculator with live seconds (closes #1221)

### DIFF
--- a/gamesformykids/app/games/[gameType]/CustomGameRenderer.tsx
+++ b/gamesformykids/app/games/[gameType]/CustomGameRenderer.tsx
@@ -62,6 +62,7 @@ const GAME_CLIENTS: Record<string, ComponentType> = {
   'kids-songs':        dynamic(() => import('../kids-songs/KidsSongsClient'),                        { ssr: false }),
   'melody-maker':        dynamic(() => import('../melody-maker/MelodyMakerClient'),                    { ssr: false }),
   'kids-encyclopedia': dynamic(() => import('../kids-encyclopedia/EncyclopediaClient'),              { ssr: false }),
+  'age-calculator':    dynamic(() => import('../age-calculator/AgeCalculatorClient'),                { ssr: false }),
 };
 
 interface Props { gameType: string; }

--- a/gamesformykids/app/games/[gameType]/gamePageConstants.ts
+++ b/gamesformykids/app/games/[gameType]/gamePageConstants.ts
@@ -80,6 +80,7 @@ export const SUPPORTED_GAMES = [
   'kids-songs',
   'melody-maker',
   'kids-encyclopedia',
+  'age-calculator',
 ] as const;
 
 export type SupportedGameType = typeof SUPPORTED_GAMES[number];
@@ -94,7 +95,7 @@ export const CUSTOM_GAME_TYPES = new Set([
   'word-builder', 'word-scramble', 'maze', 'letter-defender', 'puppet-story', 'number-slide', 'snakes-ladders',
 
 
-  'escape-room', 'robot-coder', 'find-in-scene', 'hangman', 'choose-adventure', 'picture-dictionary', 'word-search', 'israel-map', 'kids-songs', 'melody-maker', 'kids-encyclopedia',
+  'escape-room', 'robot-coder', 'find-in-scene', 'hangman', 'choose-adventure', 'picture-dictionary', 'word-search', 'israel-map', 'kids-songs', 'melody-maker', 'kids-encyclopedia', 'age-calculator',
   
   
 ]);

--- a/gamesformykids/app/games/age-calculator/AgeCalculatorClient.tsx
+++ b/gamesformykids/app/games/age-calculator/AgeCalculatorClient.tsx
@@ -1,0 +1,127 @@
+'use client';
+import { useAgeCalculator } from './useAgeCalculator';
+
+function plural(n: number, one: string, many: string) {
+  return n === 1 ? `${n} ${one}` : `${n} ${many}`;
+}
+
+function formatBig(n: number) {
+  return n.toLocaleString('he-IL');
+}
+
+export default function AgeCalculatorClient() {
+  const { birthdayInput, setBirthdayInput, result, calculated, calculate, reset } = useAgeCalculator();
+
+  const today = new Date().toISOString().split('T')[0];
+
+  const shareText = result
+    ? `אני בן/בת ${plural(result.years, 'שנה', 'שנים')}, ${plural(result.months, 'חודש', 'חודשים')} ו-${plural(result.days, 'יום', 'ימים')}! 🎂 זה ${formatBig(result.totalDays)} ימים! עוד ${result.daysUntilBirthday} ימים ליום ההולדת הבא!`
+    : '';
+
+  const whatsappUrl = `https://wa.me/?text=${encodeURIComponent(shareText + '\n' + window.location.href)}`;
+
+  return (
+    <div
+      dir="rtl"
+      className="min-h-screen flex flex-col items-center justify-center p-4"
+      style={{ background: 'linear-gradient(135deg, #fce4ec 0%, #e1f5fe 50%, #f3e5f5 100%)' }}
+    >
+      <div className="w-full max-w-md">
+        {/* Header */}
+        <div className="text-center mb-8">
+          <div className="text-6xl mb-3">🎂</div>
+          <h1 className="text-3xl font-extrabold text-purple-800">כמה אני בן/בת?</h1>
+          <p className="text-purple-600 mt-1">הזן את תאריך הלידה שלך וגלה!</p>
+        </div>
+
+        {!calculated ? (
+          /* Input card */
+          <div className="bg-white rounded-3xl shadow-xl p-6 space-y-5">
+            <div className="space-y-2">
+              <label className="block text-lg font-bold text-gray-700">תאריך לידה:</label>
+              <input
+                type="date"
+                value={birthdayInput}
+                onChange={(e) => setBirthdayInput(e.target.value)}
+                max={today}
+                className="w-full border-2 border-purple-300 rounded-xl px-4 py-3 text-lg focus:border-purple-500 focus:outline-none text-right"
+              />
+            </div>
+            <button
+              onClick={calculate}
+              disabled={!birthdayInput}
+              className="w-full bg-linear-to-br from-purple-500 to-pink-500 text-white text-xl font-bold py-4 rounded-2xl shadow-lg disabled:opacity-40 active:scale-95 transition-transform"
+            >
+              חשב! 🎉
+            </button>
+          </div>
+        ) : result ? (
+          /* Result card */
+          <div className="space-y-4">
+            {result.isBirthdayToday && (
+              <div className="bg-yellow-100 border-2 border-yellow-400 rounded-2xl p-4 text-center text-xl font-bold text-yellow-700 animate-bounce">
+                🎉 יום הולדת שמח! 🎉
+              </div>
+            )}
+
+            <div className="bg-white rounded-3xl shadow-xl p-6 text-center space-y-4">
+              <div className="text-5xl font-extrabold text-purple-700">
+                {plural(result.years, 'שנה', 'שנים')}
+              </div>
+              <div className="text-2xl text-gray-600">
+                {plural(result.months, 'חודש', 'חודשים')} ו-{plural(result.days, 'יום', 'ימים')}
+              </div>
+
+              <hr className="border-purple-100" />
+
+              <div className="grid grid-cols-2 gap-3 text-center">
+                <div className="bg-purple-50 rounded-2xl p-3">
+                  <div className="text-2xl font-bold text-purple-700">{formatBig(result.totalDays)}</div>
+                  <div className="text-sm text-gray-500">ימים</div>
+                </div>
+                <div className="bg-pink-50 rounded-2xl p-3">
+                  <div className="text-2xl font-bold text-pink-700">{formatBig(result.totalHours)}</div>
+                  <div className="text-sm text-gray-500">שעות</div>
+                </div>
+              </div>
+
+              {/* Live seconds */}
+              <div className="bg-gradient-to-br from-purple-100 to-pink-100 rounded-2xl p-4">
+                <div className="text-3xl font-extrabold text-purple-800 tabular-nums">
+                  {formatBig(result.liveSeconds)}
+                </div>
+                <div className="text-sm text-purple-600 mt-1">⏱️ שניות חיות — ממשיכות לספור!</div>
+              </div>
+
+              {/* Birthday countdown */}
+              {!result.isBirthdayToday && (
+                <div className="bg-amber-50 border border-amber-200 rounded-2xl p-3">
+                  <div className="text-2xl font-bold text-amber-700">🎈 עוד {result.daysUntilBirthday} ימים</div>
+                  <div className="text-sm text-amber-600">ליום ההולדת הבא!</div>
+                </div>
+              )}
+            </div>
+
+            {/* Action buttons */}
+            <div className="grid grid-cols-2 gap-3">
+              <button
+                onClick={reset}
+                className="bg-white border-2 border-purple-300 text-purple-700 font-bold py-3 rounded-2xl active:scale-95 transition-transform"
+              >
+                חשב מחדש
+              </button>
+              <a
+                href={whatsappUrl}
+                target="_blank"
+                rel="noreferrer"
+                className="bg-green-500 text-white font-bold py-3 rounded-2xl text-center active:scale-95 transition-transform"
+              >
+                📤 שתף
+              </a>
+            </div>
+          </div>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/gamesformykids/app/games/age-calculator/useAgeCalculator.ts
+++ b/gamesformykids/app/games/age-calculator/useAgeCalculator.ts
@@ -1,0 +1,74 @@
+'use client';
+import { useState, useEffect, useCallback } from 'react';
+
+export interface AgeResult {
+  years: number;
+  months: number;
+  days: number;
+  totalDays: number;
+  totalHours: number;
+  liveSeconds: number;
+  daysUntilBirthday: number;
+  isBirthdayToday: boolean;
+}
+
+function computeAge(birthday: Date, now: Date): AgeResult {
+  let years = now.getFullYear() - birthday.getFullYear();
+  let months = now.getMonth() - birthday.getMonth();
+  let days = now.getDate() - birthday.getDate();
+
+  if (days < 0) {
+    months -= 1;
+    const prevMonth = new Date(now.getFullYear(), now.getMonth(), 0);
+    days += prevMonth.getDate();
+  }
+  if (months < 0) {
+    years -= 1;
+    months += 12;
+  }
+
+  const msElapsed = now.getTime() - birthday.getTime();
+  const totalDays = Math.floor(msElapsed / 86400000);
+  const totalHours = Math.floor(msElapsed / 3600000);
+  const liveSeconds = Math.floor(msElapsed / 1000);
+
+  const nextBirthday = new Date(now.getFullYear(), birthday.getMonth(), birthday.getDate());
+  if (nextBirthday < now) nextBirthday.setFullYear(now.getFullYear() + 1);
+  const msUntil = nextBirthday.getTime() - now.getTime();
+  const daysUntilBirthday = Math.ceil(msUntil / 86400000);
+  const isBirthdayToday = daysUntilBirthday === 0 || daysUntilBirthday === 365;
+
+  return { years, months, days, totalDays, totalHours, liveSeconds, daysUntilBirthday, isBirthdayToday };
+}
+
+export function useAgeCalculator() {
+  const [birthdayInput, setBirthdayInput] = useState('');
+  const [result, setResult] = useState<AgeResult | null>(null);
+  const [calculated, setCalculated] = useState(false);
+
+  const calculate = useCallback(() => {
+    if (!birthdayInput) return;
+    const birthday = new Date(birthdayInput);
+    if (isNaN(birthday.getTime())) return;
+    if (birthday > new Date()) return;
+    setResult(computeAge(birthday, new Date()));
+    setCalculated(true);
+  }, [birthdayInput]);
+
+  const reset = useCallback(() => {
+    setCalculated(false);
+    setResult(null);
+    setBirthdayInput('');
+  }, []);
+
+  useEffect(() => {
+    if (!calculated || !birthdayInput) return;
+    const birthday = new Date(birthdayInput);
+    const interval = setInterval(() => {
+      setResult(computeAge(birthday, new Date()));
+    }, 1000);
+    return () => clearInterval(interval);
+  }, [calculated, birthdayInput]);
+
+  return { birthdayInput, setBirthdayInput, result, calculated, calculate, reset };
+}

--- a/gamesformykids/lib/constants/gameCategories.ts
+++ b/gamesformykids/lib/constants/gameCategories.ts
@@ -132,6 +132,6 @@ export const GAME_CATEGORIES: Record<string, GameCategory> = {
     color: "bg-teal-500",
     gradient: "from-teal-400 to-cyan-600",
 
-    gameIds: ["true-false","emoji-math","math-race","number-bubbles","word-scramble","word-builder","word-chain","trivia","clock","spelling","opposites","world-languages","riddles","english-words","singular-plural","adjectives","verbs","visual-opposites","english-cards","proverbs","story-builder","robot-coder","hangman","choose-adventure","picture-dictionary","word-search","kids-songs","kids-encyclopedia"],
+    gameIds: ["true-false","emoji-math","math-race","number-bubbles","word-scramble","word-builder","word-chain","trivia","clock","spelling","opposites","world-languages","riddles","english-words","singular-plural","adjectives","verbs","visual-opposites","english-cards","proverbs","story-builder","robot-coder","hangman","choose-adventure","picture-dictionary","word-search","kids-songs","kids-encyclopedia","age-calculator"],
   },
 };

--- a/gamesformykids/lib/registry/registryData/batch4.ts
+++ b/gamesformykids/lib/registry/registryData/batch4.ts
@@ -710,4 +710,15 @@ export const gamesRegistryBatch4: GameRegistration[] = [
     available: true,
     order: 185,
   },
+  {
+    id: "age-calculator",
+    title: "כמה אני בן/בת?",
+    description: "הזן תאריך לידה וגלה את גילך המדויק בשנים, חודשים, ימים ושניות חיות!",
+    icon: Calculator,
+    emoji: "🎂",
+    color: "bg-pink-500 hover:bg-pink-600",
+    href: "/games/age-calculator",
+    available: true,
+    order: 186,
+  },
 ];

--- a/gamesformykids/lib/types/core/base.ts
+++ b/gamesformykids/lib/types/core/base.ts
@@ -227,4 +227,6 @@ export type GameType =
   // Music & creativity
   | 'melody-maker'
   // Kids encyclopedia
-  | 'kids-encyclopedia';
+  | 'kids-encyclopedia'
+  // Fun tools
+  | 'age-calculator';


### PR DESCRIPTION
## What
Adds a Hebrew birthday age calculator (Style D custom game) that computes a child's exact age in years, months, days, hours, and live-counting seconds from a date input.

## Features
- Native date input (mobile-friendly)
- Live seconds counter via `setInterval` (updates every 1s via `useEffect` cleanup)
- Days-until-next-birthday countdown
- Happy birthday message when today is the birthday
- WhatsApp share button with Hebrew age text
- RTL layout, Hebrew plural forms (שנה/שנים, חודש/חודשים, יום/ימים)

## Why
Closes #1221

## Test plan
- [ ] Enter a birthday and tap חשב! — verify years/months/days display correctly
- [ ] Seconds counter ticks every second
- [ ] Birthday countdown shows correct days remaining
- [ ] WhatsApp share button opens with pre-filled Hebrew text
- [ ] RTL layout looks correct
- [ ] TypeScript: zero errors (`npx tsc --noEmit`)
- [ ] Build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)