### PR TITLE
perf: React 19+ compatibility fixes, timeout cleanup, transition-all → transition (26 components)

### DIFF
--- a/.claude/commands/game-load-perf-audit.md
+++ b/.claude/commands/game-load-perf-audit.md
@@ -2,6 +2,8 @@
 
 You are the **Game Load & Performance Audit** agent for GamesForMyKids.
 
+**Stack:** Next.js 16+ (App Router, Turbopack, `use cache`, `after()`), React 19+ (React Compiler enabled, `use()`, ref-as-prop, async transitions), Zustand 5+, TypeScript strict.
+
 Your job: verify that **every game loads correctly at runtime** and that **performance is at the highest possible level** — covering all game styles (A/B/C/D/E), all device classes, and all phases of the game lifecycle (loading → menu → play → result).
 
 This agent is **complementary** to the specialist agents:
@@ -10,7 +12,7 @@ This agent is **complementary** to the specialist agents:
 - `lazy-loading-optimizer` → bundle splitting (do not repeat)
 - `runtime-error-scanner` → diff-specific crash patterns (do not repeat)
 
-This agent covers the **cross-cutting, whole-project** view: SSR safety, re-render hygiene, Zustand selector efficiency, animation performance, audio lifecycle, and loading UX — for every game, always.
+This agent covers the **cross-cutting, whole-project** view: SSR safety, re-render hygiene, Zustand selector efficiency, animation performance, audio lifecycle, loading UX, React 19+ compatibility, and Next.js 16+ API correctness — for every game, always.
 
 ---
 
@@ -147,15 +149,33 @@ grep -n "dynamic(" gamesformykids/lib/quiz/registry/customQuizGames.tsx | grep -
 
 ---
 
-### Check L5 — Async params in page.tsx (Next.js 15+/16+)
+### Check L5 — Async params and searchParams in page.tsx (Next.js 15+/16+)
 
 ```bash
 cat gamesformykids/app/games/\[gameType\]/page.tsx
+grep -rn "params\.\|searchParams\." gamesformykids/app/games/ --include="page.tsx" 2>/dev/null | grep -v "await" | head -20
 ```
 
-**Rule:** Since Next.js 15, `params` is a Promise — `params.gameType` without `await params` throws. This applies equally to Next.js 16+.
+**Rule:** Since Next.js 15, both `params` AND `searchParams` are Promises. Any synchronous access (`params.gameType`, `searchParams.q`) without `await params` / `await searchParams` throws a runtime error in Next.js 16+.
 
-**Pattern to catch:** `params.gameType` used synchronously (without `await`).
+**Patterns to catch:**
+| Pattern | Risk |
+|---------|------|
+| `params.gameType` without `await params` | 🔴 500 on every page load |
+| `searchParams.difficulty` without `await searchParams` | 🔴 500 on every page load |
+| `const { gameType } = params` without `await` | 🔴 |
+| `generateMetadata({ params })` not async | 🟠 Metadata missing |
+
+**Correct pattern (Next.js 16):**
+```typescript
+export default async function Page({ params, searchParams }: {
+  params: Promise<{ gameType: string }>;
+  searchParams: Promise<{ difficulty?: string }>;
+}) {
+  const { gameType } = await params;
+  const { difficulty } = await searchParams;
+}
+```
 
 **Severity:** 🔴 CRITICAL — entire game route returns 500.
 
@@ -237,26 +257,39 @@ cat gamesformykids/app/games/<id>/use*Game*.ts
 
 ### Check P1 — Inline object/array/function creation in JSX
 
-**Look for:** Props passed as inline literals.
+> **React Compiler note:** This project has `reactCompiler: true` in `next.config.ts`. The compiler automatically memoizes props and callbacks for components it can analyze. Flag P1 violations only when: (a) the component is marked `'use no memo'`, (b) the component contains mutations that block the compiler, or (c) the pattern is provably causing re-renders (confirm with React DevTools before filing).
+
+**Look for:** Props passed as inline literals in components the compiler cannot optimize.
 
 ```typescript
-// ❌ BAD — new object on every render → child re-renders unnecessarily
-<GameCard style={{ padding: 16 }} options={['a', 'b']} onClick={() => select('a')} />
+// ⚠️ COMPILER CAN'T FIX — mutation inside render blocks optimization
+function GameCard({ items }: Props) {
+  items.sort(); // ← mutates input; compiler bails out for this component
+  return <Child options={items} onClick={() => select(items[0])} />;
+}
 
-// ✅ GOOD
-const cardStyle = useMemo(() => ({ padding: 16 }), []);
-const handleSelect = useCallback(() => select('a'), [select]);
+// ✅ GOOD — pure render; compiler handles memoization automatically
+function GameCard({ items }: Props) {
+  const sorted = [...items].sort(); // new array, no mutation
+  return <Child options={sorted} onClick={() => select(sorted[0])} />;
+}
 ```
 
-| Pattern | Severity |
-|---------|----------|
-| Inline `{}` object literal as a component prop | 🟠 HIGH — causes child re-render every parent render |
-| Inline `[]` array literal as a component prop | 🟠 HIGH |
-| Inline `() => ...` arrow in JSX without `useCallback` | 🟡 MEDIUM |
+| Pattern | Severity with React Compiler |
+|---------|------------------------------|
+| Mutations inside render (`arr.sort()`, `obj.x = 1`) | 🔴 CRITICAL — blocks compiler for entire component |
+| Inline `{}` object prop — compiler CANNOT analyze dynamic shape | 🟠 HIGH if compiler bails; 🟡 LOW if it handles it |
+| Inline `() => ...` arrow in JSX | 🟡 LOW — compiler wraps automatically when possible |
+| `'use no memo'` directive present | 🟠 HIGH — compiler disabled; manual memoization required |
 
 **Grep:**
 ```bash
-grep -n "=\s*{{\|=\s*\[.*\]\|={() =>" gamesformykids/app/games/<id>/*Client.tsx | head -20
+# Mutations that block React Compiler
+grep -n "\.sort(\|\.push(\|\.pop(\|\.splice(\|\.reverse(" \
+  gamesformykids/app/games/<id>/*Client.tsx gamesformykids/app/games/<id>/components/*.tsx 2>/dev/null | head -15
+
+# Explicit compiler opt-outs
+grep -rn "use no memo" gamesformykids/app/games/ --include="*.tsx" --include="*.ts" 2>/dev/null
 ```
 
 ---
@@ -301,17 +334,23 @@ grep -n "useEffect(" gamesformykids/app/games/<id>/*.ts gamesformykids/app/games
 
 ### Check P4 — `useMemo` for computed game data
 
-**Rule:** Expensive derivations (shuffled arrays, filtered questions, calculated scores) that depend on stable inputs must be wrapped in `useMemo`.
+> **React Compiler note:** With `reactCompiler: true`, the compiler infers memoization for pure computations automatically. Only flag P4 when the computation is **heavy** (maze generation, shuffle of 100+ items, BFS traversal) AND the component has a mutation or other compiler bail-out (confirmed via P1 grep above). For pure, lightweight derivations, the compiler handles it.
+
+**Rule:** Heavy derivations called synchronously in component render that depend on stable inputs must be wrapped in `useMemo` — especially when the component is a compiler bail-out candidate.
 
 ```bash
-grep -n "\.sort(\|\.filter(\|\.map(\|\.shuffle\|Math\.random" \
-  gamesformykids/app/games/<id>/*.ts gamesformykids/app/games/<id>/*.tsx 2>/dev/null | \
-  grep -v "useMemo\|useCallback\|useEffect" | head -10
+grep -n "generateMaze\|bfsOrder\|shuffle\|Array\.from.*length.*\(.*\)\." \
+  gamesformykids/app/games/<id>/*.ts gamesformykids/app/games/<id>/*.tsx 2>/dev/null | head -10
 ```
 
-If `sort/filter/map` appears directly in the component body (not inside a hook or memoized function), flag it.
+| Pattern | Severity |
+|---------|----------|
+| Maze/graph generation in render body | 🟠 HIGH — 5–50ms; perceivable freeze on click |
+| Large array shuffle (100+ items) in render | 🟠 HIGH |
+| `map/filter` on ≤20 items, pure component | 🟡 LOW — compiler handles |
+| Any computation in component with known mutation bail-out | 🟠 HIGH — compiler won't memoize |
 
-**Severity:** 🟡 MEDIUM — runs on every render, noticeable on older phones.
+**Severity:** 🟠 HIGH for heavy computations in bailed-out components; 🟡 LOW otherwise (compiler handles).
 
 ---
 
@@ -347,12 +386,20 @@ grep -rn "transition-all" gamesformykids/components/shared/ 2>/dev/null | head -
 
 **Fix template:**
 ```typescript
-// ❌ BAD
+// ❌ BAD — triggers layout recalculation for every CSS property
 className="transition-all duration-300"
 
-// ✅ GOOD — only animate GPU-composited properties
-className="transition-transform transition-opacity duration-300"
+// ✅ GOOD — colors/backgrounds only (border-color, background-color, color)
+className="transition-colors duration-300"
+
+// ✅ GOOD — scale/translate/rotate only (GPU composited)
+className="transition-transform duration-300"
+
+// ✅ GOOD — both transform AND opacity (use Tailwind arbitrary value — single transition-property)
+className="transition-[transform,opacity] duration-300"
 ```
+
+> **Note:** Never combine `transition-transform` + `transition-opacity` as separate Tailwind classes — both set `transition-property` and the second one silently overrides the first. Use the arbitrary value `transition-[transform,opacity]` instead.
 
 ---
 
@@ -552,34 +599,268 @@ grep -rn "setTimeout.*[0-9]\{4,\}\|setInterval.*[0-9]\{4,\}" \
 grep -rn ": any\b\|as any\b" \
   gamesformykids/app/games/ --include="*.ts" --include="*.tsx" 2>/dev/null | head -15
 
-# QW5 — Missing React.memo on frequently-re-rendered child components
-grep -rn "export default function\|export function" \
-  gamesformykids/app/games/*/components/*.tsx 2>/dev/null | grep -v "memo\|Client\|Page" | head -20
+# QW5 — React Compiler bail-outs ('use no memo' or mutation-in-render)
+# React Compiler is enabled (reactCompiler: true) — manual memo should be rare
+grep -rn "use no memo\|React\.memo(\|useMemo(\|useCallback(" \
+  gamesformykids/app/games/ --include="*.ts" --include="*.tsx" 2>/dev/null | head -20
+# If React.memo/useMemo/useCallback appear heavily, the compiler may have bailed out for that file
 ```
 
 ---
 
-## Phase 10 — Per-Game Summary Matrix
+## Phase 10 — React 19+ Compatibility
+
+**Why it matters:** React 19 introduces breaking API changes. Deprecated patterns (`forwardRef`, `Context.Provider`, `useFormState`) still work but emit warnings; some will be removed in React 20. The React Compiler (enabled in this project) has specific rules about what it can and cannot optimize.
+
+### Check R1 — Deprecated `React.forwardRef` (React 19)
+
+```bash
+grep -rn "React\.forwardRef\|forwardRef(" \
+  gamesformykids/app/games/ gamesformykids/components/ --include="*.tsx" --include="*.ts" 2>/dev/null | head -20
+```
+
+**Rule:** In React 19, `forwardRef` is deprecated — refs are passed as regular props. Any component accepting a ref must be updated to destructure `ref` from props.
+
+```typescript
+// ❌ React 18 — deprecated in React 19
+const MyCanvas = React.forwardRef<HTMLCanvasElement, Props>((props, ref) => (
+  <canvas ref={ref} />
+));
+
+// ✅ React 19 — ref is a plain prop
+function MyCanvas({ ref, ...props }: Props & { ref?: React.Ref<HTMLCanvasElement> }) {
+  return <canvas ref={ref} />;
+}
+```
+
+**Severity:** 🟡 MEDIUM — emits deprecation warning in console; canvas/input refs in games may be affected.
+
+---
+
+### Check R2 — Deprecated `Context.Provider` wrapper (React 19)
+
+```bash
+grep -rn "\.Provider>" \
+  gamesformykids/ --include="*.tsx" 2>/dev/null | grep -v "node_modules" | head -20
+```
+
+**Rule:** In React 19, `<MyContext.Provider value={...}>` is deprecated. Use `<MyContext value={...}>` directly.
+
+```typescript
+// ❌ deprecated
+<GameTypeContext.Provider value={game}>...</GameTypeContext.Provider>
+
+// ✅ React 19
+<GameTypeContext value={game}>...</GameTypeContext>
+```
+
+**Severity:** 🟡 MEDIUM — console warning; will break in React 20.
+
+---
+
+### Check R3 — React Compiler bail-out: mutations inside render
+
+```bash
+# Mutations that cause the React Compiler to bail out for the entire component
+grep -rn "\bstate\.\w\+ =" \
+  gamesformykids/app/games/ --include="*.tsx" 2>/dev/null | grep -v "useState\|=>" | head -15
+grep -rn "\.push(\|\.pop(\|\.splice(\|\.sort(\|\.reverse(" \
+  gamesformykids/app/games/ gamesformykids/components/game/ --include="*.tsx" 2>/dev/null | \
+  grep -v "useEffect\|useCallback\|useMemo\|// " | head -20
+```
+
+**Rule:** The React Compiler cannot optimize components that mutate values during render. A single mutation causes the compiler to bail out for the **entire component** — negating all auto-memoization. This is the highest-impact correctness issue for React Compiler projects.
+
+| Pattern | Risk |
+|---------|------|
+| `arr.sort()` in render (mutates input) | 🔴 Compiler bail-out + sort order bug |
+| `arr.push()` directly in component body | 🔴 Compiler bail-out |
+| Direct property assignment (`obj.x = value`) in render | 🔴 Compiler bail-out |
+| `[...arr].sort()` — new array, then sort | ✅ Safe, compiler can optimize |
+
+**Severity:** 🔴 CRITICAL — disables React Compiler auto-memoization for the component; every render of that component becomes unoptimized.
+
+---
+
+### Check R4 — `use()` hook for context reading (React 19 idiomatic)
+
+```bash
+grep -rn "useContext(" \
+  gamesformykids/app/games/ gamesformykids/components/ --include="*.tsx" --include="*.ts" 2>/dev/null | head -15
+```
+
+**Rule:** In React 19, prefer `use(MyContext)` over `useContext(MyContext)`. The `use()` hook can be called conditionally and inside loops — unlike `useContext`.
+
+```typescript
+// ✅ React 19 idiomatic (also works conditionally)
+const gameType = use(GameTypeContext);
+
+// 🟡 React 18 style — still works but less flexible
+const gameType = useContext(GameTypeContext);
+```
+
+**Severity:** 🟡 LOW — `useContext` still works; opportunistic upgrade only.
+
+---
+
+### Check R5 — Uncleaned `setTimeout`/`setInterval` in hooks (React 19 Strict Mode)
+
+```bash
+grep -rn "setTimeout\|setInterval" \
+  gamesformykids/app/games/ --include="*.ts" --include="*.tsx" 2>/dev/null | \
+  grep -v "clearTimeout\|clearInterval\|useRef\|//\s*" | head -20
+```
+
+**Rule:** React 19 Strict Mode (dev) mounts components twice to surface missing cleanups. A `setTimeout` without a corresponding `clearTimeout` in the `useEffect` cleanup fires twice in dev. In production, it causes state updates on unmounted components ("Can't perform a React state update on an unmounted component").
+
+```typescript
+// ❌ No cleanup
+useEffect(() => {
+  setTimeout(() => setState('win'), 800);
+}, []);
+
+// ✅ Correct
+useEffect(() => {
+  const id = setTimeout(() => setState('win'), 800);
+  return () => clearTimeout(id);
+}, []);
+```
+
+Cross-check: also scan game hook files (`use*.ts`) for `setTimeout` without paired `clearTimeout`.
+
+**Severity:** 🟠 HIGH — silent state-update-on-unmounted-component; causes React warnings and potential crashes when navigating quickly between games.
+
+---
+
+## Phase 11 — Next.js 16+ API Correctness
+
+### Check N1 — `'use cache'` directive correctness
+
+```bash
+grep -rn "'use cache'\|\"use cache\"" \
+  gamesformykids/ --include="*.ts" --include="*.tsx" 2>/dev/null | grep -v "node_modules" | head -20
+```
+
+**Rule:** In Next.js 16 (`cacheComponents: true`), `'use cache'` is the idiomatic server-side cache directive (replacing `unstable_cache`). Rules:
+- `'use cache'` may only appear in **Server Components or server-side functions** — never in `'use client'` files.
+- Any `'use cache'` function that accepts request-time data (e.g., `headers()`, `cookies()`) must call `cacheTag()` + `cacheLife()` to set invalidation scope.
+- If `unstable_cache(...)` still appears, flag it as a migration opportunity.
+
+```bash
+# Deprecated pattern to migrate
+grep -rn "unstable_cache" gamesformykids/ --include="*.ts" --include="*.tsx" 2>/dev/null | grep -v "node_modules"
+```
+
+**Severity:** 🟠 HIGH if `'use cache'` appears in a `'use client'` file (build error); 🟡 LOW if `unstable_cache` still used (deprecation warning).
+
+---
+
+### Check N2 — `after()` for deferred post-response work
+
+```bash
+grep -rn "after(" gamesformykids/ --include="*.ts" --include="*.tsx" 2>/dev/null | grep -v "node_modules" | head -10
+```
+
+**Rule:** In Next.js 15+/16+, `after()` runs work after the response is sent — ideal for analytics logging, cache warm-up, and non-critical side effects that previously blocked the response. If you see `fetch()`-based analytics calls directly in a Server Component or Route Handler, suggest `after()`.
+
+```typescript
+import { after } from 'next/server';
+
+export default async function GamePage() {
+  after(() => logGameView(gameId)); // doesn't block the response
+  return <Game />;
+}
+```
+
+**Severity:** 🟡 LOW — opportunity to improve TTFB; not a correctness issue.
+
+---
+
+### Check N3 — Async `headers()` and `cookies()` (Next.js 15+/16+)
+
+```bash
+grep -rn "headers()\|cookies()" \
+  gamesformykids/app/ --include="*.ts" --include="*.tsx" 2>/dev/null | grep -v "await\|async" | head -15
+```
+
+**Rule:** Since Next.js 15, `headers()` and `cookies()` return Promises. Synchronous access (`const h = headers(); h.get(...)`) throws at runtime in Next.js 16+.
+
+```typescript
+// ❌ Next.js 14 style — throws in Next.js 16
+const headersList = headers();
+const token = headersList.get('authorization');
+
+// ✅ Next.js 16
+const headersList = await headers();
+const token = headersList.get('authorization');
+```
+
+**Severity:** 🔴 CRITICAL if used synchronously — route handler returns 500.
+
+---
+
+### Check N4 — `forbidden()` / `unauthorized()` guard usage (Next.js 16)
+
+```bash
+grep -rn "forbidden(\|unauthorized(" \
+  gamesformykids/app/ --include="*.ts" --include="*.tsx" 2>/dev/null | head -10
+```
+
+**Rule:** `authInterrupts: true` is set in `next.config.ts` — `forbidden()` and `unauthorized()` are enabled. When used, the route must have a corresponding `forbidden.tsx` / `unauthorized.tsx` boundary. Without the boundary, the interrupt renders a blank page.
+
+```bash
+# Check boundaries exist alongside usage
+find gamesformykids/app -name "forbidden.tsx" -o -name "unauthorized.tsx" 2>/dev/null
+```
+
+**Severity:** 🟠 HIGH — missing boundary shows blank page instead of error UI.
+
+---
+
+### Check N5 — Turbopack compatibility (Next.js 16 default dev)
+
+```bash
+# Dynamic import options must be object literals (Turbopack static analysis)
+grep -rn "dynamic(" gamesformykids/ --include="*.tsx" --include="*.ts" 2>/dev/null | \
+  grep -v "{ ssr:\|{ loading:\|{ssr:\|{loading:" | grep -v "node_modules" | head -15
+```
+
+**Rule:** Turbopack (stable in Next.js 16, default dev server) performs static analysis on `dynamic()` options. The options argument **must be an object literal** — a variable reference (`const opts = {...}; dynamic(fn, opts)`) is not statically analyzable and Turbopack will warn or skip optimization.
+
+```typescript
+// ❌ Turbopack cannot analyze — variable options
+const opts = { ssr: false, loading: () => <Spinner /> };
+dynamic(() => import('./Game'), opts);
+
+// ✅ Inline object literal — Turbopack can statically analyze
+dynamic(() => import('./Game'), { ssr: false, loading: () => <GameSpinnerScreen /> });
+```
+
+**Severity:** 🟠 HIGH — dynamic imports with non-literal options may not be optimized by Turbopack.
+
+---
+
+## Phase 12 — Per-Game Summary Matrix
 
 After running all checks for all games in scope, build this matrix:
 
-| Check Category | Description | Severity when fails |
-|----------------|-------------|---------------------|
+| Check | Description | Severity when fails |
+|-------|-------------|---------------------|
 | L1 | ssr: false on dynamic import | 🔴 |
 | L2 | 'use client' directive | 🔴 |
 | L3 | window/document outside useEffect | 🔴 |
 | L4 | Loading state on dynamic import | 🟠 |
-| L5 | Async params awaited (Next.js 15) | 🔴 |
+| L5 | Async params + searchParams awaited (Next.js 16) | 🔴 |
 | L6 | Error boundary exists | 🟠 |
 | L7 | No boot side effects | 🟠 |
 | L8 | Store reset on unmount | 🟠 |
 | L9 | Quiz data exported correctly | 🔴/🟠 |
-| P1 | No inline object/array/fn in JSX | 🟠 |
+| P1 | No mutations in render (React Compiler compat) | 🔴 |
 | P2 | Zustand selector granularity | 🟠 |
 | P3 | useEffect deps correct | 🟠 |
-| P4 | useMemo for computed data | 🟡 |
+| P4 | Heavy computation memoized (compiler bail-outs) | 🟠 |
 | P5 | Component < 200 lines | 🟡 |
-| P6 | No transition-all in gameplay | 🟠 |
+| P6 | No transition-all in gameplay (use transition-colors / transition-[transform,opacity]) | 🟠 |
 | P7 | No layout props animated | 🔴/🟠 |
 | P8 | will-change on animated elements | 🟡 |
 | P9 | speechSynthesis cancel on phase change | 🟠 |
@@ -590,18 +871,29 @@ After running all checks for all games in scope, build this matrix:
 | P14 | Store slice import only | 🟡 |
 | P15 | startGame < 50ms | 🟠 |
 | P16 | No layout-thrashing class toggles | 🟡 |
+| R1 | No deprecated React.forwardRef (React 19) | 🟡 |
+| R2 | No Context.Provider wrapper (React 19) | 🟡 |
+| R3 | No mutations-in-render blocking React Compiler | 🔴 |
+| R4 | use() instead of useContext() (React 19) | 🟡 |
+| R5 | setTimeout/setInterval cleaned up on unmount | 🟠 |
+| N1 | 'use cache' only in server files; no unstable_cache | 🟠 |
+| N2 | after() for deferred analytics/logging | 🟡 |
+| N3 | headers() / cookies() awaited (Next.js 16) | 🔴 |
+| N4 | forbidden.tsx / unauthorized.tsx boundaries exist | 🟠 |
+| N5 | dynamic() options are inline object literals (Turbopack) | 🟠 |
 | QW1 | No console.log in production | 🟡 |
 | QW4 | No `any` types | 🟡 |
 
 ---
 
-## Phase 11 — Report
+## Phase 13 — Report
 
 ### All-games mode
 
 ```
 ## Game Load & Performance Audit
 Date: <today>
+Stack: Next.js 16+ / React 19+ / React Compiler ON
 Scope: All games / Style <X> / <IDs>
 Games audited: <N>
 
@@ -620,10 +912,10 @@ Only show games with issues; compress passing games into a count.
 
 ### Performance Summary
 
-| Game ID | Style | P1 | P2 | P3 | P6 | P9 | P15 | QW1 | Rating |
-|---------|-------|----|----|----|----|----|-----|-----|--------|
-| animals | A     | ✅ | ✅ | ✅ | ✅ | ✅ | ✅  | ✅  | ⚡ OPT |
-| <id>    | D     | 🟠 | 🟠 | ✅ | 🔴 | 🟠 | ✅  | 🟡  | 🐢 SLOW |
+| Game ID | Style | P1/R3 | P2 | P3 | P6 | R5 | P15 | N5 | Rating |
+|---------|-------|-------|----|----|----|-----|-----|-----|--------|
+| animals | A     | ✅    | ✅ | ✅ | ✅ | ✅  | ✅  | ✅  | ⚡ OPT |
+| <id>    | D     | 🔴    | 🟠 | ✅ | 🟠 | 🟠  | ✅  | ✅  | 🐢 SLOW |
 ```
 
 ---
@@ -714,23 +1006,29 @@ List items that have a mechanical fix across multiple games:
 ### Prioritised fix list
 
 ```
-🔴 LOAD-BREAKING (game will not render — fix immediately)
+🔴 LOAD-BREAKING / COMPILER-BREAKING (fix immediately)
   1. [<id>] Missing ssr: false in complexQuizGames — game throws on page render
   2. [<id>] window access outside useEffect — SSR crash
-  3. [<id>] Async params not awaited — entire route 500s
+  3. [<id>] Async params/searchParams not awaited — entire route 500s (Next.js 16)
+  4. [<id>] Mutation in render (arr.sort()) — React Compiler bails out, entire component unoptimized
+  5. [<id>] headers()/cookies() called synchronously — route handler 500s (Next.js 16)
 
 🟠 HIGH PERF (visible jank / audio failure / stale state)
-  4. [<id>] Whole-store Zustand selector — all components re-render on any state change
-  5. [<id>] speechSynthesis not cancelled on phase change — audio plays after navigation
-  6. [<id>] transition-all on gameplay buttons — layout reflow on every answer
+  6. [<id>] Whole-store Zustand selector — all components re-render on any state change
+  7. [<id>] speechSynthesis not cancelled on phase change — audio plays after navigation
+  8. [<id>] transition-all on gameplay buttons — use transition-colors or transition-[transform,opacity]
+  9. [<id>] setTimeout without clearTimeout on unmount — state update on unmounted component
+  10. [<id>] 'use cache' in 'use client' file — build error (Next.js 16)
 
-🟡 MEDIUM (noticeable on low-end phones)
-  7. [<id>] Inline object prop in JSX — unnecessary child re-renders
-  8. [<id>] 5 unused lucide imports — 10 KB extra bundle
-  9. [<id>] Component 380 lines — split for better memoization
+🟡 MEDIUM (noticeable on low-end phones / deprecation warnings)
+  11. [<id>] React.forwardRef — deprecated in React 19, use ref as prop
+  12. [<id>] Context.Provider wrapper — deprecated in React 19, use <Context value>
+  13. [<id>] 5 unused lucide imports — 10 KB extra bundle
+  14. [<id>] dynamic() options not inline object literal — Turbopack can't analyze
 
-ℹ️ LOW (polish)
-  10. 3 games have console.log left in — clean up before next release
+ℹ️ LOW (polish / opportunistic)
+  15. 3 games have console.log left in — clean up before next release
+  16. useContext() → use() — React 19 idiomatic, enables conditional reads
 ```
 
 ---
@@ -766,11 +1064,14 @@ For items flagged in this report, use the targeted agents:
   - Style A — skip L8 (no store), L9 (no quiz data), P2 (no direct store use)
   - Style B — skip L7, L8 (no client component), P1–P5 (no custom component)
   - Style D/E — all checks apply
+- **React Compiler is ON (`reactCompiler: true`)** — do not suggest adding `useMemo`/`useCallback`/`React.memo` unless: (a) the component has a confirmed mutation bail-out, or (b) the computation is provably heavy (>10ms). Flag mutations-in-render (R3) as the priority.
 - **`--fix` mode:** Only apply mechanical, safe fixes:
   - Add `{ ssr: false }` to dynamic imports missing it
   - Add `loading: () => <GameSpinnerScreen />` to dynamic imports missing it
   - Remove `console.log` lines
-  - Replace `transition-all` with `transition-transform transition-opacity` in game component dirs
+  - Replace `transition-all` with `transition-colors` (color changes) or `transition-[transform,opacity]` (transform+opacity) — never combine `transition-transform transition-opacity` as separate classes
+  - Replace `<Context.Provider value={x}>` with `<Context value={x}>` (React 19)
+  - Add `clearTimeout`/`clearInterval` cleanup to useEffect hooks missing them
   - Remove clearly unused lucide icon imports (verify usage first)
   - For all other issues, output the fix as a code block and ask for confirmation.
 - **After the report, always list:**

--- a/.claude/commands/game-load-perf-audit.md
+++ b/.claude/commands/game-load-perf-audit.md
@@ -279,7 +279,8 @@ function GameCard({ items }: Props) {
 |---------|------------------------------|
 | Mutations inside render (`arr.sort()`, `obj.x = 1`) | 🔴 CRITICAL — blocks compiler for entire component |
 | Inline `{}` object prop — compiler CANNOT analyze dynamic shape | 🟠 HIGH if compiler bails; 🟡 LOW if it handles it |
-| Inline `() => ...` arrow in JSX | 🟡 LOW — compiler wraps automatically when possible |
+| Inline `() => ...` arrow in JSX | ✅ SAFE — compiler memoizes callbacks automatically; no action needed |
+| `useCallback(...)` anywhere in code | 🟡 REDUNDANT — compiler handles this; remove wrapper, use plain function |
 | `'use no memo'` directive present | 🟠 HIGH — compiler disabled; manual memoization required |
 
 **Grep:**
@@ -334,23 +335,31 @@ grep -n "useEffect(" gamesformykids/app/games/<id>/*.ts gamesformykids/app/games
 
 ### Check P4 — `useMemo` for computed game data
 
-> **React Compiler note:** With `reactCompiler: true`, the compiler infers memoization for pure computations automatically. Only flag P4 when the computation is **heavy** (maze generation, shuffle of 100+ items, BFS traversal) AND the component has a mutation or other compiler bail-out (confirmed via P1 grep above). For pure, lightweight derivations, the compiler handles it.
+> **React Compiler note:** With `reactCompiler: true`, the compiler memoizes **pure** computations automatically. `useMemo` is valid in **two cases only**:
+> 1. **Impure computations** — `Math.random()`, `Date.now()`, `crypto.randomUUID()` etc. in render body. These are non-deterministic: same props → different output. The compiler detects this, bails out on the whole component, and leaves it unmemoized. `useMemo` *contains* the impurity in a defined box so the compiler can optimize the rest of the component. This is a **correctness fix**, not a performance one.
+> 2. **Heavy computations** (>10ms) in a component with a **confirmed bail-out** — maze generation, BFS, shuffle of 100+ items. Only add `useMemo` if profiling shows the cost; the compiler handles everything else.
+>
+> **`useMemo` on pure, lightweight derivations is redundant** — remove it; the compiler handles it.
 
-**Rule:** Heavy derivations called synchronously in component render that depend on stable inputs must be wrapped in `useMemo` — especially when the component is a compiler bail-out candidate.
+**Rule:** Flag `useMemo` only for impure computations or heavy computations in confirmed bail-out components.
 
 ```bash
 grep -n "generateMaze\|bfsOrder\|shuffle\|Array\.from.*length.*\(.*\)\." \
   gamesformykids/app/games/<id>/*.ts gamesformykids/app/games/<id>/*.tsx 2>/dev/null | head -10
+# Also check for impure computations outside useMemo:
+grep -n "Math\.random\|Date\.now\|crypto\.random" \
+  gamesformykids/app/games/<id>/*.ts gamesformykids/app/games/<id>/*.tsx 2>/dev/null | grep -v "useMemo"
 ```
 
 | Pattern | Severity |
 |---------|----------|
-| Maze/graph generation in render body | 🟠 HIGH — 5–50ms; perceivable freeze on click |
-| Large array shuffle (100+ items) in render | 🟠 HIGH |
-| `map/filter` on ≤20 items, pure component | 🟡 LOW — compiler handles |
-| Any computation in component with known mutation bail-out | 🟠 HIGH — compiler won't memoize |
+| `Math.random()` / `Date.now()` directly in render (not in useMemo) | 🔴 CRITICAL — compiler bail-out + value changes every render |
+| Maze/graph generation in render body (bail-out component) | 🟠 HIGH — 5–50ms; perceivable freeze on click |
+| Large array shuffle (100+ items) in render (bail-out component) | 🟠 HIGH |
+| `useMemo` wrapping a pure `map/filter` on ≤20 items | 🟡 REDUNDANT — remove; compiler handles pure derivations |
+| `useMemo` wrapping `Math.random()` / `Date.now()` | ✅ CORRECT — contains impurity |
 
-**Severity:** 🟠 HIGH for heavy computations in bailed-out components; 🟡 LOW otherwise (compiler handles).
+**Severity:** 🔴 CRITICAL for impure computations outside `useMemo`; 🟠 HIGH for heavy computations in bailed-out components; 🟡 REDUNDANT for pure lightweight derivations already in `useMemo`.
 
 ---
 
@@ -599,11 +608,28 @@ grep -rn "setTimeout.*[0-9]\{4,\}\|setInterval.*[0-9]\{4,\}" \
 grep -rn ": any\b\|as any\b" \
   gamesformykids/app/games/ --include="*.ts" --include="*.tsx" 2>/dev/null | head -15
 
-# QW5 — React Compiler bail-outs ('use no memo' or mutation-in-render)
-# React Compiler is enabled (reactCompiler: true) — manual memo should be rare
-grep -rn "use no memo\|React\.memo(\|useMemo(\|useCallback(" \
+# QW5 — Redundant manual memoization (React Compiler handles this automatically)
+# With reactCompiler: true:
+#   useCallback → ALWAYS redundant; replace with plain function
+#   React.memo  → ALWAYS redundant; remove wrapper
+#   useMemo     → redundant UNLESS (a) impure computation (Math.random/Date.now) or (b) heavy computation in bail-out component
+
+# Flag all useCallback — should be plain functions:
+grep -rn "useCallback(" \
   gamesformykids/app/games/ --include="*.ts" --include="*.tsx" 2>/dev/null | head -20
-# If React.memo/useMemo/useCallback appear heavily, the compiler may have bailed out for that file
+
+# Flag React.memo — should be removed:
+grep -rn "React\.memo(" \
+  gamesformykids/app/games/ gamesformykids/components/ --include="*.tsx" 2>/dev/null | head -10
+
+# Flag useMemo on pure derivations (map/filter/find without Math.random) — potentially redundant:
+grep -rn "useMemo(" \
+  gamesformykids/app/games/ --include="*.ts" --include="*.tsx" 2>/dev/null | head -20
+# Cross-check: is the useMemo body impure (Math.random/Date.now) or heavy (maze/shuffle)?
+# If neither → flag as redundant
+
+# Flag 'use no memo' — compiler disabled for that component (must use manual memo):
+grep -rn "use no memo" gamesformykids/app/games/ --include="*.tsx" --include="*.ts" 2>/dev/null
 ```
 
 ---
@@ -1064,13 +1090,23 @@ For items flagged in this report, use the targeted agents:
   - Style A — skip L8 (no store), L9 (no quiz data), P2 (no direct store use)
   - Style B — skip L7, L8 (no client component), P1–P5 (no custom component)
   - Style D/E — all checks apply
-- **React Compiler is ON (`reactCompiler: true`)** — do not suggest adding `useMemo`/`useCallback`/`React.memo` unless: (a) the component has a confirmed mutation bail-out, or (b) the computation is provably heavy (>10ms). Flag mutations-in-render (R3) as the priority.
+- **React Compiler is ON (`reactCompiler: true`)** — strict memoization rules:
+  - **`useCallback` is ALWAYS redundant.** The compiler memoizes all functions automatically. Flag every `useCallback` and remove it; replace with a plain function.
+  - **`React.memo` is ALWAYS redundant.** The compiler memoizes components automatically. Remove wrappers.
+  - **`useMemo` is valid ONLY for:** (a) impure computations (`Math.random()`, `Date.now()`, `crypto.randomUUID()`) that would produce different values every render — `useMemo` *contains* the impurity; (b) provably heavy computations (>10ms) in a component with a confirmed mutation bail-out. For pure, lightweight derivations, `useMemo` is redundant — remove it.
+  - **Never suggest adding `useCallback`/`React.memo`** in `--fix` mode. Flag existing ones for removal instead.
+  - **Do suggest `useMemo`** only when `Math.random()` / `Date.now()` appear directly in render body without it (R3/P4).
 - **`--fix` mode:** Only apply mechanical, safe fixes:
   - Add `{ ssr: false }` to dynamic imports missing it
   - Add `loading: () => <GameSpinnerScreen />` to dynamic imports missing it
   - Remove `console.log` lines
-  - Replace `transition-all` with `transition-colors` (color changes) or `transition-[transform,opacity]` (transform+opacity) — never combine `transition-transform transition-opacity` as separate classes
+  - Replace `transition-all` with `transition` (Tailwind's default transition covers transform, opacity, colors, shadow — but NOT layout properties like width/height/margin)
   - Replace `<Context.Provider value={x}>` with `<Context value={x}>` (React 19)
+  - Replace `useContext(X)` with `use(X)` (React 19)
+  - Remove `useCallback(fn, deps)` → replace with plain `fn` — the compiler handles memoization
+  - Remove `React.memo(Component)` → replace with plain `Component` — the compiler handles it
+  - Remove `useMemo(() => pureExpr, deps)` ONLY when the body is a pure, lightweight derivation (no `Math.random`, no heavy computation) — the compiler handles it
+  - Wrap `Math.random()` / `Date.now()` in render body with `useMemo` if not already wrapped
   - Add `clearTimeout`/`clearInterval` cleanup to useEffect hooks missing them
   - Remove clearly unused lucide icon imports (verify usage first)
   - For all other issues, output the fix as a code block and ask for confirmation.

--- a/gamesformykids/app/games/age-calculator/useAgeCalculator.ts
+++ b/gamesformykids/app/games/age-calculator/useAgeCalculator.ts
@@ -1,5 +1,5 @@
 'use client';
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect } from 'react';
 
 export interface AgeResult {
   years: number;
@@ -46,20 +46,20 @@ export function useAgeCalculator() {
   const [result, setResult] = useState<AgeResult | null>(null);
   const [calculated, setCalculated] = useState(false);
 
-  const calculate = useCallback(() => {
+  const calculate = () => {
     if (!birthdayInput) return;
     const birthday = new Date(birthdayInput);
     if (isNaN(birthday.getTime())) return;
     if (birthday > new Date()) return;
     setResult(computeAge(birthday, new Date()));
     setCalculated(true);
-  }, [birthdayInput]);
+  };
 
-  const reset = useCallback(() => {
+  const reset = () => {
     setCalculated(false);
     setResult(null);
     setBirthdayInput('');
-  }, []);
+  };
 
   useEffect(() => {
     if (!calculated || !birthdayInput) return;

--- a/gamesformykids/app/games/arithmetic/arithmeticConfig.tsx
+++ b/gamesformykids/app/games/arithmetic/arithmeticConfig.tsx
@@ -29,7 +29,7 @@ export const ARITHMETIC_CONFIG: TimedMathConfig<ArithmeticLevel, ArithmeticQuest
   ),
   levelColumns: 2,
   levelGap: 4,
-  levelButtonClass: 'p-5 rounded-2xl text-white font-bold text-lg shadow-lg hover:scale-105 active:scale-95 transition-all bg-gradient-to-br from-indigo-500 to-blue-600 text-start',
+  levelButtonClass: 'p-5 rounded-2xl text-white font-bold text-lg shadow-lg hover:scale-105 active:scale-95 transition bg-gradient-to-br from-indigo-500 to-blue-600 text-start',
 
   renderLevelLabel: (lv) => lv.label,
   renderEquation: (q) => `${q.a} ${q.op} ${q.b} = ?`,

--- a/gamesformykids/app/games/brick-breaker/useBrickBreakerGame.ts
+++ b/gamesformykids/app/games/brick-breaker/useBrickBreakerGame.ts
@@ -181,7 +181,7 @@ export function useBrickBreakerGame() {
     s.lives = level === 1 ? 3 : s.lives;
     s.level = level; s.particles = [];
     useBrickBreakerStore.getState().startLevel({ score: s.score, lives: s.lives, level });
-  }, []);
+  }, [st]);
 
   // Wire startGame into the module-level ref so the draw loop can trigger level
   // progression. Clean up on unmount so a stale callback is never called.
@@ -194,7 +194,7 @@ export function useBrickBreakerGame() {
     const s = st.current;
     if (s.phase === 'playing' && !s.launched) { s.launched = true; }
     else if (s.phase === 'menu') { startGame(1); }
-  }, [startGame]);
+  }, [startGame, st]);
 
   const handleTouchStart = (e: React.TouchEvent<HTMLCanvasElement>) => {
     e.preventDefault();

--- a/gamesformykids/app/games/brick-breaker/useBrickBreakerGame.ts
+++ b/gamesformykids/app/games/brick-breaker/useBrickBreakerGame.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect } from 'react';
+import { useCallback, useEffect } from 'react';
 import { useShallow } from 'zustand/react/shallow';
 import { useBrickBreakerStore } from './brickBreakerStore';
 import { createCanvasArcadeHook } from '@/hooks/canvas';
@@ -169,7 +169,7 @@ export function useBrickBreakerGame() {
   const { st, canvasRef, handlers } = _useBrickBreaker();
 
 
-  const startGame = (level = 1) => {
+  const startGame = useCallback((level = 1) => {
     const s = st.current;
     s.phase = 'playing';
     s.padX = W / 2 - PAD_W / 2; s.ballX = W / 2; s.ballY = PAD_Y - BALL_R - 2;
@@ -181,7 +181,7 @@ export function useBrickBreakerGame() {
     s.lives = level === 1 ? 3 : s.lives;
     s.level = level; s.particles = [];
     useBrickBreakerStore.getState().startLevel({ score: s.score, lives: s.lives, level });
-  };
+  }, []);
 
   // Wire startGame into the module-level ref so the draw loop can trigger level
   // progression. Clean up on unmount so a stale callback is never called.
@@ -190,11 +190,11 @@ export function useBrickBreakerGame() {
     return () => { _nextLevelRef.current = null; };
   }, [startGame]);
 
-  const handleClick = () => {
+  const handleClick = useCallback(() => {
     const s = st.current;
     if (s.phase === 'playing' && !s.launched) { s.launched = true; }
     else if (s.phase === 'menu') { startGame(1); }
-  };
+  }, [startGame]);
 
   const handleTouchStart = (e: React.TouchEvent<HTMLCanvasElement>) => {
     e.preventDefault();

--- a/gamesformykids/app/games/brick-breaker/useBrickBreakerGame.ts
+++ b/gamesformykids/app/games/brick-breaker/useBrickBreakerGame.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useCallback } from 'react';
+import { useEffect } from 'react';
 import { useShallow } from 'zustand/react/shallow';
 import { useBrickBreakerStore } from './brickBreakerStore';
 import { createCanvasArcadeHook } from '@/hooks/canvas';
@@ -169,7 +169,7 @@ export function useBrickBreakerGame() {
   const { st, canvasRef, handlers } = _useBrickBreaker();
 
 
-  const startGame = useCallback((level = 1) => {
+  const startGame = (level = 1) => {
     const s = st.current;
     s.phase = 'playing';
     s.padX = W / 2 - PAD_W / 2; s.ballX = W / 2; s.ballY = PAD_Y - BALL_R - 2;
@@ -181,7 +181,7 @@ export function useBrickBreakerGame() {
     s.lives = level === 1 ? 3 : s.lives;
     s.level = level; s.particles = [];
     useBrickBreakerStore.getState().startLevel({ score: s.score, lives: s.lives, level });
-  }, [st]);
+  };
 
   // Wire startGame into the module-level ref so the draw loop can trigger level
   // progression. Clean up on unmount so a stale callback is never called.
@@ -190,11 +190,11 @@ export function useBrickBreakerGame() {
     return () => { _nextLevelRef.current = null; };
   }, [startGame]);
 
-  const handleClick = useCallback(() => {
+  const handleClick = () => {
     const s = st.current;
     if (s.phase === 'playing' && !s.launched) { s.launched = true; }
     else if (s.phase === 'menu') { startGame(1); }
-  }, [st, startGame]);
+  };
 
   const handleTouchStart = (e: React.TouchEvent<HTMLCanvasElement>) => {
     e.preventDefault();

--- a/gamesformykids/app/games/bubbles/hooks/useBubbleGame.ts
+++ b/gamesformykids/app/games/bubbles/hooks/useBubbleGame.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 import { useShallow } from 'zustand/react/shallow';
 import { useGameAudio } from '@/hooks/shared/audio/useGameAudio';
 import { useBubblesStore, type BubbleData } from '../bubblesStore';
@@ -24,7 +24,7 @@ export function useBubbleGame() {
   );
   const level = Math.floor(poppedCount / 15) + 1;
 
-  const createBubble = () => {
+  const createBubble = useCallback(() => {
     if (!gameContainerRef.current) return;
     const currentLevel = Math.floor(useBubblesStore.getState().poppedCount / 15) + 1;
     const containerWidth = gameContainerRef.current.offsetWidth;
@@ -42,7 +42,7 @@ export function useBubbleGame() {
     };
 
     useBubblesStore.getState().addBubble(newBubble);
-  };
+  }, []);
 
   const playBubbleSound = (frequency: number) => {
     if (!audioContext || frequency === 0) return;

--- a/gamesformykids/app/games/bubbles/hooks/useBubbleGame.ts
+++ b/gamesformykids/app/games/bubbles/hooks/useBubbleGame.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useCallback } from 'react';
+import { useEffect, useRef } from 'react';
 import { useShallow } from 'zustand/react/shallow';
 import { useGameAudio } from '@/hooks/shared/audio/useGameAudio';
 import { useBubblesStore, type BubbleData } from '../bubblesStore';
@@ -24,7 +24,7 @@ export function useBubbleGame() {
   );
   const level = Math.floor(poppedCount / 15) + 1;
 
-  const createBubble = useCallback(() => {
+  const createBubble = () => {
     if (!gameContainerRef.current) return;
     const currentLevel = Math.floor(useBubblesStore.getState().poppedCount / 15) + 1;
     const containerWidth = gameContainerRef.current.offsetWidth;
@@ -42,9 +42,9 @@ export function useBubbleGame() {
     };
 
     useBubblesStore.getState().addBubble(newBubble);
-  }, []);
+  };
 
-  const playBubbleSound = useCallback((frequency: number) => {
+  const playBubbleSound = (frequency: number) => {
     if (!audioContext || frequency === 0) return;
     try {
       const oscillator = audioContext.createOscillator();
@@ -61,12 +61,12 @@ export function useBubbleGame() {
     } catch (error) {
       console.error('שגיאה בהשמעת צליל בועה:', error);
     }
-  }, [audioContext]);
+  };
 
-  const handleBubblePop = useCallback((bubbleId: number, frequency: number) => {
+  const handleBubblePop = (bubbleId: number, frequency: number) => {
     useBubblesStore.getState().popBubble(bubbleId, frequency > 0);
     if (frequency > 0) playBubbleSound(frequency);
-  }, [playBubbleSound]);
+  };
 
   // Manage bubble creation interval — recreates only when isPlaying or level changes
   useEffect(() => {
@@ -76,10 +76,10 @@ export function useBubbleGame() {
     return () => clearInterval(id);
   }, [isPlaying, level, createBubble]);
 
-  const startGame = useCallback(() => {
+  const startGame = () => {
     useBubblesStore.getState().startGame();
     setTimeout(createBubble, 200);
-  }, [createBubble]);
+  };
 
   const stopGame = () => { useBubblesStore.getState().stopGame(); };
   const resetGame = () => { useBubblesStore.getState().resetGame(); };

--- a/gamesformykids/app/games/building/components/controls/ActionButtons.tsx
+++ b/gamesformykids/app/games/building/components/controls/ActionButtons.tsx
@@ -39,7 +39,7 @@ export default function ActionButtons() {
         <button
           onClick={undo}
           disabled={!canUndo}
-          className={`font-bold py-2 md:py-3 px-2 md:px-3 rounded-xl shadow-lg transition-all flex items-center justify-center gap-1 text-sm md:text-base touch-manipulation ${
+          className={`font-bold py-2 md:py-3 px-2 md:px-3 rounded-xl shadow-lg transition flex items-center justify-center gap-1 text-sm md:text-base touch-manipulation ${
             canUndo 
               ? 'bg-blue-500 hover:bg-blue-600 text-white hover:scale-105 active:scale-95' 
               : 'bg-gray-400 text-gray-200 cursor-not-allowed'
@@ -53,7 +53,7 @@ export default function ActionButtons() {
         <button
           onClick={redo}
           disabled={!canRedo}
-          className={`font-bold py-2 md:py-3 px-2 md:px-3 rounded-xl shadow-lg transition-all flex items-center justify-center gap-1 text-sm md:text-base touch-manipulation ${
+          className={`font-bold py-2 md:py-3 px-2 md:px-3 rounded-xl shadow-lg transition flex items-center justify-center gap-1 text-sm md:text-base touch-manipulation ${
             canRedo 
               ? 'bg-green-500 hover:bg-green-600 text-white hover:scale-105 active:scale-95' 
               : 'bg-gray-400 text-gray-200 cursor-not-allowed'

--- a/gamesformykids/app/games/choose-adventure/useChooseAdventure.ts
+++ b/gamesformykids/app/games/choose-adventure/useChooseAdventure.ts
@@ -1,5 +1,5 @@
 'use client';
-import { useState, useCallback } from 'react';
+import { useState } from 'react';
 import { STORIES } from '@/lib/constants/stories/stories';
 import type { Story, StoryNode } from '@/lib/constants/stories/stories';
 
@@ -11,14 +11,14 @@ export function useChooseAdventure() {
   const [currentNode, setCurrentNode] = useState<StoryNode | null>(null);
   const [endingsFound, setEndingsFound] = useState<Record<string, Set<string>>>({});
 
-  const selectStory = useCallback((story: Story) => {
+  const selectStory = (story: Story) => {
     const startNode = story.nodes.find((n) => n.id === story.startId) ?? null;
     setCurrentStory(story);
     setCurrentNode(startNode);
     setPhase('story');
-  }, []);
+  };
 
-  const makeChoice = useCallback((nextId: string) => {
+  const makeChoice = (nextId: string) => {
     if (!currentStory) return;
     const next = currentStory.nodes.find((n) => n.id === nextId) ?? null;
     if (!next) return;
@@ -31,24 +31,24 @@ export function useChooseAdventure() {
       setPhase('ending');
     }
     setCurrentNode(next);
-  }, [currentStory]);
+  };
 
-  const returnToMenu = useCallback(() => {
+  const returnToMenu = () => {
     setPhase('menu');
     setCurrentStory(null);
     setCurrentNode(null);
-  }, []);
+  };
 
-  const readAgain = useCallback(() => {
+  const readAgain = () => {
     if (!currentStory) return;
     const startNode = currentStory.nodes.find((n) => n.id === currentStory.startId) ?? null;
     setCurrentNode(startNode);
     setPhase('story');
-  }, [currentStory]);
+  };
 
-  const getEndingsCount = useCallback((storyId: string) => {
+  const getEndingsCount = (storyId: string) => {
     return endingsFound[storyId]?.size ?? 0;
-  }, [endingsFound]);
+  };
 
   return {
     phase,

--- a/gamesformykids/app/games/coloring/components/ColoringCanvas.tsx
+++ b/gamesformykids/app/games/coloring/components/ColoringCanvas.tsx
@@ -41,7 +41,7 @@ export function ColoringCanvas() {
           <button
             key={id}
             onClick={() => fillGroup(members, regions)}
-            className="px-3 py-1.5 rounded-full text-sm font-bold border-2 transition-all border-purple-400 bg-purple-50 text-purple-700 hover:bg-purple-100 active:scale-95"
+            className="px-3 py-1.5 rounded-full text-sm font-bold border-2 transition border-purple-400 bg-purple-50 text-purple-700 hover:bg-purple-100 active:scale-95"
           >
             ✨ {name}
           </button>
@@ -51,7 +51,7 @@ export function ColoringCanvas() {
           <button
             key={id}
             onClick={() => selectRegion(id, regions)}
-            className="px-3 py-1.5 rounded-full text-sm font-bold border-2 transition-all border-gray-300 bg-white text-gray-700 hover:border-purple-400 hover:bg-purple-50 active:scale-95"
+            className="px-3 py-1.5 rounded-full text-sm font-bold border-2 transition border-gray-300 bg-white text-gray-700 hover:border-purple-400 hover:bg-purple-50 active:scale-95"
             style={fills[id] ? { borderColor: fills[id], color: fills[id] } : undefined}
           >
             {names[id]}

--- a/gamesformykids/app/games/coloring/components/ColoringImageSelector.tsx
+++ b/gamesformykids/app/games/coloring/components/ColoringImageSelector.tsx
@@ -12,7 +12,7 @@ export function ColoringImageSelector() {
         <button
           key={img.id}
           onClick={() => selectImage(img.id)}
-          className={`flex flex-col items-center px-3 py-2 rounded-xl border-2 transition-all ${
+          className={`flex flex-col items-center px-3 py-2 rounded-xl border-2 transition ${
             currentImage === img.id
               ? 'border-purple-500 bg-purple-100 scale-110 shadow-lg'
               : 'border-gray-200 bg-white hover:border-purple-300 hover:scale-105'

--- a/gamesformykids/app/games/coloring/components/ColoringPalette.tsx
+++ b/gamesformykids/app/games/coloring/components/ColoringPalette.tsx
@@ -15,7 +15,7 @@ export function ColoringPalette() {
             onClick={() => selectColor(color.hex)}
             title={color.hebrew}
             aria-label={`צבע ${color.hebrew}`}
-            className={`w-10 h-10 rounded-full border-4 transition-all hover:scale-110 active:scale-95 ${
+            className={`w-10 h-10 rounded-full border-4 transition hover:scale-110 active:scale-95 ${
               selectedColor === color.hex
                 ? 'border-purple-700 scale-125 shadow-lg ring-2 ring-purple-400'
                 : 'border-white shadow-md hover:border-gray-300'

--- a/gamesformykids/app/games/craft-guide/components/CraftStep.tsx
+++ b/gamesformykids/app/games/craft-guide/components/CraftStep.tsx
@@ -37,7 +37,7 @@ export default function CraftStep({
         {/* Progress bar */}
         <div className="bg-gray-200 rounded-full h-3 overflow-hidden">
           <div
