### PR TITLE
feat(riddles-pro): add progressive clue riddles with bonus scoring (closes #1218)

### DIFF
--- a/gamesformykids/app/games/[gameType]/gamePageConstants.ts
+++ b/gamesformykids/app/games/[gameType]/gamePageConstants.ts
@@ -84,6 +84,7 @@ export const SUPPORTED_GAMES = [
   'craft-guide',
   'jokes-browser',
   'word-maze',
+  'riddles-pro',
 ] as const;
 
 export type SupportedGameType = typeof SUPPORTED_GAMES[number];

--- a/gamesformykids/components/game/quiz/screens/RiddleProQuestion.tsx
+++ b/gamesformykids/components/game/quiz/screens/RiddleProQuestion.tsx
@@ -1,0 +1,112 @@
+'use client';
+import type { RiddlesProState } from '@/lib/quiz/useRiddlesProGame';
+import type { RiddlePro } from '@/lib/quiz/data/riddles-pro';
+
+interface Props {
+  current: RiddlePro;
+  choices: string[];
+  cluesRevealed: RiddlesProState['cluesRevealed'];
+  answersShown: boolean;
+  questionNumber: number;
+  total: number;
+  score: number;
+  lastPoints: number | null;
+  lastCorrect: boolean | null;
+  onRevealClue: () => void;
+  onShowAnswers: () => void;
+  onSelect: (choice: string) => void;
+}
+
+const POINTS_COLOR = ['text-green-600', 'text-yellow-600', 'text-orange-600'] as const;
+
+export default function RiddleProQuestion({
+  current, choices, cluesRevealed, answersShown, questionNumber, total, score,
+  lastPoints, lastCorrect, onRevealClue, onShowAnswers, onSelect,
+}: Props) {
+  const waiting = lastCorrect !== null;
+
+  return (
+    <div className="min-h-screen flex flex-col items-center p-4 pt-6"
+      style={{ background: 'linear-gradient(135deg, #fdf4ff 0%, #e0f2fe 100%)' }}
+      dir="rtl">
+
+      {/* Header */}
+      <div className="w-full max-w-sm flex justify-between items-center mb-4 text-sm text-gray-500">
+        <span>שאלה {questionNumber}/{total}</span>
+        <span className="font-bold text-purple-700">⭐ {score} נקודות</span>
+      </div>
+
+      {/* Riddle card */}
+      <div className="w-full max-w-sm bg-white rounded-3xl shadow-xl p-5 mb-4">
+        <div className="text-4xl text-center mb-3">🤔</div>
+        <p className="text-center text-lg font-semibold text-gray-800 leading-relaxed">
+          {current.riddle}
+        </p>
+      </div>
+
+      {/* Clue slots */}
+      <div className="flex gap-3 mb-4">
+        {current.clues.map((clue, i) => (
+          <div key={i}
+            className={`w-16 h-16 rounded-2xl flex items-center justify-center text-3xl shadow transition-all duration-300 ${
+              i < cluesRevealed
+                ? 'bg-purple-100 border-2 border-purple-400 scale-110'
+                : 'bg-gray-100 border-2 border-gray-200 opacity-40'
+            }`}>
+            {i < cluesRevealed ? clue : '❓'}
+          </div>
+        ))}
+      </div>
+
+      {/* Feedback */}
+      {waiting && (
+        <div className={`text-center text-xl font-bold mb-3 ${lastCorrect ? 'text-green-600' : 'text-red-500'}`}>
+          {lastCorrect
+            ? `✅ נכון! +${lastPoints} ${lastPoints === 3 ? '🌟🌟🌟' : lastPoints === 2 ? '🌟🌟' : '🌟'}`
+            : `❌ לא נכון — ${current.answer}`}
+        </div>
+      )}
+
+      {/* Scoring hint (only when no feedback shown) */}
+      {!waiting && (
+        <div className="flex gap-2 mb-4 text-xs text-gray-400">
+          <span className={`${POINTS_COLOR[0]} font-bold`}>3 נק׳</span><span>ללא רמז</span>
+          <span className="mx-1">|</span>
+          <span className={`${POINTS_COLOR[1]} font-bold`}>2 נק׳</span><span>רמז 1</span>
+          <span className="mx-1">|</span>
+          <span className={`${POINTS_COLOR[2]} font-bold`}>1 נק׳</span><span>רמז 2+</span>
+        </div>
+      )}
+
+      {/* Answer choices */}
+      {answersShown && !waiting && (
+        <div className="w-full max-w-sm grid grid-cols-2 gap-3 mb-4">
+          {choices.map((c) => (
+            <button key={c} onClick={() => onSelect(c)}
+              className="bg-white border-2 border-purple-300 text-purple-800 font-bold py-4 rounded-2xl text-lg shadow active:scale-95 transition-transform hover:bg-purple-50">
+              {c}
+            </button>
+          ))}
+        </div>
+      )}
+
+      {/* Action buttons */}
+      {!waiting && (
+        <div className="w-full max-w-sm flex flex-col gap-2">
+          {cluesRevealed < 3 && !answersShown && (
+            <button onClick={onRevealClue}
+              className="w-full bg-linear-to-br from-purple-400 to-violet-500 text-white font-bold py-3 rounded-2xl shadow-lg active:scale-95 transition-transform">
+              🔍 הצג רמז {cluesRevealed + 1} ({2 - cluesRevealed} נק׳)
+            </button>
+          )}
+          {!answersShown && (
+            <button onClick={onShowAnswers}
+              className="w-full bg-white border-2 border-purple-300 text-purple-700 font-bold py-3 rounded-2xl active:scale-95 transition-transform">
+              💡 ענה עכשיו
+            </button>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/gamesformykids/lib/constants/gameCategories.ts
+++ b/gamesformykids/lib/constants/gameCategories.ts
@@ -132,6 +132,6 @@ export const GAME_CATEGORIES: Record<string, GameCategory> = {
     color: "bg-teal-500",
     gradient: "from-teal-400 to-cyan-600",
 
-    gameIds: ["true-false","emoji-math","math-race","number-bubbles","word-scramble","word-builder","word-chain","trivia","clock","spelling","opposites","world-languages","riddles","english-words","singular-plural","adjectives","verbs","visual-opposites","english-cards","proverbs","story-builder","robot-coder","hangman","choose-adventure","picture-dictionary","word-search","kids-songs","kids-encyclopedia","age-calculator","jokes-browser","word-maze"],
+    gameIds: ["true-false","emoji-math","math-race","number-bubbles","word-scramble","word-builder","word-chain","trivia","clock","spelling","opposites","world-languages","riddles","riddles-pro","english-words","singular-plural","adjectives","verbs","visual-opposites","english-cards","proverbs","story-builder","robot-coder","hangman","choose-adventure","picture-dictionary","word-search","kids-songs","kids-encyclopedia","age-calculator","jokes-browser","word-maze"],
   },
 };

--- a/gamesformykids/lib/quiz/data/riddles-pro.ts
+++ b/gamesformykids/lib/quiz/data/riddles-pro.ts
@@ -1,0 +1,48 @@
+export interface RiddlePro {
+  id: number;
+  riddle: string;
+  clues: [string, string, string];
+  answer: string;
+  wrongOptions: [string, string, string];
+  category: 'animals' | 'food' | 'nature' | 'objects';
+}
+
+export const RIDDLES_PRO: RiddlePro[] = [
+  // Animals
+  { id: 1,  riddle: 'אני החיה הגדולה ביבשה, יש לי חוטם ארוך — מי אני?', clues: ['🌿', '🌍', '🐾'], answer: 'פיל',     category: 'animals', wrongOptions: ['גירפה', 'היפופוטם', 'קרנף'] },
+  { id: 2,  riddle: 'אני ישן כל החורף ואוהב דבש — מי אני?',              clues: ['❄️', '🍯', '🌲'], answer: 'דב',      category: 'animals', wrongOptions: ['זאב', 'שועל', 'חזיר בר'] },
+  { id: 3,  riddle: 'יש לי כיס על הבטן לנשיאת הגור שלי — מי אני?',      clues: ['🇦🇺', '🦘', '👶'], answer: 'קנגורו', category: 'animals', wrongOptions: ['קוואלה', 'וומבט', 'טסמניה'] },
+  { id: 4,  riddle: 'אני שר בלילה ורואה בחושך — מי אני?',                 clues: ['🌙', '🦉', '🌳'], answer: 'ינשוף',  category: 'animals', wrongOptions: ['עטלף', 'חתול', 'ציפור'] },
+  { id: 5,  riddle: 'אני הכי מהיר ביבשה ויש לי נקודות — מי אני?',       clues: ['⚡', '🏃', '🌾'], answer: 'צ\'יטה',  category: 'animals', wrongOptions: ['נמר', 'אריה', 'ברדלס'] },
+  { id: 6,  riddle: 'אני חי בים ואין לי עצמות — זרועות רבות לי — מי אני?', clues: ['🌊', '🔴', '💧'], answer: 'תמנון',  category: 'animals', wrongOptions: ['דיונון', 'סרטן', 'לובסטר'] },
+  { id: 7,  riddle: 'אני מעופף, שר שירים, ואוכל תולעים — מי אני?',       clues: ['🌸', '🎵', '🌿'], answer: 'ציפור',  category: 'animals', wrongOptions: ['אגם', 'חרק', 'שפרפר'] },
+  { id: 8,  riddle: 'אני הכי גדול בים, שר שירים — מי אני?',              clues: ['🌊', '🎵', '🔵'], answer: 'לוויתן', category: 'animals', wrongOptions: ['כריש', 'דולפין', 'נהר'] },
+
+  // Food
+  { id: 9,  riddle: 'אני צהוב ומתוק, יש לי קליפה לקלף — מי אני?',        clues: ['🌞', '🐒', '🍌'], answer: 'בננה',   category: 'food', wrongOptions: ['לימון', 'מנגו', 'אנanas'] },
+  { id: 10, riddle: 'אני עגול ואדום ומתוק, גדל על עץ גבוה — מי אני?',   clues: ['🌳', '❤️', '🌞'], answer: 'תפוח',   category: 'food', wrongOptions: ['עגבנייה', 'אבטיח', 'שזיף'] },
+  { id: 11, riddle: 'אני ירוק מבחוץ ואדום מבפנים — מי אני?',             clues: ['☀️', '🏖️', '🍉'], answer: 'אבטיח',  category: 'food', wrongOptions: ['מלון', 'אגס', 'קיווי'] },
+  { id: 12, riddle: 'אני עשוי מחלב ויש לי חורים — מי אני?',              clues: ['🐄', '🇨🇭', '🧀'], answer: 'גבינה',  category: 'food', wrongOptions: ['יוגורט', 'שמנת', 'חמאה'] },
+  { id: 13, riddle: 'אני קטן, סגול, וגדל על אשכולות — מי אני?',          clues: ['🌱', '🌡️', '🍇'], answer: 'ענב',    category: 'food', wrongOptions: ['זית', 'בלוברי', 'שזיף'] },
+  { id: 14, riddle: 'אני מתוק, חום ודביק — דבורים עושות אותי — מי אני?', clues: ['🐝', '🌸', '🌻'], answer: 'דבש',    category: 'food', wrongOptions: ['סירופ', 'ריבה', 'סוכר'] },
+  { id: 15, riddle: 'אני עגול, שטוח, ואתה אוכל אותי בפיצה — מי אני?',   clues: ['🇮🇹', '🍕', '🌶️'], answer: 'עגבנייה', category: 'food', wrongOptions: ['גמבה', 'פפריקה', 'צ\'ילי'] },
+
+  // Nature
+  { id: 16, riddle: 'אני גבוה בבוקר ונמוך בלילה — מי אני?',              clues: ['🌅', '🌞', '🌇'], answer: 'שמש',    category: 'nature', wrongOptions: ['ירח', 'כוכב', 'ענן'] },
+  { id: 17, riddle: 'אני לבן ורך, יורד בחורף ומכסה הכל — מי אני?',      clues: ['❄️', '☃️', '🎿'], answer: 'שלג',    category: 'nature', wrongOptions: ['גשם', 'ברד', 'ערפל'] },
+  { id: 18, riddle: 'אני מגיע עם הרעמים ומאיר את השמיים — מי אני?',      clues: ['⛈️', '🌩️', '⚡'], answer: 'ברק',    category: 'nature', wrongOptions: ['שמש', 'קשת', 'מבזק'] },
+  { id: 19, riddle: 'אני קשת צבעים שמופיעה אחרי הגשם — מי אני?',        clues: ['🌧️', '🌈', '☀️'], answer: 'קשת',    category: 'nature', wrongOptions: ['צבע', 'פרח', 'שמיים'] },
+  { id: 20, riddle: 'יש לי ענפים, עלים ושורשים — מי אני?',               clues: ['🌱', '🍂', '🌳'], answer: 'עץ',     category: 'nature', wrongOptions: ['פרח', 'שיח', 'צמח'] },
+  { id: 21, riddle: 'אני הר שפורץ ומוציא לבה — מי אני?',                 clues: ['🌋', '🔥', '💨'], answer: 'הר געש', category: 'nature', wrongOptions: ['הר שלג', 'מצוק', 'גבעה'] },
+  { id: 22, riddle: 'אני מים שנפלים ממצוק גבוה — מי אני?',               clues: ['🌊', '🏔️', '💦'], answer: 'מפל',    category: 'nature', wrongOptions: ['נהר', 'אגם', 'מעיין'] },
+
+  // Objects
+  { id: 23, riddle: 'יש לי ידיים אבל לא אוחז, פנים אבל לא רואה — מי אני?', clues: ['⏰', '🔔', '🕐'], answer: 'שעון',    category: 'objects', wrongOptions: ['מראה', 'תמונה', 'לוח'] },
+  { id: 24, riddle: 'אני עוזר לך לראות כשאין אור — מי אני?',              clues: ['🌑', '🔦', '🌟'], answer: 'פנס',     category: 'objects', wrongOptions: ['נר', 'מנורה', 'אש'] },
+  { id: 25, riddle: 'אני קר, מרובע, ושומר על האוכל שלך — מי אני?',       clues: ['🧊', '🥶', '🥩'], answer: 'מקרר',    category: 'objects', wrongOptions: ['תנור', 'ארון', 'מיקרוגל'] },
+  { id: 26, riddle: 'אני מריץ סרטים וצוחק ובוכה — מי אני?',              clues: ['🎬', '🍿', '🌟'], answer: 'טלוויזיה', category: 'objects', wrongOptions: ['מחשב', 'טלפון', 'מצלמה'] },
+  { id: 27, riddle: 'אני עשוי עור ועוזר לסחוב ספרים — מי אני?',          clues: ['📚', '🎒', '✏️'], answer: 'תיק',     category: 'objects', wrongOptions: ['ארנק', 'מזוודה', 'קופסה'] },
+  { id: 28, riddle: 'אני כותב ואפשר למחוק אותי — מי אני?',               clues: ['✏️', '🗑️', '📝'], answer: 'עיפרון',  category: 'objects', wrongOptions: ['עט', 'מרקר', 'גיר'] },
+  { id: 29, riddle: 'אני עגול ומתגלגל, אפשר לשחק איתי — מי אני?',       clues: ['⚽', '🏃', '🏟️'], answer: 'כדור',    category: 'objects', wrongOptions: ['חישוק', 'פריזבי', 'עפיפון'] },
+  { id: 30, riddle: 'אני נמצא בבית ספר, שחור ולבן, ומורה כותב עליי — מי אני?', clues: ['🏫', '📖', '✏️'], answer: 'לוח',  category: 'objects', wrongOptions: ['נייר', 'מחברת', 'ספר'] },
+];

--- a/gamesformykids/lib/quiz/registry/customQuizGames.tsx
+++ b/gamesformykids/lib/quiz/registry/customQuizGames.tsx
@@ -6,6 +6,7 @@ import { QuizMenuScreen, QuizResultScreen, CategoryIndexedQuestion } from '@/com
 import { useNikudGame } from '@/lib/quiz/useNikudGame';
 import { useDivisionGame } from '@/lib/quiz/useDivisionGame';
 import { useStoryBuilderGame } from '@/lib/quiz/useStoryBuilderGame';
+import { useRiddlesProGame } from '@/lib/quiz/useRiddlesProGame';
 
 // Hooks — small, kept static so tree-shaking inlines only what's used
 import { useClockGame } from '@/lib/quiz/useClockGame';
@@ -32,6 +33,7 @@ import GameSpinnerScreen from '@/components/ui/GameSpinnerScreen';
 
 // Screen components — lazy-loaded so each game page only downloads its own screens
 // Options must be object literals (Turbopack static analysis requirement)
+const RiddleProQuestion  = dynamic(() => import('@/components/game/quiz/screens/RiddleProQuestion'), { loading: () => <GameSpinnerScreen /> });
 const ClockMenuScreen    = dynamic(() => import('@/components/game/quiz/screens/ClockMenuScreen'), { loading: () => <GameSpinnerScreen /> });
 const ClockQuestion      = dynamic(() => import('@/components/game/quiz/screens/ClockQuestion'), { loading: () => <GameSpinnerScreen /> });
 const ClockResultScreen  = dynamic(() => import('@/components/game/quiz/screens/ClockResultScreen'), { loading: () => <GameSpinnerScreen /> });
@@ -63,6 +65,15 @@ const StoryBuilderResult   = dynamic(() => import('@/components/game/quiz/screen
  * Opening /games/clock does NOT download soccer/phonics/nature screens (and vice versa).
  */
 export const CUSTOM_QUIZ_GAMES: Record<string, ComponentType> = {
+  'riddles-pro': makeQuizGame(
+    useRiddlesProGame,
+    ({ current, choices, cluesRevealed, answersShown, questionNumber, total, score, lastPoints, lastCorrect, revealClue, showAnswers, selectAnswer, startGame, restart }) => ({
+      menu:     <QuizMenuScreen emoji="🧩" title="חידות מדורגות" description="השב מוקדם יותר — קבל יותר נקודות! עד 3 נקודות לחידה!" theme="violet" buttonLabel="🧩 בואו ניגש!" onStart={startGame} />,
+      question: current ? <RiddleProQuestion current={current} choices={choices as string[]} cluesRevealed={cluesRevealed as number} answersShown={answersShown as boolean} questionNumber={questionNumber as number} total={total as number} score={score} lastPoints={lastPoints as number | null} lastCorrect={lastCorrect as boolean | null} onRevealClue={revealClue as () => void} onShowAnswers={showAnswers as () => void} onSelect={selectAnswer} /> : null,
+      result:   <QuizResultScreen onRestart={restart} theme="violet" />,
+    }),
+  ),
+
   'clock': makeQuizGame(
     useClockGame,
     ({ current, choices, startGame, selectAnswer, restart }) => ({

--- a/gamesformykids/lib/quiz/useRiddlesProGame.ts
+++ b/gamesformykids/lib/quiz/useRiddlesProGame.ts
@@ -1,0 +1,117 @@
+'use client';
+import { useState, useCallback, useRef } from 'react';
+import { RIDDLES_PRO, type RiddlePro } from './data/riddles-pro';
+import { speakHebrew } from '@/lib/utils/speech/enhancedSpeechUtils';
+
+const SESSION_SIZE = 10;
+
+export type RiddlesProPhase = 'menu' | 'playing' | 'result';
+
+export interface RiddlesProState {
+  phase: RiddlesProPhase;
+  current: RiddlePro | null;
+  choices: string[];
+  cluesRevealed: number;
+  answersShown: boolean;
+  score: number;
+  questionNumber: number;
+  total: number;
+  lastPoints: number | null;
+  lastCorrect: boolean | null;
+  startGame: () => void;
+  revealClue: () => void;
+  showAnswers: () => void;
+  selectAnswer: (choice: string) => void;
+  restart: () => void;
+}
+
+function pickSession(): RiddlePro[] {
+  const shuffled = [...RIDDLES_PRO].sort(() => Math.random() - 0.5);
+  return shuffled.slice(0, SESSION_SIZE);
+}
+
+function makeChoices(riddle: RiddlePro): string[] {
+  return [riddle.answer, ...riddle.wrongOptions].sort(() => Math.random() - 0.5);
+}
+
+export function useRiddlesProGame(): RiddlesProState {
+  const [phase, setPhase] = useState<RiddlesProPhase>('menu');
+  const [current, setCurrent] = useState<RiddlePro | null>(null);
+  const [choices, setChoices] = useState<string[]>([]);
+  const [cluesRevealed, setCluesRevealed] = useState(0);
+  const [answersShown, setAnswersShown] = useState(false);
+  const [score, setScore] = useState(0);
+  const [questionNumber, setQuestionNumber] = useState(0);
+  const [lastPoints, setLastPoints] = useState<number | null>(null);
+  const [lastCorrect, setLastCorrect] = useState<boolean | null>(null);
+
+  const sessionRef = useRef<RiddlePro[]>([]);
+  const sessionIdxRef = useRef(0);
+  const cluesRef = useRef(0);
+
+  const loadNext = useCallback(() => {
+    const idx = sessionIdxRef.current;
+    const session = sessionRef.current;
+    if (idx >= session.length) {
+      setPhase('result');
+      return;
+    }
+    const riddle = session[idx];
+    if (!riddle) { setPhase('result'); return; }
+    setCurrent(riddle);
+    setChoices(makeChoices(riddle));
+    setCluesRevealed(0);
+    setAnswersShown(false);
+    cluesRef.current = 0;
+    setLastPoints(null);
+    setLastCorrect(null);
+    setQuestionNumber(idx + 1);
+    speakHebrew(riddle.riddle);
+  }, []);
+
+  const startGame = useCallback(() => {
+    sessionRef.current = pickSession();
+    sessionIdxRef.current = 0;
+    setScore(0);
+    setPhase('playing');
+    loadNext();
+  }, [loadNext]);
+
+  const revealClue = useCallback(() => {
+    const next = cluesRef.current + 1;
+    cluesRef.current = next;
+    setCluesRevealed(next);
+    if (next >= 3) setAnswersShown(true);
+  }, []);
+
+  const showAnswers = useCallback(() => {
+    setAnswersShown(true);
+  }, []);
+
+  const selectAnswer = useCallback((choice: string) => {
+    if (!current) return;
+    const isCorrect = choice === current.answer;
+    const points = isCorrect ? Math.max(1, 3 - cluesRef.current) : 0;
+    setLastCorrect(isCorrect);
+    setLastPoints(isCorrect ? points : null);
+    if (isCorrect) {
+      setScore(s => s + points);
+      speakHebrew(`נכון! ${current.answer}! קיבלת ${points} נקודות`);
+    } else {
+      speakHebrew(`לא נכון — התשובה היא ${current.answer}`);
+    }
+    sessionIdxRef.current += 1;
+    setTimeout(loadNext, 1800);
+  }, [current, loadNext]);
+
+  const restart = useCallback(() => {
+    setPhase('menu');
+    setCurrent(null);
+  }, []);
+
+  return {
+    phase, current, choices, cluesRevealed, answersShown,
+    score, questionNumber, total: SESSION_SIZE, lastPoints, lastCorrect,
+    startGame, revealClue, showAnswers, selectAnswer, restart,
+  };
+}

--- a/gamesformykids/lib/registry/registryData/batch4.ts
+++ b/gamesformykids/lib/registry/registryData/batch4.ts
@@ -33,6 +33,7 @@ import {
   HelpCircle,
   TextSearch,
   Laugh,
+  Lightbulb,
 } from "lucide-react";
 import type { GameRegistration } from "@/lib/types/games/base";
 
@@ -754,5 +755,16 @@ export const gamesRegistryBatch4: GameRegistration[] = [
     href: "/games/word-maze",
     available: true,
     order: 189,
+  },
+  {
+    id: "riddles-pro",
+    title: "חידות מדורגות",
+    description: "פתור חידות עם רמזים מדורגים — ככל שתנחש מוקדם יותר, כך תרוויח יותר נקודות!",
+    icon: Lightbulb,
+    emoji: "🧩",
+    color: "bg-violet-500 hover:bg-violet-600",
+    href: "/games/riddles-pro",
+    available: true,
+    order: 190,
   },
 ];

--- a/gamesformykids/lib/types/core/base.ts
+++ b/gamesformykids/lib/types/core/base.ts
@@ -235,4 +235,6 @@ export type GameType =
   // Jokes browser
   | 'jokes-browser'
   // Word maze
-  | 'word-maze';
+  | 'word-maze'
+  // Progressive riddles
+  | 'riddles-pro';


### PR DESCRIPTION
## What
Adds a new Hebrew riddles game with progressive multi-clue reveal and bonus scoring system.

## Features
- 30 riddles across 4 categories: animals, food, nature, objects
- 3 emoji clues reveal one at a time on tap
- Scoring: 3 pts (no clues used), 2 pts (1 clue), 1 pt (2+ clues)
- TTS reads each riddle aloud via `speakHebrew`
- 4-choice answer grid shown after 3rd clue OR on '💡 ענה עכשיו' tap
- Visual feedback: correct/wrong flash with points earned
- 10-riddle sessions, score accumulates across session
- RTL layout
- Built with `makeQuizGame` factory + custom `RiddleProQuestion` screen

## Why
Closes #1218

## Test plan
- [ ] Navigate to `/games/riddles-pro`
- [ ] Answer immediately — verify 3 points awarded
- [ ] Reveal 1 clue then answer — verify 2 points
- [ ] Reveal 2+ clues then answer — verify 1 point
- [ ] Wrong answer — verify 0 points and correct answer shown
- [ ] Complete 10-riddle session — verify result screen
- [ ] Game appears in 📚 Educational category on home page

🤖 Generated with [Claude Code](https://claude.com/claude-code)