### PR TITLE
feat(sound-quiz): Hebrew sound identification game with TTS (closes #1241)

### DIFF
--- a/gamesformykids/app/games/[gameType]/CustomGameRenderer.tsx
+++ b/gamesformykids/app/games/[gameType]/CustomGameRenderer.tsx
@@ -67,6 +67,7 @@ const GAME_CLIENTS: Record<string, ComponentType> = {
   'jokes-browser':     dynamic(() => import('../jokes-browser/JokesBrowserClient'),                  { ssr: false }),
   'word-maze':         dynamic(() => import('../word-maze/WordMazeClient'),                          { ssr: false }),
   'avatar-maker':      dynamic(() => import('../avatar-maker/AvatarMakerClient'),                   { ssr: false }),
+  'sound-quiz':        dynamic(() => import('../sound-quiz/SoundQuizClient'),                       { ssr: false }),
 };
 
 interface Props { gameType: string; }

--- a/gamesformykids/app/games/[gameType]/gamePageConstants.ts
+++ b/gamesformykids/app/games/[gameType]/gamePageConstants.ts
@@ -87,6 +87,7 @@ export const SUPPORTED_GAMES = [
   'riddles-pro',
   'trivia-categories',
   'avatar-maker',
+  'sound-quiz',
 ] as const;
 
 export type SupportedGameType = typeof SUPPORTED_GAMES[number];
@@ -101,7 +102,7 @@ export const CUSTOM_GAME_TYPES = new Set([
   'word-builder', 'word-scramble', 'maze', 'letter-defender', 'puppet-story', 'number-slide', 'snakes-ladders',
 
 
-  'escape-room', 'robot-coder', 'find-in-scene', 'hangman', 'choose-adventure', 'picture-dictionary', 'word-search', 'israel-map', 'kids-songs', 'melody-maker', 'kids-encyclopedia', 'age-calculator', 'craft-guide', 'jokes-browser', 'word-maze', 'avatar-maker',
+  'escape-room', 'robot-coder', 'find-in-scene', 'hangman', 'choose-adventure', 'picture-dictionary', 'word-search', 'israel-map', 'kids-songs', 'melody-maker', 'kids-encyclopedia', 'age-calculator', 'craft-guide', 'jokes-browser', 'word-maze', 'avatar-maker', 'sound-quiz',
   
   
 ]);

--- a/gamesformykids/app/games/sound-quiz/SoundQuizClient.tsx
+++ b/gamesformykids/app/games/sound-quiz/SoundQuizClient.tsx
@@ -1,0 +1,130 @@
+'use client';
+import { useSoundQuiz } from './useSoundQuiz';
+import { CATEGORY_LABELS, SOUND_CATEGORIES } from './data/soundClips';
+
+export default function SoundQuizClient() {
+  const { phase, current, choices, choicesRevealed, score, total, lastCorrect, startGame, playSound, replaySound, selectAnswer, reset } = useSoundQuiz();
+
+  if (phase === 'menu') {
+    return (
+      <div className="min-h-screen flex flex-col items-center justify-center p-6" dir="rtl"
+        style={{ background: 'linear-gradient(135deg, #e8f5e9 0%, #e3f2fd 100%)' }}>
+        <div className="bg-white rounded-3xl shadow-xl p-8 max-w-sm w-full text-center">
+          <div className="text-6xl mb-3">🔊</div>
+          <h1 className="text-3xl font-extrabold text-teal-800 mb-2">מה הצליל?</h1>
+          <p className="text-teal-600 mb-6">שמע את הצליל ובחר מה עשה אותו!</p>
+          <div className="flex flex-col gap-3">
+            <button
+              onClick={() => startGame('all')}
+              className="bg-gradient-to-r from-teal-500 to-cyan-500 text-white font-bold py-3 rounded-2xl text-lg shadow-md hover:opacity-90 active:scale-95 transition-all"
+            >
+              🎲 כל הצלילים!
+            </button>
+            {SOUND_CATEGORIES.map(cat => (
+              <button
+                key={cat}
+                onClick={() => startGame(cat)}
+                className="bg-white border-2 border-teal-200 hover:border-teal-400 hover:bg-teal-50 text-gray-700 font-bold py-3 rounded-2xl transition-all active:scale-95"
+              >
+                {CATEGORY_LABELS[cat]}
+              </button>
+            ))}
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  if (phase === 'result') {
+    const pct = total > 0 ? Math.round((score / total) * 100) : 0;
+    return (
+      <div className="min-h-screen flex flex-col items-center justify-center p-6" dir="rtl"
+        style={{ background: 'linear-gradient(135deg, #e8f5e9 0%, #e3f2fd 100%)' }}>
+        <div className="bg-white rounded-3xl shadow-xl p-8 max-w-sm w-full text-center">
+          <div className="text-6xl mb-4">{pct >= 80 ? '🏆' : pct >= 60 ? '⭐' : '🎵'}</div>
+          <h2 className="text-2xl font-extrabold text-teal-800 mb-2">כל הכבוד!</h2>
+          <p className="text-lg text-gray-600 mb-4">ענית נכון על <span className="font-bold text-teal-600">{score}</span> מתוך <span className="font-bold">{total}</span> צלילים</p>
+          <div className="text-4xl font-extrabold text-teal-700 mb-6">{pct}%</div>
+          <button
+            onClick={reset}
+            className="w-full bg-gradient-to-r from-teal-500 to-cyan-500 text-white font-bold py-3 rounded-2xl shadow hover:opacity-90 active:scale-95 transition-all"
+          >
+            🔄 שחק שוב
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  // Playing phase
+  return (
+    <div className="min-h-screen flex flex-col items-center justify-start pt-6 p-4" dir="rtl"
+      style={{ background: 'linear-gradient(135deg, #e8f5e9 0%, #e3f2fd 100%)' }}>
+      {/* HUD */}
+      <div className="flex items-center justify-between w-full max-w-sm mb-4">
+        <span className="text-sm font-bold text-teal-700 bg-white rounded-xl px-3 py-1 shadow">
+          שאלה {total + 1} / 15
+        </span>
+        <span className="text-sm font-bold text-teal-700 bg-white rounded-xl px-3 py-1 shadow">
+          ✅ {score}
+        </span>
+      </div>
+
+      <div className="bg-white rounded-3xl shadow-xl p-6 w-full max-w-sm flex flex-col items-center gap-4">
+        {/* Mystery card */}
+        <div className="text-7xl">{choicesRevealed && current ? current.emoji : '❓'}</div>
+        <p className="text-gray-500 text-sm">{choicesRevealed ? 'בחר את מקור הצליל:' : 'לחץ כדי לשמוע את הצליל'}</p>
+
+        {/* Sound button */}
+        {!choicesRevealed ? (
+          <button
+            onClick={playSound}
+            className="w-full bg-gradient-to-r from-teal-500 to-cyan-500 text-white font-extrabold py-5 rounded-2xl text-2xl shadow-lg hover:opacity-90 active:scale-95 transition-all"
+          >
+            ▶ שמע!
+          </button>
+        ) : (
+          <button
+            onClick={replaySound}
+            className="text-teal-600 text-sm font-bold border border-teal-200 rounded-xl px-4 py-1.5 hover:bg-teal-50 active:scale-95 transition-all"
+          >
+            🔄 שמע שוב
+          </button>
+        )}
+
+        {/* Choices grid */}
+        {choicesRevealed && (
+          <div className="grid grid-cols-2 gap-3 w-full">
+            {choices.map(clip => {
+              let cls = 'flex flex-col items-center gap-1 p-3 rounded-2xl border-2 font-bold text-gray-700 transition-all active:scale-95 ';
+              if (lastCorrect !== null) {
+                if (clip.id === current?.id) cls += 'border-green-400 bg-green-50 text-green-800';
+                else cls += 'border-gray-200 bg-gray-50 opacity-60';
+              } else {
+                cls += 'border-gray-200 hover:border-teal-300 hover:bg-teal-50 bg-white';
+              }
+              return (
+                <button
+                  key={clip.id}
+                  onClick={() => lastCorrect === null && selectAnswer(clip)}
+                  disabled={lastCorrect !== null}
+                  className={cls}
+                >
+                  <span className="text-4xl">{clip.emoji}</span>
+                  <span className="text-sm">{clip.name}</span>
+                </button>
+              );
+            })}
+          </div>
+        )}
+
+        {/* Feedback */}
+        {lastCorrect !== null && (
+          <div className={`text-lg font-extrabold ${lastCorrect ? 'text-green-600' : 'text-red-500'}`}>
+            {lastCorrect ? '✅ נכון!' : `❌ הצליל היה: ${current?.name}`}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/gamesformykids/app/games/sound-quiz/data/soundClips.ts
+++ b/gamesformykids/app/games/sound-quiz/data/soundClips.ts
@@ -1,0 +1,70 @@
+export type SoundCategory = 'animals' | 'instruments' | 'nature' | 'household';
+
+export interface SoundClip {
+  id: string;
+  name: string;       // Hebrew name (correct answer label)
+  emoji: string;
+  soundText: string;  // Hebrew onomatopoeia spoken by TTS
+  category: SoundCategory;
+}
+
+export const SOUND_CLIPS: SoundClip[] = [
+  // ── בעלי חיים ──────────────────────────────────────────────────────────────
+  { id: 'a1',  name: 'חתול',    emoji: '🐱', soundText: 'מיאו מיאו',       category: 'animals' },
+  { id: 'a2',  name: 'כלב',     emoji: '🐶', soundText: 'הב הב הב',        category: 'animals' },
+  { id: 'a3',  name: 'פרה',     emoji: '🐄', soundText: 'מוּ מוּ מוּ',      category: 'animals' },
+  { id: 'a4',  name: 'דבורה',   emoji: '🐝', soundText: 'בזז בזז',          category: 'animals' },
+  { id: 'a5',  name: 'תרנגול',  emoji: '🐓', soundText: 'קוקוריקו',          category: 'animals' },
+  { id: 'a6',  name: 'צפרדע',   emoji: '🐸', soundText: 'קוואק קוואק',       category: 'animals' },
+  { id: 'a7',  name: 'כבש',     emoji: '🐑', soundText: 'מֵה מֵה',           category: 'animals' },
+  { id: 'a8',  name: 'נחש',     emoji: '🐍', soundText: 'שששששש',            category: 'animals' },
+  { id: 'a9',  name: 'ציפור',   emoji: '🐦', soundText: 'צ\'יק צ\'יק',      category: 'animals' },
+  { id: 'a10', name: 'פרא',     emoji: '🐴', soundText: 'אִיִיִי',           category: 'animals' },
+  { id: 'a11', name: 'קוף',     emoji: '🐒', soundText: 'אוּ אוּ אָה',       category: 'animals' },
+  { id: 'a12', name: 'אריה',    emoji: '🦁', soundText: 'רּוּוּאר',          category: 'animals' },
+
+  // ── כלי נגינה ──────────────────────────────────────────────────────────────
+  { id: 'i1',  name: 'תוף',     emoji: '🥁', soundText: 'בום בום צַק',       category: 'instruments' },
+  { id: 'i2',  name: 'חצוצרה',  emoji: '🎺', soundText: 'טָה טָה טָטָה',    category: 'instruments' },
+  { id: 'i3',  name: 'גיטרה',   emoji: '🎸', soundText: 'לָה לָה לָה',       category: 'instruments' },
+  { id: 'i4',  name: 'פסנתר',   emoji: '🎹', soundText: 'דִינג דִינג דִינג', category: 'instruments' },
+  { id: 'i5',  name: 'כינור',   emoji: '🎻', soundText: 'לִי לִי לִי',       category: 'instruments' },
+  { id: 'i6',  name: 'מפוחית',  emoji: '🪗', soundText: 'וּאָה וּאָה',        category: 'instruments' },
+  { id: 'i7',  name: 'פלוט',    emoji: '🪈', soundText: 'פְרִי פְרִי פְרִי', category: 'instruments' },
+  { id: 'i8',  name: 'מרמבה',   emoji: '🎵', soundText: 'בּוּם בּוּם טִינג', category: 'instruments' },
+  { id: 'i9',  name: 'מצילות',  emoji: '🔔', soundText: 'טִינג טִינג',        category: 'instruments' },
+  { id: 'i10', name: 'אקורדיון', emoji: '🎶', soundText: 'לָה לָה לָלָה',     category: 'instruments' },
+
+  // ── טבע ────────────────────────────────────────────────────────────────────
+  { id: 'n1',  name: 'גשם',     emoji: '🌧️', soundText: 'טִיף טִיף טִיף',   category: 'nature' },
+  { id: 'n2',  name: 'רעם',     emoji: '⛈️', soundText: 'בוּוּוּוּם',         category: 'nature' },
+  { id: 'n3',  name: 'רוח',     emoji: '💨', soundText: 'שׁוּוּוּוּ',          category: 'nature' },
+  { id: 'n4',  name: 'ים',      emoji: '🌊', soundText: 'וּוּשׁ וּוּשׁ',       category: 'nature' },
+  { id: 'n5',  name: 'צרצר',    emoji: '🦗', soundText: 'צְרְ צְרְ צְרְ',     category: 'nature' },
+  { id: 'n6',  name: 'מפל',     emoji: '🏞️', soundText: 'שַׁשׁשׁ שַׁשׁשׁ',     category: 'nature' },
+  { id: 'n7',  name: 'אש',      emoji: '🔥', soundText: 'טַרַק טַרַק פִצ',    category: 'nature' },
+  { id: 'n8',  name: 'סופה',    emoji: '🌪️', soundText: 'וּוּוּוּוּ',           category: 'nature' },
+  { id: 'n9',  name: 'קרח',     emoji: '🧊', soundText: 'טְרִיק טְרִיק',       category: 'nature' },
+  { id: 'n10', name: 'עץ',      emoji: '🌲', soundText: 'שְׁרִיקַת עלים',      category: 'nature' },
+
+  // ── בית ────────────────────────────────────────────────────────────────────
+  { id: 'h1',  name: 'שעון',    emoji: '⏰', soundText: 'טִיק טָק טִיק טָק',  category: 'household' },
+  { id: 'h2',  name: 'טלפון',   emoji: '📱', soundText: 'טְרִינג טְרִינג',     category: 'household' },
+  { id: 'h3',  name: 'דלת',     emoji: '🚪', soundText: 'דַּנג קּלִיק',          category: 'household' },
+  { id: 'h4',  name: 'שואב אבק',emoji: '🧹', soundText: 'ווּּוּוּ ווּּוּוּ',     category: 'household' },
+  { id: 'h5',  name: 'מקלדת',   emoji: '⌨️', soundText: 'טַק טַק טַק',         category: 'household' },
+  { id: 'h6',  name: 'כיריים',  emoji: '🍳', soundText: 'שִׁיש שִׁיש שִׁיש',    category: 'household' },
+  { id: 'h7',  name: 'חשמלית',  emoji: '🔔', soundText: 'דִינג דוֹנג',           category: 'household' },
+  { id: 'h8',  name: 'מיקסר',   emoji: '🥣', soundText: 'וּוּוּוּוּ',             category: 'household' },
+  { id: 'h9',  name: 'מקלחת',   emoji: '🚿', soundText: 'שׁ שׁ שׁ שׁ',           category: 'household' },
+  { id: 'h10', name: 'מכונת כביסה', emoji: '🫧', soundText: 'גּוּרגּוּר שְׁ שְׁ', category: 'household' },
+];
+
+export const CATEGORY_LABELS: Record<SoundCategory, string> = {
+  animals:     '🐾 בעלי חיים',
+  instruments: '🎵 כלי נגינה',
+  nature:      '🌿 טבע',
+  household:   '🏠 בית',
+};
+
+export const SOUND_CATEGORIES: SoundCategory[] = ['animals', 'instruments', 'nature', 'household'];

--- a/gamesformykids/app/games/sound-quiz/soundQuizStore.ts
+++ b/gamesformykids/app/games/sound-quiz/soundQuizStore.ts
@@ -1,0 +1,46 @@
+'use client';
+import { create } from 'zustand';
+import type { SoundCategory, SoundClip } from './data/soundClips';
+
+type Phase = 'menu' | 'playing' | 'result';
+
+interface SoundQuizState {
+  phase: Phase;
+  category: SoundCategory | 'all';
+  current: SoundClip | null;
+  choices: SoundClip[];
+  choicesRevealed: boolean;
+  score: number;
+  total: number;
+  lastCorrect: boolean | null;
+  // actions
+  startGame:      (cat: SoundCategory | 'all') => void;
+  revealChoices:  () => void;
+  selectAnswer:   (clip: SoundClip, correct: boolean) => void;
+  nextQuestion:   (clip: SoundClip, choices: SoundClip[]) => void;
+  endGame:        () => void;
+  reset:          () => void;
+}
+
+export const useSoundQuizStore = create<SoundQuizState>((set) => ({
+  phase: 'menu',
+  category: 'all',
+  current: null,
+  choices: [],
+  choicesRevealed: false,
+  score: 0,
+  total: 0,
+  lastCorrect: null,
+
+  startGame: (cat) => set({ phase: 'playing', category: cat, score: 0, total: 0, lastCorrect: null }),
+  revealChoices: () => set({ choicesRevealed: true }),
+  selectAnswer: (_, correct) => set(s => ({
+    score: correct ? s.score + 1 : s.score,
+    total: s.total + 1,
+    lastCorrect: correct,
+    choicesRevealed: false,
+  })),
+  nextQuestion: (clip, choices) => set({ current: clip, choices, choicesRevealed: false, lastCorrect: null }),
+  endGame: () => set({ phase: 'result' }),
+  reset: () => set({ phase: 'menu', current: null, choices: [], score: 0, total: 0, lastCorrect: null }),
+}));

--- a/gamesformykids/app/games/sound-quiz/useSoundQuiz.ts
+++ b/gamesformykids/app/games/sound-quiz/useSoundQuiz.ts
@@ -1,0 +1,89 @@
+'use client';
+import { useCallback, useEffect } from 'react';
+import { useSoundQuizStore } from './soundQuizStore';
+import { SOUND_CLIPS, type SoundCategory } from './data/soundClips';
+import { speakHebrew } from '@/lib/utils/speech/enhancedSpeechUtils';
+
+const ROUNDS = 15;
+
+function shuffle<T>(arr: T[]): T[] {
+  const a = [...arr];
+  for (let i = a.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    const tmp = a[i] as T; a[i] = a[j] as T; a[j] = tmp;
+  }
+  return a;
+}
+
+function pickChoices(correct: typeof SOUND_CLIPS[number], pool: typeof SOUND_CLIPS) {
+  const others = shuffle(pool.filter(c => c.id !== correct.id)).slice(0, 3);
+  return shuffle([correct, ...others]);
+}
+
+export function useSoundQuiz() {
+  const store = useSoundQuizStore();
+  const { phase, category, current, choices, choicesRevealed, score, total, lastCorrect } = store;
+
+  const pool = category === 'all' ? SOUND_CLIPS : SOUND_CLIPS.filter(c => c.category === category);
+
+  const loadNext = useCallback(() => {
+    const remaining = shuffle(pool).slice(0, ROUNDS);
+    const clip = remaining[total % remaining.length];
+    if (!clip) { store.endGame(); return; }
+    store.nextQuestion(clip, pickChoices(clip, pool));
+  }, [pool, total, store]);
+
+  const startGame = useCallback((cat: SoundCategory | 'all') => {
+    store.startGame(cat);
+  }, [store]);
+
+  const playSound = useCallback(() => {
+    if (!current) return;
+    store.revealChoices();
+    speakHebrew(current.soundText);
+  }, [current, store]);
+
+  const replaySound = useCallback(() => {
+    if (!current) return;
+    speakHebrew(current.soundText);
+  }, [current]);
+
+  const selectAnswer = useCallback((clip: typeof SOUND_CLIPS[number]) => {
+    if (!current) return;
+    const correct = clip.id === current.id;
+    store.selectAnswer(clip, correct);
+    if (correct) {
+      speakHebrew(`נכון! ${current.name}`);
+    } else {
+      speakHebrew(`לא נכון. התשובה הנכונה היא ${current.name}`);
+    }
+    if (total + 1 >= ROUNDS) {
+      setTimeout(() => store.endGame(), 1800);
+    } else {
+      setTimeout(() => loadNext(), 1800);
+    }
+  }, [current, total, store, loadNext]);
+
+  // Load first question when phase becomes 'playing'
+  useEffect(() => {
+    if (phase === 'playing' && !current) {
+      loadNext();
+    }
+  }, [phase, current, loadNext]);
+
+  return {
+    phase,
+    category,
+    current,
+    choices,
+    choicesRevealed,
+    score,
+    total,
+    lastCorrect,
+    startGame,
+    playSound,
+    replaySound,
+    selectAnswer,
+    reset: store.reset,
+  };
+}

--- a/gamesformykids/lib/constants/gameCategories.ts
+++ b/gamesformykids/lib/constants/gameCategories.ts
@@ -110,7 +110,7 @@ export const GAME_CATEGORIES: Record<string, GameCategory> = {
     icon: Sparkles,
     color: "bg-gradient-to-r from-purple-500 to-pink-500",
     gradient: "from-purple-400 to-pink-600",
-    gameIds: ["sound-imitation","emotional-social","advanced-weather","advanced-colors","logic-games","visual-logic"],
+    gameIds: ["sound-imitation","emotional-social","advanced-weather","advanced-colors","logic-games","visual-logic","sound-quiz"],
   },
   arcade: {
     title: "🕹️ ארקייד",

--- a/gamesformykids/lib/registry/registryData/batch4.ts
+++ b/gamesformykids/lib/registry/registryData/batch4.ts
@@ -789,4 +789,15 @@ export const gamesRegistryBatch4: GameRegistration[] = [
     available: true,
     order: 192,
   },
+  {
+    id: "sound-quiz",
+    title: "מה הצליל?",
+    description: "שמע צליל של בעל חיים, כלי נגינה, טבע או בית — ובחר מה עשה אותו!",
+    icon: Music,
+    emoji: "🔊",
+    color: "bg-teal-500 hover:bg-teal-600",
+    href: "/games/sound-quiz",
+    available: true,
+    order: 193,
+  },
 ];

--- a/gamesformykids/lib/types/core/base.ts
+++ b/gamesformykids/lib/types/core/base.ts
@@ -241,4 +241,6 @@ export type GameType =
   // Categorised trivia with difficulty picker
   | 'trivia-categories'
   // Hebrew avatar character builder
-  | 'avatar-maker';
+  | 'avatar-maker'
+  // Identify Hebrew sounds game
+  | 'sound-quiz';


### PR DESCRIPTION
## What
Adds **sound-quiz** (Style D — Custom Game): children hear a sound and identify its source from 4 choices.

- 4 categories: 🐾 בעלי חיים (12 clips), 🎵 כלי נגינה (10), 🌿 טבע (10), 🏠 בית (10) = 42 total sounds
- Sound played via `speakHebrew` with Hebrew onomatopoeia (מיאו, הב הב, בזז, טיק טק, etc.)
- 2-step question flow: "שמע!" button → choices revealed → pick answer
- Replay button available while choices are shown
- TTS confirms correct answer after selection
- 15-round session with score tracking
- Result screen with percentage badge

## Why
Closes #1241

## Note on audio approach
Uses TTS to speak Hebrew onomatopoeia rather than audio files (no royalty-free clips available to bundle). This is actually more educational — children learn the Hebrew words for sounds (e.g., "מיאו" for cat, "הב הב" for dog).

## Test plan
- [ ] Visit `/games/sound-quiz` → category picker shown
- [ ] Pick a category → first question appears as ❓
- [ ] Tap "שמע!" → TTS speaks Hebrew onomatopoeia → 4 emoji choices appear
- [ ] Tap correct answer → "✅ נכון!" + TTS speaks name
- [ ] Tap wrong answer → "❌ הצליל היה: X"
- [ ] After 15 rounds → result screen
- [ ] Appears in home page category grid
- [ ] `npx tsc --noEmit` passes ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)