### PR TITLE
css: replace bg-opacity-*, transition-all, directional margins (15 files)

### DIFF
--- a/gamesformykids/app/analytics/page.tsx
+++ b/gamesformykids/app/analytics/page.tsx
@@ -42,7 +42,7 @@ export default async function AnalyticsPage() {
         <div className="text-center mt-12">
           <Link
             href="/"
-            className="inline-block bg-gradient-to-r from-purple-500 to-pink-500 text-white px-8 py-4 rounded-2xl font-bold text-lg shadow-lg hover:shadow-xl transition-all duration-300 transform hover:scale-105"
+            className="inline-block bg-gradient-to-r from-purple-500 to-pink-500 text-white px-8 py-4 rounded-2xl font-bold text-lg shadow-lg hover:shadow-xl transition-[transform,box-shadow] duration-300 hover:scale-105"
           >
             🏠 חזרה לעמוד הראשי
           </Link>

--- a/gamesformykids/app/games/bubbles/components/BubbleGame.tsx
+++ b/gamesformykids/app/games/bubbles/components/BubbleGame.tsx
@@ -46,7 +46,7 @@ export default function BubbleGame() {
       </div>
 
       {/* סטטיסטיקות נוספות */}
-      <div className="absolute top-20 end-4 z-20 bg-white bg-opacity-80 rounded-2xl p-4 shadow-lg">
+      <div className="absolute top-20 end-4 z-20 bg-white/80 rounded-2xl p-4 shadow-lg">
         <div className="text-center">
           <div className="text-lg font-bold text-blue-800">בועות פוצצו:</div>
           <div className="text-2xl font-bold text-blue-600">{poppedCount}</div>
@@ -71,13 +71,13 @@ export default function BubbleGame() {
       {/* אפקטים ויזואליים נוספים */}
       <div className="absolute inset-0 pointer-events-none">
         {/* עננים מאחורה */}
-        <div className="absolute top-10 left-10 w-20 h-12 bg-white bg-opacity-40 rounded-full"></div>
-        <div className="absolute top-32 right-20 w-16 h-10 bg-white bg-opacity-30 rounded-full"></div>
-        <div className="absolute top-20 left-1/2 w-24 h-14 bg-white bg-opacity-35 rounded-full"></div>
+        <div className="absolute top-10 left-10 w-20 h-12 bg-white/40 rounded-full"></div>
+        <div className="absolute top-32 right-20 w-16 h-10 bg-white/30 rounded-full"></div>
+        <div className="absolute top-20 left-1/2 w-24 h-14 bg-white/35 rounded-full"></div>
 
         {/* ציפורים קטנות */}
-        <div className="absolute top-16 right-1/4 text-white text-opacity-60">🐦</div>
-        <div className="absolute top-40 left-1/3 text-white text-opacity-60">🐦</div>
+        <div className="absolute top-16 right-1/4 text-white/60">🐦</div>
+        <div className="absolute top-40 left-1/3 text-white/60">🐦</div>
       </div>
     </div>
   );

--- a/gamesformykids/app/games/maze/components/MazeCanvas.tsx
+++ b/gamesformykids/app/games/maze/components/MazeCanvas.tsx
@@ -92,7 +92,7 @@ export default function MazeCanvas() {
       ref={canvasRef}
       width={CANVAS_SIZE}
       height={CANVAS_SIZE}
-      style={{ display: 'block', margin: '0 auto', borderRadius: '12px', border: '2px solid #334155' }}
+      className="block mx-auto rounded-xl border-2 border-slate-700"
     />
   );
 }

--- a/gamesformykids/app/games/melody-maker/MelodyMakerClient.tsx
+++ b/gamesformykids/app/games/melody-maker/MelodyMakerClient.tsx
@@ -51,7 +51,7 @@ export default function MelodyMakerClient() {
         </button>
       </div>
 
-      <div className="w-full max-w-lg bg-white bg-opacity-70 rounded-2xl p-4 shadow-lg">
+      <div className="w-full max-w-lg bg-white/70 rounded-2xl p-4 shadow-lg">
         <XylophoneKeys
           onTap={tapKey}
           flashingKey={flashingKey}
@@ -91,7 +91,7 @@ export default function MelodyMakerClient() {
           )}
 
           {recording.length > 0 && (
-            <div className="flex flex-wrap gap-1 justify-center bg-white bg-opacity-80 rounded-xl p-3 w-full">
+            <div className="flex flex-wrap gap-1 justify-center bg-white/80 rounded-xl p-3 w-full">
               {recording.map((noteIdx, i) => (
                 <span key={i} className="bg-purple-100 text-purple-700 text-xs font-bold px-2 py-1 rounded-full">
                   {NOTE_NAMES_HE[noteIdx] ?? ''}
@@ -101,7 +101,7 @@ export default function MelodyMakerClient() {
           )}
         </div>
       ) : (
-        <div className="w-full max-w-lg bg-white bg-opacity-70 rounded-2xl p-4 shadow-lg">
+        <div className="w-full max-w-lg bg-white/70 rounded-2xl p-4 shadow-lg">
           <SongGuide
             selectedSong={selectedSong}
             songProgress={songProgress}

--- a/gamesformykids/app/games/memory/components/MemoryGameHeader.tsx
+++ b/gamesformykids/app/games/memory/components/MemoryGameHeader.tsx
@@ -35,7 +35,7 @@ export default function MemoryGameHeader() {
 
   return (
     <div className="bg-gradient-to-r from-purple-600 via-pink-500 to-red-500 rounded-2xl p-6 shadow-2xl mb-6">
-      <div className="bg-white bg-opacity-10 backdrop-blur-lg rounded-xl p-4">
+      <div className="bg-white/10 backdrop-blur-lg rounded-xl p-4">
         <DuoPlayerIndicator />
         <DifficultyPicker />
         <GameStatsBar />

--- a/gamesformykids/app/games/puzzles/shared/StatCard.tsx
+++ b/gamesformykids/app/games/puzzles/shared/StatCard.tsx
@@ -15,7 +15,7 @@ export default function StatCard({ icon, label, value, color }: { icon: ReactNod
   return (
     <div className={`${c.bg} p-3 rounded-lg text-center`}>
       <div className="flex items-center justify-center mb-1">
-        <span className={`${c.icon} mr-1`}>{icon}</span>
+        <span className={`${c.icon} me-1`}>{icon}</span>
         <span className={`text-xs font-medium ${c.label}`}>{label}</span>
       </div>
       <div className={`text-lg font-bold ${c.value}`}>{value}</div>

--- a/gamesformykids/app/games/taki/components/TakiMessageArea.tsx
+++ b/gamesformykids/app/games/taki/components/TakiMessageArea.tsx
@@ -10,7 +10,7 @@ export default function TakiMessageArea() {
       <p className="text-yellow-200 text-sm font-medium bg-black/30 rounded-xl py-2 px-3 inline-block max-w-xs">
         {message}
         {playerHand.length <= 2 && (
-          <span className="ml-2 font-bold text-yellow-400 animate-bounce inline-block">טאקי! 🃏</span>
+          <span className="ms-2 font-bold text-yellow-400 animate-bounce inline-block">טאקי! 🃏</span>
         )}
       </p>
     </div>

--- a/gamesformykids/app/not-found.tsx
+++ b/gamesformykids/app/not-found.tsx
@@ -33,7 +33,7 @@ export default function NotFound() {
           <div className="space-y-4">
             <Link
               href="/"
-              className="block w-full bg-linear-to-r from-purple-500 to-pink-500 text-white px-6 py-3 rounded-xl font-bold text-lg shadow-lg hover:shadow-xl transition-all duration-300 transform hover:scale-105"
+              className="block w-full bg-linear-to-r from-purple-500 to-pink-500 text-white px-6 py-3 rounded-xl font-bold text-lg shadow-lg hover:shadow-xl transition-[transform,box-shadow] duration-300 hover:scale-105"
             >
               🏠 חזרה לעמוד הראשי
             </Link>

--- a/gamesformykids/app/offline/OfflineReloadButton.tsx
+++ b/gamesformykids/app/offline/OfflineReloadButton.tsx
@@ -4,7 +4,7 @@ export default function OfflineReloadButton() {
   return (
     <button
       onClick={() => window.location.reload()}
-      className="w-full py-3 rounded-2xl bg-gradient-to-r from-blue-500 to-indigo-600 text-white font-bold text-lg hover:opacity-90 active:scale-95 transition-all"
+      className="w-full py-3 rounded-2xl bg-gradient-to-r from-blue-500 to-indigo-600 text-white font-bold text-lg hover:opacity-90 active:scale-95 transition-[transform,opacity]"
     >
       🔄 נסה שוב
     </button>

--- a/gamesformykids/app/profile/components/GameProgressList.tsx
+++ b/gamesformykids/app/profile/components/GameProgressList.tsx
@@ -49,7 +49,7 @@ export function GameProgressList() {
                     <h4 className="font-semibold text-gray-800 truncate group-hover:text-purple-700">
                       {title}
                     </h4>
-                    <span className="text-xs text-gray-400 shrink-0 mr-2">
+                    <span className="text-xs text-gray-400 shrink-0 me-2">
                       {formatLastPlayed(gp.last_played_at)}
                     </span>
                   </div>
@@ -57,7 +57,7 @@ export function GameProgressList() {
                   {/* progress bar */}
                   <div className="w-full bg-gray-200 rounded-full h-2 mb-2">
                     <div
-                      className="bg-linear-to-r from-purple-400 to-purple-600 h-2 rounded-full transition-all"
+                      className="bg-linear-to-r from-purple-400 to-purple-600 h-2 rounded-full transition-[width]"
                       style={{ width: `${pct}%` }}
                     />
                   </div>

--- a/gamesformykids/app/profile/components/ProfileCard.tsx
+++ b/gamesformykids/app/profile/components/ProfileCard.tsx
@@ -77,7 +77,7 @@ export function ProfileCard() {
                   <button
                     key={value}
                     onClick={() => handleGenderSelect(value)}
-                    className={`flex items-center gap-1 px-3 py-1 rounded-full text-sm font-medium border-2 transition-all duration-200 ${
+                    className={`flex items-center gap-1 px-3 py-1 rounded-full text-sm font-medium border-2 transition-colors duration-200 ${
                       profile?.gender === value
                         ? 'border-purple-500 bg-purple-100 text-purple-700'
                         : 'border-gray-200 bg-gray-50 text-gray-600 hover:border-purple-300'

--- a/gamesformykids/app/sitemap-page/page.tsx
+++ b/gamesformykids/app/sitemap-page/page.tsx
@@ -95,7 +95,7 @@ export default function SitemapPage() {
         <div className="text-center mt-12">
           <Link 
             href="/"
-            className="inline-block bg-gradient-to-r from-purple-500 to-pink-500 text-white px-8 py-4 rounded-2xl font-bold text-lg shadow-lg hover:shadow-xl transition-all duration-300 transform hover:scale-105"
+            className="inline-block bg-gradient-to-r from-purple-500 to-pink-500 text-white px-8 py-4 rounded-2xl font-bold text-lg shadow-lg hover:shadow-xl transition-[transform,box-shadow] duration-300 hover:scale-105"
           >
             🏠 חזרה לעמוד הראשי
           </Link>

--- a/gamesformykids/components/game/quiz/screens/StoryBuilderQuestion.tsx
+++ b/gamesformykids/components/game/quiz/screens/StoryBuilderQuestion.tsx
@@ -74,7 +74,7 @@ export default function StoryBuilderQuestion({ story, currentBlank, currentBlank
             <button
               key={word}
               onClick={() => onSelect(word)}
-              className="py-3 px-4 bg-indigo-100 hover:bg-indigo-200 active:scale-95 text-indigo-900 font-bold rounded-2xl transition-all text-lg"
+              className="py-3 px-4 bg-indigo-100 hover:bg-indigo-200 active:scale-95 text-indigo-900 font-bold rounded-2xl transition-transform text-lg"
             >
               {word}
             </button>

--- a/gamesformykids/components/layout/LoadingScreen.tsx
+++ b/gamesformykids/components/layout/LoadingScreen.tsx
@@ -20,9 +20,9 @@ const LoadingScreen = ({ onLoadingComplete }: LoadingScreenProps) => {
         </h2>
         
         {/* Progress bar */}
-        <div className="w-80 h-4 bg-white bg-opacity-30 rounded-full overflow-hidden mb-4">
+        <div className="w-80 h-4 bg-white/30 rounded-full overflow-hidden mb-4">
           <div 
-            className="h-full bg-gradient-to-r from-yellow-400 to-orange-400 transition-all duration-200 ease-out rounded-full"
+            className="h-full bg-gradient-to-r from-yellow-400 to-orange-400 transition-[width] duration-200 ease-out rounded-full"
             style={{ width: `${progress}%` }}
           />
         </div>

--- a/gamesformykids/components/settings/SettingToggle.tsx
+++ b/gamesformykids/components/settings/SettingToggle.tsx
@@ -15,7 +15,7 @@ export function SettingToggle({ label, description, checked, onChange, disabled 
           disabled={disabled}
           className="sr-only peer"
         />
-        <div className="w-11 h-6 bg-gray-200 peer-focus:outline-none peer-focus:ring-4 peer-focus:ring-purple-300 rounded-full peer peer-checked:after:translate-x-full rtl:peer-checked:after:-translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:start-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-purple-600" />
+        <div className="w-11 h-6 bg-gray-200 peer-focus:outline-none peer-focus:ring-4 peer-focus:ring-purple-300 rounded-full peer peer-checked:after:translate-x-full rtl:peer-checked:after:-translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:start-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition peer-checked:bg-purple-600" />
       </label>
     </div>
   );


### PR DESCRIPTION
## Summary

Full-codebase CSS audit (`/css-expert --fix`) found and fixed 24 issues across 15 files in 4 categories:

### 1. Deprecated v2 opacity syntax → v3 slash syntax (11 instances)
`bg-white bg-opacity-80` → `bg-white/80` etc.
- `BubbleGame.tsx` — clouds + birds decorators
- `MelodyMakerClient.tsx` — xylophone panel backgrounds
- `MemoryGameHeader.tsx` — glass header backdrop
- `LoadingScreen.tsx` — progress bar background

### 2. `transition-all` → scoped transitions (9 instances)
`transition-all` triggers a layout recalc for every CSS property on every interaction. Replaced with the minimum needed property:

| File | Was | Now |
|---|---|---|
| `analytics/page.tsx` | `transition-all` | `transition-[transform,box-shadow]` |
| `not-found.tsx` | `transition-all` | `transition-[transform,box-shadow]` |
| `sitemap-page/page.tsx` | `transition-all` | `transition-[transform,box-shadow]` |
| `OfflineReloadButton.tsx` | `transition-all` | `transition-[transform,opacity]` |
| `GameProgressList.tsx` | `transition-all` | `transition-[width]` |
| `LoadingScreen.tsx` | `transition-all` | `transition-[width]` |
| `ProfileCard.tsx` | `transition-all` | `transition-colors` |
| `StoryBuilderQuestion.tsx` | `transition-all` | `transition-transform` |
| `SettingToggle.tsx` | `after:transition-all` | `after:transition` |

### 3. Directional margins → RTL logical properties (3 instances)
`mr-N` / `ml-N` → `me-N` / `ms-N`
- `StatCard.tsx`, `TakiMessageArea.tsx`, `GameProgressList.tsx`

### 4. Canvas inline style → Tailwind (1 instance)
`MazeCanvas.tsx`: `style={{ display, margin, borderRadius, border }}` → `className="block mx-auto rounded-xl border-2 border-slate-700"`

## Test plan
- [ ] Bubbles game — cloud/bird decorators render semi-transparent correctly
- [ ] Melody maker — panel backgrounds render at correct opacity
- [ ] Memory game header — glass effect visible
- [ ] Loading screen — progress bar animates width smoothly
- [ ] Profile page — progress bar and gender toggle animate correctly
- [ ] Maze canvas — renders with correct border and centering
- [ ] RTL layout — StatCard icon, Taki message, profile date all have correct spacing
- [ ] CI passes

Closes #1284

🤖 Generated with [Claude Code](https://claude.com/claude-code)