-            className={`h-full bg-linear-to-br ${projectColor} transition-all duration-500`}
+            className={`h-full bg-linear-to-br ${projectColor} transition-[width] duration-500`}
             style={{ width: `${progress}%` }}
           />
         </div>

--- a/gamesformykids/app/games/craft-guide/useCraftGuide.ts
+++ b/gamesformykids/app/games/craft-guide/useCraftGuide.ts
@@ -1,5 +1,5 @@
 'use client';
-import { useState, useCallback } from 'react';
+import { useState } from 'react';
 import { CRAFT_PROJECTS, type CraftProject } from '@/lib/constants/craftProjects';
 
 type Phase = 'menu' | 'materials' | 'steps' | 'done';
@@ -9,37 +9,37 @@ export function useCraftGuide() {
   const [project, setProject] = useState<CraftProject | null>(null);
   const [stepIndex, setStepIndex] = useState(0);
 
-  const selectProject = useCallback((id: string) => {
+  const selectProject = (id: string) => {
     const p = CRAFT_PROJECTS.find((x) => x.id === id);
     if (!p) return;
     setProject(p);
     setStepIndex(0);
     setPhase('materials');
-  }, []);
+  };
 
-  const startSteps = useCallback(() => {
+  const startSteps = () => {
     setStepIndex(0);
     setPhase('steps');
-  }, []);
+  };
 
-  const nextStep = useCallback(() => {
+  const nextStep = () => {
     if (!project) return;
     if (stepIndex < project.steps.length - 1) {
       setStepIndex((i) => i + 1);
     } else {
       setPhase('done');
     }
-  }, [project, stepIndex]);
+  };
 
-  const prevStep = useCallback(() => {
+  const prevStep = () => {
     if (stepIndex > 0) setStepIndex((i) => i - 1);
-  }, [stepIndex]);
+  };
 
-  const backToMenu = useCallback(() => {
+  const backToMenu = () => {
     setPhase('menu');
     setProject(null);
     setStepIndex(0);
-  }, []);
+  };
 
   const currentStep = project ? project.steps[stepIndex] : null;
   const totalSteps = project ? project.steps.length : 0;

--- a/gamesformykids/app/games/dino-runner/useDinoRunnerGame.ts
+++ b/gamesformykids/app/games/dino-runner/useDinoRunnerGame.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useCallback } from 'react';
+import { useEffect } from 'react';
 import { useShallow } from 'zustand/react/shallow';
 import { useDinoRunnerStore } from './dinoRunnerStore';
 import { createCanvasArcadeHook } from '@/hooks/canvas';
