### PR TITLE
feat(craft-guide): add step-by-step Hebrew craft activity guide with TTS (closes #1220)

### DIFF
--- a/gamesformykids/app/games/[gameType]/CustomGameRenderer.tsx
+++ b/gamesformykids/app/games/[gameType]/CustomGameRenderer.tsx
@@ -63,6 +63,7 @@ const GAME_CLIENTS: Record<string, ComponentType> = {
   'melody-maker':        dynamic(() => import('../melody-maker/MelodyMakerClient'),                    { ssr: false }),
   'kids-encyclopedia': dynamic(() => import('../kids-encyclopedia/EncyclopediaClient'),              { ssr: false }),
   'age-calculator':    dynamic(() => import('../age-calculator/AgeCalculatorClient'),                { ssr: false }),
+  'craft-guide':       dynamic(() => import('../craft-guide/CraftGuideClient'),                      { ssr: false }),
 };
 
 interface Props { gameType: string; }

--- a/gamesformykids/app/games/[gameType]/gamePageConstants.ts
+++ b/gamesformykids/app/games/[gameType]/gamePageConstants.ts
@@ -81,6 +81,7 @@ export const SUPPORTED_GAMES = [
   'melody-maker',
   'kids-encyclopedia',
   'age-calculator',
+  'craft-guide',
 ] as const;
 
 export type SupportedGameType = typeof SUPPORTED_GAMES[number];
@@ -95,7 +96,7 @@ export const CUSTOM_GAME_TYPES = new Set([
   'word-builder', 'word-scramble', 'maze', 'letter-defender', 'puppet-story', 'number-slide', 'snakes-ladders',
 
 
-  'escape-room', 'robot-coder', 'find-in-scene', 'hangman', 'choose-adventure', 'picture-dictionary', 'word-search', 'israel-map', 'kids-songs', 'melody-maker', 'kids-encyclopedia', 'age-calculator',
+  'escape-room', 'robot-coder', 'find-in-scene', 'hangman', 'choose-adventure', 'picture-dictionary', 'word-search', 'israel-map', 'kids-songs', 'melody-maker', 'kids-encyclopedia', 'age-calculator', 'craft-guide',
   
   
 ]);

--- a/gamesformykids/app/games/craft-guide/CraftGuideClient.tsx
+++ b/gamesformykids/app/games/craft-guide/CraftGuideClient.tsx
@@ -1,0 +1,106 @@
+'use client';
+import { useEffect } from 'react';
+import { useCraftGuide } from './useCraftGuide';
+import CraftMenu from './components/CraftMenu';
+import CraftStep from './components/CraftStep';
+import { speakHebrew } from '@/lib/utils/speech/enhancedSpeechUtils';
+import { printCertificate } from '@/lib/utils/game/printCertificate';
+
+export default function CraftGuideClient() {
+  const {
+    phase, project, projects, stepIndex, totalSteps, currentStep,
+    selectProject, startSteps, nextStep, prevStep, backToMenu,
+  } = useCraftGuide();
+
+  useEffect(() => {
+    if (phase === 'materials' && project) {
+      const matList = project.materials.join(', ');
+      speakHebrew(`נהדר! ל${project.name} תצטרך: ${matList}. לחץ על התחל כשאתה מוכן!`);
+    }
+  }, [phase, project]);
+
+  if (phase === 'menu') {
+    return <CraftMenu projects={projects} onSelect={selectProject} />;
+  }
+
+  if (phase === 'materials' && project) {
+    return (
+      <div className="min-h-screen flex flex-col items-center justify-center p-4"
+        style={{ background: 'linear-gradient(135deg, #fdf6e3 0%, #fce4ec 100%)' }}
+        dir="rtl">
+        <div className="w-full max-w-md space-y-6">
+          <div className="text-center">
+            <div className="text-6xl mb-2">{project.emoji}</div>
+            <h2 className="text-2xl font-extrabold text-orange-800">{project.name}</h2>
+          </div>
+          <div className="bg-white rounded-3xl shadow-xl p-6 space-y-4">
+            <h3 className="text-lg font-bold text-gray-700 text-center">🛠️ מה תצטרך?</h3>
+            <ul className="space-y-2">
+              {project.materials.map((m, i) => (
+                <li key={i} className="flex items-center gap-3 text-gray-700 text-lg">
+                  <span className="text-green-500 font-bold">✓</span>
+                  {m}
+                </li>
+              ))}
+            </ul>
+          </div>
+          <div className="grid grid-cols-2 gap-3">
+            <button onClick={backToMenu}
+              className="bg-white border-2 border-gray-300 text-gray-700 font-bold py-3 rounded-2xl active:scale-95 transition-transform">
+              ← חזרה
+            </button>
+            <button onClick={startSteps}
+              className={`bg-linear-to-br ${project.color} text-white font-bold py-3 rounded-2xl shadow-lg active:scale-95 transition-transform`}>
+              בואו נתחיל! 🎨
+            </button>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  if (phase === 'steps' && project && currentStep) {
+    return (
+      <CraftStep
+        step={currentStep}
+        stepNumber={stepIndex + 1}
+        totalSteps={totalSteps}
+        projectName={project.name}
+        projectColor={project.color}
+        onNext={nextStep}
+        onPrev={prevStep}
+        onBack={backToMenu}
+      />
+    );
+  }
+
+  if (phase === 'done' && project) {
+    return (
+      <div className="min-h-screen flex flex-col items-center justify-center p-4"
+        style={{ background: 'linear-gradient(135deg, #fef9c3 0%, #d1fae5 100%)' }}
+        dir="rtl">
+        <div className="w-full max-w-md text-center space-y-6">
+          <div className="text-7xl animate-bounce">{project.emoji}</div>
+          <h2 className="text-3xl font-extrabold text-green-700">כל הכבוד! 🎉</h2>
+          <p className="text-xl text-gray-700">יצרת {project.name} — עבודה מדהימה!</p>
+          <div className="bg-white rounded-3xl shadow-xl p-6 space-y-4">
+            <div className="text-5xl">🏅</div>
+            <p className="text-gray-600">אתה יוצר אמיתי!</p>
+          </div>
+          <div className="grid grid-cols-2 gap-3">
+            <button onClick={backToMenu}
+              className="bg-white border-2 border-orange-300 text-orange-700 font-bold py-3 rounded-2xl active:scale-95 transition-transform">
+              🎨 עוד פרויקט
+            </button>
+            <button onClick={() => printCertificate({ emoji: project.emoji, title: `יצרתי ${project.name}!`, scorePercent: 100 })}
+              className="bg-linear-to-br from-yellow-400 to-orange-500 text-white font-bold py-3 rounded-2xl shadow-lg active:scale-95 transition-transform">
+              🖨️ הדפס תעודה
+            </button>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return null;
+}

--- a/gamesformykids/app/games/craft-guide/components/CraftMenu.tsx
+++ b/gamesformykids/app/games/craft-guide/components/CraftMenu.tsx
@@ -1,0 +1,35 @@
+'use client';
+import type { CraftProject } from '@/lib/constants/craftProjects';
+
+interface Props {
+  projects: CraftProject[];
+  onSelect: (id: string) => void;
+}
+
+export default function CraftMenu({ projects, onSelect }: Props) {
+  return (
+    <div className="min-h-screen flex flex-col items-center justify-center p-4"
+      style={{ background: 'linear-gradient(135deg, #fdf6e3 0%, #fce4ec 100%)' }}>
+      <div className="w-full max-w-md">
+        <div className="text-center mb-8">
+          <div className="text-6xl mb-3">🎨</div>
+          <h1 className="text-3xl font-extrabold text-orange-800">מדריך יצירה</h1>
+          <p className="text-orange-600 mt-1">בחר פרויקט ובצע אותו שלב אחר שלב!</p>
+        </div>
+        <div className="space-y-3">
+          {projects.map((p) => (
+            <button
+              key={p.id}
+              onClick={() => onSelect(p.id)}
+              className={`w-full bg-linear-to-br ${p.color} text-white rounded-2xl p-4 flex items-center gap-4 shadow-lg active:scale-95 transition-transform`}
+            >
+              <span className="text-4xl">{p.emoji}</span>
+              <span className="text-xl font-bold">{p.name}</span>
+              <span className="mr-auto text-white/70 text-sm">{p.steps.length} שלבים</span>
+            </button>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/gamesformykids/app/games/craft-guide/components/CraftStep.tsx
+++ b/gamesformykids/app/games/craft-guide/components/CraftStep.tsx
@@ -1,0 +1,79 @@
+'use client';
+import { useEffect } from 'react';
+import { speakHebrew } from '@/lib/utils/speech/enhancedSpeechUtils';
+import type { CraftStep as CraftStepType } from '@/lib/constants/craftProjects';
+
+interface Props {
+  step: CraftStepType;
+  stepNumber: number;
+  totalSteps: number;
+  projectName: string;
+  projectColor: string;
+  onNext: () => void;
+  onPrev: () => void;
+  onBack: () => void;
+}
+
+export default function CraftStep({
+  step, stepNumber, totalSteps, projectName, projectColor, onNext, onPrev, onBack,
+}: Props) {
+  useEffect(() => {
+    speakHebrew(`שלב ${stepNumber}: ${step.instruction}`);
+  }, [stepNumber, step.instruction]);
+
+  const progress = (stepNumber / totalSteps) * 100;
+
+  return (
+    <div className="min-h-screen flex flex-col items-center justify-center p-4"
+      style={{ background: 'linear-gradient(135deg, #fdf6e3 0%, #fce4ec 100%)' }}
+      dir="rtl">
+      <div className="w-full max-w-md space-y-4">
+        {/* Header */}
+        <div className="flex items-center gap-3">
+          <button onClick={onBack} className="text-gray-500 hover:text-gray-700 text-lg">← חזרה</button>
+          <span className="font-bold text-gray-700 text-lg">{projectName}</span>
+        </div>
+
+        {/* Progress bar */}
+        <div className="bg-gray-200 rounded-full h-3 overflow-hidden">
+          <div
+            className={`h-full bg-linear-to-br ${projectColor} transition-all duration-500`}
+            style={{ width: `${progress}%` }}
+          />
+        </div>
+        <div className="text-center text-sm text-gray-500">
+          שלב {stepNumber} מתוך {totalSteps}
+        </div>
+
+        {/* Step card */}
+        <div className="bg-white rounded-3xl shadow-xl p-8 text-center space-y-6">
+          <div className="text-8xl">{step.emoji}</div>
+          <p className="text-xl font-semibold text-gray-800 leading-relaxed">{step.instruction}</p>
+          <button
+            onClick={() => speakHebrew(`שלב ${stepNumber}: ${step.instruction}`)}
+            className="text-blue-500 text-sm hover:text-blue-700 flex items-center gap-1 mx-auto"
+          >
+            🔊 שמע שוב
+          </button>
+        </div>
+
+        {/* Navigation */}
+        <div className="grid grid-cols-2 gap-3">
+          <button
+            onClick={onPrev}
+            disabled={stepNumber === 1}
+            className="bg-white border-2 border-gray-300 text-gray-700 font-bold py-3 rounded-2xl disabled:opacity-30 active:scale-95 transition-transform"
+          >
+            ← הקודם
+          </button>
+          <button
+            onClick={onNext}
+            className={`bg-linear-to-br ${projectColor} text-white font-bold py-3 rounded-2xl shadow-lg active:scale-95 transition-transform`}
+          >
+            {stepNumber === totalSteps ? 'סיום! 🎉' : 'הבא →'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/gamesformykids/app/games/craft-guide/useCraftGuide.ts
+++ b/gamesformykids/app/games/craft-guide/useCraftGuide.ts
@@ -1,0 +1,60 @@
+'use client';
+import { useState, useCallback } from 'react';
+import { CRAFT_PROJECTS, type CraftProject } from '@/lib/constants/craftProjects';
+
+type Phase = 'menu' | 'materials' | 'steps' | 'done';
+
+export function useCraftGuide() {
+  const [phase, setPhase] = useState<Phase>('menu');
+  const [project, setProject] = useState<CraftProject | null>(null);
+  const [stepIndex, setStepIndex] = useState(0);
+
+  const selectProject = useCallback((id: string) => {
+    const p = CRAFT_PROJECTS.find((x) => x.id === id);
+    if (!p) return;
+    setProject(p);
+    setStepIndex(0);
+    setPhase('materials');
+  }, []);
+
+  const startSteps = useCallback(() => {
+    setStepIndex(0);
+    setPhase('steps');
+  }, []);
+
+  const nextStep = useCallback(() => {
+    if (!project) return;
+    if (stepIndex < project.steps.length - 1) {
+      setStepIndex((i) => i + 1);
+    } else {
+      setPhase('done');
+    }
+  }, [project, stepIndex]);
+
+  const prevStep = useCallback(() => {
+    if (stepIndex > 0) setStepIndex((i) => i - 1);
+  }, [stepIndex]);
+
+  const backToMenu = useCallback(() => {
+    setPhase('menu');
+    setProject(null);
+    setStepIndex(0);
+  }, []);
+
+  const currentStep = project ? project.steps[stepIndex] : null;
+  const totalSteps = project ? project.steps.length : 0;
+
+  return {
+    phase,
+    project,
+    projects: CRAFT_PROJECTS,
+    stepIndex,
+    totalSteps,
+    currentStep,
+    selectProject,
+    startSteps,
+    nextStep,
+    prevStep,
+    backToMenu,
+  };
+}

--- a/gamesformykids/lib/constants/craftProjects.ts
+++ b/gamesformykids/lib/constants/craftProjects.ts
@@ -1,0 +1,88 @@
+export interface CraftStep {
+  emoji: string;
+  instruction: string;
+}
+
+export interface CraftProject {
+  id: string;
+  name: string;
+  emoji: string;
+  color: string;
+  materials: string[];
+  steps: CraftStep[];
+}
+
+export const CRAFT_PROJECTS: CraftProject[] = [
+  {
+    id: 'paper-boat',
+    name: 'ספינת נייר',
+    emoji: '⛵',
+    color: 'from-blue-400 to-cyan-600',
+    materials: ['דף נייר A4'],
+    steps: [
+      { emoji: '📄', instruction: 'הנח את הנייר לפניך לרוחב על שולחן ישר.' },
+      { emoji: '📐', instruction: 'קפל את הנייר לחצי מלמעלה למטה — עכשיו יש לך מלבן.' },
+      { emoji: '📐', instruction: 'קפל שוב לחצי כדי לסמן את קו האמצע, ואז פתח חזרה.' },
+      { emoji: '📐', instruction: 'קפל את שתי הפינות העליונות לכיוון קו האמצע — תקבל צורת חץ.' },
+      { emoji: '📐', instruction: 'קפל את שולי הנייר התחתונים כלפי מעלה משני הצדדים.' },
+      { emoji: '⛵', instruction: 'פתח את הסירה בעדינות ועצב אותה — כל הכבוד! סירתך מוכנה!' },
+    ],
+  },
+  {
+    id: 'greeting-card',
+    name: 'כרטיס ברכה',
+    emoji: '💌',
+    color: 'from-pink-400 to-rose-600',
+    materials: ['נייר צבעוני', 'עפרונות צבעוניים', 'מדבקות'],
+    steps: [
+      { emoji: '📄', instruction: 'קח גיליון נייר צבעוני וקפל אותו לחצי — זו הכריכה של הכרטיס.' },
+      { emoji: '🎨', instruction: 'ציור ציור יפה על הכריכה — פרח, לב, כוכב — מה שתרצה!' },
+      { emoji: '✏️', instruction: 'פתח את הכרטיס וכתוב את שם המקבל בצד הימני בפנים.' },
+      { emoji: '💌', instruction: 'כתוב מסר אישי — "אני אוהב אותך", "שתהיה בריא", או כל דבר מהלב.' },
+      { emoji: '🌟', instruction: 'קשט עם מדבקות ועיצובים צבעוניים — הכרטיס שלך מוכן לשליחה!' },
+    ],
+  },
+  {
+    id: 'sock-puppet',
+    name: 'בובת גרב',
+    emoji: '🧦',
+    color: 'from-orange-400 to-amber-600',
+    materials: ['גרב ישנה', 'כפתורים', 'נייר אדום', 'דבק'],
+    steps: [
+      { emoji: '🧦', instruction: 'הכנס את ידך לתוך הגרב — אצבעות כלפי הקצה, האגודל למטה.' },
+      { emoji: '👁️', instruction: 'הדבק שתי עיניים מלאכותיות או שני כפתורים לחלק העליון.' },
+      { emoji: '👄', instruction: 'גזור פס אדום מנייר וצור פה — הדבק אותו מתחת לעיניים.' },
+      { emoji: '👃', instruction: 'הוסף אף עגול מנייר או כפתור קטן מעל הפה.' },
+      { emoji: '💇', instruction: 'צור שיער מחתיכות חוט צבעוניות — הדבק אותן בחלק העליון של הגרב.' },
+      { emoji: '🎭', instruction: 'תן לבובה שם! עכשיו שחק בה וצור הצגה לכל המשפחה!' },
+    ],
+  },
+  {
+    id: 'window-art',
+    name: 'קישוט חלון',
+    emoji: '🌈',
+    color: 'from-violet-400 to-purple-600',
+    materials: ['נייר אורז שקוף', 'צבעי מים', 'ניר דבק שקוף', 'מספריים'],
+    steps: [
+      { emoji: '🎨', instruction: 'הכן נייר אורז שקוף לפניך על שטח נקי.' },
+      { emoji: '🖌️', instruction: 'צבע צורות יפות בצבעי מים — כוכבים, לבבות, פרחים, קשת.' },
+      { emoji: '☀️', instruction: 'המתן בסבלנות עד שהצבע יתייבש לגמרי.' },
+      { emoji: '✂️', instruction: 'גזור את הצורות בזהירות עם מספריים.' },
+      { emoji: '🌈', instruction: 'הצמד לחלון עם ניר דבק שקוף — אור השמש יגרום לצורות לזהור!' },
+    ],
+  },
+  {
+    id: 'bookmark',
+    name: 'סרגל ספרים',
+    emoji: '📚',
+    color: 'from-emerald-400 to-green-600',
+    materials: ['קרטון', 'עפרונות צבעוניים', 'מספריים'],
+    steps: [
+      { emoji: '✂️', instruction: 'גזור פס קרטון ברוחב 5 ס"מ ואורך 20 ס"מ.' },
+      { emoji: '🎨', instruction: 'צבע את הרקע בצבע האהוב עליך.' },
+      { emoji: '✏️', instruction: 'ציור ציור יפה — בעל חיים, נוף, פרח — מה שאתה אוהב!' },
+      { emoji: '📝', instruction: 'כתוב את שמך או מסר: "אני אוהב לקרוא! 📖"' },
+      { emoji: '📚', instruction: 'סרגל הספרים שלך מוכן! הכנס אותו לספר האהוב עליך.' },
+    ],
+  },
+];

--- a/gamesformykids/lib/constants/gameCategories.ts
+++ b/gamesformykids/lib/constants/gameCategories.ts
@@ -38,7 +38,7 @@ export const GAME_CATEGORIES: Record<string, GameCategory> = {
     icon: Palette,
     color: "bg-purple-500",
     gradient: "from-purple-400 to-purple-600",
-    gameIds: ["instruments","puzzles","drawing","building","tetris","magic-fairy-tales","circus-show","logic-games","art-craft","superheroes","fairy-tale-chars","famous-paintings","tech-logos","color-mix","puppet-story","melody-maker"],
+    gameIds: ["instruments","puzzles","drawing","building","tetris","magic-fairy-tales","circus-show","logic-games","art-craft","superheroes","fairy-tale-chars","famous-paintings","tech-logos","color-mix","puppet-story","melody-maker","craft-guide"],
   },
   nature: {
     title: "טבע ואוכל",

--- a/gamesformykids/lib/registry/registryData/batch4.ts
+++ b/gamesformykids/lib/registry/registryData/batch4.ts
@@ -721,4 +721,15 @@ export const gamesRegistryBatch4: GameRegistration[] = [
     available: true,
     order: 186,
   },
+  {
+    id: "craft-guide",
+    title: "מדריך יצירה",
+    description: "בצע פרויקטי יצירה שלב אחר שלב עם הנחיות קוליות — ספינת נייר, כרטיס ברכה ועוד!",
+    icon: Palette,
+    emoji: "🎨",
+    color: "bg-orange-500 hover:bg-orange-600",
+    href: "/games/craft-guide",
+    available: true,
+    order: 187,
+  },
 ];

--- a/gamesformykids/lib/types/core/base.ts
+++ b/gamesformykids/lib/types/core/base.ts
@@ -229,4 +229,6 @@ export type GameType =
   // Kids encyclopedia
   | 'kids-encyclopedia'
   // Fun tools
-  | 'age-calculator';
+  | 'age-calculator'
+  // Craft guide
+  | 'craft-guide';


### PR DESCRIPTION
## What
Adds a Hebrew craft guide (Style D custom game) with 5 projects: ספינת נייר, כרטיס ברכה, בובת גרב, קישוט חלון, סרגל ספרים. Each project walks the child through steps one at a time with TTS audio.

## Features
- Project menu with 5 craft projects (4–6 steps each)
- Materials list screen with TTS read-aloud before starting
- Step-by-step slideshow: large emoji illustration + Hebrew instruction
- Auto-TTS on each step transition via `useEffect`
- 🔊 "Hear again" button on each step
- Progress bar showing current step / total
- Prev/Next navigation
- Completion screen with printable certificate (`printCertificate` utility, 100%)
- RTL layout, mobile-friendly

## Why
Closes #1220

## Test plan
- [ ] Select a project → materials list shows, TTS reads aloud
- [ ] Press "Start" → first step shows, TTS reads
- [ ] Next/Prev buttons advance and retreat correctly
- [ ] "Hear again" button re-reads the step
- [ ] Progress bar fills as steps advance
- [ ] Final step shows "Done" → completion screen
- [ ] Print certificate opens print dialog
- [ ] Works on mobile (tablet use case)
- [ ] TypeScript: zero errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)