### PR TITLE
feat(discovery): related games row at the bottom of every game page

### DIFF
--- a/gamesformykids/app/games/[gameType]/page.tsx
+++ b/gamesformykids/app/games/[gameType]/page.tsx
@@ -7,6 +7,7 @@ import { type GamePageParams, CUSTOM_GAME_TYPES } from './gamePageConstants';
 import { resolveGameType, isSupportedGame, buildStaticParams } from './gamePageUtils';
 import CustomGameRenderer from './CustomGameRenderer';
 import { loadGameItems } from '@/lib/constants/gameItemsLoader';
+import RelatedGames from '@/components/game/RelatedGames';
 
 interface PageProps {
   params: Promise<GamePageParams>;
@@ -25,17 +26,25 @@ export default async function UniversalGamePage({ params }: PageProps) {
   if (!isSupportedGame(actualGameType)) notFound();
 
   if (CUSTOM_GAME_TYPES.has(actualGameType)) {
-    return <CustomGameRenderer gameType={actualGameType} />;
+    return (
+      <>
+        <CustomGameRenderer gameType={actualGameType} />
+        <RelatedGames gameType={actualGameType} />
+      </>
+    );
   }
 
   const gameItems = await loadGameItems(actualGameType);
 
   return (
-    <GameTypeProvider initialGameType={actualGameType} initialGameItems={gameItems}>
-      <GameLogicSync />
-      <GameEngagementSync />
-      <UltimateGamePage />
-    </GameTypeProvider>
+    <>
+      <GameTypeProvider initialGameType={actualGameType} initialGameItems={gameItems}>
+        <GameLogicSync />
+        <GameEngagementSync />
+        <UltimateGamePage />
+      </GameTypeProvider>
+      <RelatedGames gameType={actualGameType} />
+    </>
   );
 }
 

--- a/gamesformykids/components/game/RelatedGames.tsx
+++ b/gamesformykids/components/game/RelatedGames.tsx
@@ -1,0 +1,40 @@
+import Link from 'next/link';
+import { GAME_CATEGORIES } from '@/lib/constants/gameCategories';
+import { GAMES_REGISTRY } from '@/lib/registry/gamesRegistryData';
+
+interface Props {
+  gameType: string;
+}
+
+export default function RelatedGames({ gameType }: Props) {
+  const categoryEntry = Object.values(GAME_CATEGORIES).find((cat) =>
+    cat.gameIds.includes(gameType),
+  );
+  if (!categoryEntry) return null;
+
+  const related = categoryEntry.gameIds
+    .filter((id) => id !== gameType)
+    .map((id) => GAMES_REGISTRY.find((g) => g.id === id && g.available))
+    .filter(Boolean)
+    .slice(0, 4);
+
+  if (related.length === 0) return null;
+
+  return (
+    <section dir="rtl" className="bg-white border-t border-gray-100 py-4 px-4">
+      <h2 className="text-sm font-bold text-gray-500 mb-3">🎮 משחקים דומים</h2>
+      <div className="flex gap-3 overflow-x-auto pb-2 scrollbar-hide">
+        {related.map((game) => (
+          <Link
+            key={game!.id}
+            href={game!.href}
+            className={`flex-none w-24 rounded-2xl ${game!.color} p-3 text-white text-center hover:scale-105 active:scale-95 transition-transform shadow-md`}
+          >
+            <div className="text-2xl mb-1">{game!.emoji}</div>
+            <div className="text-xs font-bold leading-tight line-clamp-2">{game!.title}</div>
+          </Link>
+        ))}
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary

Adds a `RelatedGames` Server Component to the universal game page that shows up to 4 game cards from the same category as the current game. This converts a session-ending moment (after a game) into continued engagement — the same pattern that yo-yoo.co.il uses successfully.

## Changes
- `components/game/RelatedGames.tsx` — new Server Component: looks up the game's category in `GAME_CATEGORIES`, finds up to 4 sibling games from `GAMES_REGISTRY`, renders a horizontal-scroll strip
- `app/games/[gameType]/page.tsx` — renders `<RelatedGames>` below both the custom-game and card-game renderers

## Testing
- [ ] Navigating to any game page shows a row of up to 4 related games at the bottom
- [ ] The current game itself never appears in the row
- [ ] Games not belonging to any category show nothing (no crash)
- [ ] Cards link correctly to their game pages
- [ ] RTL horizontal scroll works on mobile
- [ ] `npx tsc --noEmit` passes

Closes #1203

🤖 Generated with [Claude Code](https://claude.com/claude-code)