### PR TITLE
refactor: extract UI/logic violations into dedicated hooks

### DIFF
--- a/gamesformykids/app/games/maze/MazeClient.tsx
+++ b/gamesformykids/app/games/maze/MazeClient.tsx
@@ -1,6 +1,5 @@
 'use client';
 import { useMazeGame } from './useMazeGame';
-import { useMazeStore } from './mazeStore';
 import MazeCanvas from './components/MazeCanvas';
 import { GameCompletionCelebration } from '@/components/game/shared/GameCompletionCelebration';
 
@@ -8,8 +7,7 @@ const LEVEL_NAMES = ['מפה קטנה 5×5', 'מפה בינונית 7×7', 'מפ
 const TOTAL_LEVELS = 5;
 
 export default function MazeClient() {
-  const { phase, level, starsCollectedThisLevel, totalStarsCollected, startGame, nextLevel, reset } = useMazeGame();
-  const move = useMazeStore(s => s.move);
+  const { phase, level, starsCollectedThisLevel, totalStarsCollected, startGame, move, nextLevel, reset } = useMazeGame();
 
   if (phase === 'idle') {
     return (

--- a/gamesformykids/app/games/maze/useMazeGame.ts
+++ b/gamesformykids/app/games/maze/useMazeGame.ts
@@ -26,5 +26,5 @@ export function useMazeGame() {
     return () => window.removeEventListener('keydown', handleKey);
   }, [phase, move]);
 
-  return { phase, level, starsCollectedThisLevel, totalStarsCollected, startGame, nextLevel, reset };
+  return { phase, level, starsCollectedThisLevel, totalStarsCollected, startGame, move, nextLevel, reset };
 }

--- a/gamesformykids/app/games/memory/stores/memoryStoreTypes.ts
+++ b/gamesformykids/app/games/memory/stores/memoryStoreTypes.ts
@@ -1,6 +1,6 @@
 import { AnimalData } from '@/lib/types/games';
 import { MEMORY_GAME_ANIMALS, MEMORY_GAME_CONSTANTS } from '@/lib/constants';
-import { DifficultyLevel, MemoryCard, GameStats } from '../types/memory';
+import { DifficultyLevel, MemoryCard, GameStats, MemoryPhase } from '../types/memory';
 import { DifficultyOption, PerformanceLevel, WinAchievement } from '../types/memoryDisplay';
 
 // ─── Initial values ───────────────────────────────────────────────────────────
@@ -12,9 +12,7 @@ export const initialGameStats: GameStats = {
   streak: 0,
 };
 
-// ─── Phase type ───────────────────────────────────────────────────────────────
-
-export type MemoryPhase = 'menu' | 'playing' | 'won' | 'timeout';
+export type { MemoryPhase };
 
 // ─── Duo mode types ───────────────────────────────────────────────────────────
 

--- a/gamesformykids/components/game/GameCard.tsx
+++ b/gamesformykids/components/game/GameCard.tsx
@@ -1,11 +1,10 @@
 "use client";
 
 import Link from "next/link";
-import { useState, useEffect } from "react";
 import { Star } from "lucide-react";
 import { ComponentTypes } from "@/lib/types";
 import { useFavoritesStore } from "@/lib/stores";
-import { getMasteryStars } from "@/lib/utils/engagement/masteryStars";
+import { useMasteryStars } from "@/hooks/shared/progress/useMasteryStars";
 
 interface GameCardProps extends ComponentTypes.GameCardProps {
   animationDelay?: number;
@@ -14,11 +13,7 @@ interface GameCardProps extends ComponentTypes.GameCardProps {
 export default function GameCard({ game, animationDelay }: GameCardProps) {
   const toggleFavorite = useFavoritesStore((s) => s.toggleFavorite);
   const isFav = useFavoritesStore((s) => s.favoriteIds.includes(game.id));
-  const [masteryStars, setMasteryStars] = useState(0);
-
-  useEffect(() => {
-    setMasteryStars(getMasteryStars(game.id));
-  }, [game.id]);
+  const masteryStars = useMasteryStars(game.id);
 
   if (game.available) {
     return (
@@ -34,7 +29,7 @@ export default function GameCard({ game, animationDelay }: GameCardProps) {
             `}
           >
             {/* Gradient overlay for enhanced visual appeal */}
-            <div className="absolute inset-0 bg-gradient-to-br from-white/10 to-transparent pointer-events-none"></div>
+            <div className="absolute inset-0 bg-linear-to-br from-white/10 to-transparent pointer-events-none"></div>
             
             <div className="relative text-center text-white">
               <div className="mb-2 md:mb-4 flex justify-center">

--- a/gamesformykids/components/marketing/ContinueBanner.tsx
+++ b/gamesformykids/components/marketing/ContinueBanner.tsx
@@ -1,39 +1,20 @@
 'use client';
 
-import { useEffect, useState } from 'react';
 import Link from 'next/link';
 import { X } from 'lucide-react';
-import { getLastPlayed, type LastPlayedData } from '@/lib/utils/engagement/trackGameVisit';
 import { GamesRegistry } from '@/lib/registry/gamesRegistry';
-
-const DISMISS_KEY = 'gfk_dismissed_continue';
-const MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
+import { useContinueBanner } from '@/hooks/shared/marketing/useContinueBanner';
 
 export default function ContinueBanner() {
-  const [data, setData] = useState<LastPlayedData | null>(null);
-  const [dismissed, setDismissed] = useState(false);
-
-  useEffect(() => {
-    const sessionDismissed = sessionStorage.getItem(DISMISS_KEY);
-    if (sessionDismissed) return;
-    const last = getLastPlayed();
-    if (!last) return;
-    if (Date.now() - last.timestamp > MAX_AGE_MS) return;
-    setData(last);
-  }, []);
+  const { data, dismissed, dismiss } = useContinueBanner();
 
   if (!data || dismissed) return null;
 
   const reg = GamesRegistry.getGameById(data.gameType);
   if (!reg) return null;
 
-  const dismiss = () => {
-    sessionStorage.setItem(DISMISS_KEY, '1');
-    setDismissed(true);
-  };
-
   return (
-    <div dir="rtl" className="mx-4 mt-3 rounded-2xl bg-gradient-to-l from-purple-500 to-indigo-600 text-white shadow-lg flex items-center gap-3 px-4 py-3">
+    <div dir="rtl" className="mx-4 mt-3 rounded-2xl bg-linear-to-l from-purple-500 to-indigo-600 text-white shadow-lg flex items-center gap-3 px-4 py-3">
       <span className="text-3xl">{reg.emoji}</span>
       <div className="flex-1 min-w-0">
         <p className="text-xs opacity-80 font-medium">ממשיכים מאיפה שעצרת</p>

--- a/gamesformykids/components/marketing/DailyChallenge.tsx
+++ b/gamesformykids/components/marketing/DailyChallenge.tsx
@@ -1,43 +1,19 @@
 'use client';
 
-import { useEffect, useState } from 'react';
 import Link from 'next/link';
 import { GamesRegistry } from '@/lib/registry/gamesRegistry';
-
-const DONE_KEY = 'gfk_daily_challenge_done';
-
-function getTodayKey(): string {
-  return new Date().toISOString().slice(0, 10);
-}
+import { useDailyChallenge } from '@/hooks/shared/marketing/useDailyChallenge';
 
 export default function DailyChallenge() {
-  const [gameId, setGameId] = useState<string | null>(null);
-  const [done, setDone] = useState(false);
-
-  useEffect(() => {
-    const today = getTodayKey();
-    const storedDone = localStorage.getItem(DONE_KEY);
-    setDone(storedDone === today);
-
-    const allGames = GamesRegistry.getAllGameRegistrations().filter((g) => g.available);
-    if (allGames.length === 0) return;
-    const dayIndex = Math.floor(Date.now() / 86_400_000);
-    const pick = allGames[dayIndex % allGames.length];
-    setGameId(pick?.id ?? null);
-  }, []);
+  const { gameId, done, markDone } = useDailyChallenge();
 
   if (!gameId) return null;
 
   const reg = GamesRegistry.getGameById(gameId);
   if (!reg) return null;
 
-  const markDone = () => {
-    localStorage.setItem(DONE_KEY, getTodayKey());
-    setDone(true);
-  };
-
   return (
-    <div dir="rtl" className="mx-4 mt-3 rounded-2xl bg-gradient-to-l from-amber-400 to-orange-500 text-white shadow-lg px-4 py-3">
+    <div dir="rtl" className="mx-4 mt-3 rounded-2xl bg-linear-to-l from-amber-400 to-orange-500 text-white shadow-lg px-4 py-3">
       <p className="text-xs opacity-80 font-bold mb-1">🎯 אתגר יומי</p>
       <div className="flex items-center gap-3">
         <span className="text-3xl">{reg.emoji}</span>

--- a/gamesformykids/components/marketing/OnboardingModal.tsx
+++ b/gamesformykids/components/marketing/OnboardingModal.tsx
@@ -1,7 +1,6 @@
 'use client';
-import { useState, useEffect } from 'react';
 
-const ONBOARDED_KEY = 'gfk_onboarded';
+import { useOnboardingModal } from '@/hooks/shared/marketing/useOnboardingModal';
 
 const STEPS = [
   {
@@ -22,24 +21,7 @@ const STEPS = [
 ];
 
 export default function OnboardingModal() {
-  const [step, setStep] = useState(0);
-  const [visible, setVisible] = useState(false);
-
-  useEffect(() => {
-    try {
-      if (!localStorage.getItem(ONBOARDED_KEY)) setVisible(true);
-    } catch {}
-  }, []);
-
-  const close = () => {
-    try { localStorage.setItem(ONBOARDED_KEY, '1'); } catch {}
-    setVisible(false);
-  };
-
-  const next = () => {
-    if (step < STEPS.length - 1) setStep(step + 1);
-    else close();
-  };
+  const { step, visible, next, prev, close } = useOnboardingModal(STEPS.length);
 
   if (!visible) return null;
 
@@ -47,7 +29,7 @@ export default function OnboardingModal() {
 
   return (
     <div
-      className="fixed inset-0 z-[100] flex items-center justify-center p-4 bg-black/50 backdrop-blur-sm"
+      className="fixed inset-0 z-100 flex items-center justify-center p-4 bg-black/50 backdrop-blur-sm"
       dir="rtl"
       role="dialog"
       aria-modal="true"
@@ -58,7 +40,6 @@ export default function OnboardingModal() {
         <h2 className="text-2xl font-bold text-gray-800 mb-3">{current.title}</h2>
         <p className="text-gray-600 leading-relaxed mb-6">{current.body}</p>
 
-        {/* Step dots */}
         <div className="flex justify-center gap-2 mb-6">
           {STEPS.map((_, i) => (
             <div
@@ -71,7 +52,7 @@ export default function OnboardingModal() {
         <div className="flex gap-3">
           {step > 0 && (
             <button
-              onClick={() => setStep(step - 1)}
+              onClick={prev}
               className="flex-1 py-3 rounded-2xl border-2 border-gray-200 text-gray-500 font-semibold hover:bg-gray-50 transition-colors"
             >
               ← אחורה

--- a/gamesformykids/components/marketing/RecentlyPlayedRow.tsx
+++ b/gamesformykids/components/marketing/RecentlyPlayedRow.tsx
@@ -1,31 +1,10 @@
 'use client';
 
-import { useEffect, useState } from 'react';
 import Link from 'next/link';
-import { getRecentGames, type RecentGameEntry } from '@/lib/utils/engagement/trackGameVisit';
-import { GamesRegistry } from '@/lib/registry/gamesRegistry';
-
-interface RecentItem {
-  gameType: string;
-  title: string;
-  emoji: string;
-  href: string;
-}
+import { useRecentlyPlayed } from '@/hooks/shared/marketing/useRecentlyPlayed';
 
 export default function RecentlyPlayedRow() {
-  const [items, setItems] = useState<RecentItem[]>([]);
-
-  useEffect(() => {
-    const recent: RecentGameEntry[] = getRecentGames();
-    const resolved = recent
-      .map((entry) => {
-        const reg = GamesRegistry.getGameById(entry.gameType);
-        if (!reg) return null;
-        return { gameType: entry.gameType, title: reg.title, emoji: reg.emoji, href: reg.href };
-      })
-      .filter((x): x is RecentItem => x !== null);
-    setItems(resolved);
-  }, []);
+  const items = useRecentlyPlayed();
 
   if (items.length === 0) return null;
 
@@ -38,10 +17,10 @@ export default function RecentlyPlayedRow() {
             <Link
               key={item.gameType}
               href={item.href}
-              className="flex flex-col items-center gap-1 bg-white dark:bg-gray-800 rounded-2xl shadow px-4 py-3 hover:shadow-md active:scale-95 transition-transform text-center min-w-[80px]"
+              className="flex flex-col items-center gap-1 bg-white dark:bg-gray-800 rounded-2xl shadow px-4 py-3 hover:shadow-md active:scale-95 transition-transform text-center min-w-20"
             >
               <span className="text-3xl">{item.emoji}</span>
-              <span className="text-xs font-semibold text-gray-700 dark:text-gray-200 leading-tight max-w-[72px] line-clamp-2">
+              <span className="text-xs font-semibold text-gray-700 dark:text-gray-200 leading-tight max-w-18 line-clamp-2">
                 {item.title}
               </span>
             </Link>

--- a/gamesformykids/components/marketing/VocabularyOfTheDay.tsx
+++ b/gamesformykids/components/marketing/VocabularyOfTheDay.tsx
@@ -1,64 +1,9 @@
 'use client';
 
-import { useEffect, useState } from 'react';
-import { GAME_ITEMS_MAP } from '@/lib/constants/gameItemsMap';
-import { speak } from '@/lib/utils/speech/speaker';
-import type { BaseGameItem } from '@/lib/types/core/base';
-
-const STORAGE_KEY = 'votd_last_shown';
-
-function getTodayKey(): string {
-  return new Date().toISOString().slice(0, 10); // 'YYYY-MM-DD'
-}
-
-function pickWordOfTheDay(): BaseGameItem | null {
-  const allItems: BaseGameItem[] = [];
-  const seen = new Set<string>();
-
-  for (const items of Object.values(GAME_ITEMS_MAP)) {
-    if (!items) continue;
-    for (const item of items) {
-      if (item.hebrew && !seen.has(item.name)) {
-        seen.add(item.name);
-        allItems.push(item);
-      }
-    }
-  }
-
-  if (allItems.length === 0) return null;
-
-  const dayIndex = Math.floor(Date.now() / 86_400_000);
-  return allItems[dayIndex % allItems.length] ?? null;
-}
+import { useVocabularyOfTheDay } from '@/hooks/shared/marketing/useVocabularyOfTheDay';
 
 export default function VocabularyOfTheDay() {
-  const [word, setWord] = useState<BaseGameItem | null>(null);
-  const [visible, setVisible] = useState(false);
-
-  useEffect(() => {
-    const today = getTodayKey();
-    const lastShown = localStorage.getItem(STORAGE_KEY);
-    if (lastShown === today) return;
-
-    const item = pickWordOfTheDay();
-    if (!item) return;
-
-    localStorage.setItem(STORAGE_KEY, today);
-    setWord(item);
-    setVisible(true);
-
-    // Speak after a short delay so the banner has rendered
-    const speakTimer = setTimeout(() => {
-      speak(`המילה של היום היא ${item.hebrew}`).catch(() => {});
-    }, 600);
-
-    const hideTimer = setTimeout(() => setVisible(false), 4600);
-
-    return () => {
-      clearTimeout(speakTimer);
-      clearTimeout(hideTimer);
-    };
-  }, []);
+  const { word, visible, dismiss } = useVocabularyOfTheDay();
 
   if (!word || !visible) return null;
 
@@ -66,7 +11,7 @@ export default function VocabularyOfTheDay() {
     <div
       role="status"
       aria-live="polite"
-      onClick={() => setVisible(false)}
+      onClick={dismiss}
       className="fixed top-20 inset-x-4 z-50 mx-auto max-w-sm cursor-pointer"
     >
       <div className="bg-white/95 backdrop-blur-sm rounded-2xl shadow-xl border border-purple-200 px-6 py-4 text-center animate-fade-in-up">

--- a/gamesformykids/hooks/shared/marketing/useContinueBanner.ts
+++ b/gamesformykids/hooks/shared/marketing/useContinueBanner.ts
@@ -1,0 +1,25 @@
+'use client';
+import { useState, useEffect } from 'react';
+import { getLastPlayed, type LastPlayedData } from '@/lib/utils/engagement/trackGameVisit';
+
+const DISMISS_KEY = 'gfk_dismissed_continue';
+const MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000;
+
+export function useContinueBanner() {
+  const [data, setData] = useState<LastPlayedData | null>(null);
+  const [dismissed, setDismissed] = useState(false);
+
+  useEffect(() => {
+    if (sessionStorage.getItem(DISMISS_KEY)) return;
+    const last = getLastPlayed();
+    if (!last || Date.now() - last.timestamp > MAX_AGE_MS) return;
+    setData(last);
+  }, []);
+
+  const dismiss = () => {
+    sessionStorage.setItem(DISMISS_KEY, '1');
+    setDismissed(true);
+  };
+
+  return { data, dismissed, dismiss };
+}

--- a/gamesformykids/hooks/shared/marketing/useDailyChallenge.ts
+++ b/gamesformykids/hooks/shared/marketing/useDailyChallenge.ts
@@ -1,0 +1,31 @@
+'use client';
+import { useState, useEffect } from 'react';
+import { GamesRegistry } from '@/lib/registry/gamesRegistry';
+
+const DONE_KEY = 'gfk_daily_challenge_done';
+
+function getTodayKey(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+
+export function useDailyChallenge() {
+  const [gameId, setGameId] = useState<string | null>(null);
+  const [done, setDone] = useState(false);
+
+  useEffect(() => {
+    const today = getTodayKey();
+    setDone(localStorage.getItem(DONE_KEY) === today);
+
+    const allGames = GamesRegistry.getAllGameRegistrations().filter((g) => g.available);
+    if (allGames.length === 0) return;
+    const dayIndex = Math.floor(Date.now() / 86_400_000);
+    setGameId(allGames[dayIndex % allGames.length]?.id ?? null);
+  }, []);
+
+  const markDone = () => {
+    localStorage.setItem(DONE_KEY, getTodayKey());
+    setDone(true);
+  };
+
+  return { gameId, done, markDone };
+}

--- a/gamesformykids/hooks/shared/marketing/useOnboardingModal.ts
+++ b/gamesformykids/hooks/shared/marketing/useOnboardingModal.ts
@@ -1,0 +1,29 @@
+'use client';
+import { useState, useEffect } from 'react';
+
+const ONBOARDED_KEY = 'gfk_onboarded';
+
+export function useOnboardingModal(totalSteps: number) {
+  const [step, setStep] = useState(0);
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    try {
+      if (!localStorage.getItem(ONBOARDED_KEY)) setVisible(true);
+    } catch {}
+  }, []);
+
+  const close = () => {
+    try { localStorage.setItem(ONBOARDED_KEY, '1'); } catch {}
+    setVisible(false);
+  };
+
+  const next = () => {
+    if (step < totalSteps - 1) setStep((s) => s + 1);
+    else close();
+  };
+
+  const prev = () => setStep((s) => Math.max(0, s - 1));
+
+  return { step, visible, next, prev, close };
+}

--- a/gamesformykids/hooks/shared/marketing/useRecentlyPlayed.ts
+++ b/gamesformykids/hooks/shared/marketing/useRecentlyPlayed.ts
@@ -1,0 +1,29 @@
+'use client';
+import { useState, useEffect } from 'react';
+import { getRecentGames, type RecentGameEntry } from '@/lib/utils/engagement/trackGameVisit';
+import { GamesRegistry } from '@/lib/registry/gamesRegistry';
+
+export interface RecentItem {
+  gameType: string;
+  title: string;
+  emoji: string;
+  href: string;
+}
+
+export function useRecentlyPlayed(): RecentItem[] {
+  const [items, setItems] = useState<RecentItem[]>([]);
+
+  useEffect(() => {
+    const recent: RecentGameEntry[] = getRecentGames();
+    const resolved = recent
+      .map((entry) => {
+        const reg = GamesRegistry.getGameById(entry.gameType);
+        if (!reg) return null;
+        return { gameType: entry.gameType, title: reg.title, emoji: reg.emoji, href: reg.href };
+      })
+      .filter((x): x is RecentItem => x !== null);
+    setItems(resolved);
+  }, []);
+
+  return items;
+}

--- a/gamesformykids/hooks/shared/marketing/useVocabularyOfTheDay.ts
+++ b/gamesformykids/hooks/shared/marketing/useVocabularyOfTheDay.ts
@@ -1,0 +1,61 @@
+'use client';
+import { useState, useEffect } from 'react';
+import { GAME_ITEMS_MAP } from '@/lib/constants/gameItemsMap';
+import { speak } from '@/lib/utils/speech/speaker';
+import type { BaseGameItem } from '@/lib/types/core/base';
+
+const STORAGE_KEY = 'votd_last_shown';
+
+function getTodayKey(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+
+function pickWordOfTheDay(): BaseGameItem | null {
+  const allItems: BaseGameItem[] = [];
+  const seen = new Set<string>();
+
+  for (const items of Object.values(GAME_ITEMS_MAP)) {
+    if (!items) continue;
+    for (const item of items) {
+      if (item.hebrew && !seen.has(item.name)) {
+        seen.add(item.name);
+        allItems.push(item);
+      }
+    }
+  }
+
+  if (allItems.length === 0) return null;
+  const dayIndex = Math.floor(Date.now() / 86_400_000);
+  return allItems[dayIndex % allItems.length] ?? null;
+}
+
+export function useVocabularyOfTheDay() {
+  const [word, setWord] = useState<BaseGameItem | null>(null);
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    const today = getTodayKey();
+    const lastShown = localStorage.getItem(STORAGE_KEY);
+    if (lastShown === today) return;
+
+    const item = pickWordOfTheDay();
+    if (!item) return;
+
+    localStorage.setItem(STORAGE_KEY, today);
+    setWord(item);
+    setVisible(true);
+
+    const speakTimer = setTimeout(() => {
+      speak(`המילה של היום היא ${item.hebrew}`).catch(() => {});
+    }, 600);
+
+    const hideTimer = setTimeout(() => setVisible(false), 4600);
+
+    return () => {
+      clearTimeout(speakTimer);
+      clearTimeout(hideTimer);
+    };
+  }, []);
+
+  return { word, visible, dismiss: () => setVisible(false) };
+}

--- a/gamesformykids/hooks/shared/progress/useMasteryStars.ts
+++ b/gamesformykids/hooks/shared/progress/useMasteryStars.ts
@@ -1,0 +1,13 @@
+'use client';
+import { useState, useEffect } from 'react';
+import { getMasteryStars } from '@/lib/utils/engagement/masteryStars';
+
+export function useMasteryStars(gameId: string): number {
+  const [stars, setStars] = useState(0);
+
+  useEffect(() => {
+    setStars(getMasteryStars(gameId));
+  }, [gameId]);
+
+  return stars;
+}


### PR DESCRIPTION
## Summary

- **MazeClient** — removed direct `useMazeStore` access; `move` is now returned from `useMazeGame` (was already read there, just not exposed)
- **memoryStoreTypes** — removed duplicate `MemoryPhase` definition; re-exports the canonical one from `types/memory.ts`
- **5 marketing components** — extracted `localStorage`/`sessionStorage`, TTS, timers, and data-fetching logic into `hooks/shared/marketing/`: `useVocabularyOfTheDay`, `useDailyChallenge`, `useRecentlyPlayed`, `useContinueBanner`, `useOnboardingModal`
- **GameCard** — extracted `getMasteryStars` + `useEffect` pattern into `hooks/shared/progress/useMasteryStars`

Components are now pure renderers; all side-effects and storage access live in hooks.

## Test plan

- [ ] Home page loads and marketing banners (Continue, Daily Challenge, Recently Played, Streak, Vocabulary) render correctly
- [ ] Vocabulary of the Day banner shows once per day, speaks, auto-dismisses, tap-to-close works
- [ ] Daily Challenge banner marks done after clicking "שחק עכשיו"
- [ ] Onboarding modal shows for new users, back/next/skip all work
- [ ] Game cards show mastery stars correctly
- [ ] Maze game: keyboard arrows and D-pad buttons move the player
- [ ] Memory game: win screen displays without TypeScript errors (MemoryPhase dedup)

🤖 Generated with [Claude Code](https://claude.com/claude-code)