### PR TITLE
refactor: extract UI/logic violations into hooks — round 2

### DIFF
--- a/gamesformykids/app/games/israel-map/IsraelMapClient.tsx
+++ b/gamesformykids/app/games/israel-map/IsraelMapClient.tsx
@@ -1,6 +1,5 @@
 'use client';
-import { useEffect, useRef, useState } from 'react';
-import { useMapStore } from './mapStore';
+import { useIsraelMap } from './useIsraelMap';
 import { LOCATIONS } from './data/locations';
 import IsraelSVG from './components/IsraelSVG';
 import GameResultCard from '@/components/game/shared/GameResultCard';
@@ -9,55 +8,11 @@ import { speakHebrew } from '@/lib/utils/speech/enhancedSpeechUtils';
 const QUESTIONS_PER_GAME = 10;
 
 export default function IsraelMapClient() {
-  const {
-    phase, current, foundIds, score, total, lastResult,
-    startGame, checkTap, nextLocation, resetGame,
-  } = useMapStore();
-
-  const [feedback, setFeedback] = useState<string | null>(null);
-  const feedbackTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-
-  // Announce current location via TTS whenever it changes
-  useEffect(() => {
-    if (current && phase === 'playing') {
-      const msg = `לחץ על ${current.name}`;
-      speakHebrew(msg);
-    }
-  }, [current, phase]);
-
-  const handleTap = (svgX: number, svgY: number) => {
-    if (!current || lastResult !== null) return;
-    const hit = checkTap(svgX, svgY);
-
-    if (hit) {
-      useMapStore.setState((s) => ({
-        score: s.score + 1,
-        total: s.total + 1,
-        foundIds: [...s.foundIds, current.id],
-        lastResult: 'correct',
-      }));
-      setFeedback('correct');
-      speakHebrew(`נכון! ${current.fact}`);
-      feedbackTimerRef.current = setTimeout(() => {
-        setFeedback(null);
-        nextLocation();
-      }, 2500);
-    } else {
-      useMapStore.setState((s) => ({ total: s.total + 1, lastResult: 'wrong' }));
-      setFeedback('wrong');
-      speakHebrew(`נסה שוב — לחץ על ${current.name}`);
-      feedbackTimerRef.current = setTimeout(() => {
-        setFeedback(null);
-        useMapStore.setState({ lastResult: null });
-      }, 1200);
-    }
-  };
-
-  useEffect(() => () => { if (feedbackTimerRef.current) clearTimeout(feedbackTimerRef.current); }, []);
+  const { phase, current, foundIds, score, total, lastResult, feedback, startGame, handleTap, resetGame } = useIsraelMap();
 
   if (phase === 'menu') {
     return (
-      <div className="min-h-screen bg-gradient-to-br from-blue-100 to-teal-100 flex flex-col items-center justify-center p-6">
+      <div className="min-h-screen bg-linear-to-br from-blue-100 to-teal-100 flex flex-col items-center justify-center p-6">
         <div className="text-6xl mb-4">🗺️</div>
         <h1 className="text-3xl font-bold text-blue-900 mb-2">מפת ישראל</h1>
         <p className="text-blue-700 mb-8 text-center">לחץ על המקום הנכון במפה!</p>
@@ -82,7 +37,7 @@ export default function IsraelMapClient() {
   if (phase === 'result') {
     const pct = Math.round((score / QUESTIONS_PER_GAME) * 100);
     return (
-      <div className="min-h-screen bg-gradient-to-br from-blue-100 to-teal-100 flex items-center justify-center p-6">
+      <div className="min-h-screen bg-linear-to-br from-blue-100 to-teal-100 flex items-center justify-center p-6">
         <GameResultCard
           emoji="🗺️"
           title="סיימת את מסע ישראל!"
@@ -104,7 +59,7 @@ export default function IsraelMapClient() {
   const progressPct = Math.round((total / QUESTIONS_PER_GAME) * 100);
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-blue-50 to-teal-50 flex flex-col items-center p-3">
+    <div className="min-h-screen bg-linear-to-br from-blue-50 to-teal-50 flex flex-col items-center p-3">
       {/* Header */}
       <div className="w-full max-w-md flex items-center justify-between mb-3">
         <button onClick={resetGame} className="text-blue-500 text-2xl">←</button>

--- a/gamesformykids/app/games/israel-map/useIsraelMap.ts
+++ b/gamesformykids/app/games/israel-map/useIsraelMap.ts
@@ -1,0 +1,54 @@
+'use client';
+import { useState, useCallback, useEffect, useRef } from 'react';
+import { useMapStore } from './mapStore';
+import { speakHebrew } from '@/lib/utils/speech/enhancedSpeechUtils';
+
+export function useIsraelMap() {
+  const {
+    phase, current, foundIds, score, total, lastResult,
+    startGame, checkTap, nextLocation, resetGame,
+  } = useMapStore();
+
+  const [feedback, setFeedback] = useState<string | null>(null);
+  const feedbackTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    if (current && phase === 'playing') {
+      speakHebrew(`לחץ על ${current.name}`);
+    }
+  }, [current, phase]);
+
+  const handleTap = useCallback((svgX: number, svgY: number) => {
+    if (!current || lastResult !== null) return;
+    const hit = checkTap(svgX, svgY);
+
+    if (hit) {
+      useMapStore.setState((s) => ({
+        score: s.score + 1,
+        total: s.total + 1,
+        foundIds: [...s.foundIds, current.id],
+        lastResult: 'correct',
+      }));
+      setFeedback('correct');
+      speakHebrew(`נכון! ${current.fact}`);
+      feedbackTimerRef.current = setTimeout(() => {
+        setFeedback(null);
+        nextLocation();
+      }, 2500);
+    } else {
+      useMapStore.setState((s) => ({ total: s.total + 1, lastResult: 'wrong' }));
+      setFeedback('wrong');
+      speakHebrew(`נסה שוב — לחץ על ${current.name}`);
+      feedbackTimerRef.current = setTimeout(() => {
+        setFeedback(null);
+        useMapStore.setState({ lastResult: null });
+      }, 1200);
+    }
+  }, [current, lastResult, checkTap, nextLocation]);
+
+  useEffect(() => () => {
+    if (feedbackTimerRef.current) clearTimeout(feedbackTimerRef.current);
+  }, []);
+
+  return { phase, current, foundIds, score, total, lastResult, feedback, startGame, handleTap, resetGame };
+}

--- a/gamesformykids/app/games/kids-songs/components/LyricsDisplay.tsx
+++ b/gamesformykids/app/games/kids-songs/components/LyricsDisplay.tsx
@@ -1,6 +1,6 @@
 'use client';
-import { useState, useCallback, useEffect, useRef } from 'react';
 import type { SongData } from '../data/songs';
+import { useLyricsPlayer } from '../hooks/useLyricsPlayer';
 
 interface Props {
   song: SongData;
@@ -9,80 +9,7 @@ interface Props {
 }
 
 export default function LyricsDisplay({ song, onFinish, onBack }: Props) {
-  const [lineIdx, setLineIdx] = useState(0);
-  const [wordIdx, setWordIdx] = useState(-1);
-  const [playing, setPlaying] = useState(false);
-  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const onFinishRef = useRef(onFinish);
-  onFinishRef.current = onFinish;
-
-  const cancel = useCallback(() => {
-    window.speechSynthesis.cancel();
-    if (timerRef.current) clearTimeout(timerRef.current);
-  }, []);
-
-  const advance = useCallback((idx: number) => {
-    cancel();
-    if (idx >= song.lines.length) {
-      onFinishRef.current();
-      return;
-    }
-    setLineIdx(idx);
-    setWordIdx(-1);
-    setPlaying(true);
-
-    const line = song.lines[idx] ?? '';
-    const words = line.split(' ');
-
-    // Precompute char offsets for word-boundary highlighting
-    const wordStarts: number[] = [];
-    let pos = 0;
-    for (const word of words) {
-      wordStarts.push(pos);
-      pos += word.length + 1;
-    }
-
-    const utter = new SpeechSynthesisUtterance(line);
-    utter.lang = 'he-IL';
-    utter.rate = 0.85;
-
-    utter.onboundary = (e: SpeechSynthesisEvent) => {
-      if (e.name !== 'word') return;
-      let found = 0;
-      for (let i = wordStarts.length - 1; i >= 0; i--) {
-        if ((wordStarts[i] ?? 0) <= e.charIndex) { found = i; break; }
-      }
-      setWordIdx(found);
-    };
-
-    utter.onend = () => {
-      setWordIdx(-1);
-      setPlaying(false);
-      timerRef.current = setTimeout(() => advance(idx + 1), 1000);
-    };
-
-    utter.onerror = () => setPlaying(false);
-    window.speechSynthesis.speak(utter);
-  }, [cancel, song]);
-
-  useEffect(() => {
-    advance(0);
-    return cancel;
-  }, [advance, cancel]);
-
-  const handleReplay = () => {
-    if (timerRef.current) clearTimeout(timerRef.current);
-    advance(lineIdx);
-  };
-
-  const handleNext = () => {
-    cancel();
-    if (lineIdx + 1 >= song.lines.length) {
-      onFinishRef.current();
-    } else {
-      advance(lineIdx + 1);
-    }
-  };
+  const { lineIdx, wordIdx, playing, cancel, handleReplay, handleNext } = useLyricsPlayer({ song, onFinish });
 
   const handleBack = () => {
     cancel();
@@ -90,7 +17,7 @@ export default function LyricsDisplay({ song, onFinish, onBack }: Props) {
   };
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-indigo-50 to-purple-100 flex flex-col items-center p-6">
+    <div className="min-h-screen bg-linear-to-br from-indigo-50 to-purple-100 flex flex-col items-center p-6">
       <div className="w-full max-w-lg">
         {/* Header */}
         <div className="flex items-center mb-6 mt-2">

--- a/gamesformykids/app/games/kids-songs/hooks/useLyricsPlayer.ts
+++ b/gamesformykids/app/games/kids-songs/hooks/useLyricsPlayer.ts
@@ -1,0 +1,86 @@
+'use client';
+import { useState, useCallback, useEffect, useRef } from 'react';
+import type { SongData } from '../data/songs';
+
+interface Options {
+  song: SongData;
+  onFinish: () => void;
+}
+
+export function useLyricsPlayer({ song, onFinish }: Options) {
+  const [lineIdx, setLineIdx] = useState(0);
+  const [wordIdx, setWordIdx] = useState(-1);
+  const [playing, setPlaying] = useState(false);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const onFinishRef = useRef(onFinish);
+  onFinishRef.current = onFinish;
+
+  const cancel = useCallback(() => {
+    window.speechSynthesis.cancel();
+    if (timerRef.current) clearTimeout(timerRef.current);
+  }, []);
+
+  const advance = useCallback((idx: number) => {
+    cancel();
+    if (idx >= song.lines.length) {
+      onFinishRef.current();
+      return;
+    }
+    setLineIdx(idx);
+    setWordIdx(-1);
+    setPlaying(true);
+
+    const line = song.lines[idx] ?? '';
+    const words = line.split(' ');
+
+    const wordStarts: number[] = [];
+    let pos = 0;
+    for (const word of words) {
+      wordStarts.push(pos);
+      pos += word.length + 1;
+    }
+
+    const utter = new SpeechSynthesisUtterance(line);
+    utter.lang = 'he-IL';
+    utter.rate = 0.85;
+
+    utter.onboundary = (e: SpeechSynthesisEvent) => {
+      if (e.name !== 'word') return;
+      let found = 0;
+      for (let i = wordStarts.length - 1; i >= 0; i--) {
+        if ((wordStarts[i] ?? 0) <= e.charIndex) { found = i; break; }
+      }
+      setWordIdx(found);
+    };
+
+    utter.onend = () => {
+      setWordIdx(-1);
+      setPlaying(false);
+      timerRef.current = setTimeout(() => advance(idx + 1), 1000);
+    };
+
+    utter.onerror = () => setPlaying(false);
+    window.speechSynthesis.speak(utter);
+  }, [cancel, song]);
+
+  useEffect(() => {
+    advance(0);
+    return cancel;
+  }, [advance, cancel]);
+
+  const handleReplay = useCallback(() => {
+    if (timerRef.current) clearTimeout(timerRef.current);
+    advance(lineIdx);
+  }, [advance, lineIdx]);
+
+  const handleNext = useCallback(() => {
+    cancel();
+    if (lineIdx + 1 >= song.lines.length) {
+      onFinishRef.current();
+    } else {
+      advance(lineIdx + 1);
+    }
+  }, [cancel, advance, lineIdx, song.lines.length]);
+
+  return { lineIdx, wordIdx, playing, cancel, handleReplay, handleNext };
+}

--- a/gamesformykids/components/marketing/PWAInstallBanner.tsx
+++ b/gamesformykids/components/marketing/PWAInstallBanner.tsx
@@ -1,48 +1,8 @@
 'use client';
-import { useState, useEffect } from 'react';
-
-interface BeforeInstallPromptEvent extends Event {
-  prompt(): Promise<void>;
-  userChoice: Promise<{ outcome: 'accepted' | 'dismissed' }>;
-}
-
-const DISMISSED_KEY = 'gfk_pwa_dismissed';
-const VISIT_KEY = 'gfk_visit_count';
-const MIN_VISITS = 3;
+import { usePWAInstallBanner } from '@/hooks/shared/marketing/usePWAInstallBanner';
 
 export default function PWAInstallBanner() {
-  const [deferredPrompt, setDeferredPrompt] = useState<BeforeInstallPromptEvent | null>(null);
-  const [visible, setVisible] = useState(false);
-
-  useEffect(() => {
-    if (localStorage.getItem(DISMISSED_KEY)) return;
-    if (window.matchMedia('(display-mode: standalone)').matches) return;
-
-    const count = parseInt(localStorage.getItem(VISIT_KEY) ?? '0', 10) + 1;
-    localStorage.setItem(VISIT_KEY, String(count));
-    if (count < MIN_VISITS) return;
-
-    const handler = (e: Event) => {
-      e.preventDefault();
-      setDeferredPrompt(e as BeforeInstallPromptEvent);
-      setVisible(true);
-    };
-    window.addEventListener('beforeinstallprompt', handler);
-    return () => window.removeEventListener('beforeinstallprompt', handler);
-  }, []);
-
-  const install = async () => {
-    if (!deferredPrompt) return;
-    await deferredPrompt.prompt();
-    const { outcome } = await deferredPrompt.userChoice;
-    if (outcome === 'accepted') dismiss();
-    else setDeferredPrompt(null);
-  };
-
-  const dismiss = () => {
-    localStorage.setItem(DISMISSED_KEY, '1');
-    setVisible(false);
-  };
+  const { visible, install, dismiss } = usePWAInstallBanner();
 
   if (!visible) return null;
 

--- a/gamesformykids/hooks/shared/marketing/usePWAInstallBanner.ts
+++ b/gamesformykids/hooks/shared/marketing/usePWAInstallBanner.ts
@@ -1,0 +1,48 @@
+'use client';
+import { useState, useEffect } from 'react';
+
+interface BeforeInstallPromptEvent extends Event {
+  prompt(): Promise<void>;
+  userChoice: Promise<{ outcome: 'accepted' | 'dismissed' }>;
+}
+
+const DISMISSED_KEY = 'gfk_pwa_dismissed';
+const VISIT_KEY = 'gfk_visit_count';
+const MIN_VISITS = 3;
+
+export function usePWAInstallBanner() {
+  const [deferredPrompt, setDeferredPrompt] = useState<BeforeInstallPromptEvent | null>(null);
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    if (localStorage.getItem(DISMISSED_KEY)) return;
+    if (window.matchMedia('(display-mode: standalone)').matches) return;
+
+    const count = parseInt(localStorage.getItem(VISIT_KEY) ?? '0', 10) + 1;
+    localStorage.setItem(VISIT_KEY, String(count));
+    if (count < MIN_VISITS) return;
+
+    const handler = (e: Event) => {
+      e.preventDefault();
+      setDeferredPrompt(e as BeforeInstallPromptEvent);
+      setVisible(true);
+    };
+    window.addEventListener('beforeinstallprompt', handler);
+    return () => window.removeEventListener('beforeinstallprompt', handler);
+  }, []);
+
+  const install = async () => {
+    if (!deferredPrompt) return;
+    await deferredPrompt.prompt();
+    const { outcome } = await deferredPrompt.userChoice;
+    if (outcome === 'accepted') dismiss();
+    else setDeferredPrompt(null);
+  };
+
+  const dismiss = () => {
+    localStorage.setItem(DISMISSED_KEY, '1');
+    setVisible(false);
+  };
+
+  return { visible, install, dismiss };
+}


### PR DESCRIPTION
## Summary
- `LyricsDisplay.tsx` (🔴): Extract full SpeechSynthesis playback — `lineIdx`/`wordIdx`/`playing` state + `advance`/`cancel` callbacks → `useLyricsPlayer.ts`
- `IsraelMapClient.tsx` (🟠): Extract `feedback` state + `handleTap` (direct `useMapStore.setState`, TTS, timers) → `useIsraelMap.ts`
- `PWAInstallBanner.tsx` (🟠): Extract `deferredPrompt`/`visible` state + `beforeinstallprompt` event listener + async `install` logic → `usePWAInstallBanner.ts`
- Bonus: fix `bg-gradient-to-br` → `bg-linear-to-br` (Tailwind v4 canonical classes) in both updated components

## Test plan
- [ ] Kids Songs game: lyrics auto-play on song open, word-by-word highlighting works, replay/next buttons work
- [ ] Israel Map game: tapping correct/wrong location shows feedback banner, TTS announces location, timer clears on unmount
- [ ] PWA banner: appears after 3 visits on supported browsers, install/dismiss buttons work
- [ ] `npx tsc --noEmit` — zero errors ✅

Closes #1287

🤖 Generated with [Claude Code](https://claude.com/claude-code)