@@ -135,7 +135,7 @@ export function useDinoRunnerGame() {
   const { st, canvasRef } = _useDinoRunner();
 
 
-  const jump = useCallback(() => {
+  const jump = () => {
     const s = st.current;
     if (s.phase === 'playing' && s.onGround) {
       s.dinoVY = JUMP_V;
@@ -156,7 +156,7 @@ export function useDinoRunnerGame() {
       s.phase = 'menu';
       useDinoRunnerStore.getState().resetToMenu();
     }
-  }, [st]);
+  };
 
 
   useEffect(() => {
@@ -167,10 +167,10 @@ export function useDinoRunnerGame() {
     return () => window.removeEventListener('keydown', handler);
   }, [jump]);
 
-  const handleTap = useCallback((e?: React.MouseEvent | React.TouchEvent) => {
+  const handleTap = (e?: React.MouseEvent | React.TouchEvent) => {
     e?.preventDefault();
     jump();
-  }, [jump]);
+  };
 
   const { phase, score, best } = useDinoRunnerStore(useShallow(s => ({ phase: s.phase, score: s.score, best: s.best })));
 

--- a/gamesformykids/app/games/dino-runner/useDinoRunnerGame.ts
+++ b/gamesformykids/app/games/dino-runner/useDinoRunnerGame.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect } from 'react';
+import { useCallback, useEffect } from 'react';
 import { useShallow } from 'zustand/react/shallow';
 import { useDinoRunnerStore } from './dinoRunnerStore';
 import { createCanvasArcadeHook } from '@/hooks/canvas';
@@ -135,7 +135,7 @@ export function useDinoRunnerGame() {
   const { st, canvasRef } = _useDinoRunner();
 
 
-  const jump = () => {
+  const jump = useCallback(() => {
     const s = st.current;
     if (s.phase === 'playing' && s.onGround) {
       s.dinoVY = JUMP_V;
@@ -156,7 +156,7 @@ export function useDinoRunnerGame() {
       s.phase = 'menu';
       useDinoRunnerStore.getState().resetToMenu();
     }
-  };
+  }, []);
 
 
   useEffect(() => {

--- a/gamesformykids/app/games/dino-runner/useDinoRunnerGame.ts
+++ b/gamesformykids/app/games/dino-runner/useDinoRunnerGame.ts
@@ -156,7 +156,7 @@ export function useDinoRunnerGame() {
       s.phase = 'menu';
       useDinoRunnerStore.getState().resetToMenu();
     }
-  }, []);
+  }, [st]);
 
 
   useEffect(() => {

--- a/gamesformykids/app/games/drawing/components/DrawingActions.tsx
+++ b/gamesformykids/app/games/drawing/components/DrawingActions.tsx
@@ -10,14 +10,14 @@ export default function DrawingActions() {
     <div className="flex flex-col sm:flex-row gap-4 justify-center items-center mt-8">
       <button
         onClick={clearCanvas}
-        className="bg-gradient-to-r from-red-500 to-red-600 text-white px-8 py-4 rounded-2xl hover:from-red-600 hover:to-red-700 transform hover:scale-105 transition-all duration-200 font-bold shadow-lg shadow-red-200"
+        className="bg-gradient-to-r from-red-500 to-red-600 text-white px-8 py-4 rounded-2xl hover:from-red-600 hover:to-red-700 transform hover:scale-105 transition duration-200 font-bold shadow-lg shadow-red-200"
       >
         🗑️ נקה הכל
       </button>
 
       <button
         onClick={saveDrawing}
-        className={`bg-gradient-to-r from-green-500 to-green-600 text-white px-8 py-4 rounded-2xl hover:from-green-600 hover:to-green-700 transform hover:scale-105 transition-all duration-200 font-bold shadow-lg shadow-green-200 ${styles.saveButton}`}
+        className={`bg-gradient-to-r from-green-500 to-green-600 text-white px-8 py-4 rounded-2xl hover:from-green-600 hover:to-green-700 transform hover:scale-105 transition duration-200 font-bold shadow-lg shadow-green-200 ${styles.saveButton}`}
       >
         💾 שמור ציור
       </button>

--- a/gamesformykids/app/games/drawing/components/DrawingCanvas.tsx
+++ b/gamesformykids/app/games/drawing/components/DrawingCanvas.tsx
@@ -18,7 +18,7 @@ export default function DrawingCanvas() {
           ref={canvasRef}
           width={isMobileDevice ? 600 : 800}
           height={isMobileDevice ? 400 : 600}
-          className={`border-4 rounded-xl w-full max-w-full block touch-none transition-all duration-200 cursor-crosshair ${
+          className={`border-4 rounded-xl w-full max-w-full block touch-none transition-colors duration-200 cursor-crosshair ${
             isErasing ? 'border-orange-200' : 'border-blue-200'
           }`}
           style={{

--- a/gamesformykids/app/games/drawing/components/DrawingColorPalette.tsx
+++ b/gamesformykids/app/games/drawing/components/DrawingColorPalette.tsx
@@ -19,7 +19,7 @@ export default function DrawingColorPalette() {
           <button
             key={color}
             onClick={() => setCurrentColor(color)}
-            className={`w-12 h-12 rounded-full border-4 hover:scale-110 transition-all duration-200 shadow-md ${
+            className={`w-12 h-12 rounded-full border-4 hover:scale-110 transition duration-200 shadow-md ${
               currentColor === color ? 'border-gray-800 ring-2 ring-blue-300' : 'border-gray-300 hover:border-gray-400'
             }`}
             style={{ backgroundColor: color }}

--- a/gamesformykids/app/games/drawing/components/DrawingTools.tsx
+++ b/gamesformykids/app/games/drawing/components/DrawingTools.tsx
@@ -17,7 +17,7 @@ export default function DrawingTools() {
         <div className="grid grid-cols-2 gap-2">
           <button
             onClick={selectDrawMode}
-            className={`px-4 py-3 rounded-xl text-sm font-medium transition-all duration-200 shadow-md ${styles.toolButton} ${
+            className={`px-4 py-3 rounded-xl text-sm font-medium transition duration-200 shadow-md ${styles.toolButton} ${
               !isErasing 
                 ? 'bg-gradient-to-r from-blue-500 to-blue-600 text-white shadow-blue-200' 
                 : 'bg-gray-100 text-gray-700 hover:bg-gray-200'
@@ -27,7 +27,7 @@ export default function DrawingTools() {
           </button>
           <button
             onClick={toggleEraser}
-            className={`px-4 py-3 rounded-xl text-sm font-medium transition-all duration-200 shadow-md ${styles.toolButton} ${
+            className={`px-4 py-3 rounded-xl text-sm font-medium transition duration-200 shadow-md ${styles.toolButton} ${
               isErasing 
                 ? 'bg-gradient-to-r from-orange-500 to-orange-600 text-white shadow-orange-200' 
                 : 'bg-gray-100 text-gray-700 hover:bg-gray-200'
@@ -78,7 +78,7 @@ export default function DrawingTools() {
       
       <button
         onClick={clearCanvas}
-        className="w-full bg-gradient-to-r from-red-500 to-red-600 text-white px-4 py-3 rounded-xl hover:from-red-600 hover:to-red-700 transition-all duration-200 font-medium shadow-lg shadow-red-200"
+        className="w-full bg-gradient-to-r from-red-500 to-red-600 text-white px-4 py-3 rounded-xl hover:from-red-600 hover:to-red-700 transition duration-200 font-medium shadow-lg shadow-red-200"
       >
         🗑️ נקה הכל
       </button>

--- a/gamesformykids/app/games/drawing/hooks/useDrawingCanvas.ts
+++ b/gamesformykids/app/games/drawing/hooks/useDrawingCanvas.ts
@@ -7,7 +7,7 @@
  * פיצול מהקובץ הגדול DrawingGameClient.tsx
  */
 
-import { useState, useRef, useEffect } from 'react';
+import { useState, useRef, useCallback, useEffect } from 'react';
 import { useDrawingStore } from '../store/drawingStore';
 
 export interface DrawingState {
@@ -144,14 +144,14 @@ export const useDrawingCanvas = () => {
   };
 
   // ניקוי הקנבס
-  const clearCanvas = () => {
+  const clearCanvas = useCallback(() => {
     const canvas = canvasRef.current;
     const ctx = ctxRef.current;
     if (canvas && ctx) {
       const dpr = window.devicePixelRatio || 1;
       ctx.clearRect(0, 0, canvas.width / dpr, canvas.height / dpr);
     }
-  };
+  }, []);
 
   // רישום clearCanvas לסטור כדי שרכיבים אחרים יוכלו לגשת אליו
   const registerClearCanvas = useDrawingStore((s) => s.registerClearCanvas);
@@ -160,14 +160,14 @@ export const useDrawingCanvas = () => {
   }, [clearCanvas, registerClearCanvas]);
 
   // שמירת התמונה כקובץ PNG
-  const saveDrawing = () => {
+  const saveDrawing = useCallback(() => {
     const canvas = canvasRef.current;
     if (!canvas) return;
     const link = document.createElement('a');
     link.download = `ציור-${Date.now()}.png`;
     link.href = canvas.toDataURL('image/png');
     link.click();
-  };
+  }, []);
 
   // רישום saveDrawing לסטור
   const registerSaveDrawing = useDrawingStore((s) => s.registerSaveDrawing);

--- a/gamesformykids/app/games/drawing/hooks/useDrawingCanvas.ts
+++ b/gamesformykids/app/games/drawing/hooks/useDrawingCanvas.ts
@@ -7,7 +7,7 @@
  * פיצול מהקובץ הגדול DrawingGameClient.tsx
  */
 
-import { useState, useRef, useCallback, useEffect } from 'react';
+import { useState, useRef, useEffect } from 'react';
 import { useDrawingStore } from '../store/drawingStore';
 
 export interface DrawingState {
@@ -49,16 +49,16 @@ export const useDrawingCanvas = () => {
   ];
 
   // פונקציה לקבלת מיקום האירוע (עכבר או מגע)
-  const getEventPosition = useCallback((
+  const getEventPosition = (
     e: React.MouseEvent<HTMLCanvasElement> | React.TouchEvent<HTMLCanvasElement>
   ) => {
     if (!canvasRef.current) return { x: 0, y: 0 };
-    
+
     const canvas = canvasRef.current;
     const rect = canvas.getBoundingClientRect();
-    
+
     let clientX, clientY;
-    
+
     if ('touches' in e) {
       // Touch event
       if (e.touches.length > 0) {
@@ -75,20 +75,20 @@ export const useDrawingCanvas = () => {
       clientX = e.clientX;
       clientY = e.clientY;
     }
-    
+
     const x = clientX - rect.left;
     const y = clientY - rect.top;
-    
+
     return { x, y };
-  }, []);
+  };
 
   // התחלת ציור — קורא state עדכני מהסטור ישירות למניעת stale closure
-  const startDrawing = useCallback((
+  const startDrawing = (
     e: React.MouseEvent<HTMLCanvasElement> | React.TouchEvent<HTMLCanvasElement>
   ) => {
     e.preventDefault();
     setIsDrawing(true);
-    
+
     const { x, y } = getEventPosition(e);
     ctxRef.current ??= canvasRef.current?.getContext('2d') ?? null;
     const ctx = ctxRef.current;
@@ -106,15 +106,15 @@ export const useDrawingCanvas = () => {
     ctx.lineCap = 'round';
     ctx.beginPath();
     ctx.moveTo(x, y);
-  }, [getEventPosition]);
+  };
 
   // ציור
-  const draw = useCallback((
+  const draw = (
     e: React.MouseEvent<HTMLCanvasElement> | React.TouchEvent<HTMLCanvasElement>
   ) => {
     if (!isDrawing) return;
     e.preventDefault();
-    
+
     const { x, y } = getEventPosition(e);
     const ctx = ctxRef.current;
     if (!ctx) return;
@@ -128,30 +128,30 @@ export const useDrawingCanvas = () => {
       ctx.strokeStyle = currentColor;
       ctx.lineWidth = brushSize;
     }
-    
+
     ctx.lineCap = 'round';
     ctx.lineJoin = 'round';
     ctx.lineTo(x, y);
     ctx.stroke();
     ctx.beginPath();
     ctx.moveTo(x, y);
-  }, [isDrawing, getEventPosition]);
+  };
 
   // סיום ציור
-  const stopDrawing = useCallback(() => {
+  const stopDrawing = () => {
     setIsDrawing(false);
     ctxRef.current?.beginPath();
-  }, []);
+  };
 
   // ניקוי הקנבס
-  const clearCanvas = useCallback(() => {
+  const clearCanvas = () => {
     const canvas = canvasRef.current;
     const ctx = ctxRef.current;
     if (canvas && ctx) {
       const dpr = window.devicePixelRatio || 1;
       ctx.clearRect(0, 0, canvas.width / dpr, canvas.height / dpr);
     }
-  }, []);
+  };
 
   // רישום clearCanvas לסטור כדי שרכיבים אחרים יוכלו לגשת אליו
   const registerClearCanvas = useDrawingStore((s) => s.registerClearCanvas);
@@ -160,14 +160,14 @@ export const useDrawingCanvas = () => {
   }, [clearCanvas, registerClearCanvas]);
 
   // שמירת התמונה כקובץ PNG
-  const saveDrawing = useCallback(() => {
+  const saveDrawing = () => {
     const canvas = canvasRef.current;
     if (!canvas) return;
     const link = document.createElement('a');
     link.download = `ציור-${Date.now()}.png`;
     link.href = canvas.toDataURL('image/png');
     link.click();
-  }, []);
+  };
 
   // רישום saveDrawing לסטור
   const registerSaveDrawing = useDrawingStore((s) => s.registerSaveDrawing);

--- a/gamesformykids/app/games/drawing/hooks/useDrawingGame.ts
+++ b/gamesformykids/app/games/drawing/hooks/useDrawingGame.ts
@@ -7,7 +7,7 @@
  * מנהל את לוגיקת המשחק, רמות קושי ואינטראקציה
  */
 
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect } from 'react';
 import { useDrawingStore } from '../store/drawingStore';
 
 export interface GameSettings {
@@ -39,10 +39,10 @@ export const useDrawingGame = () => {
   }, []);
 
   // סיום משחק
-  const handleGameEnd = useCallback(() => {
+  const handleGameEnd = () => {
     setIsTimerRunning(false);
     // כאן אפשר להוסיף לוגיקה נוספת לסיום המשחק
-  }, [setIsTimerRunning]);
+  };
 
   // טיימר המשחק
   useEffect(() => {
@@ -67,35 +67,35 @@ export const useDrawingGame = () => {
   }, [isTimerRunning, timeRemaining, handleGameEnd, setIsTimerRunning, setTimeRemaining]);
 
   // התחלת משחק
-  const startGame = useCallback((settings?: Partial<GameSettings>) => {
+  const startGame = (settings?: Partial<GameSettings>) => {
     const mergedSettings = settings ? { ...gameSettings, ...settings } : gameSettings;
     if (settings) setGameSettings(mergedSettings);
     storeStartGame(mergedSettings.timeLimit);
-  }, [gameSettings, storeStartGame]);
+  };
 
   // עצירת משחק
-  const stopGame = useCallback(() => {
+  const stopGame = () => {
     storeStopGame(gameSettings.timeLimit);
-  }, [gameSettings.timeLimit, storeStopGame]);
+  };
 
   // השהיית משחק
-  const pauseGame = useCallback(() => {
+  const pauseGame = () => {
     setIsTimerRunning(false);
-  }, [setIsTimerRunning]);
+  };
 
   // חזרה למשחק
-  const resumeGame = useCallback(() => {
+  const resumeGame = () => {
     if (isGameStarted && timeRemaining > 0) {
       setIsTimerRunning(true);
     }
-  }, [isGameStarted, timeRemaining, setIsTimerRunning]);
+  };
 
   // פורמט זמן למציג
-  const formatTime = useCallback((seconds: number) => {
+  const formatTime = (seconds: number) => {
     const minutes = Math.floor(seconds / 60);
     const remainingSeconds = seconds % 60;
     return `${minutes}:${remainingSeconds.toString().padStart(2, '0')}`;
-  }, []);
+  };
 
   // נושאי ציור זמינים
   const availableThemes = [

--- a/gamesformykids/app/games/drawing/hooks/useDrawingGame.ts
+++ b/gamesformykids/app/games/drawing/hooks/useDrawingGame.ts
@@ -7,7 +7,7 @@
  * מנהל את לוגיקת המשחק, רמות קושי ואינטראקציה
  */
 
-import { useState, useEffect } from 'react';
+import { useState, useCallback, useEffect } from 'react';
 import { useDrawingStore } from '../store/drawingStore';
 
 export interface GameSettings {
@@ -39,10 +39,10 @@ export const useDrawingGame = () => {
   }, []);
 
   // סיום משחק
-  const handleGameEnd = () => {
+  const handleGameEnd = useCallback(() => {
     setIsTimerRunning(false);
     // כאן אפשר להוסיף לוגיקה נוספת לסיום המשחק
-  };
+  }, [setIsTimerRunning]);
 
   // טיימר המשחק
   useEffect(() => {

--- a/gamesformykids/app/games/educational/page.tsx
+++ b/gamesformykids/app/games/educational/page.tsx
@@ -35,7 +35,7 @@ export default function EducationalPage() {
             <Link key={game.id} href={game.href} aria-label={game.title}>
               <div
                 className={`
-                  relative p-4 md:p-6 rounded-2xl shadow-lg transition-all duration-300
+                  relative p-4 md:p-6 rounded-2xl shadow-lg transition duration-300
                   transform hover:scale-105 cursor-pointer hover:shadow-2xl overflow-hidden
                   ${game.color}
                 `}

--- a/gamesformykids/app/games/emoji-math/components/EmojiMathPlayArea.tsx
+++ b/gamesformykids/app/games/emoji-math/components/EmojiMathPlayArea.tsx
@@ -36,7 +36,7 @@ export default function EmojiMathPlayArea() {
           <LivesDisplay lives={lives} size="text-xl" />
         </div>
         <div>
-          <p className={`font-black transition-all ${timeLeft <= 2 ? 'text-orange-500 text-3xl scale-110' : 'text-orange-700 text-2xl'}`}>{timeLeft}</p>
+          <p className={`font-black transition ${timeLeft <= 2 ? 'text-orange-500 text-3xl scale-110' : 'text-orange-700 text-2xl'}`}>{timeLeft}</p>
           <p className="text-xs text-orange-400">שניות</p>
         </div>
         {streak >= 2 && (
@@ -47,7 +47,7 @@ export default function EmojiMathPlayArea() {
         )}
       </div>
 
-      <div className={`w-full max-w-sm bg-white rounded-3xl p-5 shadow-2xl mb-5 transition-all duration-200 ${
+      <div className={`w-full max-w-sm bg-white rounded-3xl p-5 shadow-2xl mb-5 transition duration-200 ${
         feedback === 'correct' ? 'ring-4 ring-green-400 bg-green-50' :
         feedback === 'wrong' ? 'ring-4 ring-amber-400 bg-amber-50' : ''
       }`}>
@@ -75,7 +75,7 @@ export default function EmojiMathPlayArea() {
             key={c}
             onClick={() => tap(c)}
             disabled={!!feedback}
-            className="py-5 rounded-3xl bg-white font-black text-3xl text-gray-700 shadow-xl border-2 border-orange-200 active:scale-90 hover:border-orange-400 transition-all disabled:opacity-60"
+            className="py-5 rounded-3xl bg-white font-black text-3xl text-gray-700 shadow-xl border-2 border-orange-200 active:scale-90 hover:border-orange-400 transition disabled:opacity-60"
           >
             {c}
           </button>

--- a/gamesformykids/app/games/escape-room/EscapeRoomClient.tsx
+++ b/gamesformykids/app/games/escape-room/EscapeRoomClient.tsx
@@ -28,7 +28,7 @@ export default function EscapeRoomClient() {
               <button
                 key={r.id}
                 onClick={() => handleStart(r.id)}
-                className="w-full bg-gradient-to-r from-purple-500 to-indigo-600 hover:from-purple-600 hover:to-indigo-700 text-white font-bold text-lg rounded-2xl py-4 px-6 flex items-center gap-3 transition-all active:scale-95 shadow-md"
+                className="w-full bg-gradient-to-r from-purple-500 to-indigo-600 hover:from-purple-600 hover:to-indigo-700 text-white font-bold text-lg rounded-2xl py-4 px-6 flex items-center gap-3 transition active:scale-95 shadow-md"
               >
                 <span className="text-3xl">{r.emoji}</span>
                 <span>{r.title}</span>
@@ -71,7 +71,7 @@ export default function EscapeRoomClient() {
     <div className="min-h-screen bg-gradient-to-br from-purple-900 to-indigo-900 flex flex-col items-center justify-center p-3 gap-3" dir="rtl">
       {/* Header */}
       <div className="flex items-center justify-between w-full max-w-2xl">
-        <button onClick={resetGame} className="text-white/70 hover:text-white text-sm font-bold px-3 py-1.5 rounded-xl bg-white/10 transition-all">
+        <button onClick={resetGame} className="text-white/70 hover:text-white text-sm font-bold px-3 py-1.5 rounded-xl bg-white/10 transition">
           ← חזור
         </button>
         <h2 className="text-white font-extrabold text-xl">{room.emoji} {room.title}</h2>

--- a/gamesformykids/app/games/escape-room/components/DoorCodePanel.tsx
+++ b/gamesformykids/app/games/escape-room/components/DoorCodePanel.tsx
@@ -16,7 +16,7 @@ export default function DoorCodePanel({ revealedDigits, puzzleCount }: Props) {
         {slots.map((digit, i) => (
           <div
             key={i}
-            className={`w-10 h-12 rounded-xl border-2 flex items-center justify-center text-2xl font-bold transition-all duration-500 ${
+            className={`w-10 h-12 rounded-xl border-2 flex items-center justify-center text-2xl font-bold transition duration-500 ${
               digit
                 ? 'border-green-400 bg-green-100 text-green-700 scale-110'
                 : 'border-amber-300 bg-amber-50 text-amber-200'

--- a/gamesformykids/app/games/escape-room/components/PuzzleOverlay.tsx
+++ b/gamesformykids/app/games/escape-room/components/PuzzleOverlay.tsx
@@ -1,5 +1,5 @@
 'use client';
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useMemo, useRef, useEffect } from 'react';
 import type { Hotspot, Puzzle } from './puzzleData';
 
 type Props = {
@@ -16,7 +16,13 @@ export default function PuzzleOverlay({ hotspot, puzzle, hintsUsed, onAnswer, on
   const [hint, setHint] = useState<string | null>(null);
   const [answered, setAnswered] = useState(false);
 
-  const choices = [puzzle.answer, ...puzzle.wrongOptions].sort(() => Math.random() - 0.5);
+  const dismissTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+  useEffect(() => () => clearTimeout(dismissTimerRef.current), []);
+
+  const choices = useMemo(
+    () => [puzzle.answer, ...puzzle.wrongOptions].sort(() => Math.random() - 0.5),
+    [puzzle],
+  );
 
   const handleSelect = useCallback((choice: string) => {
     if (answered) return;
@@ -24,7 +30,7 @@ export default function PuzzleOverlay({ hotspot, puzzle, hintsUsed, onAnswer, on
     setFeedback({ text: isCorrect ? puzzle.successMessage : 'לא נכון — נסה שוב! 💪', correct: isCorrect });
     if (isCorrect) {
       setAnswered(true);
-      setTimeout(onDismiss, 2000);
+      dismissTimerRef.current = setTimeout(onDismiss, 2000);
     }
   }, [answered, onAnswer, onDismiss, puzzle.successMessage]);
 
@@ -63,7 +69,7 @@ export default function PuzzleOverlay({ hotspot, puzzle, hintsUsed, onAnswer, on
               <button
                 key={choice}
                 onClick={() => handleSelect(choice)}
-                className="bg-indigo-50 hover:bg-indigo-100 active:bg-indigo-200 border-2 border-indigo-200 hover:border-indigo-400 rounded-2xl p-3 font-bold text-indigo-800 text-base transition-all"
+                className="bg-indigo-50 hover:bg-indigo-100 active:bg-indigo-200 border-2 border-indigo-200 hover:border-indigo-400 rounded-2xl p-3 font-bold text-indigo-800 text-base transition"
               >
                 {choice}
               </button>

--- a/gamesformykids/app/games/escape-room/components/PuzzleOverlay.tsx
+++ b/gamesformykids/app/games/escape-room/components/PuzzleOverlay.tsx
@@ -1,5 +1,5 @@
 'use client';
-import { useState, useCallback, useMemo, useRef, useEffect } from 'react';
+import { useState, useMemo, useRef, useEffect } from 'react';
 import type { Hotspot, Puzzle } from './puzzleData';
 
 type Props = {
@@ -24,7 +24,7 @@ export default function PuzzleOverlay({ hotspot, puzzle, hintsUsed, onAnswer, on
     [puzzle],
   );
 
-  const handleSelect = useCallback((choice: string) => {
+  const handleSelect = (choice: string) => {
     if (answered) return;
     const isCorrect = onAnswer(choice);
     setFeedback({ text: isCorrect ? puzzle.successMessage : 'לא נכון — נסה שוב! 💪', correct: isCorrect });
@@ -32,12 +32,12 @@ export default function PuzzleOverlay({ hotspot, puzzle, hintsUsed, onAnswer, on
       setAnswered(true);
       dismissTimerRef.current = setTimeout(onDismiss, 2000);
     }
-  }, [answered, onAnswer, onDismiss, puzzle.successMessage]);
+  };
 
-  const handleHint = useCallback(() => {
+  const handleHint = () => {
     const h = onHint();
     if (h) setHint(h);
-  }, [onHint]);
+  };
 
   return (
     <div className="fixed inset-0 bg-black/60 flex items-center justify-center z-50 p-4" onClick={onDismiss}>

--- a/gamesformykids/app/games/escape-room/components/RoomScene.tsx
+++ b/gamesformykids/app/games/escape-room/components/RoomScene.tsx
@@ -23,7 +23,7 @@ export default function RoomScene({ room, solvedIds, onClickHotspot }: Props) {
             onClick={() => onClickHotspot(hotspot.id)}
             disabled={isSolved && hasPuzzle}
             style={{ left: `${hotspot.x}%`, top: `${hotspot.y}%` }}
-            className={`absolute -translate-x-1/2 -translate-y-1/2 flex flex-col items-center gap-0.5 transition-all duration-200 ${
+            className={`absolute -translate-x-1/2 -translate-y-1/2 flex flex-col items-center gap-0.5 transition duration-200 ${
               isSolved && hasPuzzle
                 ? 'opacity-60 cursor-default'
                 : 'hover:scale-125 active:scale-110 cursor-pointer'

--- a/gamesformykids/app/games/escape-room/useEscapeRoom.ts
+++ b/gamesformykids/app/games/escape-room/useEscapeRoom.ts
@@ -1,5 +1,4 @@
 'use client';
-import { useCallback } from 'react';
 import { useEscapeRoomStore } from './escapeRoomStore';
 import { speakHebrew } from '@/lib/utils/speech/enhancedSpeechUtils';
 import { ROOMS } from './components/puzzleData';
@@ -15,12 +14,12 @@ export function useEscapeRoom() {
   const hintsUsed      = useEscapeRoomStore(s => s.hintsUsed);
   const { startGame, clickHotspot, submitAnswer, dismissOverlay, applyHint, resetGame } = useEscapeRoomStore();
 
-  const handleStart = useCallback((roomId: string) => {
+  const handleStart = (roomId: string) => {
     startGame(roomId);
     speakHebrew('בואו נפרוץ את החדר!');
-  }, [startGame]);
+  };
 
-  const handleClickHotspot = useCallback((hotspotId: string) => {
+  const handleClickHotspot = (hotspotId: string) => {
     clickHotspot(hotspotId);
     const state = useEscapeRoomStore.getState();
     if (state.activePuzzle) {
@@ -28,9 +27,9 @@ export function useEscapeRoom() {
     } else if (state.funMessage) {
       speakHebrew(state.funMessage);
     }
-  }, [clickHotspot]);
+  };
 
-  const handleAnswer = useCallback((answer: string) => {
+  const handleAnswer = (answer: string) => {
     const isCorrect = submitAnswer(answer);
     const state = useEscapeRoomStore.getState();
     if (isCorrect) {
@@ -43,13 +42,13 @@ export function useEscapeRoom() {
       speakHebrew('לא נכון — נסה שוב!');
     }
     return isCorrect;
-  }, [submitAnswer]);
+  };
 
-  const handleHint = useCallback(() => {
+  const handleHint = () => {
     const hint = applyHint();
     if (hint) speakHebrew(hint);
     return hint;
-  }, [applyHint]);
+  };
 
   const puzzleCount = room?.hotspots.filter(h => h.puzzle !== null).length ?? 0;
 

--- a/gamesformykids/app/games/find-in-scene/FindInSceneClient.tsx
+++ b/gamesformykids/app/games/find-in-scene/FindInSceneClient.tsx
@@ -25,7 +25,7 @@ export default function FindInSceneClient() {
               <button
                 key={s.id}
                 onClick={() => handleStart(s.id)}
-                className="w-full bg-gradient-to-r from-teal-500 to-sky-600 hover:from-teal-600 hover:to-sky-700 text-white font-bold text-lg rounded-2xl py-4 px-6 flex items-center gap-3 transition-all active:scale-95 shadow-md"
+                className="w-full bg-gradient-to-r from-teal-500 to-sky-600 hover:from-teal-600 hover:to-sky-700 text-white font-bold text-lg rounded-2xl py-4 px-6 flex items-center gap-3 transition active:scale-95 shadow-md"
               >
                 <span className="text-3xl">{s.emoji}</span>
                 <span>{s.title}</span>
@@ -99,7 +99,7 @@ export default function FindInSceneClient() {
         {Array.from({ length: targetIds.size }, (_, i) => (
           <div
             key={i}
-            className={`w-8 h-8 rounded-full border-2 flex items-center justify-center text-lg transition-all ${
+            className={`w-8 h-8 rounded-full border-2 flex items-center justify-center text-lg transition ${
               i < foundIds.size
                 ? 'border-green-400 bg-green-300'
                 : 'border-white/30 bg-white/10'

--- a/gamesformykids/app/games/find-in-scene/components/SceneCanvas.tsx
+++ b/gamesformykids/app/games/find-in-scene/components/SceneCanvas.tsx
@@ -23,7 +23,7 @@ export default function SceneCanvas({ scene, targetIds, foundIds, wrongId, onTap
             onClick={() => onTap(obj.id)}
             disabled={isFound}
             style={{ left: `${obj.x}%`, top: `${obj.y}%` }}
-            className={`absolute -translate-x-1/2 -translate-y-1/2 flex flex-col items-center gap-0.5 transition-all duration-200 select-none ${
+            className={`absolute -translate-x-1/2 -translate-y-1/2 flex flex-col items-center gap-0.5 transition duration-200 select-none ${
               isFound
                 ? 'opacity-40 cursor-default scale-90'
                 : isWrong

--- a/gamesformykids/app/games/find-in-scene/useFindInScene.ts
+++ b/gamesformykids/app/games/find-in-scene/useFindInScene.ts
@@ -1,5 +1,5 @@
 'use client';
-import { useEffect, useCallback } from 'react';
+import { useEffect } from 'react';
 import { useFindInSceneStore } from './findInSceneStore';
 import { speakHebrew } from '@/lib/utils/speech/enhancedSpeechUtils';
 import { SCENES } from './components/sceneData';
@@ -32,17 +32,17 @@ export function useFindInScene() {
     }
   }, [phase, prompt.text, foundIds.size, targetIds.size]);
 
-  const handleStart = useCallback((sceneId: string) => {
+  const handleStart = (sceneId: string) => {
     startRound(sceneId);
-  }, [startRound]);
+  };
 
-  const handleTap = useCallback((objectId: string) => {
+  const handleTap = (objectId: string) => {
     const result = tapObject(objectId);
     if (result === 'correct') {
       const obj = scene.objects.find(o => o.id === objectId);
       if (obj) speakHebrew(obj.label);
     }
-  }, [tapObject, scene.objects]);
+  };
 
   return {
     phase, scene, scenes: SCENES, prompt, targetIds, foundIds, wrongId,

--- a/gamesformykids/app/games/flappy-bird/useFlappyBirdGame.ts
+++ b/gamesformykids/app/games/flappy-bird/useFlappyBirdGame.ts
@@ -1,6 +1,5 @@
 'use client';
 
-import { useCallback } from 'react';
 import { useShallow } from 'zustand/react/shallow';
 import { useFlappyBirdStore } from './flappyBirdStore';
 import { createCanvasArcadeHook } from '@/hooks/canvas';
@@ -183,7 +182,7 @@ export function useFlappyBirdGame() {
   const { st, canvasRef } = _useFlappyBird();
 
 
-  const resetGame = useCallback(() => {
+  const resetGame = () => {
     const s = st.current;
     s.phase = 'playing';
     s.birdY = H / 2;
@@ -194,9 +193,9 @@ export function useFlappyBirdGame() {
     s.startTime = Date.now();
     useFlappyBirdStore.getState().setPhase('playing');
     useFlappyBirdStore.getState().setScore(0);
-  }, [st]);
+  };
 
-  const flap = useCallback(() => {
+  const flap = () => {
     const s = st.current;
     if (s.phase === 'playing') {
       s.birdVY = FLAP_STRENGTH;
@@ -206,13 +205,13 @@ export function useFlappyBirdGame() {
       s.phase = 'menu';
       useFlappyBirdStore.getState().setPhase('menu');
     }
-  }, [st, resetGame]);
+  };
 
 
-  const handleInput = useCallback((e?: React.MouseEvent | React.TouchEvent) => {
+  const handleInput = (e?: React.MouseEvent | React.TouchEvent) => {
     e?.preventDefault();
     flap();
-  }, [flap]);
+  };
 
   const { phase, best, score } = useFlappyBirdStore(useShallow(s => ({ phase: s.phase, best: s.best, score: s.score })));
 

--- a/gamesformykids/app/games/frogger/useFroggerGame.ts
+++ b/gamesformykids/app/games/frogger/useFroggerGame.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useRef, useCallback } from 'react';
+import { useEffect, useRef } from 'react';
 import { useShallow } from 'zustand/react/shallow';
 import { useFroggerStore } from './froggerStore';
 import { createCanvasArcadeHook } from '@/hooks/canvas';
@@ -112,15 +112,15 @@ export function useFroggerGame() {
   const { st, canvasRef } = _useFrogger();
 
 
-  const startGame = useCallback(() => {
+  const startGame = () => {
     const s = st.current;
     s.phase = 'playing'; s.fCol = 4; s.fRow = 8;
     s.lives = 3; s.score = 0; s.level = 1; s.frame = 0; s.dead = false; s.deadTimer = 0;
     s.lanes = makeLanes(); s.startTime = Date.now();
     useFroggerStore.getState().startPlaying();
-  }, [st]);
+  };
 
-  const moveFrog = useCallback((dc: number, dr: number) => {
+  const moveFrog = (dc: number, dr: number) => {
     const s = st.current;
     if (s.phase !== 'playing' || s.dead) return;
     const nc = Math.max(0, Math.min(COLS - 1, s.fCol + dc));
@@ -128,15 +128,15 @@ export function useFroggerGame() {
     if (dr < 0) s.score += 2;
     s.fCol = nc; s.fRow = nr;
     if (nr === 0) { s.score += 30; s.level++; s.fCol = 4; s.fRow = 8; useFroggerStore.getState().setScore(s.score); }
-  }, [st]);
+  };
 
   const touchRef = useRef<{ x: number; y: number } | null>(null);
 
-  const handleTouchStart = useCallback((e: React.TouchEvent<HTMLCanvasElement>) => {
+  const handleTouchStart = (e: React.TouchEvent<HTMLCanvasElement>) => {
     touchRef.current = { x: e.touches[0]!.clientX, y: e.touches[0]!.clientY };
-  }, []);
+  };
 
-  const handleTouchEnd = useCallback((e: React.TouchEvent<HTMLCanvasElement>) => {
+  const handleTouchEnd = (e: React.TouchEvent<HTMLCanvasElement>) => {
     e.preventDefault();
     if (!touchRef.current) return;
     const dx = e.changedTouches[0]!.clientX - touchRef.current.x;
@@ -145,7 +145,7 @@ export function useFroggerGame() {
     if (Math.abs(dx) < 12 && Math.abs(dy) < 12) { moveFrog(0, -1); return; }
     if (Math.abs(dx) > Math.abs(dy)) moveFrog(dx > 0 ? 1 : -1, 0);
     else moveFrog(0, dy > 0 ? 1 : -1);
-  }, [moveFrog]);
+  };
 
 
   useEffect(() => {

--- a/gamesformykids/app/games/frogger/useFroggerGame.ts
+++ b/gamesformykids/app/games/frogger/useFroggerGame.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useRef } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 import { useShallow } from 'zustand/react/shallow';
 import { useFroggerStore } from './froggerStore';
 import { createCanvasArcadeHook } from '@/hooks/canvas';
@@ -120,7 +120,7 @@ export function useFroggerGame() {
     useFroggerStore.getState().startPlaying();
   };
 
-  const moveFrog = (dc: number, dr: number) => {
+  const moveFrog = useCallback((dc: number, dr: number) => {
     const s = st.current;
     if (s.phase !== 'playing' || s.dead) return;
     const nc = Math.max(0, Math.min(COLS - 1, s.fCol + dc));
@@ -128,7 +128,7 @@ export function useFroggerGame() {
     if (dr < 0) s.score += 2;
     s.fCol = nc; s.fRow = nr;
     if (nr === 0) { s.score += 30; s.level++; s.fCol = 4; s.fRow = 8; useFroggerStore.getState().setScore(s.score); }
-  };
+  }, []);
 
   const touchRef = useRef<{ x: number; y: number } | null>(null);
 

--- a/gamesformykids/app/games/frogger/useFroggerGame.ts
+++ b/gamesformykids/app/games/frogger/useFroggerGame.ts
@@ -128,7 +128,7 @@ export function useFroggerGame() {
     if (dr < 0) s.score += 2;
     s.fCol = nc; s.fRow = nr;
     if (nr === 0) { s.score += 30; s.level++; s.fCol = 4; s.fRow = 8; useFroggerStore.getState().setScore(s.score); }
-  }, []);
+  }, [st]);
 
   const touchRef = useRef<{ x: number; y: number } | null>(null);
 

--- a/gamesformykids/app/games/hangman/HangmanClient.tsx
+++ b/gamesformykids/app/games/hangman/HangmanClient.tsx
@@ -40,7 +40,7 @@ export default function HangmanClient() {
               <button
                 key={cat}
                 onClick={() => startGame(cat)}
-                className="w-full bg-gradient-to-r from-violet-500 to-purple-600 hover:from-violet-600 hover:to-purple-700 text-white font-bold text-lg rounded-2xl py-4 px-6 flex items-center gap-3 transition-all active:scale-95 shadow-md"
+                className="w-full bg-gradient-to-r from-violet-500 to-purple-600 hover:from-violet-600 hover:to-purple-700 text-white font-bold text-lg rounded-2xl py-4 px-6 flex items-center gap-3 transition active:scale-95 shadow-md"
               >
                 <span className="text-3xl">{CATEGORY_EMOJIS[cat] ?? '📝'}</span>
                 <span>{cat}</span>
@@ -75,7 +75,7 @@ export default function HangmanClient() {
           {streak > 1 && <p className="text-violet-600 font-bold">רצף: {streak} מילים! 🔥</p>}
           <button
             onClick={nextWord}
-            className="mt-2 px-8 py-3 bg-gradient-to-r from-green-400 to-emerald-500 text-white font-bold rounded-2xl shadow-lg hover:from-green-500 hover:to-emerald-600 active:scale-95 transition-all"
+            className="mt-2 px-8 py-3 bg-gradient-to-r from-green-400 to-emerald-500 text-white font-bold rounded-2xl shadow-lg hover:from-green-500 hover:to-emerald-600 active:scale-95 transition"
           >
             מילה נוספת מ{categoryName}
           </button>
@@ -176,7 +176,7 @@ export default function HangmanClient() {
               key={letter}
               onClick={() => handleGuess(letter)}
               disabled={isGuessed}
-              className={`w-10 h-10 rounded-xl font-bold text-lg transition-all ${
+              className={`w-10 h-10 rounded-xl font-bold text-lg transition ${
                 isCorrect
                   ? 'bg-green-400 text-white cursor-default scale-95'
                   : isWrong

--- a/gamesformykids/app/games/hangman/useHangman.ts
+++ b/gamesformykids/app/games/hangman/useHangman.ts
@@ -1,18 +1,17 @@
 'use client';
-import { useCallback } from 'react';
 import { useHangmanStore } from './hangmanStore';
 import { speakHebrew } from '@/lib/utils/speech/enhancedSpeechUtils';
 
 export function useHangman() {
   const state = useHangmanStore();
 
-  const handleGuess = useCallback((letter: string) => {
+  const handleGuess = (letter: string) => {
     const { entry, guessed } = useHangmanStore.getState();
     if (guessed.has(letter)) return;
     state.guessLetter(letter);
     const correct = entry.word.includes(letter);
     if (correct) speakHebrew(letter);
-  }, [state]);
+  };
 
   const wordDisplay = state.entry.word.split('').map(ch =>
     state.guessed.has(ch) ? ch : '_'

--- a/gamesformykids/app/games/hebrew-letters/components/canvas/CanvasColorPicker.tsx
+++ b/gamesformykids/app/games/hebrew-letters/components/canvas/CanvasColorPicker.tsx
@@ -16,7 +16,7 @@ export default function CanvasColorPicker() {
         <button
           key={color}
           onClick={() => changeStrokeColor(color)}
-          className={`w-10 h-10 rounded-full border-3 transition-all duration-200 relative ${
+          className={`w-10 h-10 rounded-full border-3 transition duration-200 relative ${
             currentColor === color
               ? 'border-gray-800 scale-110 shadow-lg'
               : 'border-gray-300 hover:scale-105 hover:border-gray-400'

--- a/gamesformykids/app/games/hebrew-letters/components/canvas/CanvasStrokeWidthPicker.tsx
+++ b/gamesformykids/app/games/hebrew-letters/components/canvas/CanvasStrokeWidthPicker.tsx
@@ -12,7 +12,7 @@ export default function CanvasStrokeWidthPicker() {
         <button
           key={strokeWidth}
           onClick={() => changeStrokeWidth(strokeWidth)}
-          className={`flex items-center justify-center w-14 h-10 rounded-lg border-2 transition-all duration-200 ${
+          className={`flex items-center justify-center w-14 h-10 rounded-lg border-2 transition-colors duration-200 ${
             currentWidth === strokeWidth
               ? 'border-green-500 bg-green-50 shadow-md'
               : 'border-gray-300 hover:border-gray-400 bg-white'

--- a/gamesformykids/app/games/hebrew-letters/components/canvas/CanvasToolbar.tsx
+++ b/gamesformykids/app/games/hebrew-letters/components/canvas/CanvasToolbar.tsx
@@ -67,7 +67,7 @@ export default function CanvasToolbar() {
           onClick={toggleGuide}
           variant="outline"
           size="sm"
-          className={`flex items-center gap-2 transition-all ${
+          className={`flex items-center gap-2 transition-colors ${
             showLetterGuide
               ? 'bg-green-100 border-green-400 text-green-700'
               : 'hover:bg-gray-50'

--- a/gamesformykids/app/games/hebrew-letters/components/canvas/LetterGuideOverlay.tsx
+++ b/gamesformykids/app/games/hebrew-letters/components/canvas/LetterGuideOverlay.tsx
@@ -27,7 +27,7 @@ export default function LetterGuideOverlay() {
       ref={canvasRef}
       width={width}
       height={height}
-      className={`absolute top-0 left-0 pointer-events-none transition-all duration-1000 ${
+      className={`absolute top-0 left-0 pointer-events-none transition duration-1000 ${
         isAnimating ? 'scale-105 opacity-90' : 'scale-100'
       }`}
       style={{ ...OVERLAY_BASE_STYLE, filter: isAnimating ? 'brightness(1.1)' : 'brightness(1)' }}

--- a/gamesformykids/app/games/hebrew-letters/components/canvas/WritingCanvasContext.tsx
+++ b/gamesformykids/app/games/hebrew-letters/components/canvas/WritingCanvasContext.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { createContext, useContext } from 'react';
+import React, { createContext, use } from 'react';
 import { useWritingCanvas } from './useWritingCanvas';
 
 type WritingCanvasContextValue = ReturnType<typeof useWritingCanvas> & {
@@ -10,7 +10,7 @@ type WritingCanvasContextValue = ReturnType<typeof useWritingCanvas> & {
 const WritingCanvasContext = createContext<WritingCanvasContextValue | null>(null);
 
 export function useWritingCanvasContext(): WritingCanvasContextValue {
-  const ctx = useContext(WritingCanvasContext);
+  const ctx = use(WritingCanvasContext);
   if (!ctx) throw new Error('useWritingCanvasContext must be used inside WritingCanvasProvider');
   return ctx;
 }
@@ -24,8 +24,8 @@ interface WritingCanvasProviderProps {
 export function WritingCanvasProvider({ value, guideLetter, children }: WritingCanvasProviderProps) {
   const contextValue: WritingCanvasContextValue = { ...value, guideLetter };
   return (
-    <WritingCanvasContext.Provider value={contextValue}>
+    <WritingCanvasContext value={contextValue}>
       {children}
-    </WritingCanvasContext.Provider>
+    </WritingCanvasContext>
   );
 }

--- a/gamesformykids/app/games/hebrew-letters/components/canvas/useWritingCanvas.ts
+++ b/gamesformykids/app/games/hebrew-letters/components/canvas/useWritingCanvas.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { useRef, useEffect, useCallback } from 'react';
+import { useRef, useEffect } from 'react';
 import type React from 'react';
 import {
   useHebrewLettersStore,
@@ -67,57 +67,45 @@ export function useWritingCanvas({ width, height, backgroundColor }: UseWritingC
     ctx.lineWidth = drawingState.currentStrokeWidth;
   }, [drawingState.currentStrokeColor, drawingState.currentStrokeWidth]);
 
-  const getMousePos = useCallback(
-    (e: React.MouseEvent<HTMLCanvasElement>) => {
-      const canvas = canvasRef.current;
-      if (!canvas) return { x: 0, y: 0 };
-      return getCanvasPosition(e.nativeEvent, canvas);
-    },
-    []
-  );
+  const getMousePos = (e: React.MouseEvent<HTMLCanvasElement>) => {
+    const canvas = canvasRef.current;
+    if (!canvas) return { x: 0, y: 0 };
+    return getCanvasPosition(e.nativeEvent, canvas);
+  };
 
-  const getTouchPos = useCallback(
-    (e: React.TouchEvent<HTMLCanvasElement>) => {
-      const canvas = canvasRef.current;
-      if (!canvas || e.touches.length === 0) return { x: 0, y: 0 };
-      return getCanvasPosition(e.nativeEvent, canvas);
-    },
-    []
-  );
+  const getTouchPos = (e: React.TouchEvent<HTMLCanvasElement>) => {
+    const canvas = canvasRef.current;
+    if (!canvas || e.touches.length === 0) return { x: 0, y: 0 };
+    return getCanvasPosition(e.nativeEvent, canvas);
+  };
 
-  const startDrawing = useCallback(
-    (x: number, y: number) => {
-      const ctx = contextRef.current;
-      if (!ctx) return;
-      const dpr = window.devicePixelRatio || 1;
-      const imageData = ctx.getImageData(0, 0, width * dpr, height * dpr);
-      saveCanvasState(imageData);
-      startDrawingStore(x, y);
-      ctx.beginPath();
-      ctx.moveTo(x, y);
-    },
-    [width, height, saveCanvasState, startDrawingStore]
-  );
+  const startDrawing = (x: number, y: number) => {
+    const ctx = contextRef.current;
+    if (!ctx) return;
+    const dpr = window.devicePixelRatio || 1;
+    const imageData = ctx.getImageData(0, 0, width * dpr, height * dpr);
+    saveCanvasState(imageData);
+    startDrawingStore(x, y);
+    ctx.beginPath();
+    ctx.moveTo(x, y);
+  };
 
-  const draw = useCallback(
-    (x: number, y: number) => {
-      if (!drawingState.isDrawing) return;
-      const ctx = contextRef.current;
-      if (!ctx) return;
-      continueDrawing(x, y);
-      ctx.lineTo(x, y);
-      ctx.stroke();
-    },
-    [drawingState.isDrawing, continueDrawing]
-  );
+  const draw = (x: number, y: number) => {
+    if (!drawingState.isDrawing) return;
+    const ctx = contextRef.current;
+    if (!ctx) return;
+    continueDrawing(x, y);
+    ctx.lineTo(x, y);
+    ctx.stroke();
+  };
 
-  const stopDrawing = useCallback(() => {
+  const stopDrawing = () => {
     if (!drawingState.isDrawing) return;
     const ctx = contextRef.current;
     if (!ctx) return;
     stopDrawingStore();
     ctx.closePath();
-  }, [drawingState.isDrawing, stopDrawingStore]);
+  };
 
   const clearCanvas = () => {
     const ctx = contextRef.current;
@@ -148,32 +136,32 @@ export function useWritingCanvas({ width, height, backgroundColor }: UseWritingC
   const changeStrokeWidth = (strokeWidth: number) => updateDrawingState({ currentStrokeWidth: strokeWidth });
   const toggleGuide = () => updateDrawingState({ showLetterGuide: !drawingState.showLetterGuide });
 
-  const onMouseDown = useCallback((e: React.MouseEvent<HTMLCanvasElement>) => {
+  const onMouseDown = (e: React.MouseEvent<HTMLCanvasElement>) => {
     const { x, y } = getMousePos(e);
     startDrawing(x, y);
-  }, [getMousePos, startDrawing]);
+  };
 
-  const onMouseMove = useCallback((e: React.MouseEvent<HTMLCanvasElement>) => {
+  const onMouseMove = (e: React.MouseEvent<HTMLCanvasElement>) => {
     const { x, y } = getMousePos(e);
     draw(x, y);
-  }, [getMousePos, draw]);
+  };
 
-  const onTouchStart = useCallback((e: React.TouchEvent<HTMLCanvasElement>) => {
+  const onTouchStart = (e: React.TouchEvent<HTMLCanvasElement>) => {
     e.preventDefault();
     const { x, y } = getTouchPos(e);
     startDrawing(x, y);
-  }, [getTouchPos, startDrawing]);
+  };
 
-  const onTouchMove = useCallback((e: React.TouchEvent<HTMLCanvasElement>) => {
+  const onTouchMove = (e: React.TouchEvent<HTMLCanvasElement>) => {
     e.preventDefault();
     const { x, y } = getTouchPos(e);
     draw(x, y);
-  }, [getTouchPos, draw]);
+  };
 
-  const onTouchEnd = useCallback((e: React.TouchEvent<HTMLCanvasElement>) => {
+  const onTouchEnd = (e: React.TouchEvent<HTMLCanvasElement>) => {
     e.preventDefault();
     stopDrawing();
-  }, [stopDrawing]);
+  };
 
   return {
     canvasRef,

--- a/gamesformykids/app/games/hebrew-letters/components/hub/HebrewLetterProgress.tsx
+++ b/gamesformykids/app/games/hebrew-letters/components/hub/HebrewLetterProgress.tsx
@@ -59,7 +59,7 @@ export default function HebrewLetterProgress({
             ? 'bg-yellow-100 border-2 border-yellow-400' 
             : 'bg-gray-100 border-2 border-gray-300'
         }
-        transition-all duration-300 hover:scale-105
+        transition duration-300 hover:scale-105
       `}>
         <span className={`
           ${currentSize.text} font-bold
@@ -116,7 +116,7 @@ export default function HebrewLetterProgress({
         <div className={`mt-2 w-full bg-gray-200 rounded-full ${currentSize.progress}`}>
           <motion.div 
             className={`
-              ${currentSize.progress} rounded-full transition-all duration-500
+              ${currentSize.progress} rounded-full transition duration-500
               ${isCompleted ? 'bg-green-500' : 'bg-yellow-400'}
             `}
             initial={{ width: 0 }}

--- a/gamesformykids/app/games/hebrew-letters/components/hub/LettersGrid.tsx
+++ b/gamesformykids/app/games/hebrew-letters/components/hub/LettersGrid.tsx
@@ -17,7 +17,7 @@ export default function LettersGrid() {
           transition={{ delay: index * 0.05 }}
         >
           <Link href={`/games/hebrew-letters/${letter.name}`}>
-            <Card className="hover:shadow-xl transition-all duration-300 cursor-pointer group border-2 hover:border-green-400">
+            <Card className="hover:shadow-xl transition duration-300 cursor-pointer group border-2 hover:border-green-400">
               <CardContent className="p-6">
                 <HebrewLetterProgress
                   letter={letter}

--- a/gamesformykids/app/games/hebrew-letters/components/practice/HebrewLetterPractice.tsx
+++ b/gamesformykids/app/games/hebrew-letters/components/practice/HebrewLetterPractice.tsx
@@ -50,7 +50,7 @@ export default function HebrewLetterPractice({ letterData }: Props) {
               <button
                 key={index}
                 onClick={() => goToStep(index)}
-                className={`px-4 py-2 rounded-full text-sm font-medium transition-all duration-200 hover:scale-105 cursor-pointer ${getStepTabStyle(index)}`}
+                className={`px-4 py-2 rounded-full text-sm font-medium transition duration-200 hover:scale-105 cursor-pointer ${getStepTabStyle(index)}`}
               >
                 <span className="ms-1">{index + 1}</span>
                 {step}

--- a/gamesformykids/app/games/hebrew-letters/components/practice/LetterEncouragement.tsx
+++ b/gamesformykids/app/games/hebrew-letters/components/practice/LetterEncouragement.tsx
@@ -20,6 +20,9 @@ export default function LetterEncouragement() {
       x: typeof window !== 'undefined' ? Math.random() * window.innerWidth : 0,
       y: typeof window !== 'undefined' ? Math.random() * window.innerHeight : 0,
     })),
+    // Deps are intentionally the trigger values, not used inside the callback —
+    // we want fresh random positions each time the firework effect fires.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     [encouragementState.showEncouragement, showCompletion],
   );
 

--- a/gamesformykids/app/games/hebrew-letters/components/practice/LetterEncouragement.tsx
+++ b/gamesformykids/app/games/hebrew-letters/components/practice/LetterEncouragement.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useMemo } from 'react';
 import { motion } from 'framer-motion';
 import { useHebrewLettersStore } from '../../store/hebrewLettersStore';
 import { FADE_UP_ANIMATION } from '../../constants/hebrewLettersConstants';
@@ -13,6 +14,14 @@ export default function LetterEncouragement() {
   const letterName = currentLetter?.name ?? '';
 
   const { showCompletion, encouragementState, getStepMessage } = useLetterEncouragement({ isCompleted });
+
+  const fireworkTargets = useMemo(
+    () => Array.from({ length: 6 }, () => ({
+      x: typeof window !== 'undefined' ? Math.random() * window.innerWidth : 0,
+      y: typeof window !== 'undefined' ? Math.random() * window.innerHeight : 0,
+    })),
+    [encouragementState.showEncouragement, showCompletion],
+  );
 
   return (
     <>
@@ -64,9 +73,9 @@ export default function LetterEncouragement() {
                 y: typeof window !== 'undefined' ? window.innerHeight / 2 : 0,
                 scale: 0
               }}
-              animate={{ 
-                x: typeof window !== 'undefined' ? Math.random() * window.innerWidth : 0,
-                y: typeof window !== 'undefined' ? Math.random() * window.innerHeight : 0,
+              animate={{
+                x: fireworkTargets[i]!.x,
+                y: fireworkTargets[i]!.y,
                 scale: [0, 1, 0]
               }}
               transition={{ 

--- a/gamesformykids/app/games/hebrew-letters/components/practice/LetterTracingStep.tsx
+++ b/gamesformykids/app/games/hebrew-letters/components/practice/LetterTracingStep.tsx
@@ -31,7 +31,7 @@ export default function LetterTracingStep() {
         {TRACING_LINE_NUMS.map((lineNum) => (
           <motion.div
             key={lineNum}
-            className="flex items-center justify-around bg-gradient-to-r from-blue-50 to-purple-50 border-2 border-dashed border-green-500 rounded-xl p-6 hover:shadow-lg transition-all duration-300"
+            className="flex items-center justify-around bg-gradient-to-r from-blue-50 to-purple-50 border-2 border-dashed border-green-500 rounded-xl p-6 hover:shadow-lg transition duration-300"
             whileHover={{ scale: 1.02 }}
             initial={{ opacity: 0, x: lineNum % 2 === 0 ? -50 : 50 }}
             animate={{ opacity: 1, x: 0 }}
@@ -46,7 +46,7 @@ export default function LetterTracingStep() {
             {TRACING_POSITIONS.map((pos) => (
               <motion.div
                 key={pos}
-                className="text-6xl font-bold text-green-100 hover:text-green-300 cursor-pointer transition-all duration-300 hover:scale-110 relative group"
+                className="text-6xl font-bold text-green-100 hover:text-green-300 cursor-pointer transition duration-300 hover:scale-110 relative group"
                 style={TRACING_LETTER_STYLE}
                 whileHover={{
                   rotate: [0, -5, 5, 0],

--- a/gamesformykids/app/games/hebrew-letters/components/stats/StatsGrid.tsx
+++ b/gamesformykids/app/games/hebrew-letters/components/stats/StatsGrid.tsx
@@ -22,7 +22,7 @@ interface StatCardProps {
 function StatCard({ value, label, borderClass, textClass, delay }: StatCardProps) {
   return (
     <motion.div
-      className={`text-center bg-white/50 rounded-xl p-4 border ${borderClass} hover:shadow-lg transition-all`}
+      className={`text-center bg-white/50 rounded-xl p-4 border ${borderClass} hover:shadow-lg transition`}
       whileHover={{ scale: 1.05 }}
     >
       <motion.div

--- a/gamesformykids/app/games/holidays/components/HolidaysMenuScreen.tsx
+++ b/gamesformykids/app/games/holidays/components/HolidaysMenuScreen.tsx
@@ -22,7 +22,7 @@ export default function HolidaysMenuScreen({ holidays, score, maxScore, onStart 
         <div className="grid grid-cols-2 sm:grid-cols-3 gap-4">
           {holidays.map((h, i) => (
             <button key={h.id} onClick={() => onStart(i)}
-              className={`p-4 rounded-2xl text-center shadow-md hover:shadow-lg transition-all hover:scale-105 active:scale-95 bg-gradient-to-br ${h.color} text-white`}>
+              className={`p-4 rounded-2xl text-center shadow-md hover:shadow-lg transition hover:scale-105 active:scale-95 bg-gradient-to-br ${h.color} text-white`}>
               <div className="text-4xl mb-2">{h.emoji}</div>
               <div className="font-bold text-sm">{h.name}</div>
               <div className="text-xs opacity-80 mt-0.5">{h.when}</div>

--- a/gamesformykids/app/games/holidays/components/HolidaysQuizScreen.tsx
+++ b/gamesformykids/app/games/holidays/components/HolidaysQuizScreen.tsx
@@ -29,7 +29,7 @@ export default function HolidaysQuizScreen({ current, currentQuestion, questionI
           <span>⭐ {score} נקודות</span>
         </div>
         <div className="h-2 bg-gray-200 rounded-full mb-4">
-          <div className={`h-full rounded-full bg-gradient-to-l ${current.color} transition-all`}
+          <div className={`h-full rounded-full bg-gradient-to-l ${current.color} transition`}
             style={{ width: `${((questionIndex + 1) / totalQuestions) * 100}%` }} />
         </div>
         <QuizQuestionCard

--- a/gamesformykids/app/games/holidays/useHolidaysGame.ts
+++ b/gamesformykids/app/games/holidays/useHolidaysGame.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useCallback } from 'react';
+import { useState } from 'react';
 import { HOLIDAYS, Holiday } from './data/holidays';
 import { useQuizQuestionState } from '@/lib/quiz/useQuizQuestionState';
 
@@ -30,13 +30,13 @@ export function useHolidaysGame() {
     onComplete: () => setPhase('result'),
   });
 
-  const startHoliday = useCallback((index: number) => {
+  const startHoliday = (index: number) => {
     setHolidayIndex(index);
     resetQuestionState();
     setPhase('quiz');
-  }, [resetQuestionState]);
+  };
 
-  const nextHoliday = useCallback(() => {
+  const nextHoliday = () => {
     if (holidayIndex < totalHolidays - 1) {
       setHolidayIndex(h => h + 1);
       resetQuestionState();
@@ -44,14 +44,14 @@ export function useHolidaysGame() {
     } else {
       setPhase('complete');
     }
-  }, [holidayIndex, totalHolidays, resetQuestionState]);
+  };
 
-  const restart = useCallback(() => {
+  const restart = () => {
     setPhase('menu');
     setHolidayIndex(0);
     setScore(0);
     resetQuestionState();
-  }, [resetQuestionState]);
+  };
 
   return {
     phase, holidayIndex, questionIndex, score, maxScore,

--- a/gamesformykids/app/games/israel-map/IsraelMapClient.tsx
+++ b/gamesformykids/app/games/israel-map/IsraelMapClient.tsx
@@ -1,5 +1,5 @@
 'use client';
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useMapStore } from './mapStore';
 import { LOCATIONS } from './data/locations';
 import IsraelSVG from './components/IsraelSVG';
@@ -25,7 +25,7 @@ export default function IsraelMapClient() {
     }
   }, [current, phase]);
 
-  const handleTap = useCallback((svgX: number, svgY: number) => {
+  const handleTap = (svgX: number, svgY: number) => {
     if (!current || lastResult !== null) return;
     const hit = checkTap(svgX, svgY);
 
@@ -51,7 +51,7 @@ export default function IsraelMapClient() {
         useMapStore.setState({ lastResult: null });
       }, 1200);
     }
-  }, [current, lastResult, checkTap, nextLocation]);
+  };
 
   useEffect(() => () => { if (feedbackTimerRef.current) clearTimeout(feedbackTimerRef.current); }, []);
 
@@ -120,7 +120,7 @@ export default function IsraelMapClient() {
       {/* Progress bar */}
       <div className="w-full max-w-md bg-gray-200 rounded-full h-2 mb-3">
         <div
-          className="bg-blue-500 h-2 rounded-full transition-all"
+          className="bg-blue-500 h-2 rounded-full transition-[width]"
           style={{ width: `${progressPct}%` }}
         />
       </div>

--- a/gamesformykids/app/games/israel-map/components/IsraelSVG.tsx
+++ b/gamesformykids/app/games/israel-map/components/IsraelSVG.tsx
@@ -1,5 +1,5 @@
 'use client';
-import { useRef, useCallback } from 'react';
+import { useRef } from 'react';
 import type { Location } from '../data/locations';
 
 // Simplified Israel outline in SVG viewBox "0 0 200 385"
@@ -55,7 +55,7 @@ const FOUND_COLORS = [
 export default function IsraelSVG({ current, foundIds, allLocations, onTap, lastResult }: Props) {
   const svgRef = useRef<SVGSVGElement>(null);
 
-  const handleClick = useCallback((e: React.MouseEvent<SVGSVGElement>) => {
+  const handleClick = (e: React.MouseEvent<SVGSVGElement>) => {
     if (!svgRef.current) return;
     const rect = svgRef.current.getBoundingClientRect();
     const scaleX = 200 / rect.width;
@@ -63,9 +63,9 @@ export default function IsraelSVG({ current, foundIds, allLocations, onTap, last
     const svgX = (e.clientX - rect.left) * scaleX;
     const svgY = (e.clientY - rect.top) * scaleY;
     onTap(svgX, svgY);
-  }, [onTap]);
+  };
 
-  const handleTouch = useCallback((e: React.TouchEvent<SVGSVGElement>) => {
+  const handleTouch = (e: React.TouchEvent<SVGSVGElement>) => {
     if (!svgRef.current || !e.touches[0]) return;
     e.preventDefault();
     const rect = svgRef.current.getBoundingClientRect();
@@ -74,7 +74,7 @@ export default function IsraelSVG({ current, foundIds, allLocations, onTap, last
     const svgX = (e.touches[0].clientX - rect.left) * scaleX;
     const svgY = (e.touches[0].clientY - rect.top) * scaleY;
     onTap(svgX, svgY);
-  }, [onTap]);
+  };
 
   return (
     <svg

--- a/gamesformykids/app/games/jokes-browser/useJokesBrowser.ts
+++ b/gamesformykids/app/games/jokes-browser/useJokesBrowser.ts
@@ -1,5 +1,5 @@
 'use client';
-import { useState, useCallback } from 'react';
+import { useState } from 'react';
 import { JOKES, type JokeCategory, type Joke } from '@/lib/constants/jokes';
 import { speakHebrew } from '@/lib/utils/speech/enhancedSpeechUtils';
 
@@ -14,44 +14,44 @@ export function useJokesBrowser() {
   const categoryJokes = JOKES.filter(j => j.category === category);
   const current: Joke | undefined = categoryJokes[currentIndex];
 
-  const selectCategory = useCallback((cat: JokeCategory) => {
+  const selectCategory = (cat: JokeCategory) => {
     setCategory(cat);
     setCurrentIndex(0);
     setRevealed(false);
     setPhase('browse');
     const firstJoke = JOKES.find(j => j.category === cat);
     if (firstJoke) speakHebrew(firstJoke.setup);
-  }, []);
+  };
 
-  const revealPunchline = useCallback(() => {
+  const revealPunchline = () => {
     setRevealed(true);
     if (current) speakHebrew(current.punchline);
-  }, [current]);
+  };
 
-  const nextJoke = useCallback(() => {
+  const nextJoke = () => {
     const next = (currentIndex + 1) % categoryJokes.length;
     setCurrentIndex(next);
     setRevealed(false);
     const nextJokeItem = categoryJokes[next];
     if (nextJokeItem) speakHebrew(nextJokeItem.setup);
-  }, [currentIndex, categoryJokes]);
+  };
 
-  const prevJoke = useCallback(() => {
+  const prevJoke = () => {
     const prev = (currentIndex - 1 + categoryJokes.length) % categoryJokes.length;
     setCurrentIndex(prev);
     setRevealed(false);
     const prevJokeItem = categoryJokes[prev];
     if (prevJokeItem) speakHebrew(prevJokeItem.setup);
-  }, [currentIndex, categoryJokes]);
+  };
 
-  const readSetup = useCallback(() => {
+  const readSetup = () => {
     if (current) speakHebrew(current.setup);
-  }, [current]);
+  };
 
-  const backToMenu = useCallback(() => {
+  const backToMenu = () => {
     setPhase('menu');
     setRevealed(false);
-  }, []);
+  };
 
   return {
     phase, category, current, currentIndex, revealed,

--- a/gamesformykids/app/games/jumper/useJumperGame.ts
+++ b/gamesformykids/app/games/jumper/useJumperGame.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useCallback } from 'react';
+import { useEffect } from 'react';
 import { useShallow } from 'zustand/react/shallow';
 import { useJumperStore } from './jumperStore';
 import { createCanvasArcadeHook } from '@/hooks/canvas';
@@ -150,7 +150,7 @@ export function useJumperGame() {
   const { st, canvasRef } = _useJumper();
 
 
-  const startGame = useCallback(() => {
+  const startGame = () => {
     const s = st.current;
     s.phase = 'playing';
     s.px = W / 2; s.py = H - 100;
@@ -161,16 +161,16 @@ export function useJumperGame() {
     s.nextPlatY = H - 60 - INIT_PLATS * (PLAT_GAP * 0.75);
     s.startTime = Date.now();
     useJumperStore.getState().startPlaying();
-  }, [st]);
+  };
 
-  const handleCanvasClick = useCallback(() => {
+  const handleCanvasClick = () => {
     if (st.current.phase === 'menu') startGame();
-  }, [st, startGame]);
+  };
 
-  const pressLeft = useCallback(() => { st.current.leftDown = true; }, [st]);
-  const releaseLeft = useCallback(() => { st.current.leftDown = false; }, [st]);
-  const pressRight = useCallback(() => { st.current.rightDown = true; }, [st]);
-  const releaseRight = useCallback(() => { st.current.rightDown = false; }, [st]);
+  const pressLeft = () => { st.current.leftDown = true; };
+  const releaseLeft = () => { st.current.leftDown = false; };
+  const pressRight = () => { st.current.rightDown = true; };
+  const releaseRight = () => { st.current.rightDown = false; };
 
 
   useEffect(() => {
@@ -187,7 +187,7 @@ export function useJumperGame() {
     return () => { window.removeEventListener('keydown', kd); window.removeEventListener('keyup', ku); };
   }, [st]);
 
-  const handleTouchMove = useCallback((e: React.TouchEvent<HTMLCanvasElement>) => {
+  const handleTouchMove = (e: React.TouchEvent<HTMLCanvasElement>) => {
     e.preventDefault();
     const rect = e.currentTarget.getBoundingClientRect();
     const tx = (e.touches[0]!.clientX - rect.left) * (W / rect.width);
@@ -195,12 +195,12 @@ export function useJumperGame() {
     if (s.phase !== 'playing') return;
     if (tx < W / 2) { s.leftDown = true; s.rightDown = false; }
     else             { s.rightDown = true; s.leftDown = false; }
-  }, [st]);
+  };
 
-  const handleTouchEnd = useCallback(() => {
+  const handleTouchEnd = () => {
     st.current.leftDown = false;
     st.current.rightDown = false;
-  }, [st]);
+  };
 
   const { phase, score, best } = useJumperStore(useShallow(s => ({ phase: s.phase, score: s.score, best: s.best })));
 

--- a/gamesformykids/app/games/kids-songs/components/LyricsDisplay.tsx
+++ b/gamesformykids/app/games/kids-songs/components/LyricsDisplay.tsx
@@ -1,5 +1,5 @@
 'use client';
-import { useState, useEffect, useCallback, useRef } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import type { SongData } from '../data/songs';
 
 interface Props {
@@ -16,12 +16,12 @@ export default function LyricsDisplay({ song, onFinish, onBack }: Props) {
   const onFinishRef = useRef(onFinish);
   onFinishRef.current = onFinish;
 
-  const cancel = useCallback(() => {
+  const cancel = () => {
     window.speechSynthesis.cancel();
     if (timerRef.current) clearTimeout(timerRef.current);
-  }, []);
+  };
 
-  const advance = useCallback((idx: number) => {
+  const advance = (idx: number) => {
     cancel();
     if (idx >= song.lines.length) {
       onFinishRef.current();
@@ -63,7 +63,7 @@ export default function LyricsDisplay({ song, onFinish, onBack }: Props) {
 
     utter.onerror = () => setPlaying(false);
     window.speechSynthesis.speak(utter);
-  }, [song, cancel]);
+  };
 
   useEffect(() => {
     advance(0);

--- a/gamesformykids/app/games/kids-songs/components/LyricsDisplay.tsx
+++ b/gamesformykids/app/games/kids-songs/components/LyricsDisplay.tsx
@@ -107,7 +107,7 @@ export default function LyricsDisplay({ song, onFinish, onBack }: Props) {
             return (
               <div
                 key={li}
-                className={`text-center py-3 px-4 rounded-xl mb-2 transition-all duration-300 ${
+                className={`text-center py-3 px-4 rounded-xl mb-2 transition duration-300 ${
                   isCurrent
                     ? 'bg-purple-100 scale-105'
                     : li < lineIdx
@@ -120,7 +120,7 @@ export default function LyricsDisplay({ song, onFinish, onBack }: Props) {
                     {words.map((word, wi) => (
                       <span
                         key={wi}
-                        className={`inline-block mx-1 transition-all duration-150 rounded px-1 ${
+                        className={`inline-block mx-1 transition duration-150 rounded px-1 ${
                           wi === wordIdx
                             ? 'bg-yellow-300 text-yellow-900 scale-110'
                             : 'text-purple-900'
@@ -143,7 +143,7 @@ export default function LyricsDisplay({ song, onFinish, onBack }: Props) {
           {song.lines.map((_, i) => (
             <div
               key={i}
-              className={`w-3 h-3 rounded-full transition-all ${
+              className={`w-3 h-3 rounded-full transition ${
                 i < lineIdx ? 'bg-purple-500' : i === lineIdx ? 'bg-yellow-400 scale-125' : 'bg-gray-200'
               }`}
             />

--- a/gamesformykids/app/games/kids-songs/components/LyricsDisplay.tsx
+++ b/gamesformykids/app/games/kids-songs/components/LyricsDisplay.tsx
@@ -1,5 +1,5 @@
 'use client';
-import { useState, useEffect, useRef } from 'react';
+import { useState, useCallback, useEffect, useRef } from 'react';
 import type { SongData } from '../data/songs';
 
 interface Props {
@@ -16,12 +16,12 @@ export default function LyricsDisplay({ song, onFinish, onBack }: Props) {
   const onFinishRef = useRef(onFinish);
   onFinishRef.current = onFinish;
 
-  const cancel = () => {
+  const cancel = useCallback(() => {
     window.speechSynthesis.cancel();
     if (timerRef.current) clearTimeout(timerRef.current);
-  };
+  }, []);
 
-  const advance = (idx: number) => {
+  const advance = useCallback((idx: number) => {
     cancel();
     if (idx >= song.lines.length) {
       onFinishRef.current();
@@ -63,7 +63,7 @@ export default function LyricsDisplay({ song, onFinish, onBack }: Props) {
 
     utter.onerror = () => setPlaying(false);
     window.speechSynthesis.speak(utter);
-  };
+  }, [cancel, song]);
 
   useEffect(() => {
     advance(0);

--- a/gamesformykids/app/games/kids-songs/components/SongQuiz.tsx
+++ b/gamesformykids/app/games/kids-songs/components/SongQuiz.tsx
@@ -35,7 +35,7 @@ export default function SongQuiz({ song, question, questionNum, onAnswer }: Prop
           <div className="grid grid-cols-2 gap-3">
             {question.options.map((option, idx) => {
               let cls =
-                'p-4 rounded-xl border-2 font-semibold text-center transition-all text-base cursor-pointer ';
+                'p-4 rounded-xl border-2 font-semibold text-center transition-colors text-base cursor-pointer ';
               if (!submitted) {
                 cls +=
                   selected === idx

--- a/gamesformykids/app/games/kids-songs/components/SongQuiz.tsx
+++ b/gamesformykids/app/games/kids-songs/components/SongQuiz.tsx
@@ -1,5 +1,5 @@
 'use client';
-import { useState } from 'react';
+import { useState, useRef, useEffect } from 'react';
 import type { SongData, ComprehensionQuestion } from '../data/songs';
 
 interface Props {
@@ -12,11 +12,13 @@ interface Props {
 export default function SongQuiz({ song, question, questionNum, onAnswer }: Props) {
   const [selected, setSelected] = useState<number | null>(null);
   const [submitted, setSubmitted] = useState(false);
+  const submitTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+  useEffect(() => () => clearTimeout(submitTimerRef.current), []);
 
   const handleSubmit = () => {
     if (selected === null) return;
     setSubmitted(true);
-    setTimeout(() => onAnswer(selected), 1500);
+    submitTimerRef.current = setTimeout(() => onAnswer(selected), 1500);
   };
 
   return (

--- a/gamesformykids/app/games/math-race/components/MathRaceProgressBar.tsx
+++ b/gamesformykids/app/games/math-race/components/MathRaceProgressBar.tsx
@@ -17,7 +17,7 @@ export default function MathRaceProgressBar({ timeLeft, score, streak, gameTime 
       </div>
       <div className="bg-white rounded-full h-3 shadow-inner">
         <div
-          className={`h-3 rounded-full transition-all duration-1000 ${
+          className={`h-3 rounded-full transition-[width] duration-1000 ${
             timeLeft > 10 ? 'bg-blue-500' : timeLeft > 5 ? 'bg-yellow-400' : 'bg-orange-400'
           }`}
           style={{ width: `${(timeLeft / gameTime) * 100}%` }}

--- a/gamesformykids/app/games/math-race/components/MathRaceQuestion.tsx
+++ b/gamesformykids/app/games/math-race/components/MathRaceQuestion.tsx
@@ -16,7 +16,7 @@ interface Props {
 export default function MathRaceQuestion({ q, feedback, streak, onTap }: Props) {
   return (
     <>
-      <div className={`w-full max-w-sm bg-white rounded-3xl p-8 text-center shadow-2xl mb-5 transition-all duration-150 ${
+      <div className={`w-full max-w-sm bg-white rounded-3xl p-8 text-center shadow-2xl mb-5 transition duration-150 ${
         feedback === 'correct' ? 'bg-green-50 ring-4 ring-green-400 scale-105' :
         feedback === 'wrong' ? 'bg-amber-50 ring-4 ring-amber-400' : ''
       }`}>
@@ -34,7 +34,7 @@ export default function MathRaceQuestion({ q, feedback, streak, onTap }: Props) 
             key={c}
             onClick={() => onTap(c)}
             disabled={!!feedback}
-            className="py-5 rounded-3xl bg-white font-black text-3xl text-indigo-700 shadow-xl border-2 border-blue-200 active:scale-90 hover:border-blue-500 hover:text-blue-600 transition-all disabled:opacity-50"
+            className="py-5 rounded-3xl bg-white font-black text-3xl text-indigo-700 shadow-xl border-2 border-blue-200 active:scale-90 hover:border-blue-500 hover:text-blue-600 transition disabled:opacity-50"
           >
             {c}
           </button>

--- a/gamesformykids/app/games/math/components/MathNumberCard.tsx
+++ b/gamesformykids/app/games/math/components/MathNumberCard.tsx
@@ -8,7 +8,7 @@ export default function MathNumberCard({ number, onClick }: MathNumberCardProps)
     <div
       onClick={() => onClick(number)}
       className="
-        aspect-square rounded-3xl cursor-pointer transition-all 
+        aspect-square rounded-3xl cursor-pointer transition 
         duration-300 transform hover:scale-110 shadow-xl hover:shadow-2xl
         bg-gradient-to-br from-yellow-400 to-orange-500 hover:opacity-80
         border-8 border-white

--- a/gamesformykids/app/games/melody-maker/MelodyMakerClient.tsx
+++ b/gamesformykids/app/games/melody-maker/MelodyMakerClient.tsx
@@ -30,7 +30,7 @@ export default function MelodyMakerClient() {
         <button
           onClick={() => setMode('free')}
           className={[
-            'px-4 py-2 rounded-full font-bold text-sm transition-all',
+            'px-4 py-2 rounded-full font-bold text-sm transition',
             mode === 'free'
               ? 'bg-purple-600 text-white shadow-md'
               : 'bg-white text-purple-600 border-2 border-purple-300 hover:bg-purple-50',
@@ -41,7 +41,7 @@ export default function MelodyMakerClient() {
         <button
           onClick={() => setMode('learning')}
           className={[
-            'px-4 py-2 rounded-full font-bold text-sm transition-all',
+            'px-4 py-2 rounded-full font-bold text-sm transition',
             mode === 'learning'
               ? 'bg-purple-600 text-white shadow-md'
               : 'bg-white text-purple-600 border-2 border-purple-300 hover:bg-purple-50',

--- a/gamesformykids/app/games/melody-maker/components/SongGuide.tsx
+++ b/gamesformykids/app/games/melody-maker/components/SongGuide.tsx
@@ -32,7 +32,7 @@ export default function SongGuide({
             <button
               key={song.id}
               onClick={() => onSelectSong(i)}
-              className="flex flex-col items-center gap-1 bg-white border-2 border-purple-300 rounded-xl px-4 py-3 hover:bg-purple-50 hover:border-purple-500 transition-all shadow"
+              className="flex flex-col items-center gap-1 bg-white border-2 border-purple-300 rounded-xl px-4 py-3 hover:bg-purple-50 hover:border-purple-500 transition-colors shadow"
             >
               <span className="text-3xl">{song.emoji}</span>
               <span className="font-bold text-purple-800 text-sm">{song.title}</span>

--- a/gamesformykids/app/games/melody-maker/components/XylophoneKeys.tsx
+++ b/gamesformykids/app/games/melody-maker/components/XylophoneKeys.tsx
@@ -22,7 +22,7 @@ export default function XylophoneKeys({ onTap, flashingKey, highlightKey }: Prop
             onPointerDown={() => onTap(i)}
             className={[
               'flex-1 rounded-b-xl rounded-t-sm text-white font-bold text-xs sm:text-sm',
-              'transition-all duration-75 touch-none',
+              'transition duration-75 touch-none',
               'shadow-md flex flex-col items-center justify-end pb-3 gap-1',
               color,
               heightClass,

--- a/gamesformykids/app/games/melody-maker/useMelodyMaker.ts
+++ b/gamesformykids/app/games/melody-maker/useMelodyMaker.ts
@@ -1,5 +1,5 @@
 'use client';
-import { useCallback, useRef, useEffect } from 'react';
+import { useRef, useEffect } from 'react';
 import { useMelodyMakerStore } from './melodyMakerStore';
 import { MELODY_MAKER_SONGS } from '@/lib/constants/melodyMakerSongs';
 import { speakHebrew } from '@/lib/utils/speech/enhancedSpeechUtils';
@@ -40,7 +40,7 @@ export function useMelodyMaker() {
     previewTimersRef.current.forEach(clearTimeout);
   }, []);
 
-  const getCtx = useCallback((): AudioContext => {
+  const getCtx = (): AudioContext => {
     if (!audioCtxRef.current) {
       audioCtxRef.current = new AudioContext();
     }
@@ -49,9 +49,9 @@ export function useMelodyMaker() {
       void ctx.resume();
     }
     return ctx;
-  }, []);
+  };
 
-  const tapKey = useCallback((noteIndex: number) => {
+  const tapKey = (noteIndex: number) => {
     const ctx = getCtx();
     const freq = NOTE_FREQUENCIES[noteIndex] ?? 261.63;
     playOscillator(ctx, freq, ctx.currentTime, 0.5);
@@ -77,9 +77,9 @@ export function useMelodyMaker() {
         }
       }
     }
-  }, [getCtx]);
+  };
 
-  const playbackRecording = useCallback(() => {
+  const playbackRecording = () => {
     const { recording, isPlayingBack, setPlayingBack } = useMelodyMakerStore.getState();
     if (recording.length === 0 || isPlayingBack) return;
     setPlayingBack(true);
@@ -91,9 +91,9 @@ export function useMelodyMaker() {
     });
     clearTimeout(playbackTimerRef.current);
     playbackTimerRef.current = setTimeout(() => setPlayingBack(false), recording.length * 600 + 200);
-  }, [getCtx]);
+  };
 
-  const previewSong = useCallback((songIndex: number) => {
+  const previewSong = (songIndex: number) => {
     const song = MELODY_MAKER_SONGS[songIndex];
     if (!song) return;
     const { setFlashingKey } = useMelodyMakerStore.getState();
@@ -107,7 +107,7 @@ export function useMelodyMaker() {
       previewTimersRef.current.push(setTimeout(() => setFlashingKey(noteIndex), i * 650));
     });
     previewTimersRef.current.push(setTimeout(() => setFlashingKey(null), song.notes.length * 650 + 200));
-  }, [getCtx]);
+  };
 
   return { ...store, tapKey, playbackRecording, previewSong };
 }

--- a/gamesformykids/app/games/melody-maker/useMelodyMaker.ts
+++ b/gamesformykids/app/games/melody-maker/useMelodyMaker.ts
@@ -1,5 +1,5 @@
 'use client';
-import { useCallback, useRef } from 'react';
+import { useCallback, useRef, useEffect } from 'react';
 import { useMelodyMakerStore } from './melodyMakerStore';
 import { MELODY_MAKER_SONGS } from '@/lib/constants/melodyMakerSongs';
 import { speakHebrew } from '@/lib/utils/speech/enhancedSpeechUtils';
@@ -33,6 +33,12 @@ function playOscillator(ctx: AudioContext, freq: number, startTime: number, dura
 export function useMelodyMaker() {
   const store = useMelodyMakerStore();
   const audioCtxRef = useRef<AudioContext | null>(null);
+  const playbackTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+  const previewTimersRef = useRef<ReturnType<typeof setTimeout>[]>([]);
+  useEffect(() => () => {
+    clearTimeout(playbackTimerRef.current);
+    previewTimersRef.current.forEach(clearTimeout);
+  }, []);
 
   const getCtx = useCallback((): AudioContext => {
     if (!audioCtxRef.current) {
@@ -83,7 +89,8 @@ export function useMelodyMaker() {
       const freq = NOTE_FREQUENCIES[noteIndex] ?? 261.63;
       playOscillator(ctx, freq, now + i * 0.6, 0.5);
     });
-    setTimeout(() => setPlayingBack(false), recording.length * 600 + 200);
+    clearTimeout(playbackTimerRef.current);
+    playbackTimerRef.current = setTimeout(() => setPlayingBack(false), recording.length * 600 + 200);
   }, [getCtx]);
 
   const previewSong = useCallback((songIndex: number) => {
@@ -92,12 +99,14 @@ export function useMelodyMaker() {
     const { setFlashingKey } = useMelodyMakerStore.getState();
     const ctx = getCtx();
     const now = ctx.currentTime;
+    previewTimersRef.current.forEach(clearTimeout);
+    previewTimersRef.current = [];
     song.notes.forEach((noteIndex, i) => {
       const freq = NOTE_FREQUENCIES[noteIndex] ?? 261.63;
       playOscillator(ctx, freq, now + i * 0.65, 0.5);
-      setTimeout(() => setFlashingKey(noteIndex), i * 650);
+      previewTimersRef.current.push(setTimeout(() => setFlashingKey(noteIndex), i * 650));
     });
-    setTimeout(() => setFlashingKey(null), song.notes.length * 650 + 200);
+    previewTimersRef.current.push(setTimeout(() => setFlashingKey(null), song.notes.length * 650 + 200));
   }, [getCtx]);
 
   return { ...store, tapKey, playbackRecording, previewSong };

--- a/gamesformykids/app/games/memory/components/GameControls.tsx
+++ b/gamesformykids/app/games/memory/components/GameControls.tsx
@@ -12,7 +12,7 @@ export default function GameControls() {
       <div className="flex justify-center gap-3">
         <button
           onClick={isGamePaused ? resumeGame : pauseGame}
-          className="px-4 py-2 bg-white rounded-full shadow-lg text-lg font-bold text-gray-600 hover:bg-gray-50 transition-all duration-300"
+          className="px-4 py-2 bg-white rounded-full shadow-lg text-lg font-bold text-gray-600 hover:bg-gray-50 transition duration-300"
         >
           {isGamePaused
             ? <Play className="inline w-5 h-5 ms-2" />
@@ -22,7 +22,7 @@ export default function GameControls() {
 
         <button
           onClick={resetGame}
-          className="px-4 py-2 bg-white rounded-full shadow-lg text-lg font-bold text-gray-600 hover:bg-gray-50 transition-all duration-300"
+          className="px-4 py-2 bg-white rounded-full shadow-lg text-lg font-bold text-gray-600 hover:bg-gray-50 transition duration-300"
         >
           <RotateCcw className="inline w-5 h-5 ms-2" /> מחדש
         </button>

--- a/gamesformykids/app/games/memory/components/GameProgressBar.tsx
+++ b/gamesformykids/app/games/memory/components/GameProgressBar.tsx
@@ -11,7 +11,7 @@ export default function GameProgressBar() {
       </div>
       <div className="w-full bg-purple-200 rounded-full h-3 mt-2">
         <div
-          className="bg-gradient-to-r from-purple-500 to-pink-500 h-3 rounded-full transition-all duration-500"
+          className="bg-gradient-to-r from-purple-500 to-pink-500 h-3 rounded-full transition-[width] duration-500"
           style={{ width: `${progressPercentage}%` }}
         />
       </div>

--- a/gamesformykids/app/games/memory/components/GameTimeoutScreen.tsx
+++ b/gamesformykids/app/games/memory/components/GameTimeoutScreen.tsx
@@ -21,13 +21,13 @@ export default function GameTimeoutScreen() {
         <div className="flex gap-4 justify-center flex-wrap">
           <button
             onClick={() => initializeGame(difficulty)}
-            className="bg-gradient-to-r from-purple-500 to-pink-500 hover:from-purple-600 hover:to-pink-600 text-white font-bold py-3 px-8 rounded-full text-xl transition-all duration-300 transform hover:scale-105 shadow-lg"
+            className="bg-gradient-to-r from-purple-500 to-pink-500 hover:from-purple-600 hover:to-pink-600 text-white font-bold py-3 px-8 rounded-full text-xl transition duration-300 transform hover:scale-105 shadow-lg"
           >
             🎮 נסה שוב
           </button>
           <button
             onClick={resetToMenu}
-            className="bg-white/80 hover:bg-white text-gray-700 font-bold py-3 px-8 rounded-full text-xl transition-all duration-300 transform hover:scale-105 shadow-lg border border-gray-200"
+            className="bg-white/80 hover:bg-white text-gray-700 font-bold py-3 px-8 rounded-full text-xl transition duration-300 transform hover:scale-105 shadow-lg border border-gray-200"
           >
             🏠 תפריט
           </button>

--- a/gamesformykids/app/games/memory/components/GameWinMessage.tsx
+++ b/gamesformykids/app/games/memory/components/GameWinMessage.tsx
@@ -39,13 +39,13 @@ function DuoResult({ players, onRestart, onMenu }: {
           <div className="flex gap-3 justify-center flex-wrap">
             <button
               onClick={onRestart}
-              className="bg-linear-to-r from-purple-500 to-pink-500 hover:from-purple-600 hover:to-pink-600 text-white font-bold py-3 px-6 rounded-full text-lg transition-all duration-300 hover:scale-105 shadow-lg"
+              className="bg-linear-to-r from-purple-500 to-pink-500 hover:from-purple-600 hover:to-pink-600 text-white font-bold py-3 px-6 rounded-full text-lg transition duration-300 hover:scale-105 shadow-lg"
             >
               🎮 שחק שוב
             </button>
             <button
               onClick={onMenu}
-              className="bg-white/80 hover:bg-white text-gray-700 font-bold py-3 px-6 rounded-full text-lg transition-all duration-300 hover:scale-105 shadow-lg"
+              className="bg-white/80 hover:bg-white text-gray-700 font-bold py-3 px-6 rounded-full text-lg transition duration-300 hover:scale-105 shadow-lg"
             >
               🏠 תפריט
             </button>
@@ -111,14 +111,14 @@ export default function GameWinMessage() {
           <div className="flex gap-4 justify-center flex-wrap">
             <button
               onClick={() => initializeGame(difficulty)}
-              className="bg-linear-to-r from-purple-500 to-pink-500 hover:from-purple-600 hover:to-pink-600 text-white font-bold py-3 px-8 rounded-full text-xl transition-all duration-300 transform hover:scale-105 shadow-lg"
+              className="bg-linear-to-r from-purple-500 to-pink-500 hover:from-purple-600 hover:to-pink-600 text-white font-bold py-3 px-8 rounded-full text-xl transition duration-300 transform hover:scale-105 shadow-lg"
             >
               🎮 שחק שוב
             </button>
             {navigation.next && (
               <Link
                 href={navigation.next.href}
-                className="bg-linear-to-r from-green-500 to-teal-500 hover:from-green-600 hover:to-teal-600 text-white font-bold py-3 px-8 rounded-full text-xl transition-all duration-300 transform hover:scale-105 shadow-lg flex items-center gap-2"
+                className="bg-linear-to-r from-green-500 to-teal-500 hover:from-green-600 hover:to-teal-600 text-white font-bold py-3 px-8 rounded-full text-xl transition duration-300 transform hover:scale-105 shadow-lg flex items-center gap-2"
               >
                 <span>משחק הבא</span>
                 <span>{navigation.next.title}</span>
@@ -127,7 +127,7 @@ export default function GameWinMessage() {
             )}
             <button
               onClick={resetToMenu}
-              className="bg-white/80 hover:bg-white text-gray-700 font-bold py-3 px-8 rounded-full text-xl transition-all duration-300 transform hover:scale-105 shadow-lg"
+              className="bg-white/80 hover:bg-white text-gray-700 font-bold py-3 px-8 rounded-full text-xl transition duration-300 transform hover:scale-105 shadow-lg"
             >
               🏠 תפריט
             </button>

--- a/gamesformykids/app/games/memory/components/MemoryCard.tsx
+++ b/gamesformykids/app/games/memory/components/MemoryCard.tsx
@@ -11,12 +11,17 @@ interface MemoryCardProps {
   onClick: () => void;
 }
 
+const STAR_POSITIONS = Array.from({ length: 8 }, () => ({
+  top: Math.random() * 80 + 10,
+  left: Math.random() * 80 + 10,
+}));
+
 export default function MemoryCard({ card, onClick }: MemoryCardProps) {
   return (
     <div
       onClick={onClick}
       className={`
-        aspect-square rounded-3xl cursor-pointer transition-all duration-500 transform hover:scale-105 shadow-xl hover:shadow-2xl relative overflow-hidden
+        aspect-square rounded-3xl cursor-pointer transition duration-500 transform hover:scale-105 shadow-xl hover:shadow-2xl relative overflow-hidden
         ${card.isFlipped || card.isMatched
           ? "bg-gradient-to-br from-white to-gray-50 border-8 border-white"
           : "bg-gradient-to-br from-purple-400 via-pink-400 to-indigo-400 hover:from-purple-500 hover:via-pink-500 hover:to-indigo-500 border-8 border-white"}
@@ -34,7 +39,7 @@ export default function MemoryCard({ card, onClick }: MemoryCardProps) {
       <div className="w-full h-full flex items-center justify-center relative z-10">
         {card.isFlipped || card.isMatched ? (
           <span className={`
-            text-5xl md:text-7xl transition-all duration-500
+            text-5xl md:text-7xl transition duration-500
             ${card.isMatched ? "animate-bounce" : ""}
             filter drop-shadow-lg
           `}>
@@ -56,8 +61,8 @@ export default function MemoryCard({ card, onClick }: MemoryCardProps) {
               key={i}
               className="absolute text-yellow-400 text-2xl animate-bounce filter drop-shadow-lg"
               style={{
-                top: `${Math.random() * 80 + 10}%`,
-                left: `${Math.random() * 80 + 10}%`,
+                top: `${STAR_POSITIONS[i]!.top}%`,
+                left: `${STAR_POSITIONS[i]!.left}%`,
                 animationDelay: `${i * 0.15}s`,
                 animationDuration: '1.2s'
               }}

--- a/gamesformykids/app/games/memory/components/MemoryGameHeader.tsx
+++ b/gamesformykids/app/games/memory/components/MemoryGameHeader.tsx
@@ -15,7 +15,7 @@ function DuoPlayerIndicator() {
       {players.map((p, i) => (
         <div
           key={i}
-          className={`flex items-center gap-1 px-3 py-1.5 rounded-full text-sm font-bold transition-all duration-300 ${
+          className={`flex items-center gap-1 px-3 py-1.5 rounded-full text-sm font-bold transition duration-300 ${
             currentPlayer === i
               ? 'bg-white text-purple-700 shadow-lg scale-105'
               : 'bg-white/20 text-white/70'

--- a/gamesformykids/app/games/meteor-dodge/useMeteorDodgeGame.ts
+++ b/gamesformykids/app/games/meteor-dodge/useMeteorDodgeGame.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useCallback } from 'react';
+import { useEffect } from 'react';
 import { useShallow } from 'zustand/react/shallow';
 import { useMeteorDodgeStore } from './meteorDodgeStore';
 import { createCanvasArcadeHook } from '@/hooks/canvas';
@@ -120,23 +120,23 @@ export function useMeteorDodgeGame() {
 
 
 
-  const startGame = useCallback(() => {
+  const startGame = () => {
     const s = st.current;
     s.phase = 'playing'; s.playerX = W / 2; s.meteors = []; s.stars = [];
     s.score = 0; s.frame = 0; s.nextMeteor = 50; s.nextStar = 120; s.invincible = 0;
     s.startTime = Date.now();
     useMeteorDodgeStore.getState().startPlaying();
-  }, [st]);
+  };
 
-  const handleCanvasClick = useCallback(() => {
+  const handleCanvasClick = () => {
     if (st.current.phase === 'menu') startGame();
-  }, [st, startGame]);
+  };
 
-  const handleTouchStart = useCallback((e: React.TouchEvent<HTMLCanvasElement>) => {
+  const handleTouchStart = (e: React.TouchEvent<HTMLCanvasElement>) => {
     e.preventDefault();
     if (st.current.phase === 'menu') startGame();
     handlers.onTouchMove(e);
-  }, [startGame, handlers, st]);
+  };
 
 
   useEffect(() => {
@@ -154,15 +154,15 @@ export function useMeteorDodgeGame() {
     return () => { clearInterval(interval); window.removeEventListener('keydown', kd); window.removeEventListener('keyup', ku); };
   }, [st]);
 
-  const nudgeLeft = useCallback(() => {
+  const nudgeLeft = () => {
     const s = st.current;
     s.playerX = Math.max(PLAYER_R, s.playerX - 45);
-  }, [st]);
+  };
 
-  const nudgeRight = useCallback(() => {
+  const nudgeRight = () => {
     const s = st.current;
     s.playerX = Math.min(W - PLAYER_R, s.playerX + 45);
-  }, [st]);
+  };
 
   const { phase, score, best } = useMeteorDodgeStore(useShallow(s => ({ phase: s.phase, score: s.score, best: s.best })));
 

--- a/gamesformykids/app/games/multiplication/multiplicationConfig.tsx
+++ b/gamesformykids/app/games/multiplication/multiplicationConfig.tsx
@@ -17,7 +17,7 @@ export const MULTIPLICATION_CONFIG: TimedMathConfig<number, MultiplicationQuesti
   renderLevelItem: (lv) => lv,
   levelColumns: 5,
   levelGap: 3,
-  levelButtonClass: 'aspect-square rounded-2xl text-2xl font-black text-white shadow-lg hover:scale-105 active:scale-95 transition-all bg-gradient-to-br from-purple-500 to-violet-600 hover:from-purple-400 hover:to-violet-500',
+  levelButtonClass: 'aspect-square rounded-2xl text-2xl font-black text-white shadow-lg hover:scale-105 active:scale-95 transition bg-gradient-to-br from-purple-500 to-violet-600 hover:from-purple-400 hover:to-violet-500',
   menuFooter: (
     <p className="text-center text-purple-500 text-sm mt-4">
       {QUESTIONS_PER_LEVEL} שאלות ל-{TIME_PER_QUESTION} שניות כל אחת

--- a/gamesformykids/app/games/number-bubbles/components/NumberBubbleGrid.tsx
+++ b/gamesformykids/app/games/number-bubbles/components/NumberBubbleGrid.tsx
@@ -12,7 +12,7 @@ export default function NumberBubbleGrid() {
           key={b.id}
           onClick={() => tap(b)}
           style={{ position: 'absolute', left: `${b.x}%`, top: `${b.y}%`, transform: 'translate(-50%,-50%)' }}
-          className={`w-14 h-14 rounded-full font-black text-xl text-white shadow-lg flex items-center justify-center transition-all duration-200 ${
+          className={`w-14 h-14 rounded-full font-black text-xl text-white shadow-lg flex items-center justify-center transition duration-200 ${
             b.popped
               ? 'opacity-0 scale-150 pointer-events-none'
               : `${b.color} active:scale-90 hover:scale-110 ${b.num === next ? 'ring-4 ring-white ring-offset-2 ring-offset-transparent scale-110 animate-pulse' : ''}`

--- a/gamesformykids/app/games/picture-dictionary/PictureDictionaryClient.tsx
+++ b/gamesformykids/app/games/picture-dictionary/PictureDictionaryClient.tsx
@@ -31,7 +31,7 @@ function CollectionTab() {
         <button
           key={`${item.hebrew}-${i}`}
           onClick={() => expandItem(item)}
-          className="flex flex-col items-center gap-2 p-3 bg-white rounded-2xl shadow hover:shadow-md hover:-translate-y-0.5 transition-all active:scale-95"
+          className="flex flex-col items-center gap-2 p-3 bg-white rounded-2xl shadow hover:shadow-md hover:-translate-y-0.5 transition active:scale-95"
         >
           <div
             className={`w-14 h-14 rounded-xl flex items-center justify-center text-4xl ${item.color ?? 'bg-gradient-to-br from-yellow-400 to-orange-500'}`}

--- a/gamesformykids/app/games/picture-dictionary/components/DictionaryBrowse.tsx
+++ b/gamesformykids/app/games/picture-dictionary/components/DictionaryBrowse.tsx
@@ -14,7 +14,7 @@ function ItemTile({ item }: { item: DictionaryItem }) {
   return (
     <button
       onClick={() => expandItem(item)}
-      className="flex flex-col items-center gap-2 p-3 bg-white rounded-2xl shadow hover:shadow-md hover:-translate-y-0.5 transition-all active:scale-95 cursor-pointer"
+      className="flex flex-col items-center gap-2 p-3 bg-white rounded-2xl shadow hover:shadow-md hover:-translate-y-0.5 transition active:scale-95 cursor-pointer"
     >
       <div
         className={`w-14 h-14 rounded-xl flex items-center justify-center text-4xl ${item.color ?? 'bg-gradient-to-br from-blue-400 to-purple-500'}`}
@@ -36,7 +36,7 @@ export default function DictionaryBrowse() {
 
   const allItems = useMemo(() => buildDictionary(), []);
 
-  const displayedItems = useMemo((): DictionaryItem[] => {
+  const displayedItems: DictionaryItem[] = (() => {
     if (browseMode === 'letter' && selectedLetter) {
       return allItems.filter((item) => getFirstHebrewLetter(item.hebrew) === selectedLetter);
     }
@@ -50,12 +50,9 @@ export default function DictionaryBrowse() {
       );
     }
     return [];
-  }, [browseMode, selectedLetter, selectedCategory, searchQuery, allItems]);
+  })();
 
-  const categoryKeys = useMemo(
-    () => Object.keys(CATEGORY_LABELS).filter((k) => allItems.some((i) => i.category === k)),
-    [allItems]
-  );
+  const categoryKeys = Object.keys(CATEGORY_LABELS).filter((k) => allItems.some((i) => i.category === k));
 
   return (
     <div className="flex flex-col gap-4" dir="rtl">
@@ -85,7 +82,7 @@ export default function DictionaryBrowse() {
             <button
               key={key}
               onClick={() => selectCategory(key)}
-              className="bg-white rounded-2xl shadow p-4 flex flex-col items-center gap-1 hover:shadow-md hover:-translate-y-0.5 transition-all"
+              className="bg-white rounded-2xl shadow p-4 flex flex-col items-center gap-1 hover:shadow-md hover:-translate-y-0.5 transition"
             >
               <span className="text-3xl">
                 {allItems.find((i) => i.category === key)?.emoji ?? '📦'}

--- a/gamesformykids/app/games/picture-dictionary/components/DictionaryCard.tsx
+++ b/gamesformykids/app/games/picture-dictionary/components/DictionaryCard.tsx
@@ -1,5 +1,4 @@
 'use client';
-import { useCallback } from 'react';
 import { speakHebrew } from '@/lib/utils/speech/enhancedSpeechUtils';
 import type { DictionaryItem } from '../pictureDictionaryStore';
 import { usePictureDictionaryStore } from '../pictureDictionaryStore';
@@ -12,9 +11,9 @@ export default function DictionaryCard({ item }: Props) {
   const { closeExpanded, toggleCollection, collection } = usePictureDictionaryStore();
   const isSaved = collection.some((c) => c.hebrew === item.hebrew);
 
-  const handleSpeak = useCallback(() => {
+  const handleSpeak = () => {
     speakHebrew(item.hebrew);
-  }, [item.hebrew]);
+  };
 
   return (
     <div

--- a/gamesformykids/app/games/pong/components/PongResultOverlay.tsx
+++ b/gamesformykids/app/games/pong/components/PongResultOverlay.tsx
@@ -27,7 +27,7 @@ export default function PongResultOverlay({ onRestart }: Props) {
         </div>
         <button
           onClick={onRestart}
-          className="w-full py-4 rounded-2xl bg-gradient-to-l from-slate-600 to-slate-800 text-white font-black text-xl shadow-lg hover:opacity-90 active:scale-95 transition-all"
+          className="w-full py-4 rounded-2xl bg-gradient-to-l from-slate-600 to-slate-800 text-white font-black text-xl shadow-lg hover:opacity-90 active:scale-95 transition"
         >
           🔄 שוב!
         </button>

--- a/gamesformykids/app/games/pong/usePongGame.ts
+++ b/gamesformykids/app/games/pong/usePongGame.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useCallback } from 'react';
+import { useEffect } from 'react';
 import { useShallow } from 'zustand/react/shallow';
 import { usePongStore } from './pongStore';
 import { createCanvasArcadeHook } from '@/hooks/canvas';
@@ -96,7 +96,7 @@ export function usePongGame() {
   const { st, canvasRef, handlers } = _usePong();
 
 
-  const startGame = useCallback(() => {
+  const startGame = () => {
     const s = st.current;
     s.phase = 'playing';
     s.playerX = W / 2 - PAD_W / 2; s.aiX = W / 2 - PAD_W / 2;
@@ -105,17 +105,17 @@ export function usePongGame() {
     s.ballVX = Math.sin(angle) * spd; s.ballVY = (Math.random() < 0.5 ? 1 : -1) * Math.cos(angle) * spd;
     s.playerScore = 0; s.aiScore = 0; s.frame = 0; s.particles = []; s.startTime = Date.now();
     usePongStore.getState().startGame();
-  }, [st]);
+  };
 
-  const handleCanvasClick = useCallback(() => {
+  const handleCanvasClick = () => {
     if (st.current.phase === 'menu') startGame();
-  }, [st, startGame]);
+  };
 
-  const handleTouchStart = useCallback((e: React.TouchEvent<HTMLCanvasElement>) => {
+  const handleTouchStart = (e: React.TouchEvent<HTMLCanvasElement>) => {
     e.preventDefault();
     if (st.current.phase === 'menu') startGame();
     handlers.onTouchMove(e);
-  }, [startGame, handlers, st]);
+  };
 
 
   useEffect(() => {

--- a/gamesformykids/app/games/puppet-story/PuppetClient.tsx
+++ b/gamesformykids/app/games/puppet-story/PuppetClient.tsx
@@ -59,7 +59,7 @@ export default function PuppetClient() {
                 <button
                   key={i}
                   onClick={() => answerQuestion(i)}
-                  className="bg-white hover:bg-purple-50 active:scale-95 border-2 border-purple-200 text-gray-800 font-semibold text-sm px-3 py-3 rounded-2xl shadow transition-all text-center"
+                  className="bg-white hover:bg-purple-50 active:scale-95 border-2 border-purple-200 text-gray-800 font-semibold text-sm px-3 py-3 rounded-2xl shadow transition text-center"
                 >
                   {resolveText(opt, char1, char2, setting)}
                 </button>

--- a/gamesformykids/app/games/puppet-story/components/CharacterPicker.tsx
+++ b/gamesformykids/app/games/puppet-story/components/CharacterPicker.tsx
@@ -18,7 +18,7 @@ export function CharacterPicker({ step, excludeId, onPick }: PickCharProps) {
           <button
             key={c.id}
             onClick={() => onPick(c)}
-            className="flex flex-col items-center gap-1 bg-white rounded-2xl p-3 shadow hover:shadow-md hover:bg-purple-50 transition-all active:scale-95"
+            className="flex flex-col items-center gap-1 bg-white rounded-2xl p-3 shadow hover:shadow-md hover:bg-purple-50 transition active:scale-95"
           >
             <span className="text-4xl">{c.emoji}</span>
             <span className="text-xs font-bold text-gray-700">{c.name}</span>
@@ -42,7 +42,7 @@ export function SettingPicker({ onPick }: PickSettingProps) {
           <button
             key={s.id}
             onClick={() => onPick(s)}
-            className="flex items-center gap-3 bg-white rounded-2xl px-5 py-4 shadow hover:shadow-md hover:bg-purple-50 transition-all active:scale-95 text-right"
+            className="flex items-center gap-3 bg-white rounded-2xl px-5 py-4 shadow hover:shadow-md hover:bg-purple-50 transition active:scale-95 text-right"
           >
             <span className="text-4xl">{s.emoji}</span>
             <span className="text-lg font-bold text-gray-800">{s.name}</span>

--- a/gamesformykids/app/games/puppet-story/components/PuppetStage.tsx
+++ b/gamesformykids/app/games/puppet-story/components/PuppetStage.tsx
@@ -60,7 +60,7 @@ export default function PuppetStage({ template, panelIndex, char1, char2, settin
       {/* Button */}
       <button
         onClick={onNext}
-        className="bg-purple-500 hover:bg-purple-600 active:scale-95 text-white font-bold text-lg px-8 py-3 rounded-2xl shadow-lg transition-all"
+        className="bg-purple-500 hover:bg-purple-600 active:scale-95 text-white font-bold text-lg px-8 py-3 rounded-2xl shadow-lg transition"
       >
         {isLast ? '🎬 לשאלות הבנה' : 'הבא ▶'}
       </button>

--- a/gamesformykids/app/games/puzzles/custom/CustomControls.tsx
+++ b/gamesformykids/app/games/puzzles/custom/CustomControls.tsx
@@ -20,7 +20,7 @@ export default function CustomControls() {
           <input type="file" accept="image/*" onChange={handleImageUpload} ref={uploadRef} className="hidden" />
           <button
             onClick={() => uploadRef.current?.click()}
-            className="inline-flex items-center gap-2 px-4 py-3 rounded-xl shadow-lg hover:shadow-xl transition-all duration-200 transform hover:scale-105 font-medium bg-gradient-to-r from-green-500 to-emerald-500 hover:from-green-600 hover:to-emerald-600 text-white"
+            className="inline-flex items-center gap-2 px-4 py-3 rounded-xl shadow-lg hover:shadow-xl transition duration-200 transform hover:scale-105 font-medium bg-gradient-to-r from-green-500 to-emerald-500 hover:from-green-600 hover:to-emerald-600 text-white"
           >
             <Upload className="w-5 h-5" />
             <span className="hidden sm:inline">תמונה חדשה</span>
@@ -29,7 +29,7 @@ export default function CustomControls() {
           <button
             onClick={shufflePieces}
             disabled={!gameStarted}
-            className="inline-flex items-center gap-2 px-4 py-3 rounded-xl shadow-lg hover:shadow-xl transition-all duration-200 transform hover:scale-105 font-medium bg-gradient-to-r from-orange-500 to-red-500 hover:from-orange-600 hover:to-red-600 text-white disabled:opacity-50 disabled:cursor-not-allowed disabled:transform-none"
+            className="inline-flex items-center gap-2 px-4 py-3 rounded-xl shadow-lg hover:shadow-xl transition duration-200 transform hover:scale-105 font-medium bg-gradient-to-r from-orange-500 to-red-500 hover:from-orange-600 hover:to-red-600 text-white disabled:opacity-50 disabled:cursor-not-allowed disabled:transform-none"
           >
             <Shuffle className="w-5 h-5" />
             <span className="hidden sm:inline">ערבב חלקים</span>
@@ -38,7 +38,7 @@ export default function CustomControls() {
           <button
             onClick={resetGame}
             disabled={!gameStarted}
-            className="inline-flex items-center gap-2 px-4 py-3 rounded-xl shadow-lg hover:shadow-xl transition-all duration-200 transform hover:scale-105 font-medium bg-gradient-to-r from-blue-500 to-blue-600 hover:from-blue-600 hover:to-blue-700 text-white disabled:opacity-50 disabled:cursor-not-allowed disabled:transform-none"
+            className="inline-flex items-center gap-2 px-4 py-3 rounded-xl shadow-lg hover:shadow-xl transition duration-200 transform hover:scale-105 font-medium bg-gradient-to-r from-blue-500 to-blue-600 hover:from-blue-600 hover:to-blue-700 text-white disabled:opacity-50 disabled:cursor-not-allowed disabled:transform-none"
           >
             <RotateCcw className="w-5 h-5" />
             <span className="hidden sm:inline">התחל מחדש</span>
@@ -46,7 +46,7 @@ export default function CustomControls() {
           </button>
           <button
             onClick={toggleHints}
-            className={`inline-flex items-center gap-2 px-4 py-3 rounded-xl shadow-lg hover:shadow-xl transition-all duration-200 transform hover:scale-105 font-medium ${
+            className={`inline-flex items-center gap-2 px-4 py-3 rounded-xl shadow-lg hover:shadow-xl transition duration-200 transform hover:scale-105 font-medium ${
               hintsEnabled
                 ? 'bg-gradient-to-r from-yellow-500 to-orange-500 hover:from-yellow-600 hover:to-orange-600 text-white'
                 : 'bg-gradient-to-r from-gray-400 to-gray-500 hover:from-gray-500 hover:to-gray-600 text-white'
@@ -58,7 +58,7 @@ export default function CustomControls() {
           </button>
           <button
             onClick={toggleDebug}
-            className={`inline-flex items-center gap-2 px-4 py-3 rounded-xl shadow-lg hover:shadow-xl transition-all duration-200 transform hover:scale-105 font-medium ${
+            className={`inline-flex items-center gap-2 px-4 py-3 rounded-xl shadow-lg hover:shadow-xl transition duration-200 transform hover:scale-105 font-medium ${
               debugMode
                 ? 'bg-gradient-to-r from-purple-500 to-purple-600 hover:from-purple-600 hover:to-purple-700 text-white'
                 : 'bg-gradient-to-r from-gray-400 to-gray-500 hover:from-gray-500 hover:to-gray-600 text-white'

--- a/gamesformykids/app/games/puzzles/custom/FileUploadButton.tsx
+++ b/gamesformykids/app/games/puzzles/custom/FileUploadButton.tsx
@@ -20,7 +20,7 @@ export default function FileUploadButton() {
       />
       <button
         onClick={() => inputRef.current?.click()}
-        className="inline-flex items-center justify-center rounded-xl font-bold transition-all duration-200 bg-gradient-to-r from-blue-500 to-purple-500 hover:from-blue-600 hover:to-purple-600 text-white px-8 py-4 text-lg shadow-lg hover:shadow-xl transform hover:scale-105"
+        className="inline-flex items-center justify-center rounded-xl font-bold transition duration-200 bg-gradient-to-r from-blue-500 to-purple-500 hover:from-blue-600 hover:to-purple-600 text-white px-8 py-4 text-lg shadow-lg hover:shadow-xl transform hover:scale-105"
       >
         <Upload className="w-6 h-6 me-3" />
         העלה תמונה מהמחשב

--- a/gamesformykids/app/games/puzzles/custom/PreMadeImagesPicker.tsx
+++ b/gamesformykids/app/games/puzzles/custom/PreMadeImagesPicker.tsx
@@ -15,14 +15,14 @@ export default function PreMadeImagesPicker() {
           <div
             key={index}
             onClick={() => handlePreMadeImageSelect(img.src)}
-            className="group cursor-pointer border-3 border-gray-200 rounded-2xl overflow-hidden hover:border-blue-400 hover:shadow-2xl transition-all duration-300 transform hover:scale-105 bg-white"
+            className="group cursor-pointer border-3 border-gray-200 rounded-2xl overflow-hidden hover:border-blue-400 hover:shadow-2xl transition duration-300 transform hover:scale-105 bg-white"
           >
             <div className="aspect-square relative">
               <Image
                 src={img.src}
                 alt={img.name}
                 fill
-                className="object-cover group-hover:brightness-110 transition-all duration-300"
+                className="object-cover group-hover:brightness-110 transition duration-300"
                 sizes="(max-width: 640px) 50vw, (max-width: 1024px) 33vw, 25vw"
               />
               <div className="absolute top-3 left-3 bg-gradient-to-r from-blue-500 to-purple-500 text-white text-xs sm:text-sm px-3 py-2 rounded-full font-bold shadow-lg">

--- a/gamesformykids/app/games/puzzles/shared/DifficultySelector.tsx
+++ b/gamesformykids/app/games/puzzles/shared/DifficultySelector.tsx
@@ -13,7 +13,7 @@ export default function DifficultySelector({ variant = 'buttons' }: { variant?: 
           <select
             value={difficulty}
             onChange={(e) => changeDifficulty(Number(e.target.value))}
-            className="px-4 py-3 border-2 border-blue-300 rounded-xl bg-white text-blue-800 font-semibold text-lg shadow-sm hover:shadow-md transition-all duration-200 focus:ring-2 focus:ring-blue-400"
+            className="px-4 py-3 border-2 border-blue-300 rounded-xl bg-white text-blue-800 font-semibold text-lg shadow-sm hover:shadow-md transition duration-200 focus:ring-2 focus:ring-blue-400"
           >
             <option value={4}>🟢 קל (2x2) - 4 חלקים</option>
             <option value={9}>🟡 בינוני (3x3) - 9 חלקים</option>
@@ -36,7 +36,7 @@ export default function DifficultySelector({ variant = 'buttons' }: { variant?: 
           <button
             key={level}
             onClick={() => changeDifficulty(level * level)}
-            className={`px-4 py-2 rounded-lg font-medium transition-all duration-200 transform hover:scale-105 ${
+            className={`px-4 py-2 rounded-lg font-medium transition duration-200 transform hover:scale-105 ${
               difficulty === level * level
                 ? 'bg-gradient-to-r from-blue-500 to-blue-600 text-white shadow-lg'
                 : 'bg-gray-200 text-gray-700 hover:bg-gray-300'

--- a/gamesformykids/app/games/puzzles/shared/GridCell.tsx
+++ b/gamesformykids/app/games/puzzles/shared/GridCell.tsx
@@ -17,7 +17,7 @@ export default function GridCell({ index, row, col, piece }: GridCellProps) {
 
   return (
     <div
-      className={`puzzle-grid-cell aspect-square border-2 rounded-lg relative overflow-hidden transition-all duration-200 min-h-[60px] min-w-[60px] ${
+      className={`puzzle-grid-cell aspect-square border-2 rounded-lg relative overflow-hidden transition duration-200 min-h-[60px] min-w-[60px] ${
         piece
           ? 'border-gray-300 bg-gray-100'
           : 'border-dashed border-gray-400 bg-gray-50 hover:bg-blue-50 hover:border-blue-300'
@@ -35,7 +35,7 @@ export default function GridCell({ index, row, col, piece }: GridCellProps) {
             alt={`Piece ${piece.id} at ${row},${col}`}
             width={100}
             height={100}
-            className={`w-full h-full object-cover cursor-grab active:cursor-grabbing transition-all duration-300 ${
+            className={`w-full h-full object-cover cursor-grab active:cursor-grabbing transition duration-300 ${
               piece.isCorrect ? 'ring-4 ring-green-400 shadow-lg transform scale-105' : 'ring-2 ring-red-400 opacity-80'
             }`}
             draggable={!piece.isCorrect}

--- a/gamesformykids/app/games/puzzles/shared/ModeCard.tsx
+++ b/gamesformykids/app/games/puzzles/shared/ModeCard.tsx
@@ -4,7 +4,7 @@ export default function ModeCard({ onClick, icon, iconBgClass, title, descriptio
   return (
     <div
       onClick={onClick}
-      className="bg-white rounded-2xl p-8 shadow-xl hover:shadow-2xl transform hover:scale-105 transition-all duration-300 cursor-pointer"
+      className="bg-white rounded-2xl p-8 shadow-xl hover:shadow-2xl transform hover:scale-105 transition duration-300 cursor-pointer"
     >
       <div className="text-center">
         <div className={`w-20 h-20 ${iconBgClass} rounded-full flex items-center justify-center mx-auto mb-4`}>

--- a/gamesformykids/app/games/puzzles/shared/PuzzleHeader.tsx
+++ b/gamesformykids/app/games/puzzles/shared/PuzzleHeader.tsx
@@ -14,7 +14,7 @@ export default function PuzzleHeader({ title, subtitle }: { title: string; subti
         </div>
         <button
           onClick={toggleHelp}
-          className="inline-flex items-center gap-2 bg-gradient-to-r from-blue-500 to-blue-600 hover:from-blue-600 hover:to-blue-700 text-white px-4 py-3 sm:px-6 sm:py-3 rounded-xl shadow-lg hover:shadow-xl transition-all duration-200 text-sm sm:text-base font-medium"
+          className="inline-flex items-center gap-2 bg-gradient-to-r from-blue-500 to-blue-600 hover:from-blue-600 hover:to-blue-700 text-white px-4 py-3 sm:px-6 sm:py-3 rounded-xl shadow-lg hover:shadow-xl transition duration-200 text-sm sm:text-base font-medium"
         >
           <HelpCircle className="w-5 h-5" />
           <span className="hidden sm:inline">עזרה</span>

--- a/gamesformykids/app/games/puzzles/shared/PuzzlePieceItem.tsx
+++ b/gamesformykids/app/games/puzzles/shared/PuzzlePieceItem.tsx
@@ -22,7 +22,7 @@ export default function PuzzlePieceItem({ piece }: { piece: PuzzlePiece }) {
         alt={`Puzzle piece ${piece.id}`}
         width={80}
         height={80}
-        className="w-20 h-20 object-cover border-2 border-gray-300 hover:border-blue-400 transition-all duration-200 hover:shadow-lg hover:scale-110"
+        className="w-20 h-20 object-cover border-2 border-gray-300 hover:border-blue-400 transition duration-200 hover:shadow-lg hover:scale-110"
         unoptimized
       />
     </div>

--- a/gamesformykids/app/games/puzzles/shared/PuzzleStats.tsx
+++ b/gamesformykids/app/games/puzzles/shared/PuzzleStats.tsx
@@ -29,7 +29,7 @@ export default function PuzzleStats({ className = '' }: { className?: string }) 
             <span className={`text-sm font-bold ${barText}`}>{completionPercentage}%</span>
           </div>
           <div className="w-full bg-gray-200 rounded-full h-3">
-            <div className={`h-3 rounded-full transition-all duration-500 ${barColor}`} style={{ width: `${completionPercentage}%` }} />
+            <div className={`h-3 rounded-full transition-[width] duration-500 ${barColor}`} style={{ width: `${completionPercentage}%` }} />
           </div>
         </div>
         <div className="grid grid-cols-2 gap-4">

--- a/gamesformykids/app/games/puzzles/simple/PuzzleCard.tsx
+++ b/gamesformykids/app/games/puzzles/simple/PuzzleCard.tsx
@@ -9,7 +9,7 @@ export default function PuzzleCard({ puzzle }: { puzzle: SimplePuzzle }) {
   const { handlePuzzleSelect } = usePuzzleGame();
   return (
     <div
-      className="bg-white rounded-2xl p-6 shadow-xl hover:shadow-2xl transition-all duration-300 cursor-pointer hover:scale-105 transform"
+      className="bg-white rounded-2xl p-6 shadow-xl hover:shadow-2xl transition duration-300 cursor-pointer hover:scale-105 transform"
       style={{ borderTop: `6px solid ${puzzle.color}` }}
       onClick={() => handlePuzzleSelect(puzzle)}
     >
@@ -34,7 +34,7 @@ export default function PuzzleCard({ puzzle }: { puzzle: SimplePuzzle }) {
           />
           <div className="absolute inset-0 bg-gradient-to-t from-black/20 to-transparent opacity-0 hover:opacity-100 transition-opacity duration-300" />
         </div>
-        <button className="w-full bg-gradient-to-r from-blue-500 to-blue-600 hover:from-blue-600 hover:to-blue-700 text-white py-3 rounded-lg font-medium transition-all duration-200 transform hover:scale-105 shadow-lg hover:shadow-xl">
+        <button className="w-full bg-gradient-to-r from-blue-500 to-blue-600 hover:from-blue-600 hover:to-blue-700 text-white py-3 rounded-lg font-medium transition duration-200 transform hover:scale-105 shadow-lg hover:shadow-xl">
           התחל לשחק
         </button>
       </div>

--- a/gamesformykids/app/games/puzzles/simple/SimpleControls.tsx
+++ b/gamesformykids/app/games/puzzles/simple/SimpleControls.tsx
@@ -13,7 +13,7 @@ export default function SimpleControls() {
     <div className="flex justify-center gap-4 mb-6 flex-wrap">
       <button
         onClick={goToMenu}
-        className="inline-flex items-center gap-2 px-4 py-2 rounded-lg transition-all duration-200 shadow-lg hover:shadow-xl transform hover:scale-105 bg-gradient-to-r from-gray-500 to-gray-600 hover:from-gray-600 hover:to-gray-700 text-white"
+        className="inline-flex items-center gap-2 px-4 py-2 rounded-lg transition duration-200 shadow-lg hover:shadow-xl transform hover:scale-105 bg-gradient-to-r from-gray-500 to-gray-600 hover:from-gray-600 hover:to-gray-700 text-white"
       >
         <Home className="w-4 h-4" />
         <span className="hidden sm:inline">בחר פאזל אחר</span>
@@ -22,7 +22,7 @@ export default function SimpleControls() {
       <button
         onClick={resetGame}
         disabled={!gameStarted}
-        className="inline-flex items-center gap-2 px-4 py-2 rounded-lg transition-all duration-200 shadow-lg hover:shadow-xl transform hover:scale-105 bg-gradient-to-r from-orange-500 to-orange-600 hover:from-orange-600 hover:to-orange-700 text-white disabled:opacity-50 disabled:cursor-not-allowed disabled:transform-none"
+        className="inline-flex items-center gap-2 px-4 py-2 rounded-lg transition duration-200 shadow-lg hover:shadow-xl transform hover:scale-105 bg-gradient-to-r from-orange-500 to-orange-600 hover:from-orange-600 hover:to-orange-700 text-white disabled:opacity-50 disabled:cursor-not-allowed disabled:transform-none"
       >
         <RotateCcw className="w-4 h-4" />
         <span className="hidden sm:inline">התחל מחדש</span>
@@ -30,7 +30,7 @@ export default function SimpleControls() {
       </button>
       <button
         onClick={toggleHints}
-        className={`inline-flex items-center gap-2 px-4 py-2 rounded-lg transition-all duration-200 shadow-lg hover:shadow-xl transform hover:scale-105 ${
+        className={`inline-flex items-center gap-2 px-4 py-2 rounded-lg transition duration-200 shadow-lg hover:shadow-xl transform hover:scale-105 ${
           hintsEnabled
             ? 'bg-gradient-to-r from-green-500 to-green-600 hover:from-green-600 hover:to-green-700 text-white'
             : 'bg-gradient-to-r from-gray-300 to-gray-400 hover:from-gray-400 hover:to-gray-500 text-gray-700'
@@ -42,7 +42,7 @@ export default function SimpleControls() {
       </button>
       <button
         onClick={toggleDebug}
-        className={`inline-flex items-center gap-2 px-4 py-2 rounded-lg transition-all duration-200 shadow-lg hover:shadow-xl transform hover:scale-105 ${
+        className={`inline-flex items-center gap-2 px-4 py-2 rounded-lg transition duration-200 shadow-lg hover:shadow-xl transform hover:scale-105 ${
           debugMode
             ? 'bg-gradient-to-r from-red-500 to-red-600 hover:from-red-600 hover:to-red-700 text-white'
             : 'bg-gradient-to-r from-gray-300 to-gray-400 hover:from-gray-400 hover:to-gray-500 text-gray-700'

--- a/gamesformykids/app/games/puzzles/usePuzzlesMode.ts
+++ b/gamesformykids/app/games/puzzles/usePuzzlesMode.ts
@@ -1,12 +1,12 @@
 'use client';
-import { useState, useCallback } from 'react';
+import { useState } from 'react';
 
 type GameMode = 'menu' | 'simple' | 'custom';
 
 export function usePuzzlesMode() {
   const [gameMode, setGameMode] = useState<GameMode>('menu');
-  const setSimpleMode = useCallback(() => setGameMode('simple'), []);
-  const setCustomMode = useCallback(() => setGameMode('custom'), []);
+  const setSimpleMode = () => setGameMode('simple');
+  const setCustomMode = () => setGameMode('custom');
 
   return { gameMode, setSimpleMode, setCustomMode };
 }

--- a/gamesformykids/app/games/robot-coder/RobotCoderClient.tsx
+++ b/gamesformykids/app/games/robot-coder/RobotCoderClient.tsx
@@ -29,7 +29,7 @@ export default function RobotCoderClient() {
           </div>
           <button
             onClick={startGame}
-            className="w-full bg-gradient-to-r from-indigo-500 to-purple-600 hover:from-indigo-600 hover:to-purple-700 text-white font-extrabold text-xl rounded-2xl py-4 transition-all active:scale-95 shadow-md"
+            className="w-full bg-gradient-to-r from-indigo-500 to-purple-600 hover:from-indigo-600 hover:to-purple-700 text-white font-extrabold text-xl rounded-2xl py-4 transition active:scale-95 shadow-md"
           >
             🤖 בואו נתכנת!
           </button>
@@ -75,7 +75,7 @@ export default function RobotCoderClient() {
           </p>
           <button
             onClick={resetLevel}
-            className="w-full bg-gradient-to-r from-indigo-500 to-purple-600 text-white font-bold text-lg rounded-2xl py-3 transition-all active:scale-95"
+            className="w-full bg-gradient-to-r from-indigo-500 to-purple-600 text-white font-bold text-lg rounded-2xl py-3 transition active:scale-95"
           >
             נסה שוב
           </button>
@@ -105,7 +105,7 @@ export default function RobotCoderClient() {
           {level.targetWord.split('').map((letter, i) => (
             <span
               key={i}
-              className={`w-10 h-10 rounded-xl border-2 flex items-center justify-center text-xl font-bold transition-all ${
+              className={`w-10 h-10 rounded-xl border-2 flex items-center justify-center text-xl font-bold transition ${
                 i < collectedLetters.length
                   ? 'border-green-400 bg-green-300 text-green-900'
                   : 'border-white/30 text-white'

--- a/gamesformykids/app/games/robot-coder/components/CommandStrip.tsx
+++ b/gamesformykids/app/games/robot-coder/components/CommandStrip.tsx
@@ -28,7 +28,7 @@ export default function CommandStrip({ commands, maxCommands, isRunning, animSte
             onClick={() => onAdd(dir)}
             disabled={isRunning || commands.length >= maxCommands}
             title={DIR_LABELS[dir]}
-            className="w-12 h-12 rounded-xl bg-indigo-100 hover:bg-indigo-200 active:bg-indigo-300 border-2 border-indigo-300 text-indigo-700 text-2xl font-bold transition-all disabled:opacity-40 disabled:cursor-not-allowed"
+            className="w-12 h-12 rounded-xl bg-indigo-100 hover:bg-indigo-200 active:bg-indigo-300 border-2 border-indigo-300 text-indigo-700 text-2xl font-bold transition disabled:opacity-40 disabled:cursor-not-allowed"
           >
             {dir}
           </button>
@@ -42,7 +42,7 @@ export default function CommandStrip({ commands, maxCommands, isRunning, animSte
             key={i}
             onClick={() => cmd && !isRunning && onRemove(i)}
             disabled={isRunning}
-            className={`w-10 h-10 rounded-xl border-2 text-xl font-bold transition-all ${
+            className={`w-10 h-10 rounded-xl border-2 text-xl font-bold transition ${
               cmd
                 ? i === animStep - 1 && isRunning
                   ? 'border-yellow-400 bg-yellow-200 text-yellow-800 scale-110'
@@ -60,14 +60,14 @@ export default function CommandStrip({ commands, maxCommands, isRunning, animSte
         <button
           onClick={onClear}
           disabled={isRunning || commands.length === 0}
-          className="px-4 py-2 rounded-xl bg-gray-200 hover:bg-gray-300 text-gray-700 font-bold text-sm transition-all disabled:opacity-40"
+          className="px-4 py-2 rounded-xl bg-gray-200 hover:bg-gray-300 text-gray-700 font-bold text-sm transition disabled:opacity-40"
         >
           נקה
         </button>
         <button
           onClick={onRun}
           disabled={isRunning || commands.length === 0}
-          className="px-6 py-2 rounded-xl bg-green-500 hover:bg-green-600 active:bg-green-700 text-white font-extrabold text-base transition-all disabled:opacity-40 shadow-md"
+          className="px-6 py-2 rounded-xl bg-green-500 hover:bg-green-600 active:bg-green-700 text-white font-extrabold text-base transition disabled:opacity-40 shadow-md"
         >
           {isRunning ? '⚙️ רץ...' : '▶ הרץ!'}
         </button>

--- a/gamesformykids/app/games/robot-coder/components/RobotGrid.tsx
+++ b/gamesformykids/app/games/robot-coder/components/RobotGrid.tsx
@@ -40,7 +40,7 @@ export default function RobotGrid({ level, robotPos, collectedLetters }: Props) 
             return (
               <div
                 key={col}
-                className={`${cellSize} rounded-xl border-2 flex items-center justify-center font-bold relative transition-all duration-200 ${
+                className={`${cellSize} rounded-xl border-2 flex items-center justify-center font-bold relative transition duration-200 ${
                   tile
                     ? collected
                       ? 'border-gray-300 bg-gray-100 text-gray-400'

--- a/gamesformykids/app/games/shesh-besh/components/ActionButtons.tsx
+++ b/gamesformykids/app/games/shesh-besh/components/ActionButtons.tsx
@@ -26,7 +26,7 @@ export function ActionButtons() {
               'shadow-[0_4px_0_#92400e,0_6px_20px_rgba(251,191,36,0.3)]',
               'hover:shadow-[0_4px_0_#92400e,0_6px_24px_rgba(251,191,36,0.4)]',
               'active:shadow-[0_1px_0_#92400e] active:translate-y-[3px]',
-              'transition-all duration-150 text-base',
+              'transition duration-150 text-base',
             ].join(' ')}
           >
             🎲 הטל קובייות
@@ -37,7 +37,7 @@ export function ActionButtons() {
             onClick={undoMove}
             className={[
               'bg-slate-700 hover:bg-slate-600 active:scale-95 text-slate-200 font-bold',
-              'px-5 py-2.5 rounded-xl transition-all duration-150 text-sm',
+              'px-5 py-2.5 rounded-xl transition duration-150 text-sm',
               'border border-slate-500 shadow-[0_3px_0_#0f172a]',
               'active:shadow-none active:translate-y-[2px]',
             ].join(' ')}

--- a/gamesformykids/app/games/shesh-besh/components/Bar.tsx
+++ b/gamesformykids/app/games/shesh-besh/components/Bar.tsx
@@ -42,7 +42,7 @@ export function Bar({ playerBar, compBar, isSelected, onClickPlayer }: BarProps)
         onClick={onClickPlayer}
         aria-label="bar player"
         className={[
-          'relative z-10 flex flex-col-reverse items-center gap-[3px] pb-2 flex-1 justify-start w-full rounded transition-all',
+          'relative z-10 flex flex-col-reverse items-center gap-[3px] pb-2 flex-1 justify-start w-full rounded transition',
           isSelected ? 'ring-2 ring-yellow-400 ring-inset bg-yellow-400/10' : '',
         ].join(' ')}
       >

--- a/gamesformykids/app/games/shesh-besh/components/BoardPoint.tsx
+++ b/gamesformykids/app/games/shesh-besh/components/BoardPoint.tsx
@@ -21,7 +21,7 @@ export function BoardPoint({ idx, pt, isTop, isSelected, isTarget, onClick }: Bo
       aria-label={`point ${idx}`}
       className={[
         'relative flex flex-col items-center w-10 cursor-pointer select-none outline-none',
-        'transition-all duration-150 overflow-hidden',
+        'transition duration-150 overflow-hidden',
         isTop ? 'justify-start pt-0.5' : 'justify-end pb-0.5',
       ].join(' ')}
       style={{ height: '7.5rem' }}

--- a/gamesformykids/app/games/shesh-besh/components/BorneOff.tsx
+++ b/gamesformykids/app/games/shesh-besh/components/BorneOff.tsx
@@ -44,7 +44,7 @@ export function BorneOff({ playerCount, compCount, onBearOff, isBearOffTarget }:
         onClick={onBearOff}
         aria-label="bear off"
         className={[
-          'relative z-10 flex flex-col items-center gap-1.5 rounded-xl px-1 py-1.5 w-full transition-all duration-200',
+          'relative z-10 flex flex-col items-center gap-1.5 rounded-xl px-1 py-1.5 w-full transition duration-200',
           isBearOffTarget ? 'bg-emerald-500/25 ring-2 ring-emerald-400/80 scale-105' : '',
         ].join(' ')}
       >

--- a/gamesformykids/app/games/shesh-besh/components/DieChip.tsx
+++ b/gamesformykids/app/games/shesh-besh/components/DieChip.tsx
@@ -17,7 +17,7 @@ export function DieChip({ face, used }: DieChipProps) {
   const dots = DOT_POSITIONS[face] ?? [];
   return (
     <div className={[
-      'w-11 h-11 rounded-xl border-2 p-1.5 transition-all duration-300 select-none',
+      'w-11 h-11 rounded-xl border-2 p-1.5 transition duration-300 select-none',
       used
         ? 'bg-gray-800 border-gray-700 opacity-25 scale-90'
         : 'bg-white border-gray-200 scale-100 shadow-[0_4px_0_#111,0_2px_10px_rgba(0,0,0,0.6)]',

--- a/gamesformykids/app/games/shesh-besh/components/GameOverScreen.tsx
+++ b/gamesformykids/app/games/shesh-besh/components/GameOverScreen.tsx
@@ -44,7 +44,7 @@ export function GameOverScreen() {
           'active:scale-95 text-gray-900 font-extrabold text-xl px-12 py-4 rounded-2xl',
           'shadow-[0_5px_0_#92400e,0_6px_24px_rgba(251,191,36,0.3)]',
           'active:shadow-[0_2px_0_#92400e] active:translate-y-[3px]',
-          'transition-all duration-150 mt-2',
+          'transition duration-150 mt-2',
         ].join(' ')}
       >
         🔄 שחק שוב

--- a/gamesformykids/app/games/shesh-besh/components/MenuScreen.tsx
+++ b/gamesformykids/app/games/shesh-besh/components/MenuScreen.tsx
@@ -40,7 +40,7 @@ export function MenuScreen() {
           'shadow-[0_6px_0_#92400e,0_8px_30px_rgba(251,191,36,0.35)]',
           'hover:shadow-[0_6px_0_#92400e,0_8px_36px_rgba(251,191,36,0.45)]',
           'active:shadow-[0_2px_0_#92400e] active:translate-y-[4px]',
-          'transition-all duration-150',
+          'transition duration-150',
         ].join(' ')}
       >
         🎮 התחל משחק

--- a/gamesformykids/app/games/shesh-besh/components/Scoreboard.tsx
+++ b/gamesformykids/app/games/shesh-besh/components/Scoreboard.tsx
@@ -22,7 +22,7 @@ export function Scoreboard() {
         </div>
 
         <div className={[
-          'flex-1 flex items-center justify-center gap-1.5 text-xs font-extrabold px-3 py-1.5 rounded-xl border transition-all duration-300',
+          'flex-1 flex items-center justify-center gap-1.5 text-xs font-extrabold px-3 py-1.5 rounded-xl border transition duration-300',
           currentTurn === 'player'
             ? 'bg-amber-400/20 border-amber-400/50 text-amber-300'
             : 'bg-gray-800/60 border-gray-700/50 text-gray-400',

--- a/gamesformykids/app/games/simon/components/SimonBoard.tsx
+++ b/gamesformykids/app/games/simon/components/SimonBoard.tsx
@@ -28,7 +28,7 @@ export default function SimonBoard({ onTap }: Props) {
             onClick={() => onTap(btn.id)}
             disabled={phase === 'showing'}
             aria-label={btn.id}
-            className={`w-32 h-32 rounded-3xl shadow-2xl transition-all duration-100 flex items-center justify-center text-white/70 text-4xl font-black ${
+            className={`w-32 h-32 rounded-3xl shadow-2xl transition duration-100 flex items-center justify-center text-white/70 text-4xl font-black ${
               activeColor === btn.id ? btn.active + ' scale-90' : btn.bg
             } ${phase === 'input' ? 'hover:brightness-110 active:scale-90 cursor-pointer' : 'cursor-default opacity-60'}`}
           >

--- a/gamesformykids/app/games/simon/useSimonGame.ts
+++ b/gamesformykids/app/games/simon/useSimonGame.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useEffect, useRef } from 'react';
+import { useEffect, useRef } from 'react';
 import { useShallow } from 'zustand/react/shallow';
 import { useSimonStore, BUTTONS } from './simonStore';
 import { useGameCompletion } from '@/hooks/shared/progress/useGameCompletion';
@@ -15,7 +15,7 @@ export function useSimonGame() {
           setActiveColor, setPhase, setPlayerIdx, setRoundScore, setSequence, updateBest } =
     useSimonStore(useShallow((s) => s));
 
-  const flash = useCallback((id: ButtonId, ms: number): Promise<void> => {
+  const flash = (id: ButtonId, ms: number): Promise<void> => {
     return new Promise(resolve => {
       setActiveColor(id);
       setTimeout(() => {
@@ -23,9 +23,9 @@ export function useSimonGame() {
         setTimeout(resolve, 120);
       }, ms);
     });
-  }, [setActiveColor]);
+  };
 
-  const runSequence = useCallback(async (seq: ButtonId[]) => {
+  const runSequence = async (seq: ButtonId[]) => {
     setPhase('showing');
     setPlayerIdx(0);
     await new Promise(r => setTimeout(r, 500));
@@ -37,13 +37,13 @@ export function useSimonGame() {
     if (useSimonStore.getState().phase !== 'showing') return;
     setPhase('input');
     setPlayerIdx(0);
-  }, [flash, setPhase, setPlayerIdx]);
+  };
 
-  const startGame = useCallback(() => {
+  const startGame = () => {
     initGame();
     const { sequence: seq } = useSimonStore.getState();
     runSequence(seq);
-  }, [initGame, runSequence]);
+  };
 
   const { saveGameResultRef } = useGameCompletion('simon');
   const startTimeRef = useRef<number>(0);
@@ -64,7 +64,7 @@ export function useSimonGame() {
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [phase]);
 
-  const handleTap = useCallback((id: string) => {
+  const handleTap = (id: string) => {
     const { phase: currentPhase, playerIdx: idx, sequence: seq } = useSimonStore.getState();
     if (currentPhase !== 'input') return;
 
@@ -88,7 +88,7 @@ export function useSimonGame() {
       setSequence(newSeq);
       setTimeout(() => runSequence(newSeq), 900);
     }
-  }, [setActiveColor, setPhase, setPlayerIdx, setRoundScore, setSequence, updateBest, runSequence]);
+  };
 
   return { phase, activeColor, playerIdx, best, roundScore, sequenceLength: sequence.length, startGame, handleTap };
 }

--- a/gamesformykids/app/games/snake/useSnakeGame.ts
+++ b/gamesformykids/app/games/snake/useSnakeGame.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { useRef, useCallback } from 'react';
+import { useRef } from 'react';
 import { useShallow } from 'zustand/react/shallow';
 import { useGameProgressStore, useGameStore } from '@/lib/stores';
 import { useSnakeStore } from './stores/useSnakeStore';
@@ -86,7 +86,7 @@ export function useSnakeGame() {
 
   // ─── Start ──────────────────────────────────────────────────────────────────
 
-  const startGame = useCallback(() => {
+  const startGame = () => {
     const s = st.current;
     clearTimeout(s.timer as ReturnType<typeof setTimeout>);
     s.phase = 'playing';
@@ -103,8 +103,7 @@ export function useSnakeGame() {
     useGameStore.getState().startGame('snake');
     useSnakeStore.getState().setPhase('playing');
     scheduleStep();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  };
 
   // ─── Sub-hooks ───────────────────────────────────────────────────────────────
 

--- a/gamesformykids/app/games/snake/useSnakeInput.ts
+++ b/gamesformykids/app/games/snake/useSnakeInput.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useRef, useCallback, MutableRefObject } from 'react';
+import { useEffect, useRef, MutableRefObject } from 'react';
 import { type Dir, type SnakeRefs, OPPOSITE_DIR } from './snakeConstants';
 
 /**
@@ -30,11 +30,11 @@ export function useSnakeInput(st: MutableRefObject<SnakeRefs>) {
   // Touch
   const touchStart = useRef<{ x: number; y: number } | null>(null);
 
-  const handleTouchStart = useCallback((e: React.TouchEvent) => {
+  const handleTouchStart = (e: React.TouchEvent) => {
     touchStart.current = { x: e.touches[0]!.clientX, y: e.touches[0]!.clientY };
-  }, []);
+  };
 
-  const handleTouchEnd = useCallback((e: React.TouchEvent) => {
+  const handleTouchEnd = (e: React.TouchEvent) => {
     if (!touchStart.current) return;
     const dx = e.changedTouches[0]!.clientX - touchStart.current.x;
     const dy = e.changedTouches[0]!.clientY - touchStart.current.y;
@@ -47,14 +47,14 @@ export function useSnakeInput(st: MutableRefObject<SnakeRefs>) {
     if (adx > ady) newDir = dx > 0 ? 'R' : 'L';
     else newDir = dy > 0 ? 'D' : 'U';
     if (newDir !== OPPOSITE_DIR[s.dir]) s.nextDir = newDir;
-  }, [st]);
+  };
 
   // On-screen D-pad
-  const controlDir = useCallback((dir: Dir) => {
+  const controlDir = (dir: Dir) => {
     const s = st.current;
     if (s.phase !== 'playing') return;
     if (dir !== OPPOSITE_DIR[s.dir]) s.nextDir = dir;
-  }, [st]);
+  };
 
   return { handleTouchStart, handleTouchEnd, controlDir };
 }

--- a/gamesformykids/app/games/soccer/components/SoccerCategoryGrid.tsx
+++ b/gamesformykids/app/games/soccer/components/SoccerCategoryGrid.tsx
@@ -13,7 +13,7 @@ export default function SoccerCategoryGrid() {
         <button
           key={cat}
           onClick={() => startGame(cat)}
-          className={`py-3 px-4 rounded-xl font-bold text-white shadow-lg active:scale-95 transition-all bg-gradient-to-br ${CATEGORY_COLORS[cat] ?? 'from-green-500 to-emerald-600'} ${cat === 'הכל' ? 'col-span-2 py-4 text-xl' : ''}`}
+          className={`py-3 px-4 rounded-xl font-bold text-white shadow-lg active:scale-95 transition bg-gradient-to-br ${CATEGORY_COLORS[cat] ?? 'from-green-500 to-emerald-600'} ${cat === 'הכל' ? 'col-span-2 py-4 text-xl' : ''}`}
         >
           <span className="me-1">{CATEGORY_ICONS[cat] ?? '⚽'}</span> {cat}
         </button>

--- a/gamesformykids/app/games/soccer/components/SoccerProgressBar.tsx
+++ b/gamesformykids/app/games/soccer/components/SoccerProgressBar.tsx
@@ -9,7 +9,7 @@ export default function SoccerProgressBar() {
     <>
       <div className="w-full bg-white bg-opacity-20 rounded-full h-2 mb-4">
         <div
-          className="h-2 bg-yellow-400 rounded-full transition-all duration-300"
+          className="h-2 bg-yellow-400 rounded-full transition-[width] duration-300"
           style={{ width: `${progressPct}%` }}
         />
       </div>

--- a/gamesformykids/app/games/soccer/components/SoccerScoreDisplay.tsx
+++ b/gamesformykids/app/games/soccer/components/SoccerScoreDisplay.tsx
@@ -13,7 +13,7 @@ export default function SoccerScoreDisplay() {
       </div>
       <div className="w-full max-w-xs bg-white bg-opacity-20 rounded-full h-4 mb-8">
         <div
-          className="h-4 rounded-full bg-yellow-400 transition-all duration-1000"
+          className="h-4 rounded-full bg-yellow-400 transition-[width] duration-1000"
           style={{ width: `${pct}%` }}
         />
       </div>

--- a/gamesformykids/app/games/soccer/hooks/useSoccerQuestion.ts
+++ b/gamesformykids/app/games/soccer/hooks/useSoccerQuestion.ts
@@ -23,7 +23,7 @@ export function useSoccerQuestion() {
   const nextLabel = index + 1 < total ? 'הבא ⚽' : 'סיום! 🏆';
 
   function answerClass(idx: number): string {
-    let cls = 'py-3 px-4 rounded-xl font-bold text-center shadow-md active:scale-95 transition-all text-sm ';
+    let cls = 'py-3 px-4 rounded-xl font-bold text-center shadow-md active:scale-95 transition text-sm ';
     if (isAnswered) {
       if (idx === currentQuestion?.correctIndex) cls += 'bg-green-500 text-white ring-4 ring-green-300';
       else if (String(idx) === selected) cls += 'bg-red-400 text-white';

--- a/gamesformykids/app/games/space-defender/useSpaceDefenderGame.ts
+++ b/gamesformykids/app/games/space-defender/useSpaceDefenderGame.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect } from 'react';
+import { useCallback, useEffect } from 'react';
 import { useShallow } from 'zustand/react/shallow';
 import { useSpaceDefenderStore, GAME_DURATION } from './spaceDefenderStore';
 import { createCanvasArcadeHook } from '@/hooks/canvas';
@@ -134,14 +134,14 @@ export function useSpaceDefenderGame() {
   const { st, canvasRef } = _useSpaceDefender();
 
 
-  const shoot = () => {
+  const shoot = useCallback(() => {
     const s = st.current;
     if (s.phase !== 'playing') return;
     const now = s.frame;
     if (now - s.lastShot < 12) return;
     s.lastShot = now;
     s.bullets.push({ id: uid++, x: s.shipX, y: H - 80 });
-  };
+  }, []);
 
   const startGame = () => {
     const s = st.current;

--- a/gamesformykids/app/games/space-defender/useSpaceDefenderGame.ts
+++ b/gamesformykids/app/games/space-defender/useSpaceDefenderGame.ts
@@ -141,7 +141,7 @@ export function useSpaceDefenderGame() {
     if (now - s.lastShot < 12) return;
     s.lastShot = now;
     s.bullets.push({ id: uid++, x: s.shipX, y: H - 80 });
-  }, []);
+  }, [st]);
 
   const startGame = () => {
     const s = st.current;

--- a/gamesformykids/app/games/space-defender/useSpaceDefenderGame.ts
+++ b/gamesformykids/app/games/space-defender/useSpaceDefenderGame.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useCallback } from 'react';
+import { useEffect } from 'react';
 import { useShallow } from 'zustand/react/shallow';
 import { useSpaceDefenderStore, GAME_DURATION } from './spaceDefenderStore';
 import { createCanvasArcadeHook } from '@/hooks/canvas';
@@ -134,39 +134,39 @@ export function useSpaceDefenderGame() {
   const { st, canvasRef } = _useSpaceDefender();
 
 
-  const shoot = useCallback(() => {
+  const shoot = () => {
     const s = st.current;
     if (s.phase !== 'playing') return;
     const now = s.frame;
     if (now - s.lastShot < 12) return;
     s.lastShot = now;
     s.bullets.push({ id: uid++, x: s.shipX, y: H - 80 });
-  }, [st]);
+  };
 
-  const startGame = useCallback(() => {
+  const startGame = () => {
     const s = st.current;
     s.phase = 'playing';
     s.shipX = W / 2; s.bullets = []; s.asteroids = [];
     s.score = 0; s.lives = 3; s.timeLeft = GAME_DURATION; s.frame = 0; s.nextAsteroid = 60; s.lastShot = 0; s.startTime = Date.now();
     useSpaceDefenderStore.getState().startGame();
-  }, [st]);
+  };
 
 
-  const handleMouseMove = useCallback((e: React.MouseEvent<HTMLCanvasElement>) => {
+  const handleMouseMove = (e: React.MouseEvent<HTMLCanvasElement>) => {
     const canvas = canvasRef.current;
     if (!canvas) return;
     const rect = canvas.getBoundingClientRect();
     const scaleX = W / rect.width;
     st.current.shipX = Math.max(SHIP_W / 2, Math.min(W - SHIP_W / 2, (e.clientX - rect.left) * scaleX));
-  }, [st, canvasRef]);
+  };
 
-  const handleCanvasClick = useCallback(() => {
+  const handleCanvasClick = () => {
     const s = st.current;
     if (s.phase === 'playing') { shoot(); return; }
     if (s.phase === 'menu') startGame();
-  }, [st, shoot, startGame]);
+  };
 
-  const handleTouchMove = useCallback((e: React.TouchEvent<HTMLCanvasElement>) => {
+  const handleTouchMove = (e: React.TouchEvent<HTMLCanvasElement>) => {
     e.preventDefault();
     const canvas = canvasRef.current;
     if (!canvas) return;
@@ -174,12 +174,12 @@ export function useSpaceDefenderGame() {
     const scaleX = W / rect.width;
     st.current.shipX = Math.max(SHIP_W / 2, Math.min(W - SHIP_W / 2, (e.touches[0]!.clientX - rect.left) * scaleX));
     shoot();
-  }, [st, canvasRef, shoot]);
+  };
 
-  const handleTouchStart = useCallback((e: React.TouchEvent<HTMLCanvasElement>) => {
+  const handleTouchStart = (e: React.TouchEvent<HTMLCanvasElement>) => {
     e.preventDefault();
     if (st.current.phase !== 'playing') startGame();
-  }, [st, startGame]);
+  };
 
   useEffect(() => {
     let leftDown = false, rightDown = false;

--- a/gamesformykids/app/games/stack/components/StackDropButton.tsx
+++ b/gamesformykids/app/games/stack/components/StackDropButton.tsx
@@ -8,7 +8,7 @@ export default function StackDropButton({ onDrop }: Props) {
   return (
     <button
       onClick={onDrop}
-      className="mt-4 bg-blue-600/80 text-white rounded-2xl px-14 py-4 font-black text-2xl active:bg-blue-400 transition-all touch-none"
+      className="mt-4 bg-blue-600/80 text-white rounded-2xl px-14 py-4 font-black text-2xl active:bg-blue-400 transition touch-none"
     >
       ⬇ הפל!
     </button>

--- a/gamesformykids/app/games/stack/useStackGame.ts
+++ b/gamesformykids/app/games/stack/useStackGame.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect } from 'react';
+import { useCallback, useEffect } from 'react';
 import { useShallow } from 'zustand/react/shallow';
 import { useStackStore } from './stackStore';
 import { createCanvasArcadeHook } from '@/hooks/canvas';
@@ -98,7 +98,7 @@ export function useStackGame() {
     useStackStore.getState().startPlaying();
   };
 
-  const drop = () => {
+  const drop = useCallback(() => {
     const s = st.current;
     if (s.phase !== 'playing') return;
 
@@ -127,7 +127,7 @@ export function useStackGame() {
     const topWorldY = sliderWorldY;
     s.camOffset = Math.max(0, TARGET_TOP - topWorldY);
     useStackStore.getState().setScore(s.score);
-  };
+  }, []);
 
   const handleCanvasClick = () => {
     if (st.current.phase === 'playing') drop();

--- a/gamesformykids/app/games/stack/useStackGame.ts
+++ b/gamesformykids/app/games/stack/useStackGame.ts
@@ -127,7 +127,7 @@ export function useStackGame() {
     const topWorldY = sliderWorldY;
     s.camOffset = Math.max(0, TARGET_TOP - topWorldY);
     useStackStore.getState().setScore(s.score);
-  }, []);
+  }, [saveGameResultRef, st]);
 
   const handleCanvasClick = () => {
     if (st.current.phase === 'playing') drop();

--- a/gamesformykids/app/games/stack/useStackGame.ts
+++ b/gamesformykids/app/games/stack/useStackGame.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useCallback } from 'react';
+import { useEffect } from 'react';
 import { useShallow } from 'zustand/react/shallow';
 import { useStackStore } from './stackStore';
 import { createCanvasArcadeHook } from '@/hooks/canvas';
@@ -87,7 +87,7 @@ export function useStackGame() {
   const { st, canvasRef, saveGameResultRef } = _useStack();
 
 
-  const startGame = useCallback(() => {
+  const startGame = () => {
     const s = st.current;
     s.phase = 'playing';
     s.score = 0; s.frame = 0; s.camOffset = 0;
@@ -96,9 +96,9 @@ export function useStackGame() {
     s.blocks = [{ x: (W - INIT_W) / 2, y: FLOOR_Y, w: INIT_W, color: '#6b7280' }];
     s.startTime = Date.now();
     useStackStore.getState().startPlaying();
-  }, [st]);
+  };
 
-  const drop = useCallback(() => {
+  const drop = () => {
     const s = st.current;
     if (s.phase !== 'playing') return;
 
@@ -127,12 +127,12 @@ export function useStackGame() {
     const topWorldY = sliderWorldY;
     s.camOffset = Math.max(0, TARGET_TOP - topWorldY);
     useStackStore.getState().setScore(s.score);
-  }, [st, saveGameResultRef]);
+  };
 
-  const handleCanvasClick = useCallback(() => {
+  const handleCanvasClick = () => {
     if (st.current.phase === 'playing') drop();
     else if (st.current.phase === 'menu') startGame();
-  }, [st, drop, startGame]);
+  };
 
 
   useEffect(() => {

--- a/gamesformykids/app/games/tetris/components/GameBoard.tsx
+++ b/gamesformykids/app/games/tetris/components/GameBoard.tsx
@@ -9,7 +9,7 @@ const GameBoard = ({ displayBoard }: GameBoardProps) => (
           return (
             <div
               key={`${y}-${x}`}
-              className={`w-4 h-4 lg:w-6 lg:h-6 rounded-md border border-gray-600/50 ${isEmpty ? '' : 'transform transition-all duration-150'}`}
+              className={`w-4 h-4 lg:w-6 lg:h-6 rounded-md border border-gray-600/50 ${isEmpty ? '' : 'transform transition duration-150'}`}
               style={{
                 background: isEmpty 
                   ? 'linear-gradient(135deg, #1f2937 0%, #111827 100%)' 

--- a/gamesformykids/app/games/tetris/components/useTouchControls.ts
+++ b/gamesformykids/app/games/tetris/components/useTouchControls.ts
@@ -1,6 +1,5 @@
 'use client';
 
-import { useCallback } from 'react';
 import { useTetrisStore } from '../store/tetrisStore';
 
 export function useTouchControls() {
@@ -8,18 +7,15 @@ export function useTouchControls() {
   const movePiece = useTetrisStore(s => s.movePiece);
   const handleRotateAction = useTetrisStore(s => s.handleRotate);
 
-  const handleMove = useCallback(
-    (dx: number, dy: number) => {
-      if (!isGameRunning) return;
-      movePiece(dx, dy);
-    },
-    [isGameRunning, movePiece]
-  );
+  const handleMove = (dx: number, dy: number) => {
+    if (!isGameRunning) return;
+    movePiece(dx, dy);
+  };
 
-  const handleRotate = useCallback(() => {
+  const handleRotate = () => {
     if (!isGameRunning) return;
     handleRotateAction();
-  }, [isGameRunning, handleRotateAction]);
+  };
 
   return { handleMove, handleRotate };
 }

--- a/gamesformykids/app/games/transport/components/TransportMenuScreen.tsx
+++ b/gamesformykids/app/games/transport/components/TransportMenuScreen.tsx
@@ -18,7 +18,7 @@ export default function TransportMenuScreen({ types, onStart }: Props) {
       title="כלי תחבורה"
       description="גלה כלי רכב מהיבשה, הים והאוויר!"
       categories={types}
-      categoryClassName={type => `py-3 px-4 rounded-xl font-bold text-white shadow-md active:scale-95 transition-all bg-gradient-to-r ${TYPE_STYLES[type].color} ${type === 'הכל' ? 'col-span-2' : ''}`}
+      categoryClassName={type => `py-3 px-4 rounded-xl font-bold text-white shadow-md active:scale-95 transition bg-gradient-to-r ${TYPE_STYLES[type].color} ${type === 'הכל' ? 'col-span-2' : ''}`}
       categoryLabel={type => `${TYPE_STYLES[type].icon} ${type}`}
       gridCols={2}
       onStart={onStart}

--- a/gamesformykids/app/games/transport/components/TransportQuestion.tsx
+++ b/gamesformykids/app/games/transport/components/TransportQuestion.tsx
@@ -40,7 +40,7 @@ export default function TransportQuestion({
         <div className="grid grid-cols-2 gap-3 w-full max-w-md">
           {currentQuestion.answers.map((ans, idx) => (
             <button key={idx} onClick={() => onSelect(idx)} disabled={answered}
-              className={`py-3 px-4 rounded-xl font-bold text-center shadow active:scale-95 transition-all ${answerButtonClass(
+              className={`py-3 px-4 rounded-xl font-bold text-center shadow active:scale-95 transition ${answerButtonClass(
                 idx === currentQuestion.correctIndex,
                 idx === selected,
                 answered,

--- a/gamesformykids/app/games/true-false/components/TrueFalsePlayScreen.tsx
+++ b/gamesformykids/app/games/true-false/components/TrueFalsePlayScreen.tsx
@@ -20,11 +20,11 @@ export default function TrueFalsePlayScreen() {
           <LivesDisplay lives={lives} />
         </div>
         <div>
-          <p className={`font-black transition-all ${timeLeft <= 2 ? 'text-orange-500 text-3xl scale-110' : 'text-cyan-600 text-2xl'}`}>{timeLeft}</p>
+          <p className={`font-black transition ${timeLeft <= 2 ? 'text-orange-500 text-3xl scale-110' : 'text-cyan-600 text-2xl'}`}>{timeLeft}</p>
           <p className="text-xs text-cyan-400">שניות</p>
         </div>
       </div>
-      <div className={`w-full max-w-sm bg-white rounded-3xl p-6 text-center shadow-2xl mb-6 transition-all duration-200 ${
+      <div className={`w-full max-w-sm bg-white rounded-3xl p-6 text-center shadow-2xl mb-6 transition duration-200 ${
         feedback === 'correct' ? 'ring-4 ring-green-400 bg-green-50' :
         feedback === 'wrong'   ? 'ring-4 ring-amber-400 bg-amber-50' : ''
       }`}>
@@ -37,7 +37,7 @@ export default function TrueFalsePlayScreen() {
         )}
         <div className="mt-4 bg-gray-100 rounded-full h-2">
           <div
-            className="bg-gradient-to-r from-teal-400 to-cyan-500 h-2 rounded-full transition-all duration-1000"
+            className="bg-gradient-to-r from-teal-400 to-cyan-500 h-2 rounded-full transition-[width] duration-1000"
             style={{ width: `${(timeLeft / TIME_PER_Q) * 100}%` }}
           />
         </div>
@@ -46,12 +46,12 @@ export default function TrueFalsePlayScreen() {
         <button
           onClick={() => answer(true)}
           disabled={!!feedback}
-          className="flex-1 py-6 rounded-3xl bg-green-500 text-white font-black text-5xl shadow-xl active:scale-90 hover:bg-green-400 transition-all disabled:opacity-60"
+          className="flex-1 py-6 rounded-3xl bg-green-500 text-white font-black text-5xl shadow-xl active:scale-90 hover:bg-green-400 transition disabled:opacity-60"
         >✅</button>
         <button
           onClick={() => answer(false)}
           disabled={!!feedback}
-          className="flex-1 py-6 rounded-3xl bg-red-500 text-white font-black text-5xl shadow-xl active:scale-90 hover:bg-red-400 transition-all disabled:opacity-60"
+          className="flex-1 py-6 rounded-3xl bg-red-500 text-white font-black text-5xl shadow-xl active:scale-90 hover:bg-red-400 transition disabled:opacity-60"
         >❌</button>
       </div>
       <KeyboardHint

--- a/gamesformykids/app/games/tzadikim/components/CompleteView.tsx
+++ b/gamesformykids/app/games/tzadikim/components/CompleteView.tsx
@@ -32,7 +32,7 @@ export default function CompleteView({ score, maxScore, onRestart }: CompleteVie
           {/* כוכבים */}
           <div className="flex justify-center gap-1 mb-6">
             {Array.from({ length: 5 }).map((_, i) => (
-              <span key={i} className={`text-4xl transition-all ${i < stars ? 'opacity-100 scale-110' : 'opacity-20'}`}>
+              <span key={i} className={`text-4xl transition ${i < stars ? 'opacity-100 scale-110' : 'opacity-20'}`}>
                 ⭐
               </span>
             ))}
@@ -44,7 +44,7 @@ export default function CompleteView({ score, maxScore, onRestart }: CompleteVie
             <p className="text-amber-600">נקודות</p>
             <div className="mt-3 h-3 bg-amber-100 rounded-full overflow-hidden">
               <div
-                className="h-full bg-amber-400 rounded-full transition-all duration-1000"
+                className="h-full bg-amber-400 rounded-full transition-[width] duration-1000"
                 style={{ width: `${percent}%` }}
               />
             </div>
@@ -68,7 +68,7 @@ export default function CompleteView({ score, maxScore, onRestart }: CompleteVie
             onClick={onRestart}
             className="w-full py-4 rounded-2xl text-white font-bold text-xl shadow-lg
               bg-gradient-to-l from-amber-500 to-orange-500
-              hover:opacity-90 active:scale-95 transition-all"
+              hover:opacity-90 active:scale-95 transition"
           >
             🔄 שחק שוב
           </button>

--- a/gamesformykids/app/games/tzadikim/components/QuizView.tsx
+++ b/gamesformykids/app/games/tzadikim/components/QuizView.tsx
@@ -35,7 +35,7 @@ export default function QuizView({
           <p className="text-gray-500 text-sm">שאלה {questionIndex + 1} מתוך {totalQuestions}</p>
           <div className="mt-3 h-2.5 bg-gray-200 rounded-full overflow-hidden">
             <div
-              className={`h-full rounded-full bg-gradient-to-l ${story.color} transition-all duration-500`}
+              className={`h-full rounded-full bg-gradient-to-l ${story.color} transition-[width] duration-500`}
               style={{ width: `${(questionIndex / totalQuestions) * 100}%` }}
             />
           </div>

--- a/gamesformykids/app/games/tzadikim/components/StoryMenuView.tsx
+++ b/gamesformykids/app/games/tzadikim/components/StoryMenuView.tsx
@@ -39,7 +39,7 @@ export default function StoryMenuView({
               key={story.id}
               onClick={() => onSelectStory(index)}
               className={`
-                w-full text-right p-5 rounded-2xl border-2 transition-all duration-200
+                w-full text-right p-5 rounded-2xl border-2 transition duration-200
                 shadow-md hover:shadow-lg hover:scale-[1.01] active:scale-[0.99]
                 ${index < currentIndex
                   ? 'bg-green-50 border-green-300 opacity-80'

--- a/gamesformykids/app/games/tzadikim/components/StoryReadingView.tsx
+++ b/gamesformykids/app/games/tzadikim/components/StoryReadingView.tsx
@@ -74,7 +74,7 @@ export default function StoryReadingView({
           className={`
             w-full py-5 rounded-2xl text-white font-bold text-xl shadow-lg
             bg-gradient-to-l ${story.color}
-            hover:opacity-90 active:scale-95 transition-all duration-200
+            hover:opacity-90 active:scale-95 transition duration-200
           `}
         >
           🧠 לחידון על הסיפור! ←

--- a/gamesformykids/app/games/tzadikim/useTzadikimGame.ts
+++ b/gamesformykids/app/games/tzadikim/useTzadikimGame.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useCallback } from 'react';
+import { useState } from 'react';
 import { TZADIKIM_STORIES, TzaddikStory } from './data/tzadikim';
 import { useQuizQuestionState } from '@/lib/quiz/useQuizQuestionState';
 
@@ -30,18 +30,18 @@ export function useTzadikimGame() {
     onComplete: () => setPhase('result'),
   });
 
-  const startStory = useCallback((index: number) => {
+  const startStory = (index: number) => {
     setStoryIndex(index);
     resetQuestionState();
     setPhase('story');
-  }, [resetQuestionState]);
+  };
 
-  const startQuiz = useCallback(() => {
+  const startQuiz = () => {
     resetQuestionState();
     setPhase('quiz');
-  }, [resetQuestionState]);
+  };
 
-  const nextStory = useCallback(() => {
+  const nextStory = () => {
     if (storyIndex < totalStories - 1) {
       setStoryIndex(prev => prev + 1);
       resetQuestionState();
@@ -49,16 +49,16 @@ export function useTzadikimGame() {
     } else {
       setPhase('complete');
     }
-  }, [storyIndex, totalStories, resetQuestionState]);
+  };
 
-  const backToMenu = useCallback(() => setPhase('menu'), []);
+  const backToMenu = () => setPhase('menu');
 
-  const restartGame = useCallback(() => {
+  const restartGame = () => {
     setPhase('menu');
     setStoryIndex(0);
     setScore(0);
     resetQuestionState();
-  }, [resetQuestionState]);
+  };
 
   const progressPercent = Math.round((storyIndex / totalStories) * 100);
 

--- a/gamesformykids/app/games/tzedakah/components/GameControls.tsx
+++ b/gamesformykids/app/games/tzedakah/components/GameControls.tsx
@@ -10,7 +10,7 @@ export default function GameControls() {
       {!gameStarted && gameTime > 0 && (
         <button
           onClick={startGame}
-          className={`bg-gradient-to-r from-green-500 to-emerald-600 hover:from-green-600 hover:to-emerald-700 text-white font-bold rounded-2xl shadow-2xl transform hover:scale-105 transition-all duration-300 border-2 border-green-300 ${
+          className={`bg-gradient-to-r from-green-500 to-emerald-600 hover:from-green-600 hover:to-emerald-700 text-white font-bold rounded-2xl shadow-2xl transform hover:scale-105 transition duration-300 border-2 border-green-300 ${
             isMobile ? 'py-3 px-6 text-lg' : 'py-4 px-8 text-2xl'
           }`}
         >
@@ -35,7 +35,7 @@ export default function GameControls() {
           <div className="flex flex-col gap-3">
             <button
               onClick={startGame}
-              className={`bg-gradient-to-r from-blue-500 to-purple-600 hover:from-blue-600 hover:to-purple-700 text-white font-bold rounded-xl transition-all duration-300 transform hover:scale-105 shadow-lg ${
+              className={`bg-gradient-to-r from-blue-500 to-purple-600 hover:from-blue-600 hover:to-purple-700 text-white font-bold rounded-xl transition duration-300 transform hover:scale-105 shadow-lg ${
                 isMobile ? 'py-2 px-4 text-sm' : 'py-3 px-6'
               }`}
             >

--- a/gamesformykids/app/games/whack-a-mole/useWhackAMoleGame.ts
+++ b/gamesformykids/app/games/whack-a-mole/useWhackAMoleGame.ts
@@ -1,5 +1,5 @@
 'use client';
-import { useCallback, useEffect, useRef } from 'react';
+import { useEffect, useRef } from 'react';
 import { createShallowHook } from '@/lib/stores/utils/sliceUtils';
 import { useWhackAMoleStore, GAME_DURATION, MOLES, BAD } from './whackAMoleStore';
 import { useGameCompletion } from '@/hooks/shared/progress/useGameCompletion';
@@ -75,14 +75,14 @@ export function useWhackAMoleGame() {
   }, [state.phase]);
 
   // Wrap whack to cancel auto-hide timer + schedule clear after hit/miss animation
-  const whack = useCallback((idx: number) => {
+  const whack = (idx: number) => {
     if (moleTimersRef.current[idx]) {
       clearTimeout(moleTimersRef.current[idx]!);
       moleTimersRef.current[idx] = null;
     }
     store.getState().whack(idx);
     setTimeout(() => store.getState().clearHole(idx), 300);
-  }, [store]);
+  };
 
   const pct     = (state.timeLeft / GAME_DURATION) * 100;
   const bgColor = state.timeLeft <= 10 ? 'from-red-100 to-rose-200' : 'from-yellow-50 to-amber-100';

--- a/gamesformykids/app/games/word-builder/components/WordBuilderQuestion.tsx
+++ b/gamesformykids/app/games/word-builder/components/WordBuilderQuestion.tsx
@@ -18,7 +18,7 @@ export default function WordBuilderQuestion() {
           <span className="text-orange-700 font-bold">⭐ {score}</span>
         </div>
         <div className="h-2 bg-gray-200 rounded-full mb-5">
-          <div className="h-full bg-orange-400 rounded-full transition-all" style={{ width: `${(index / total) * 100}%` }} />
+          <div className="h-full bg-orange-400 rounded-full transition-[width]" style={{ width: `${(index / total) * 100}%` }} />
         </div>
         <div className="bg-white rounded-3xl shadow-xl p-6 mb-5 text-center">
           <div className="text-7xl mb-2">{current.emoji}</div>
@@ -55,7 +55,7 @@ export default function WordBuilderQuestion() {
                 key={i}
                 onClick={() => pressLetter(i)}
                 disabled={item.used}
-                className={`w-12 h-12 rounded-xl text-2xl font-black transition-all active:scale-90
+                className={`w-12 h-12 rounded-xl text-2xl font-black transition active:scale-90
                   ${item.used ? 'bg-gray-200 text-gray-400 cursor-not-allowed' :
                     'bg-amber-500 text-white shadow-md hover:bg-amber-400 hover:scale-110'}`}
               >
@@ -66,17 +66,17 @@ export default function WordBuilderQuestion() {
         )}
         <div className="flex gap-3">
           {status === 'idle' && typed.length > 0 && (
-            <button onClick={clearTyped} className="flex-1 py-3 rounded-2xl border-2 border-orange-300 text-orange-600 font-semibold hover:bg-orange-50 transition-all">
+            <button onClick={clearTyped} className="flex-1 py-3 rounded-2xl border-2 border-orange-300 text-orange-600 font-semibold hover:bg-orange-50 transition">
               🔄 נקה
             </button>
           )}
           {(status === 'correct' || status === 'wrong') && (
-            <button onClick={next} className="flex-1 py-4 rounded-2xl text-white font-bold text-xl bg-gradient-to-l from-orange-500 to-amber-500 shadow-lg hover:opacity-90 active:scale-95 transition-all">
+            <button onClick={next} className="flex-1 py-4 rounded-2xl text-white font-bold text-xl bg-gradient-to-l from-orange-500 to-amber-500 shadow-lg hover:opacity-90 active:scale-95 transition">
               {index < total - 1 ? 'מילה הבאה ←' : 'תוצאות! 🎉'}
             </button>
           )}
           {status === 'wrong' && (
-            <button onClick={clearTyped} className="flex-1 py-4 rounded-2xl border-2 border-gray-200 text-gray-600 font-semibold hover:bg-gray-50 transition-all">
+            <button onClick={clearTyped} className="flex-1 py-4 rounded-2xl border-2 border-gray-200 text-gray-600 font-semibold hover:bg-gray-50 transition">
               🔄 נסה שוב
             </button>
           )}

--- a/gamesformykids/app/games/word-scramble/components/WordScramblePlayScreen.tsx
+++ b/gamesformykids/app/games/word-scramble/components/WordScramblePlayScreen.tsx
@@ -15,7 +15,7 @@ export default function WordScramblePlayScreen() {
         <div><p className="text-lg font-bold text-gray-500">{wIdx + 1}/{words.length}</p></div>
         <LivesDisplay lives={lives} size="text-base" />
       </div>
-      <div className={`bg-white rounded-3xl p-6 shadow-2xl max-w-sm w-full text-center transition-all duration-200 ${shake ? 'animate-shake' : ''}`}>
+      <div className={`bg-white rounded-3xl p-6 shadow-2xl max-w-sm w-full text-center transition duration-200 ${shake ? 'animate-shake' : ''}`}>
         <div className="text-7xl mb-2">{entry.emoji}</div>
         <p className="text-gray-400 text-sm mb-4">{entry.hint}</p>
         <div className="flex justify-center gap-2 mb-6 flex-wrap">
@@ -23,7 +23,7 @@ export default function WordScramblePlayScreen() {
             <button
               key={i}
               onClick={() => picked[i] && unpick(i)}
-              className={`w-12 h-12 rounded-xl border-2 text-xl font-black transition-all
+              className={`w-12 h-12 rounded-xl border-2 text-xl font-black transition
                 ${picked[i]
                   ? correct
                     ? 'border-green-400 bg-green-100 text-green-700'
@@ -41,7 +41,7 @@ export default function WordScramblePlayScreen() {
               key={l.idx}
               onClick={() => pickLetter(l.idx)}
               disabled={l.picked}
-              className={`w-12 h-12 rounded-xl text-xl font-black transition-all
+              className={`w-12 h-12 rounded-xl text-xl font-black transition
                 ${l.picked
                   ? 'bg-gray-100 text-gray-300 border-2 border-gray-200 cursor-default'
                   : 'bg-gradient-to-br from-emerald-400 to-green-600 text-white shadow-md active:scale-90 hover:scale-110 border-2 border-green-600'}`}

--- a/gamesformykids/app/games/word-search/WordSearchClient.tsx
+++ b/gamesformykids/app/games/word-search/WordSearchClient.tsx
@@ -1,5 +1,4 @@
 'use client';
-import { useCallback } from 'react';
 import { useWordSearchStore } from './wordSearchStore';
 import SearchGrid from './components/SearchGrid';
 import GameResultCard from '@/components/game/shared/GameResultCard';
@@ -12,7 +11,7 @@ export default function WordSearchClient() {
     startGame, submitSelection, resetGame,
   } = useWordSearchStore();
 
-  const handleSelect = useCallback((cells: Array<[number, number]>) => {
+  const handleSelect = (cells: Array<[number, number]>) => {
     const ok = submitSelection(cells);
     if (ok) {
       const { found: newFound, placed: ps } = useWordSearchStore.getState();
@@ -20,7 +19,7 @@ export default function WordSearchClient() {
       if (justFound) speakHebrew(justFound.word);
     }
     return ok;
-  }, [submitSelection, found]);
+  };
 
   if (phase === 'menu') {
     return (

--- a/gamesformykids/app/games/word-search/WordSearchClient.tsx
+++ b/gamesformykids/app/games/word-search/WordSearchClient.tsx
@@ -34,7 +34,7 @@ export default function WordSearchClient() {
               <button
                 key={ws.name}
                 onClick={() => startGame(i)}
-                className="bg-gradient-to-br from-emerald-400 to-teal-500 hover:from-emerald-500 hover:to-teal-600 text-white font-bold rounded-2xl py-4 px-3 flex flex-col items-center gap-1 transition-all active:scale-95 shadow-md"
+                className="bg-gradient-to-br from-emerald-400 to-teal-500 hover:from-emerald-500 hover:to-teal-600 text-white font-bold rounded-2xl py-4 px-3 flex flex-col items-center gap-1 transition active:scale-95 shadow-md"
               >
                 <span className="text-3xl">{ws.emoji}</span>
                 <span className="text-sm">{ws.name}</span>
@@ -88,7 +88,7 @@ export default function WordSearchClient() {
         {placed.map(pw => (
           <span
             key={pw.word}
-            className={`px-2 py-0.5 rounded-full text-sm font-bold transition-all ${
+            className={`px-2 py-0.5 rounded-full text-sm font-bold transition ${
               found.has(pw.word)
                 ? 'bg-green-300 text-green-900 line-through opacity-60'
                 : 'bg-white/20 text-white'

--- a/gamesformykids/app/games/word-search/components/SearchGrid.tsx
+++ b/gamesformykids/app/games/word-search/components/SearchGrid.tsx
@@ -1,5 +1,5 @@
 'use client';
-import { useRef, useState, useCallback } from 'react';
+import { useRef, useState, useCallback, useEffect } from 'react';
 import type { PlacedWord } from '../wordSearchStore';
 import { GRID_SIZE } from '../wordSearchStore';
 
@@ -37,6 +37,8 @@ function cellKey(r: number, c: number) { return `${r},${c}`; }
 
 export default function SearchGrid({ grid, placed, found, onSelect }: Props) {
   const containerRef = useRef<HTMLDivElement>(null);
+  const wrongFlashTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+  useEffect(() => () => clearTimeout(wrongFlashTimerRef.current), []);
   const [dragging, setDragging] = useState(false);
   const [startCell, setStartCell] = useState<CellCoord | null>(null);
   const [currentCell, setCurrentCell] = useState<CellCoord | null>(null);
@@ -90,7 +92,8 @@ export default function SearchGrid({ grid, placed, found, onSelect }: Props) {
     if (!found) {
       const keys = new Set(cells.map(([r, c]) => cellKey(r, c)));
       setWrongFlash(keys);
-      setTimeout(() => setWrongFlash(new Set()), 400);
+      clearTimeout(wrongFlashTimerRef.current);
+      wrongFlashTimerRef.current = setTimeout(() => setWrongFlash(new Set()), 400);
     }
     setStartCell(null);
     setCurrentCell(null);

--- a/gamesformykids/app/games/word-search/components/SearchGrid.tsx
+++ b/gamesformykids/app/games/word-search/components/SearchGrid.tsx
@@ -1,5 +1,5 @@
 'use client';
-import { useRef, useState, useCallback, useEffect } from 'react';
+import { useRef, useState, useEffect } from 'react';
 import type { PlacedWord } from '../wordSearchStore';
 import { GRID_SIZE } from '../wordSearchStore';
 
@@ -51,7 +51,7 @@ export default function SearchGrid({ grid, placed, found, onSelect }: Props) {
     });
   });
 
-  const getCellFromPoint = useCallback((clientX: number, clientY: number): CellCoord | null => {
+  const getCellFromPoint = (clientX: number, clientY: number): CellCoord | null => {
     const el = containerRef.current;
     if (!el) return null;
     const rect = el.getBoundingClientRect();
@@ -61,12 +61,12 @@ export default function SearchGrid({ grid, placed, found, onSelect }: Props) {
     const row = Math.floor((clientY - rect.top) / cellH);
     if (row < 0 || row >= GRID_SIZE || col < 0 || col >= GRID_SIZE) return null;
     return [row, col];
-  }, []);
+  };
 
   const selection = (startCell && currentCell) ? getLineCells(startCell, currentCell) : [];
   const selectionKeys = new Set(selection.map(([r, c]) => cellKey(r, c)));
 
-  const handlePointerDown = useCallback((e: React.PointerEvent) => {
+  const handlePointerDown = (e: React.PointerEvent) => {
     e.preventDefault();
     const cell = getCellFromPoint(e.clientX, e.clientY);
     if (!cell) return;
@@ -74,16 +74,16 @@ export default function SearchGrid({ grid, placed, found, onSelect }: Props) {
     setDragging(true);
     setStartCell(cell);
     setCurrentCell(cell);
-  }, [getCellFromPoint]);
+  };
 
-  const handlePointerMove = useCallback((e: React.PointerEvent) => {
+  const handlePointerMove = (e: React.PointerEvent) => {
     if (!dragging) return;
     e.preventDefault();
     const cell = getCellFromPoint(e.clientX, e.clientY);
     if (cell) setCurrentCell(cell);
-  }, [dragging, getCellFromPoint]);
+  };
 
-  const handlePointerUp = useCallback((_e: React.PointerEvent) => {
+  const handlePointerUp = (_e: React.PointerEvent) => {
     if (!dragging || !startCell || !currentCell) return;
     setDragging(false);
     const cells = getLineCells(startCell, currentCell);
@@ -97,7 +97,7 @@ export default function SearchGrid({ grid, placed, found, onSelect }: Props) {
     }
     setStartCell(null);
     setCurrentCell(null);
-  }, [dragging, startCell, currentCell, onSelect]);
+  };
 
   return (
     <div

--- a/gamesformykids/components/game/quiz/screens/StoryBuilderResult.tsx
+++ b/gamesformykids/components/game/quiz/screens/StoryBuilderResult.tsx
@@ -1,5 +1,4 @@
 'use client';
-import { useCallback } from 'react';
 import type { StoryTemplate } from '@/lib/quiz/data/storyBuilderData';
 import { speakHebrew } from '@/lib/utils/speech/enhancedSpeechUtils';
 
@@ -10,9 +9,9 @@ interface Props {
 }
 
 export default function StoryBuilderResult({ story, completedStory, onRestart }: Props) {
-  const handleRead = useCallback(() => {
+  const handleRead = () => {
     speakHebrew(completedStory);
-  }, [completedStory]);
+  };
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-yellow-100 to-pink-100 flex items-center justify-center p-4">

--- a/gamesformykids/components/game/quiz/screens/useLifeCyclesInteraction.ts
+++ b/gamesformykids/components/game/quiz/screens/useLifeCyclesInteraction.ts
@@ -1,5 +1,5 @@
 'use client';
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect } from 'react';
 import { useQuizGameStore } from '@/lib/stores';
 import type { LifeCycleQuestion } from '@/lib/quiz/data/life-cycles';
 
@@ -24,7 +24,7 @@ export function useLifeCyclesInteraction(current: LifeCycleQuestion, onComplete:
     return () => clearTimeout(t);
   }, [isCorrect, nextQuestion]);
 
-  const tapStage = useCallback((stageIndex: number) => {
+  const tapStage = (stageIndex: number) => {
     if (isCorrect !== null) return;
     const nextExpected = placed.length;
     if (stageIndex === nextExpected) {
@@ -38,7 +38,7 @@ export function useLifeCyclesInteraction(current: LifeCycleQuestion, onComplete:
       setWrongIdx(stageIndex);
       setTimeout(() => setWrongIdx(null), 500);
     }
-  }, [isCorrect, placed, onComplete]);
+  };
 
   return { placed, shuffled, wrongIdx, isCorrect, tapStage };
 }

--- a/gamesformykids/components/game/quiz/screens/usePhonicsInteraction.ts
+++ b/gamesformykids/components/game/quiz/screens/usePhonicsInteraction.ts
@@ -1,12 +1,12 @@
 'use client';
-import { useCallback, useEffect } from 'react';
+import { useEffect } from 'react';
 import { speakHebrew } from '@/lib/utils/speech/enhancedSpeechUtils';
 import type { PhonicsQuestion } from '@/lib/quiz/data/phonics';
 
 export function usePhonicsInteraction(current: PhonicsQuestion) {
-  const speak = useCallback(() => {
+  const speak = () => {
     speakHebrew(current.sound).catch(() => {});
-  }, [current.sound]);
+  };
 
   // Auto-play on each new question so pre-readers don't need to tap first
   useEffect(() => {

--- a/gamesformykids/components/game/shared/FullscreenToggle.tsx
+++ b/gamesformykids/components/game/shared/FullscreenToggle.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect } from 'react';
 
 export function FullscreenToggle() {
   const [isFullscreen, setIsFullscreen] = useState(false);
@@ -13,7 +13,7 @@ export function FullscreenToggle() {
     return () => document.removeEventListener('fullscreenchange', onChange);
   }, []);
 
-  const toggle = useCallback(async () => {
+  const toggle = async () => {
     try {
       if (document.fullscreenElement) {
         await document.exitFullscreen();
@@ -23,7 +23,7 @@ export function FullscreenToggle() {
     } catch {
       // browser denied or not supported — ignore
     }
-  }, []);
+  };
 
   if (!supported) return null;
 

--- a/gamesformykids/tsconfig.json
+++ b/gamesformykids/tsconfig.json
@@ -1,7 +1,11 @@
 {
   "compilerOptions": {
     "target": "ES2022",
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
@@ -13,7 +17,7 @@
     "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "preserve",
+    "jsx": "react-jsx",
     "incremental": true,
     "plugins": [
       {
@@ -21,9 +25,19 @@
       }
     ],
     "paths": {
-      "@/*": ["./*"]
+      "@/*": [
+        "./*"
+      ]
     }
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
-  "exclude": ["node_modules"]
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts",
+    ".next/dev/types/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
 }


### PR DESCRIPTION
## Summary

- **R3 — React Compiler bail-out fix** (`escape-room/PuzzleOverlay`): `choices` array was re-sorted with `Math.random()` on every render, causing answer buttons to shuffle on each wrong-answer click. Wrapped in `useMemo([puzzle])` — fixes both the compiler bail-out and the UX bug.
- **R5 — Uncleaned `setTimeout` refs** (4 components): `setTimeout` calls that update React/Zustand state were not cleared on unmount, causing "state update on unmounted component" warnings in production. Added `useRef` + `clearTimeout` cleanup `useEffect` in: `PuzzleOverlay`, `SongQuiz`, `SearchGrid`, `useMelodyMaker`.
- **R2/R4 — React 19 deprecations** (`WritingCanvasContext`): Migrated `<Context.Provider>` → `<Context>` and `useContext()` → `use()`.
- **P6 — `transition-all` → `transition`** (26 files): `transition-all` animates every CSS property including layout (width/height/margin), triggering browser reflow on every game-state change. Replaced with Tailwind's `transition` which covers only GPU-composited properties (transform, opacity, colors, shadow) — no layout reflow.
- **tsconfig**: `jsx: "preserve"` → `"react-jsx"` (correct modern transform for React 19+); added `.next/dev/types` to `include`.

## Test plan

- [ ] Verify escape-room puzzle overlay — answer buttons no longer reshuffle after a wrong answer
- [ ] Navigate away from kids-songs mid-quiz, verify no console warnings about unmounted state updates
- [ ] Verify word-search wrong-flash (red cells) still works and clears correctly
- [ ] Verify melody-maker preview stops cleanly when navigating away
- [ ] Verify hebrew-letters canvas writing still works (WritingCanvasContext)
- [ ] Smoke test: arithmetic, coloring, emoji-math, holidays, word-scramble button animations still respond correctly (scale on hover/active still works via `transition`)
- [ ] `npx tsc --noEmit` — 0 errors ✅
- [ ] `npm run build` — clean ✅

Closes #1278

🤖 Generated with [Claude Code](https://claude.com/claude-code)