### PR TITLE
css: fix globals.css duplicate keyframes, RTL margin, redundant inline style

### DIFF
--- a/gamesformykids/app/games/kids-songs/components/LyricsDisplay.tsx
+++ b/gamesformykids/app/games/kids-songs/components/LyricsDisplay.tsx
@@ -94,7 +94,7 @@ export default function LyricsDisplay({ song, onFinish, onBack }: Props) {
       <div className="w-full max-w-lg">
         {/* Header */}
         <div className="flex items-center mb-6 mt-2">
-          <button onClick={handleBack} className="text-purple-500 hover:text-purple-700 text-2xl ml-3">→</button>
+          <button onClick={handleBack} className="text-purple-500 hover:text-purple-700 text-2xl me-3">→</button>
           <div className="text-4xl mx-3">{song.emoji}</div>
           <h2 className="text-2xl font-bold text-purple-800">{song.title}</h2>
         </div>

--- a/gamesformykids/app/games/word-search/components/SearchGrid.tsx
+++ b/gamesformykids/app/games/word-search/components/SearchGrid.tsx
@@ -103,7 +103,6 @@ export default function SearchGrid({ grid, placed, found, onSelect }: Props) {
     <div
       ref={containerRef}
       className="relative w-full aspect-square select-none touch-none cursor-crosshair"
-      style={{ userSelect: 'none' }}
       onPointerDown={handlePointerDown}
       onPointerMove={handlePointerMove}
       onPointerUp={handlePointerUp}

--- a/gamesformykids/app/globals.css
+++ b/gamesformykids/app/globals.css
@@ -86,7 +86,7 @@ body {
   }
 }
 
-@keyframes glow {
+@keyframes glow-gold {
   0%, 100% {
     box-shadow: 0 0 5px rgba(255, 215, 0, 0.5);
   }
@@ -115,8 +115,8 @@ body {
   animation: float 3s ease-in-out infinite;
 }
 
-.animate-glow {
-  animation: glow 2s ease-in-out infinite;
+.animate-glow-gold {
+  animation: glow-gold 2s ease-in-out infinite;
 }
 
 .animate-shake {
@@ -156,15 +156,6 @@ body {
     width: 800px;
     height: 600px;
   }
-}
-
-@keyframes bounce-gentle {
-  0%, 100% { transform: translateY(0); }
-  50% { transform: translateY(-5px); }
-}
-
-.animate-bounce-gentle {
-  animation: bounce-gentle 2s infinite;
 }
 
 /* הסתרת scrollbar אך שמירה על פונקציונליות */
@@ -234,21 +225,6 @@ body {
 
 .animate-flip-in {
   animation: flip-in 0.5s ease-out;
-}
-
-@keyframes fade-in {
-  0% { 
-    opacity: 0;
-    transform: translateY(20px);
-  }
-  100% { 
-    opacity: 1;
-    transform: translateY(0);
-  }
-}
-
-.animate-fade-in {
-  animation: fade-in 0.5s ease-out;
 }
 
 @keyframes shimmer {


### PR DESCRIPTION
## Summary

- **globals.css — 3 duplicate `@keyframes` removed**: `glow-gold` renamed to distinguish from the green `glow`, first `fade-in` block removed (was a 0.5s dupe of the canonical 0.6s-forwards definition), first `bounce-gentle` block removed (was a 2-step dupe of the canonical 4-step definition). The browser silently used whichever definition appeared last — now each keyframe is unique.
- **SearchGrid.tsx**: removed `style={{ userSelect: 'none' }}` which was a direct duplicate of the `select-none` Tailwind class on the same element.
- **LyricsDisplay.tsx**: changed `ml-3` → `me-3` on the back button (logical margin, RTL-safe).

## Test plan

- [ ] Word-search grid still prevents text selection on drag
- [ ] Kids-songs back button margin renders correctly in RTL (right side)
- [ ] `.animate-glow` still shows green glow (memory game win state)
- [ ] `.animate-fade-in` still fades elements in (jokes browser, memory board)
- [ ] `.animate-bounce-gentle` still bounces (memory card flipped, win message)
- [ ] CI passes

Closes #1280

🤖 Generated with [Claude Code](https://claude.com/claude-code)