### PR TITLE
feat(avatar-maker): Hebrew character builder with PNG export (closes #1217)

### DIFF
--- a/gamesformykids/app/games/[gameType]/CustomGameRenderer.tsx
+++ b/gamesformykids/app/games/[gameType]/CustomGameRenderer.tsx
@@ -66,6 +66,7 @@ const GAME_CLIENTS: Record<string, ComponentType> = {
   'craft-guide':       dynamic(() => import('../craft-guide/CraftGuideClient'),                      { ssr: false }),
   'jokes-browser':     dynamic(() => import('../jokes-browser/JokesBrowserClient'),                  { ssr: false }),
   'word-maze':         dynamic(() => import('../word-maze/WordMazeClient'),                          { ssr: false }),
+  'avatar-maker':      dynamic(() => import('../avatar-maker/AvatarMakerClient'),                   { ssr: false }),
 };
 
 interface Props { gameType: string; }

--- a/gamesformykids/app/games/[gameType]/gamePageConstants.ts
+++ b/gamesformykids/app/games/[gameType]/gamePageConstants.ts
@@ -86,6 +86,7 @@ export const SUPPORTED_GAMES = [
   'word-maze',
   'riddles-pro',
   'trivia-categories',
+  'avatar-maker',
 ] as const;
 
 export type SupportedGameType = typeof SUPPORTED_GAMES[number];
@@ -100,7 +101,7 @@ export const CUSTOM_GAME_TYPES = new Set([
   'word-builder', 'word-scramble', 'maze', 'letter-defender', 'puppet-story', 'number-slide', 'snakes-ladders',
 
 
-  'escape-room', 'robot-coder', 'find-in-scene', 'hangman', 'choose-adventure', 'picture-dictionary', 'word-search', 'israel-map', 'kids-songs', 'melody-maker', 'kids-encyclopedia', 'age-calculator', 'craft-guide', 'jokes-browser', 'word-maze',
+  'escape-room', 'robot-coder', 'find-in-scene', 'hangman', 'choose-adventure', 'picture-dictionary', 'word-search', 'israel-map', 'kids-songs', 'melody-maker', 'kids-encyclopedia', 'age-calculator', 'craft-guide', 'jokes-browser', 'word-maze', 'avatar-maker',
   
   
 ]);

--- a/gamesformykids/app/games/avatar-maker/AvatarMakerClient.tsx
+++ b/gamesformykids/app/games/avatar-maker/AvatarMakerClient.tsx
@@ -1,0 +1,81 @@
+'use client';
+import { useState } from 'react';
+import { useAvatarMaker } from './useAvatarMaker';
+import AvatarPreview from './components/AvatarPreview';
+import AvatarOptionGrid from './components/AvatarOptionGrid';
+import { AVATAR_AREAS, AREA_LABELS, type AvatarArea } from '@/lib/constants/avatarParts';
+
+export default function AvatarMakerClient() {
+  const { selections, previewRef, handleSelect, exportPNG, shareWhatsApp, reset } = useAvatarMaker();
+  const [activeArea, setActiveArea] = useState<AvatarArea>('face');
+
+  return (
+    <div
+      dir="rtl"
+      className="min-h-screen flex flex-col items-center p-4 pb-8"
+      style={{ background: 'linear-gradient(135deg, #fce4ec 0%, #e8f5e9 50%, #e3f2fd 100%)' }}
+    >
+      {/* Header */}
+      <div className="text-center mb-4 mt-2">
+        <div className="text-5xl mb-1">🧑‍🎨</div>
+        <h1 className="text-2xl font-extrabold text-purple-800">יוצר הדמות שלי</h1>
+        <p className="text-purple-600 text-sm">בנה דמות מגניבה!</p>
+      </div>
+
+      <div className="w-full max-w-md flex flex-col gap-4">
+        {/* Character Preview */}
+        <div className="flex justify-center">
+          <AvatarPreview selections={selections} previewRef={previewRef} />
+        </div>
+
+        {/* Tab Picker */}
+        <div className="flex rounded-2xl overflow-hidden shadow bg-white border border-gray-100">
+          {AVATAR_AREAS.map(area => (
+            <button
+              key={area}
+              onClick={() => setActiveArea(area)}
+              className={`flex-1 py-2 text-xs font-bold transition-colors ${
+                activeArea === area
+                  ? 'bg-amber-400 text-white'
+                  : 'text-gray-600 hover:bg-amber-50'
+              }`}
+            >
+              {AREA_LABELS[area]}
+            </button>
+          ))}
+        </div>
+
+        {/* Option Grid */}
+        <div className="bg-white rounded-3xl shadow overflow-hidden">
+          <AvatarOptionGrid
+            area={activeArea}
+            selectedId={selections[activeArea]}
+            onSelect={handleSelect}
+          />
+        </div>
+
+        {/* Action buttons */}
+        <div className="flex gap-3">
+          <button
+            onClick={exportPNG}
+            className="flex-1 bg-gradient-to-r from-green-500 to-emerald-500 text-white font-bold py-3 rounded-2xl text-sm shadow-md hover:opacity-90 active:scale-95 transition-all"
+          >
+            📥 שמור כתמונה
+          </button>
+          <button
+            onClick={shareWhatsApp}
+            className="flex-1 bg-gradient-to-r from-green-600 to-teal-600 text-white font-bold py-3 rounded-2xl text-sm shadow-md hover:opacity-90 active:scale-95 transition-all"
+          >
+            📲 שתף בוואטסאפ
+          </button>
+        </div>
+        <button
+          onClick={reset}
+          className="w-full bg-white border-2 border-gray-200 text-gray-500 font-bold py-2 rounded-2xl text-sm hover:border-red-200 hover:text-red-400 active:scale-95 transition-all"
+        >
+          🔄 התחל מחדש
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/gamesformykids/app/games/avatar-maker/avatarMakerStore.ts
+++ b/gamesformykids/app/games/avatar-maker/avatarMakerStore.ts
@@ -1,0 +1,15 @@
+'use client';
+import { create } from 'zustand';
+import { DEFAULT_SELECTIONS, type AvatarArea } from '@/lib/constants/avatarParts';
+
+interface AvatarMakerState {
+  selections: Record<AvatarArea, string>;
+  selectPart: (area: AvatarArea, partId: string) => void;
+  reset: () => void;
+}
+
+export const useAvatarMakerStore = create<AvatarMakerState>((set) => ({
+  selections: { ...DEFAULT_SELECTIONS },
+  selectPart: (area, partId) => set(s => ({ selections: { ...s.selections, [area]: partId } })),
+  reset: () => set({ selections: { ...DEFAULT_SELECTIONS } }),
+}));

--- a/gamesformykids/app/games/avatar-maker/components/AvatarOptionGrid.tsx
+++ b/gamesformykids/app/games/avatar-maker/components/AvatarOptionGrid.tsx
@@ -1,0 +1,40 @@
+'use client';
+import { AVATAR_PARTS, type AvatarArea } from '@/lib/constants/avatarParts';
+
+interface Props {
+  area: AvatarArea;
+  selectedId: string;
+  onSelect: (area: AvatarArea, id: string) => void;
+}
+
+export default function AvatarOptionGrid({ area, selectedId, onSelect }: Props) {
+  const parts = AVATAR_PARTS[area];
+
+  return (
+    <div className="grid grid-cols-4 gap-2 p-2">
+      {parts.map(part => (
+        <button
+          key={part.id}
+          onClick={() => onSelect(area, part.id)}
+          title={part.label}
+          className={`flex flex-col items-center justify-center rounded-2xl p-2 transition-all active:scale-95 border-2 ${
+            selectedId === part.id
+              ? 'border-amber-400 bg-amber-50 shadow-md scale-105'
+              : 'border-transparent bg-white hover:border-amber-200 hover:bg-amber-50'
+          }`}
+          style={{ minHeight: 64 }}
+        >
+          {area === 'hair' && part.color ? (
+            <div
+              className="rounded-full mb-1 border border-gray-200"
+              style={{ width: 28, height: 28, backgroundColor: part.color }}
+            />
+          ) : (
+            <span style={{ fontSize: 28, lineHeight: 1 }}>{part.emoji}</span>
+          )}
+          <span className="text-xs text-gray-600 mt-1 leading-tight text-center">{part.label}</span>
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/gamesformykids/app/games/avatar-maker/components/AvatarPreview.tsx
+++ b/gamesformykids/app/games/avatar-maker/components/AvatarPreview.tsx
@@ -1,0 +1,74 @@
+'use client';
+import type { RefObject } from 'react';
+import { AVATAR_PARTS, type AvatarArea } from '@/lib/constants/avatarParts';
+
+interface Props {
+  selections: Record<AvatarArea, string>;
+  previewRef: RefObject<HTMLDivElement | null>;
+}
+
+export default function AvatarPreview({ selections, previewRef }: Props) {
+  const face      = AVATAR_PARTS.face.find(p => p.id === selections.face);
+  const hair      = AVATAR_PARTS.hair.find(p => p.id === selections.hair);
+  const clothing  = AVATAR_PARTS.clothing.find(p => p.id === selections.clothing);
+  const accessory = AVATAR_PARTS.accessories.find(p => p.id === selections.accessories);
+  const showAccessory = accessory && accessory.id !== 'a0';
+
+  return (
+    <div
+      ref={previewRef}
+      className="relative mx-auto flex flex-col items-center justify-center rounded-3xl shadow-2xl overflow-hidden select-none"
+      style={{
+        width: 200, height: 260,
+        background: 'linear-gradient(160deg, #fff9c4 0%, #e1f5fe 100%)',
+      }}
+    >
+      {/* Hair blob behind head */}
+      <div
+        className="absolute rounded-full"
+        style={{
+          width: 110, height: 65,
+          top: 28,
+          left: '50%',
+          transform: 'translateX(-50%)',
+          backgroundColor: hair?.color ?? '#8B4513',
+          borderRadius: '50% 50% 0 0',
+        }}
+      />
+
+      {/* Head circle */}
+      <div
+        className="absolute rounded-full flex items-center justify-center"
+        style={{
+          width: 100, height: 100,
+          top: 40,
+          left: '50%',
+          transform: 'translateX(-50%)',
+          backgroundColor: '#FFDAB9',
+          fontSize: 68,
+          lineHeight: 1,
+        }}
+      >
+        {face?.emoji ?? '😊'}
+      </div>
+
+      {/* Accessory (top-right of head) */}
+      {showAccessory && (
+        <div
+          className="absolute"
+          style={{ top: 20, left: '50%', transform: 'translateX(18px)', fontSize: 36 }}
+        >
+          {accessory.emoji}
+        </div>
+      )}
+
+      {/* Clothing below head */}
+      <div
+        className="absolute"
+        style={{ top: 148, left: '50%', transform: 'translateX(-50%)', fontSize: 64, lineHeight: 1 }}
+      >
+        {clothing?.emoji ?? '👕'}
+      </div>
+    </div>
+  );
+}

--- a/gamesformykids/app/games/avatar-maker/useAvatarMaker.ts
+++ b/gamesformykids/app/games/avatar-maker/useAvatarMaker.ts
@@ -1,0 +1,96 @@
+'use client';
+import { useCallback, useRef } from 'react';
+import { useAvatarMakerStore } from './avatarMakerStore';
+import { AVATAR_PARTS, type AvatarArea } from '@/lib/constants/avatarParts';
+import { speakHebrew } from '@/lib/utils/speech/enhancedSpeechUtils';
+
+export function useAvatarMaker() {
+  const { selections, selectPart, reset } = useAvatarMakerStore();
+  const previewRef = useRef<HTMLDivElement>(null);
+
+  const handleSelect = useCallback((area: AvatarArea, partId: string) => {
+    selectPart(area, partId);
+    const part = AVATAR_PARTS[area].find(p => p.id === partId);
+    if (part) speakHebrew(part.label);
+  }, [selectPart]);
+
+  const exportPNG = useCallback(async () => {
+    const face        = AVATAR_PARTS.face.find(p => p.id === selections.face);
+    const hair        = AVATAR_PARTS.hair.find(p => p.id === selections.hair);
+    const clothing    = AVATAR_PARTS.clothing.find(p => p.id === selections.clothing);
+    const accessory   = AVATAR_PARTS.accessories.find(p => p.id === selections.accessories);
+
+    const W = 300, H = 380;
+    const canvas = document.createElement('canvas');
+    canvas.width = W; canvas.height = H;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+
+    // Background gradient
+    const bg = ctx.createLinearGradient(0, 0, W, H);
+    bg.addColorStop(0, '#fff9c4');
+    bg.addColorStop(1, '#e1f5fe');
+    ctx.fillStyle = bg;
+    ctx.fillRect(0, 0, W, H);
+
+    // Hair semi-circle (top of head)
+    const cx = W / 2, headY = 130, headR = 70;
+    ctx.fillStyle = hair?.color ?? '#8B4513';
+    ctx.beginPath();
+    ctx.arc(cx, headY, headR + 12, Math.PI, 2 * Math.PI);
+    ctx.fill();
+
+    // Head circle
+    ctx.fillStyle = '#FFDAB9';
+    ctx.beginPath();
+    ctx.arc(cx, headY, headR, 0, 2 * Math.PI);
+    ctx.fill();
+
+    // Draw emoji layers
+    ctx.textAlign = 'center';
+    ctx.textBaseline = 'middle';
+
+    // Face expression
+    ctx.font = `${headR * 1.5}px serif`;
+    ctx.fillText(face?.emoji ?? '😊', cx, headY + 5);
+
+    // Accessory above face (if not "none")
+    if (accessory && accessory.id !== 'a0') {
+      ctx.font = '48px serif';
+      ctx.fillText(accessory.emoji, cx + headR - 10, headY - headR + 10);
+    }
+
+    // Clothing below face
+    ctx.font = '72px serif';
+    ctx.fillText(clothing?.emoji ?? '👕', cx, headY + headR + 65);
+
+    // Border
+    ctx.strokeStyle = 'rgba(0,0,0,0.08)';
+    ctx.lineWidth = 2;
+    ctx.roundRect?.(4, 4, W - 8, H - 8, 16);
+    ctx.stroke();
+
+    const url = canvas.toDataURL('image/png');
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'הדמות-שלי.png';
+    a.click();
+  }, [selections]);
+
+  const shareWhatsApp = useCallback(async () => {
+    const face     = AVATAR_PARTS.face.find(p => p.id === selections.face);
+    const clothing = AVATAR_PARTS.clothing.find(p => p.id === selections.clothing);
+    const text = `הדמות שלי: ${face?.emoji ?? '😊'} ${clothing?.emoji ?? '👕'} — נוצר ב-GamesForMyKids 🎮`;
+    const url = `https://wa.me/?text=${encodeURIComponent(text)}`;
+    window.open(url, '_blank');
+  }, [selections]);
+
+  return {
+    selections,
+    previewRef,
+    handleSelect,
+    exportPNG,
+    shareWhatsApp,
+    reset,
+  };
+}

--- a/gamesformykids/lib/constants/avatarParts.ts
+++ b/gamesformykids/lib/constants/avatarParts.ts
@@ -1,0 +1,67 @@
+export type AvatarArea = 'face' | 'hair' | 'clothing' | 'accessories';
+
+export interface AvatarPart {
+  id: string;
+  emoji: string;
+  label: string;
+  color?: string;
+}
+
+export const AVATAR_PARTS: Record<AvatarArea, AvatarPart[]> = {
+  face: [
+    { id: 'f1', emoji: '😊', label: 'פנים שמחות' },
+    { id: 'f2', emoji: '😄', label: 'פנים מאושרות' },
+    { id: 'f3', emoji: '😎', label: 'פנים קרירות' },
+    { id: 'f4', emoji: '🥳', label: 'פנים חגיגיות' },
+    { id: 'f5', emoji: '🤩', label: 'פנים נרגשות' },
+    { id: 'f6', emoji: '😇', label: 'פנים תמימות' },
+    { id: 'f7', emoji: '😜', label: 'פנים שובבות' },
+    { id: 'f8', emoji: '🤗', label: 'פנים חמות' },
+  ],
+  hair: [
+    { id: 'hr1', emoji: '🟤', label: 'שיער חום',     color: '#8B4513' },
+    { id: 'hr2', emoji: '🟡', label: 'שיער בלונד',   color: '#F0E68C' },
+    { id: 'hr3', emoji: '⬛', label: 'שיער שחור',    color: '#1C1C1C' },
+    { id: 'hr4', emoji: '🔴', label: 'שיער אדום',    color: '#CC2200' },
+    { id: 'hr5', emoji: '⬜', label: 'שיער לבן',     color: '#E8E8E8' },
+    { id: 'hr6', emoji: '🟣', label: 'שיער סגול',   color: '#7B2FBE' },
+    { id: 'hr7', emoji: '🌈', label: 'שיער קשת',    color: '#FF6B9D' },
+    { id: 'hr8', emoji: '🩶', label: 'שיער אפור',   color: '#888888' },
+  ],
+  clothing: [
+    { id: 'c1', emoji: '👕', label: 'חולצה כחולה' },
+    { id: 'c2', emoji: '👗', label: 'שמלה יפה' },
+    { id: 'c3', emoji: '🧥', label: 'מעיל חם' },
+    { id: 'c4', emoji: '👚', label: 'חולצת ספורט' },
+    { id: 'c5', emoji: '🎽', label: 'גופיית ספורט' },
+    { id: 'c6', emoji: '👔', label: 'חולצה מכופתרת' },
+    { id: 'c7', emoji: '🧣', label: 'צעיף צבעוני' },
+    { id: 'c8', emoji: '🩱', label: 'בגד ים' },
+  ],
+  accessories: [
+    { id: 'a0', emoji: '❌', label: 'ללא אביזר' },
+    { id: 'a1', emoji: '🎀', label: 'סרט שיער' },
+    { id: 'a2', emoji: '🕶️', label: 'משקפי שמש' },
+    { id: 'a3', emoji: '🧢', label: 'כובע שטח' },
+    { id: 'a4', emoji: '👑', label: 'כתר' },
+    { id: 'a5', emoji: '🌟', label: 'כוכב מזהיר' },
+    { id: 'a6', emoji: '🎸', label: 'גיטרה' },
+    { id: 'a7', emoji: '🌈', label: 'קשת קסם' },
+  ],
+};
+
+export const AREA_LABELS: Record<AvatarArea, string> = {
+  face:        '😊 הבעה',
+  hair:        '💇 שיער',
+  clothing:    '👕 ביגוד',
+  accessories: '🌟 אביזרים',
+};
+
+export const AVATAR_AREAS: AvatarArea[] = ['face', 'hair', 'clothing', 'accessories'];
+
+export const DEFAULT_SELECTIONS: Record<AvatarArea, string> = {
+  face:        'f1',
+  hair:        'hr1',
+  clothing:    'c1',
+  accessories: 'a0',
+};

--- a/gamesformykids/lib/constants/gameCategories.ts
+++ b/gamesformykids/lib/constants/gameCategories.ts
@@ -38,7 +38,7 @@ export const GAME_CATEGORIES: Record<string, GameCategory> = {
     icon: Palette,
     color: "bg-purple-500",
     gradient: "from-purple-400 to-purple-600",
-    gameIds: ["instruments","puzzles","drawing","building","tetris","magic-fairy-tales","circus-show","logic-games","art-craft","superheroes","fairy-tale-chars","famous-paintings","tech-logos","color-mix","puppet-story","melody-maker","craft-guide"],
+    gameIds: ["instruments","puzzles","drawing","building","tetris","magic-fairy-tales","circus-show","logic-games","art-craft","superheroes","fairy-tale-chars","famous-paintings","tech-logos","color-mix","puppet-story","melody-maker","craft-guide","avatar-maker"],
   },
   nature: {
     title: "טבע ואוכל",

--- a/gamesformykids/lib/registry/registryData/batch4.ts
+++ b/gamesformykids/lib/registry/registryData/batch4.ts
@@ -778,4 +778,15 @@ export const gamesRegistryBatch4: GameRegistration[] = [
     available: true,
     order: 191,
   },
+  {
+    id: "avatar-maker",
+    title: "יוצר הדמות שלי",
+    description: "בנה דמות מגניבה עם הבעות, שיער, ביגוד ואביזרים — שמור כתמונה ושתף!",
+    icon: Palette,
+    emoji: "🧑‍🎨",
+    color: "bg-pink-500 hover:bg-pink-600",
+    href: "/games/avatar-maker",
+    available: true,
+    order: 192,
+  },
 ];

--- a/gamesformykids/lib/types/core/base.ts
+++ b/gamesformykids/lib/types/core/base.ts
@@ -239,4 +239,6 @@ export type GameType =
   // Progressive riddles
   | 'riddles-pro'
   // Categorised trivia with difficulty picker
-  | 'trivia-categories';
+  | 'trivia-categories'
+  // Hebrew avatar character builder
+  | 'avatar-maker';


### PR DESCRIPTION
## What
Adds a new **avatar-maker** custom game (Style D) where children build a cartoon character:
- 4 customisation tabs: **הבעה** (expression), **שיער** (hair color), **ביגוד** (clothing), **אביזרים** (accessories)
- 8 options per area (6+ per acceptance criteria)
- TTS announces Hebrew label on each selection via `speakHebrew`
- Real-time character preview: hair color semi-circle + head + face emoji + clothing + accessory
- PNG export: draws character to a canvas and triggers download
- WhatsApp share: opens wa.me with emoji description
- Reset button to start over
- Full RTL layout

## Why
Closes #1217

## Test plan
- [ ] Visit `/games/avatar-maker`
- [ ] Tap each tab — options update correctly
- [ ] TTS speaks Hebrew label on selection
- [ ] Character preview updates instantly
- [ ] Click "שמור כתמונה" → PNG downloads
- [ ] Click "שתף בוואטסאפ" → WhatsApp opens
- [ ] Appears in home page creative category grid
- [ ] `npx tsc --noEmit` passes ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)