### PR TITLE
feat(jokes-browser): add browsable Hebrew kids joke library (closes #1215)

### DIFF
--- a/gamesformykids/app/games/[gameType]/CustomGameRenderer.tsx
+++ b/gamesformykids/app/games/[gameType]/CustomGameRenderer.tsx
@@ -64,6 +64,7 @@ const GAME_CLIENTS: Record<string, ComponentType> = {
   'kids-encyclopedia': dynamic(() => import('../kids-encyclopedia/EncyclopediaClient'),              { ssr: false }),
   'age-calculator':    dynamic(() => import('../age-calculator/AgeCalculatorClient'),                { ssr: false }),
   'craft-guide':       dynamic(() => import('../craft-guide/CraftGuideClient'),                      { ssr: false }),
+  'jokes-browser':     dynamic(() => import('../jokes-browser/JokesBrowserClient'),                  { ssr: false }),
 };
 
 interface Props { gameType: string; }

--- a/gamesformykids/app/games/[gameType]/gamePageConstants.ts
+++ b/gamesformykids/app/games/[gameType]/gamePageConstants.ts
@@ -82,6 +82,7 @@ export const SUPPORTED_GAMES = [
   'kids-encyclopedia',
   'age-calculator',
   'craft-guide',
+  'jokes-browser',
 ] as const;
 
 export type SupportedGameType = typeof SUPPORTED_GAMES[number];
@@ -96,7 +97,7 @@ export const CUSTOM_GAME_TYPES = new Set([
   'word-builder', 'word-scramble', 'maze', 'letter-defender', 'puppet-story', 'number-slide', 'snakes-ladders',
 
 
-  'escape-room', 'robot-coder', 'find-in-scene', 'hangman', 'choose-adventure', 'picture-dictionary', 'word-search', 'israel-map', 'kids-songs', 'melody-maker', 'kids-encyclopedia', 'age-calculator', 'craft-guide',
+  'escape-room', 'robot-coder', 'find-in-scene', 'hangman', 'choose-adventure', 'picture-dictionary', 'word-search', 'israel-map', 'kids-songs', 'melody-maker', 'kids-encyclopedia', 'age-calculator', 'craft-guide', 'jokes-browser',
   
   
 ]);

--- a/gamesformykids/app/games/jokes-browser/JokesBrowserClient.tsx
+++ b/gamesformykids/app/games/jokes-browser/JokesBrowserClient.tsx
@@ -1,0 +1,98 @@
+'use client';
+import { useJokesBrowser } from './useJokesBrowser';
+import { CATEGORY_LABELS, CATEGORY_COLORS, type JokeCategory } from '@/lib/constants/jokes';
+
+const CATEGORIES: JokeCategory[] = ['animals', 'school', 'food'];
+
+export default function JokesBrowserClient() {
+  const {
+    phase, current, currentIndex, revealed, totalInCategory,
+    selectCategory, revealPunchline, nextJoke, prevJoke, readSetup, backToMenu,
+  } = useJokesBrowser();
+
+  if (phase === 'menu') {
+    return (
+      <div className="min-h-screen flex flex-col items-center justify-center p-4"
+        style={{ background: 'linear-gradient(135deg, #fef9c3 0%, #dcfce7 100%)' }}
+        dir="rtl">
+        <div className="w-full max-w-sm space-y-6 text-center">
+          <div className="text-7xl animate-bounce">😂</div>
+          <h1 className="text-3xl font-extrabold text-yellow-800">ספריית בדיחות</h1>
+          <p className="text-gray-600">בחר קטגוריה ותצחק!</p>
+          <div className="space-y-3">
+            {CATEGORIES.map((cat) => (
+              <button key={cat} onClick={() => selectCategory(cat)}
+                className={`w-full bg-linear-to-br ${CATEGORY_COLORS[cat]} text-white font-bold py-4 rounded-2xl shadow-lg text-xl active:scale-95 transition-transform`}>
+                {CATEGORY_LABELS[cat]}
+              </button>
+            ))}
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  if (!current) return null;
+
+  const shareText = encodeURIComponent(`${current.setup}\n\n${current.punchline}\n\nבדיחות מצחיקות ב-GamesForMyKids! 😂`);
+  const whatsappUrl = `https://wa.me/?text=${shareText}`;
+
+  return (
+    <div className="min-h-screen flex flex-col items-center p-4 pt-6"
+      style={{ background: 'linear-gradient(135deg, #fef9c3 0%, #dcfce7 100%)' }}
+      dir="rtl">
+
+      {/* Header */}
+      <div className="w-full max-w-sm flex justify-between items-center mb-4">
+        <button onClick={backToMenu} className="text-gray-500 underline text-sm">⬅ קטגוריות</button>
+        <span className="text-sm text-gray-400">{currentIndex + 1} / {totalInCategory}</span>
+      </div>
+
+      {/* Joke card */}
+      <div className="w-full max-w-sm bg-white rounded-3xl shadow-xl p-6 mb-4 text-center">
+        <div className="text-6xl mb-4">{current.emoji}</div>
+        <p className="text-xl font-bold text-gray-800 leading-relaxed mb-4">
+          {current.setup}
+        </p>
+        <button onClick={readSetup}
+          className="text-gray-400 text-sm underline mb-2">
+          🔊 שמע שוב
+        </button>
+
+        {/* Punchline */}
+        {revealed ? (
+          <div className="mt-4 bg-yellow-50 border-2 border-yellow-300 rounded-2xl p-4 animate-fade-in">
+            <p className="text-2xl font-extrabold text-yellow-700 leading-relaxed">
+              {current.punchline}
+            </p>
+          </div>
+        ) : (
+          <button onClick={revealPunchline}
+            className="mt-4 w-full bg-linear-to-br from-yellow-400 to-orange-400 text-white font-bold py-4 rounded-2xl text-lg shadow-lg active:scale-95 transition-transform">
+            🤔 גלה תשובה!
+          </button>
+        )}
+      </div>
+
+      {/* Navigation */}
+      <div dir="ltr" className="flex gap-4 w-full max-w-sm mb-3">
+        <button onClick={prevJoke}
+          className="flex-1 bg-white border-2 border-gray-200 font-bold py-3 rounded-2xl text-xl active:scale-95 transition-transform shadow">
+          ←
+        </button>
+        <button onClick={nextJoke}
+          className="flex-1 bg-linear-to-br from-green-400 to-emerald-500 text-white font-bold py-3 rounded-2xl text-xl shadow-lg active:scale-95 transition-transform">
+          → הבאה
+        </button>
+      </div>
+
+      {/* WhatsApp share */}
+      {revealed && (
+        <a href={whatsappUrl} target="_blank" rel="noopener noreferrer"
+          className="w-full max-w-sm block text-center bg-[#25d366] text-white font-bold py-3 rounded-2xl shadow-lg active:scale-95 transition-transform">
+          📲 שתף בWhatsApp
+        </a>
+      )}
+    </div>
+  );
+}

--- a/gamesformykids/app/games/jokes-browser/useJokesBrowser.ts
+++ b/gamesformykids/app/games/jokes-browser/useJokesBrowser.ts
@@ -1,0 +1,61 @@
+'use client';
+import { useState, useCallback } from 'react';
+import { JOKES, type JokeCategory, type Joke } from '@/lib/constants/jokes';
+import { speakHebrew } from '@/lib/utils/speech/enhancedSpeechUtils';
+
+export type JokesPhase = 'menu' | 'browse';
+
+export function useJokesBrowser() {
+  const [phase, setPhase] = useState<JokesPhase>('menu');
+  const [category, setCategory] = useState<JokeCategory>('animals');
+  const [currentIndex, setCurrentIndex] = useState(0);
+  const [revealed, setRevealed] = useState(false);
+
+  const categoryJokes = JOKES.filter(j => j.category === category);
+  const current: Joke | undefined = categoryJokes[currentIndex];
+
+  const selectCategory = useCallback((cat: JokeCategory) => {
+    setCategory(cat);
+    setCurrentIndex(0);
+    setRevealed(false);
+    setPhase('browse');
+    const firstJoke = JOKES.find(j => j.category === cat);
+    if (firstJoke) speakHebrew(firstJoke.setup);
+  }, []);
+
+  const revealPunchline = useCallback(() => {
+    setRevealed(true);
+    if (current) speakHebrew(current.punchline);
+  }, [current]);
+
+  const nextJoke = useCallback(() => {
+    const next = (currentIndex + 1) % categoryJokes.length;
+    setCurrentIndex(next);
+    setRevealed(false);
+    const nextJokeItem = categoryJokes[next];
+    if (nextJokeItem) speakHebrew(nextJokeItem.setup);
+  }, [currentIndex, categoryJokes]);
+
+  const prevJoke = useCallback(() => {
+    const prev = (currentIndex - 1 + categoryJokes.length) % categoryJokes.length;
+    setCurrentIndex(prev);
+    setRevealed(false);
+    const prevJokeItem = categoryJokes[prev];
+    if (prevJokeItem) speakHebrew(prevJokeItem.setup);
+  }, [currentIndex, categoryJokes]);
+
+  const readSetup = useCallback(() => {
+    if (current) speakHebrew(current.setup);
+  }, [current]);
+
+  const backToMenu = useCallback(() => {
+    setPhase('menu');
+    setRevealed(false);
+  }, []);
+
+  return {
+    phase, category, current, currentIndex, revealed,
+    totalInCategory: categoryJokes.length,
+    selectCategory, revealPunchline, nextJoke, prevJoke, readSetup, backToMenu,
+  };
+}

--- a/gamesformykids/lib/constants/gameCategories.ts
+++ b/gamesformykids/lib/constants/gameCategories.ts
@@ -132,6 +132,6 @@ export const GAME_CATEGORIES: Record<string, GameCategory> = {
     color: "bg-teal-500",
     gradient: "from-teal-400 to-cyan-600",
 
-    gameIds: ["true-false","emoji-math","math-race","number-bubbles","word-scramble","word-builder","word-chain","trivia","clock","spelling","opposites","world-languages","riddles","english-words","singular-plural","adjectives","verbs","visual-opposites","english-cards","proverbs","story-builder","robot-coder","hangman","choose-adventure","picture-dictionary","word-search","kids-songs","kids-encyclopedia","age-calculator"],
+    gameIds: ["true-false","emoji-math","math-race","number-bubbles","word-scramble","word-builder","word-chain","trivia","clock","spelling","opposites","world-languages","riddles","english-words","singular-plural","adjectives","verbs","visual-opposites","english-cards","proverbs","story-builder","robot-coder","hangman","choose-adventure","picture-dictionary","word-search","kids-songs","kids-encyclopedia","age-calculator","jokes-browser"],
   },
 };

--- a/gamesformykids/lib/constants/jokes.ts
+++ b/gamesformykids/lib/constants/jokes.ts
@@ -1,0 +1,65 @@
+export type JokeCategory = 'animals' | 'school' | 'food';
+
+export interface Joke {
+  id: number;
+  category: JokeCategory;
+  setup: string;
+  punchline: string;
+  emoji: string;
+}
+
+export const JOKES: Joke[] = [
+  // Animals — בעלי חיים
+  { id: 1,  category: 'animals', emoji: '🐟', setup: 'למה הדג לא הלך לבית ספר?',           punchline: 'כי הוא כבר ים חכם! 😂' },
+  { id: 2,  category: 'animals', emoji: '🐘', setup: 'למה לפיל לא יכול להסתתר?',           punchline: 'כי הוא תמיד בולט! 😄' },
+  { id: 3,  category: 'animals', emoji: '🐸', setup: 'מה אומר הצפרדע לחברו?',              punchline: 'כבה לי, ידידי! 🐸' },
+  { id: 4,  category: 'animals', emoji: '🐶', setup: 'איך הכלב אומר שלום?',               punchline: 'הב הב הב — שלום רב! 🐾' },
+  { id: 5,  category: 'animals', emoji: '🐱', setup: 'למה החתול ישב על המחשב?',            punchline: 'כי הוא רצה לשמור על העכבר! 😹' },
+  { id: 6,  category: 'animals', emoji: '🐧', setup: 'מה הפינגווין עשה בחוף הים?',         punchline: 'הוא הצטנן — כמו תמיד! ❄️' },
+  { id: 7,  category: 'animals', emoji: '🐄', setup: 'למה הפרה עברה את הכביש?',            punchline: 'כי היה שם עשב ירוק יותר! 🌿' },
+  { id: 8,  category: 'animals', emoji: '🦁', setup: 'מה אומר הארי כשנפגש עם חמשה אחרים?', punchline: 'מה ה-ה-הזדמנות! 🦁' },
+  { id: 9,  category: 'animals', emoji: '🐰', setup: 'מה אוכלים ארנבות מרקיסות?',          punchline: 'גזר בשמפניה! 🥕' },
+  { id: 10, category: 'animals', emoji: '🐍', setup: 'למה הנחש קיבל ציון גרוע?',           punchline: 'כי לא הצליח להחזיק עט! 😂' },
+  { id: 11, category: 'animals', emoji: '🦊', setup: 'מה עושה שועל שמרגיש עצוב?',          punchline: 'בוכה כמו גור! 🦊' },
+  { id: 12, category: 'animals', emoji: '🐻', setup: 'למה הדב לא שמע את השעון?',           punchline: 'כי הוא ישן כל החורף! 😴' },
+
+  // School — בית ספר
+  { id: 13, category: 'school', emoji: '📚', setup: 'למה הספר ביקש הפסקה?',               punchline: 'כי היו בו יותר מדי פרקים! 😄' },
+  { id: 14, category: 'school', emoji: '✏️', setup: 'מה אמר העיפרון לדף?',                punchline: 'כבר ציירתי עליך! ✏️' },
+  { id: 15, category: 'school', emoji: '🎒', setup: 'למה התיק לא הצליח לרוץ?',            punchline: 'כי היה עמוס בשיעורי בית! 🎒' },
+  { id: 16, category: 'school', emoji: '📐', setup: 'למה המחשבון עצוב?',                  punchline: 'כי הוא סה"כ בעניין! 🔢' },
+  { id: 17, category: 'school', emoji: '🍎', setup: 'מה עשה התלמיד עם תפוח המורה?',      punchline: 'אכל אותו ואמר: זה היה חינוכי! 😂' },
+  { id: 18, category: 'school', emoji: '🖊️', setup: 'למה העט לא יכול לשמור סוד?',        punchline: 'כי הוא תמיד מוציא לאור! 📝' },
+  { id: 19, category: 'school', emoji: '📏', setup: 'מה אמרה הסרגל לעיפרון?',            punchline: 'אתה מאוד ישר! 📏' },
+  { id: 20, category: 'school', emoji: '🔬', setup: 'למה המיקרוסקופ פחד?',               punchline: 'כי ראה דברים גדולים יותר מדי! 😨' },
+  { id: 21, category: 'school', emoji: '🎓', setup: 'מה ההבדל בין מורה לרכבת?',           punchline: 'המורה אומר: תוציאו הגומי! הרכבת אומרת: תשמרו על הפסים! 🚂' },
+  { id: 22, category: 'school', emoji: '📓', setup: 'למה המחברת בכתה?',                   punchline: 'כי היו בה הרבה שגיאות! 😢' },
+  { id: 23, category: 'school', emoji: '🎨', setup: 'מה אמר הצבע האדום לצבע הכחול?',     punchline: 'אני צובע ממך! 🎨' },
+  { id: 24, category: 'school', emoji: '📊', setup: 'למה הגרף עלה למעלה?',               punchline: 'כי הוא רצה להגיע לפסגה! 📈' },
+
+  // Food — אוכל
+  { id: 25, category: 'food', emoji: '🍕', setup: 'למה הפיצה לא הצטחקה?',               punchline: 'כי היא הייתה עגולה מאוד! 🍕' },
+  { id: 26, category: 'food', emoji: '🍌', setup: 'מה אמרה הבננה לתפוח?',               punchline: 'הי, אתה מאוד אדום היום! 🍎' },
+  { id: 27, category: 'food', emoji: '🥕', setup: 'למה הגזר עצוב?',                     punchline: 'כי כולם רוצים לנגוס בו! 😄' },
+  { id: 28, category: 'food', emoji: '🥚', setup: 'מה אמר הביצה לחבה?',                 punchline: 'אתה מחמם את ליבי! 🍳' },
+  { id: 29, category: 'food', emoji: '🍦', setup: 'למה הגלידה בכתה?',                   punchline: 'כי הילד לקח ממנה כדור! 🍦' },
+  { id: 30, category: 'food', emoji: '🥪', setup: 'מה אמר הכריך לחלב?',                punchline: 'אתה מלבין את שמי! 🥛' },
+  { id: 31, category: 'food', emoji: '🍫', setup: 'למה השוקולד כל כך פופולרי?',          punchline: 'כי כולם נמסים ממנו! 😍' },
+  { id: 32, category: 'food', emoji: '🍇', setup: 'מה אמר הענב לחברו?',                 punchline: 'אני כזה מרוסק היום! 🍷' },
+  { id: 33, category: 'food', emoji: '🥜', setup: 'למה הבוטן התגלגל ברחוב?',            punchline: 'כי הוא ניסה לברוח מחמאת הבוטנים! 😂' },
+  { id: 34, category: 'food', emoji: '🍰', setup: 'מה אמרה העוגה לנרות?',              punchline: 'תפסיקו להצית אותי! 🎂' },
+  { id: 35, category: 'food', emoji: '🥦', setup: 'למה הברוקולי לא רצה להיאכל?',       punchline: 'כי הוא לא רצה להיות ירוק מכעס! 🥦' },
+  { id: 36, category: 'food', emoji: '🍓', setup: 'מה אמרה התות לאוכל שלה?',           punchline: 'אתה מאוד מתוק איתי! 💕' },
+];
+
+export const CATEGORY_LABELS: Record<JokeCategory, string> = {
+  animals: '🐾 בעלי חיים',
+  school:  '📚 בית ספר',
+  food:    '🍕 אוכל',
+};
+
+export const CATEGORY_COLORS: Record<JokeCategory, string> = {
+  animals: 'from-green-400 to-emerald-500',
+  school:  'from-blue-400 to-indigo-500',
+  food:    'from-orange-400 to-amber-500',
+};

--- a/gamesformykids/lib/registry/registryData/batch4.ts
+++ b/gamesformykids/lib/registry/registryData/batch4.ts
@@ -32,6 +32,7 @@ import {
   Search,
   HelpCircle,
   TextSearch,
+  Laugh,
 } from "lucide-react";
 import type { GameRegistration } from "@/lib/types/games/base";
 
@@ -731,5 +732,16 @@ export const gamesRegistryBatch4: GameRegistration[] = [
     href: "/games/craft-guide",
     available: true,
     order: 187,
+  },
+  {
+    id: "jokes-browser",
+    title: "ספריית בדיחות",
+    description: "בדיחות מצחיקות לילדים לפי קטגוריות — בעלי חיים, בית ספר ואוכל!",
+    icon: Laugh,
+    emoji: "😂",
+    color: "bg-yellow-500 hover:bg-yellow-600",
+    href: "/games/jokes-browser",
+    available: true,
+    order: 188,
   },
 ];

--- a/gamesformykids/lib/types/core/base.ts
+++ b/gamesformykids/lib/types/core/base.ts
@@ -231,4 +231,6 @@ export type GameType =
   // Fun tools
   | 'age-calculator'
   // Craft guide
-  | 'craft-guide';
+  | 'craft-guide'
+  // Jokes browser
+  | 'jokes-browser';


### PR DESCRIPTION
## What
Adds a new Hebrew jokes browser game with 36 jokes across 3 categories.

## Features
- 3 categories: 🐾 בעלי חיים (12), 📚 בית ספר (12), 🍕 אוכל (12)
- Menu screen with colored category buttons
- Joke setup displayed, TTS reads it aloud
- 'גלה תשובה' button reveals punchline with flip animation
- Next/Prev navigation through jokes within a category
- WhatsApp share button appears after punchline is revealed
- 'שמע שוב' button re-reads the setup
- RTL layout

## Why
Closes #1215

## Test plan
- [ ] Navigate to `/games/jokes-browser`
- [ ] Select each category — verify jokes load for that category
- [ ] Tap 'גלה תשובה' — verify punchline appears and TTS reads it
- [ ] Navigate next/prev — verify counter updates and next joke loads
- [ ] WhatsApp share button appears only after punchline revealed
- [ ] Game appears in 📚 Educational category on home page

🤖 Generated with [Claude Code](https://claude.com/claude-code)