### PR TITLE
feat(hub): content-type tab bar on home page (closes #1214)

### DIFF
--- a/gamesformykids/app/HomePageClient.tsx
+++ b/gamesformykids/app/HomePageClient.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useState, useEffect } from "react";
 import Header from "@/components/layout/Header";
 import Footer from "@/components/layout/Footer";
 import FeaturedGame from "@/components/marketing/ClientOnlyFeaturedGame";
@@ -16,10 +17,27 @@ import OnboardingModal from "@/components/marketing/OnboardingModal";
 import PWAInstallBanner from "@/components/marketing/PWAInstallBanner";
 import DailyStreakBadge from "@/components/marketing/DailyStreakBadge";
 import CategoryJumpBar from "@/components/marketing/CategoryJumpBar";
+import ContentTypeTabBar, { type ContentType } from "@/components/marketing/ContentTypeTabBar";
+import ContentTypeGrid from "@/components/marketing/ContentTypeGrid";
 import { useHomePage } from "./useHomePage";
+
+const SESSION_KEY = 'home-content-tab';
 
 export default function HomePageClient() {
   const { isLoading, shouldShowLoader, handleLoadingComplete } = useHomePage();
+  const [activeTab, setActiveTab] = useState<ContentType>('games');
+
+  useEffect(() => {
+    const saved = sessionStorage.getItem(SESSION_KEY);
+    if (saved === 'creative' || saved === 'riddles' || saved === 'tools') {
+      setActiveTab(saved);
+    }
+  }, []);
+
+  function handleTabChange(tab: ContentType) {
+    setActiveTab(tab);
+    sessionStorage.setItem(SESSION_KEY, tab);
+  }
 
   if (isLoading && shouldShowLoader) {
     return <LoadingScreen onLoadingComplete={handleLoadingComplete} />;
@@ -30,16 +48,24 @@ export default function HomePageClient() {
       <VocabularyOfTheDay />
       <Header />
       <CategoryJumpBar />
+      <ContentTypeTabBar active={activeTab} onChange={handleTabChange} />
       <main>
-        <DailyStreakBadge />
-        <FeaturedGame />
-        <ContinueBanner />
-        <DailyChallenge />
-        <RecentlyPlayedRow />
-        <GamesTodayBadge />
-        <GameRecommendations />
-        <SurpriseMeButton />
-        <CategorizedGamesGrid />
+        {activeTab === 'games' && (
+          <>
+            <DailyStreakBadge />
+            <FeaturedGame />
+            <ContinueBanner />
+            <DailyChallenge />
+            <RecentlyPlayedRow />
+            <GamesTodayBadge />
+            <GameRecommendations />
+            <SurpriseMeButton />
+            <CategorizedGamesGrid />
+          </>
+        )}
+        {activeTab !== 'games' && (
+          <ContentTypeGrid contentType={activeTab} />
+        )}
       </main>
       <Footer />
       <OnboardingModal />

--- a/gamesformykids/components/marketing/ContentTypeGrid.tsx
+++ b/gamesformykids/components/marketing/ContentTypeGrid.tsx
@@ -1,0 +1,74 @@
+'use client';
+import { useMemo, useState, useEffect } from 'react';
+import GameCard from '@/components/game/GameCard';
+import { GamesRegistry } from '@/lib/registry/gamesRegistry';
+import type { ContentType } from './ContentTypeTabBar';
+
+const CONTENT_IDS: Record<Exclude<ContentType, 'games'>, string[]> = {
+  creative: [
+    'drawing', 'coloring', 'color-mix', 'art-craft', 'building', 'puzzles',
+    'melody-maker', 'craft-guide', 'avatar-maker', 'tetris', 'puppet-story',
+    'famous-paintings',
+  ],
+  riddles: [
+    'riddles', 'riddles-pro', 'trivia', 'trivia-categories', 'true-false',
+    'opposites', 'word-scramble', 'jokes-browser', 'rhyming', 'proverbs',
+    'visual-opposites', 'emoji-math',
+  ],
+  tools: [
+    'spinner', 'age-calculator', 'kids-encyclopedia', 'kids-songs', 'clock',
+    'days-of-week', 'months-of-year', 'israel-map',
+  ],
+};
+
+const TAB_TITLES: Record<Exclude<ContentType, 'games'>, { title: string; subtitle: string }> = {
+  creative: { title: '🎨 יצירה ואומנות', subtitle: 'ציור, יצירה, מוזיקה ועוד' },
+  riddles:  { title: '🤣 חידות וטריוויה', subtitle: 'חידות, ניחושים ושאלות' },
+  tools:    { title: '🎲 כלים חינוכיים', subtitle: 'כלים שימושיים לכיתה ולבית' },
+};
+
+interface Props {
+  contentType: Exclude<ContentType, 'games'>;
+}
+
+export default function ContentTypeGrid({ contentType }: Props) {
+  const [hydrated, setHydrated] = useState(false);
+  useEffect(() => { setHydrated(true); }, []);
+
+  const games = useMemo(() => {
+    const ids = CONTENT_IDS[contentType];
+    return ids.flatMap((id) => {
+      const g = GamesRegistry.getGameById(id);
+      return g ? [g] : [];
+    });
+  }, [contentType]);
+
+  const { title, subtitle } = TAB_TITLES[contentType];
+
+  if (!hydrated) {
+    return (
+      <div className="max-w-6xl mx-auto px-4 pb-8">
+        <div className="h-10 w-64 bg-gray-200 animate-pulse rounded-xl mx-auto mb-6" />
+        <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-3 md:gap-4">
+          {Array.from({ length: 8 }).map((_, i) => (
+            <div key={i} className="h-32 bg-gray-200 animate-pulse rounded-2xl" />
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="max-w-6xl mx-auto px-4 pb-8" dir="rtl">
+      <div className="text-center mb-6">
+        <h2 className="text-2xl md:text-3xl font-bold text-gray-800 dark:text-gray-100">{title}</h2>
+        <p className="text-gray-500 dark:text-gray-400 text-sm mt-1">{subtitle}</p>
+      </div>
+      <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-3 md:gap-4 lg:gap-6">
+        {games.map((game, index) => (
+          <GameCard key={game.id} game={game} animationDelay={Math.min(index * 50, 600)} />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/gamesformykids/components/marketing/ContentTypeTabBar.tsx
+++ b/gamesformykids/components/marketing/ContentTypeTabBar.tsx
@@ -1,0 +1,45 @@
+'use client';
+
+export type ContentType = 'games' | 'creative' | 'riddles' | 'tools';
+
+const TABS: { id: ContentType; label: string; emoji: string; color: string }[] = [
+  { id: 'games',    label: 'משחקים', emoji: '🎮', color: 'from-blue-500 to-indigo-600' },
+  { id: 'creative', label: 'יצירה',  emoji: '🎨', color: 'from-pink-500 to-purple-600' },
+  { id: 'riddles',  label: 'חידות',  emoji: '🤣', color: 'from-yellow-500 to-orange-500' },
+  { id: 'tools',    label: 'כלים',   emoji: '🎲', color: 'from-teal-500 to-green-600' },
+];
+
+interface Props {
+  active: ContentType;
+  onChange: (tab: ContentType) => void;
+}
+
+export default function ContentTypeTabBar({ active, onChange }: Props) {
+  return (
+    <div className="max-w-6xl mx-auto px-4 py-4" dir="rtl">
+      <div className="flex gap-2 overflow-x-auto pb-1 scrollbar-hide">
+        {TABS.map((tab) => {
+          const isActive = active === tab.id;
+          return (
+            <button
+              key={tab.id}
+              onClick={() => onChange(tab.id)}
+              className={`
+                flex items-center gap-2 px-5 py-2.5 rounded-2xl text-sm font-bold
+                whitespace-nowrap transition-all duration-200 flex-shrink-0
+                ${isActive
+                  ? `bg-gradient-to-l ${tab.color} text-white shadow-lg scale-105`
+                  : 'bg-white/70 dark:bg-gray-800/70 text-gray-600 dark:text-gray-300 hover:bg-white dark:hover:bg-gray-700 shadow-sm hover:shadow-md'
+                }
+              `}
+              aria-current={isActive ? 'true' : undefined}
+            >
+              <span className="text-base leading-none">{tab.emoji}</span>
+              <span>{tab.label}</span>
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## What
Adds a `ContentTypeTabBar` above `CategorizedGamesGrid` in `HomePageClient`, letting users switch between 4 content sections:

| Tab | Label | Content |
|-----|-------|---------|
| 🎮 | משחקים | Current home page (full grid — default) |
| 🎨 | יצירה | Drawing, coloring, color-mix, avatar-maker, melody-maker, craft-guide, puzzles, building, art-craft, puppet-story, famous-paintings, tetris |
| 🤣 | חידות | Riddles, riddles-pro, trivia, trivia-categories, true-false, opposites, word-scramble, jokes-browser, rhyming, proverbs, visual-opposites, emoji-math |
| 🎲 | כלים | Spinner, age-calculator, kids-encyclopedia, kids-songs, clock, days-of-week, months-of-year, israel-map |

**New files:**
- `ContentTypeTabBar.tsx` — pill tabs with gradient active state, horizontally scrollable on mobile
- `ContentTypeGrid.tsx` — reuses `GameCard` + `GamesRegistry.getGameById()` to render per-tab game lists

**Behaviour:**
- Active tab persisted in `sessionStorage` (`home-content-tab`) — survives navigation
- Switching tabs hides the full `CategorizedGamesGrid` so it won't load until "משחקים" is active
- RTL layout; tabs read right to left

## Why
Closes #1214

## Test plan
- [ ] Home page loads with 🎮 משחקים selected (default)
- [ ] Click 🎨 יצירה — grid of creative games appears, full home grid hidden
- [ ] Click 🤣 חידות — riddles/trivia grid appears
- [ ] Click 🎲 כלים — tools grid including spinner appears
- [ ] Click 🎮 משחקים — full home page grid returns
- [ ] Navigate away and back — last selected tab persists

🤖 Generated with [Claude Code](https://claude.com/claude-code)