### PR TITLE
feat(game): letter-race — Hebrew first-letter recognition racing game

### DIFF
--- a/gamesformykids/app/games/[gameType]/CustomGameRenderer.tsx
+++ b/gamesformykids/app/games/[gameType]/CustomGameRenderer.tsx
@@ -72,6 +72,7 @@ const GAME_CLIENTS: Record<string, ComponentType> = {
   'team-picker':       dynamic(() => import('../team-picker/TeamPickerClient'),                     { ssr: false }),
   'dice':              dynamic(() => import('../dice/DiceClient'),                                    { ssr: false }),
   'timer':             dynamic(() => import('../timer/TimerClient'),                                  { ssr: false }),
+  'letter-race':       dynamic(() => import('../letter-race/LetterRaceClient'),                      { ssr: false }),
 };
 
 interface Props { gameType: string; }

--- a/gamesformykids/app/games/[gameType]/gamePageConstants.ts
+++ b/gamesformykids/app/games/[gameType]/gamePageConstants.ts
@@ -92,6 +92,7 @@ export const SUPPORTED_GAMES = [
   'team-picker',
   'dice',
   'timer',
+  'letter-race',
 ] as const;
 
 export type SupportedGameType = typeof SUPPORTED_GAMES[number];
@@ -106,7 +107,7 @@ export const CUSTOM_GAME_TYPES = new Set([
   'word-builder', 'word-scramble', 'maze', 'letter-defender', 'puppet-story', 'number-slide', 'snakes-ladders',
 
 
-  'escape-room', 'robot-coder', 'find-in-scene', 'hangman', 'choose-adventure', 'picture-dictionary', 'word-search', 'israel-map', 'kids-songs', 'melody-maker', 'kids-encyclopedia', 'age-calculator', 'craft-guide', 'jokes-browser', 'word-maze', 'avatar-maker', 'sound-quiz', 'spinner', 'team-picker', 'dice', 'timer',
+  'escape-room', 'robot-coder', 'find-in-scene', 'hangman', 'choose-adventure', 'picture-dictionary', 'word-search', 'israel-map', 'kids-songs', 'melody-maker', 'kids-encyclopedia', 'age-calculator', 'craft-guide', 'jokes-browser', 'word-maze', 'avatar-maker', 'sound-quiz', 'spinner', 'team-picker', 'dice', 'timer', 'letter-race',
   
   
 ]);

--- a/gamesformykids/app/games/letter-race/LetterRaceClient.tsx
+++ b/gamesformykids/app/games/letter-race/LetterRaceClient.tsx
@@ -1,0 +1,3 @@
+'use client';
+import { makeGameClient } from '@/components/game/shared/makeGameClient';
+export default makeGameClient(() => import('./LetterRaceGame'));

--- a/gamesformykids/app/games/letter-race/LetterRaceGame.tsx
+++ b/gamesformykids/app/games/letter-race/LetterRaceGame.tsx
@@ -1,0 +1,13 @@
+'use client';
+import { useLetterRaceGame } from './useLetterRaceGame';
+import LetterRaceMenuScreen from './components/LetterRaceMenuScreen';
+import LetterRaceResultScreen from './components/LetterRaceResultScreen';
+import LetterRacePlayScreen from './components/LetterRacePlayScreen';
+
+export default function LetterRaceGame() {
+  const { phase } = useLetterRaceGame();
+
+  if (phase === 'menu') return <LetterRaceMenuScreen />;
+  if (phase === 'dead') return <LetterRaceResultScreen />;
+  return <LetterRacePlayScreen />;
+}

--- a/gamesformykids/app/games/letter-race/components/LetterRaceMenuScreen.tsx
+++ b/gamesformykids/app/games/letter-race/components/LetterRaceMenuScreen.tsx
@@ -1,0 +1,17 @@
+import { createDifficultyMenuScreen } from '@/components/game/shared/createDifficultyMenuScreen';
+import { useLetterRaceGame } from '../useLetterRaceGame';
+
+const TIME_BY_DIFF = { easy: 45, medium: 30, hard: 20 } as const;
+
+export default createDifficultyMenuScreen(
+  {
+    emoji: '🔤',
+    title: 'מרוץ אותיות',
+    description: 'ראה תמונה — בחר את האות הראשונה!',
+    hintFn: (d) => `${TIME_BY_DIFF[d]} שניות · רצף 3+ = 20 נקודות · תראה תמונה ובחר את האות`,
+    gradientClass: 'from-violet-100 to-purple-200',
+    buttonClass: 'from-violet-500 to-purple-600',
+    startLabel: '🔤 התחל!',
+  },
+  useLetterRaceGame,
+);

--- a/gamesformykids/app/games/letter-race/components/LetterRacePlayScreen.tsx
+++ b/gamesformykids/app/games/letter-race/components/LetterRacePlayScreen.tsx
@@ -1,0 +1,65 @@
+'use client';
+import { useLetterRaceGame, GAME_TIME } from '../useLetterRaceGame';
+import { speakHebrew } from '@/lib/utils/speech/speaker';
+
+export default function LetterRacePlayScreen() {
+  const { q, score, timeLeft, feedback, streak, correct, total, tap, accuracy } = useLetterRaceGame();
+
+  const timeColor = timeLeft > 10 ? 'bg-violet-500' : timeLeft > 5 ? 'bg-yellow-400' : 'bg-orange-400';
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-violet-100 to-purple-200 flex flex-col items-center justify-center p-4 select-none" dir="rtl">
+      {/* HUD */}
+      <div className="w-full max-w-sm mb-4">
+        <div className="flex justify-between text-sm text-violet-700 font-bold mb-1">
+          <span>⏱️ {timeLeft}s</span>
+          <span>🏆 {score}</span>
+          {streak >= 2 && <span className="text-yellow-500">🔥×{streak}</span>}
+        </div>
+        <div className="bg-white rounded-full h-3 shadow-inner">
+          <div
+            className={`h-3 rounded-full transition-[width] duration-1000 ${timeColor}`}
+            style={{ width: `${(timeLeft / GAME_TIME) * 100}%` }}
+          />
+        </div>
+      </div>
+
+      {/* Question card */}
+      <div className={`w-full max-w-sm bg-white rounded-3xl p-8 text-center shadow-2xl mb-5 transition duration-150 ${
+        feedback === 'correct' ? 'bg-green-50 ring-4 ring-green-400 scale-105' :
+        feedback === 'wrong'   ? 'bg-amber-50 ring-4 ring-amber-400' : ''
+      }`}>
+        <button
+          onClick={() => speakHebrew(`באיזו אות מתחיל ${q.word}?`)}
+          className="text-6xl mb-3 block mx-auto leading-none hover:scale-110 transition-transform"
+          aria-label={`שמע: ${q.word}`}
+        >
+          {q.emoji}
+        </button>
+        <p className="text-2xl font-black text-gray-700 mb-1">{q.word}</p>
+        <p className="text-base text-violet-500 font-semibold">באיזו אות מתחיל?</p>
+        {feedback && (
+          <p className={`text-2xl mt-3 font-bold ${feedback === 'correct' ? 'text-green-500' : 'text-amber-600'}`}>
+            {feedback === 'correct' ? `✅ ${streak >= 3 ? 'בום! +20' : 'נכון! +10'}` : `❌ האות: ${q.answer}`}
+          </p>
+        )}
+      </div>
+
+      {/* Choices */}
+      <div className="grid grid-cols-2 gap-3 w-full max-w-sm">
+        {q.choices.map((c) => (
+          <button
+            key={c}
+            onClick={() => tap(c)}
+            disabled={!!feedback}
+            className="py-5 rounded-3xl bg-white font-black text-4xl text-violet-700 shadow-xl border-2 border-violet-200 active:scale-90 hover:border-violet-500 hover:text-violet-600 transition disabled:opacity-50"
+          >
+            {c}
+          </button>
+        ))}
+      </div>
+
+      <p className="mt-4 text-xs text-violet-400">{correct}/{total} נכון · {accuracy}% דיוק</p>
+    </div>
+  );
+}

--- a/gamesformykids/app/games/letter-race/components/LetterRaceResultScreen.tsx
+++ b/gamesformykids/app/games/letter-race/components/LetterRaceResultScreen.tsx
@@ -1,0 +1,30 @@
+'use client';
+import GameResultCard from '@/components/game/shared/GameResultCard';
+import { StatCell, StatGrid } from '@/components/game/shared/StatGrid';
+import { useLetterRaceStore } from '../letterRaceStore';
+
+export default function LetterRaceResultScreen() {
+  const { score, best, correct, total, startGame } = useLetterRaceStore();
+  const accuracy = total > 0 ? Math.round((correct / total) * 100) : 0;
+
+  return (
+    <GameResultCard
+      emoji="🏁"
+      title="הסיום!"
+      gradientClass="from-violet-100 to-purple-200"
+      buttonClass="from-violet-500 to-purple-600"
+      onRestart={startGame}
+      restartLabel="🔄 שוב!"
+      shareText={`🔤 זיהיתי ${score} נקודות במרוץ אותיות!`}
+      score={score}
+      best={best}
+    >
+      <StatGrid>
+        <StatCell label="ניקוד" value={score} bgClass="bg-violet-50" textClass="text-violet-600" labelClass="text-violet-400" />
+        <StatCell label="שיא" value={best} bgClass="bg-yellow-50" textClass="text-yellow-500" labelClass="text-yellow-400" />
+        <StatCell label='נכון/סה"כ' value={`${correct}/${total}`} bgClass="bg-green-50" textClass="text-green-600" labelClass="text-green-400" />
+        <StatCell label="דיוק" value={`${accuracy}%`} bgClass="bg-purple-50" textClass="text-purple-600" labelClass="text-purple-400" />
+      </StatGrid>
+    </GameResultCard>
+  );
+}

--- a/gamesformykids/app/games/letter-race/letterRaceStore.ts
+++ b/gamesformykids/app/games/letter-race/letterRaceStore.ts
@@ -1,0 +1,149 @@
+import { makePersistStore } from '@/lib/stores/createStore';
+import { setupGameTimer } from '@/lib/stores/gameTimerHelpers';
+import { useGameDifficulty } from '@/lib/stores/gameDifficultyStore';
+import type { PhaseDead as Phase } from '@/lib/types';
+
+export const GAME_TIME = 30;
+
+const DIFFICULTY_TIME = { easy: 45, medium: 30, hard: 20 } as const;
+
+// ── Word-letter dataset ─────────────────────────────────────────────────────
+
+const WORDS: Array<{ word: string; emoji: string; letter: string }> = [
+  { word: 'ארנב', emoji: '🐰', letter: 'א' },
+  { word: 'בלון', emoji: '🎈', letter: 'ב' },
+  { word: 'גמל', emoji: '🐪', letter: 'ג' },
+  { word: 'דגל', emoji: '🚩', letter: 'ד' },
+  { word: 'הר', emoji: '⛰️', letter: 'ה' },
+  { word: 'ורד', emoji: '🌹', letter: 'ו' },
+  { word: 'זנב', emoji: '🦊', letter: 'ז' },
+  { word: 'חתול', emoji: '🐱', letter: 'ח' },
+  { word: 'טבעת', emoji: '💍', letter: 'ט' },
+  { word: 'ילד', emoji: '👦', letter: 'י' },
+  { word: 'כלב', emoji: '🐶', letter: 'כ' },
+  { word: 'לב', emoji: '❤️', letter: 'ל' },
+  { word: 'מכונית', emoji: '🚗', letter: 'מ' },
+  { word: 'נחש', emoji: '🐍', letter: 'נ' },
+  { word: 'ספל', emoji: '☕', letter: 'ס' },
+  { word: 'עיט', emoji: '🦅', letter: 'ע' },
+  { word: 'פיל', emoji: '🐘', letter: 'פ' },
+  { word: 'צב', emoji: '🐢', letter: 'צ' },
+  { word: 'קוף', emoji: '🐒', letter: 'ק' },
+  { word: 'ראש', emoji: '👤', letter: 'ר' },
+  { word: 'שמש', emoji: '☀️', letter: 'ש' },
+  { word: 'תפוח', emoji: '🍎', letter: 'ת' },
+  { word: 'אוטובוס', emoji: '🚌', letter: 'א' },
+  { word: 'ברדלס', emoji: '🦁', letter: 'ב' },
+  { word: 'גזר', emoji: '🥕', letter: 'ג' },
+  { word: 'דבורה', emoji: '🐝', letter: 'ד' },
+  { word: 'הליקופטר', emoji: '🚁', letter: 'ה' },
+  { word: 'זברה', emoji: '🦓', letter: 'ז' },
+  { word: 'חמור', emoji: '🫏', letter: 'ח' },
+  { word: 'ירח', emoji: '🌙', letter: 'י' },
+  { word: 'כוכב', emoji: '⭐', letter: 'כ' },
+  { word: 'לימון', emoji: '🍋', letter: 'ל' },
+  { word: 'מלון', emoji: '🍈', letter: 'מ' },
+  { word: 'ניל', emoji: '🎵', letter: 'נ' },
+  { word: 'סוס', emoji: '🐴', letter: 'ס' },
+  { word: 'עגלה', emoji: '🛒', letter: 'ע' },
+  { word: 'פרה', emoji: '🐄', letter: 'פ' },
+  { word: 'צפרדע', emoji: '🐸', letter: 'צ' },
+  { word: 'קשת', emoji: '🌈', letter: 'ק' },
+  { word: 'רכבת', emoji: '🚂', letter: 'ר' },
+  { word: 'שן', emoji: '🦷', letter: 'ש' },
+  { word: 'תרנגול', emoji: '🐓', letter: 'ת' },
+];
+
+const HEBREW_LETTERS = 'אבגדהוזחטיכלמנסעפצקרשת'.split('');
+
+export interface LetterQuestion {
+  emoji: string;
+  word: string;
+  answer: string;
+  choices: string[];
+}
+
+export function makeLetterQ(): LetterQuestion {
+  const item = WORDS[Math.floor(Math.random() * WORDS.length)]!;
+  const wrong = new Set<string>();
+  while (wrong.size < 3) {
+    const l = HEBREW_LETTERS[Math.floor(Math.random() * HEBREW_LETTERS.length)]!;
+    if (l !== item.letter) wrong.add(l);
+  }
+  return {
+    emoji: item.emoji,
+    word: item.word,
+    answer: item.letter,
+    choices: [...wrong, item.letter].sort(() => Math.random() - 0.5),
+  };
+}
+
+// ── Store ────────────────────────────────────────────────────────────────────
+
+interface State {
+  phase:    Phase;
+  q:        LetterQuestion;
+  score:    number;
+  best:     number;
+  timeLeft: number;
+  feedback: 'correct' | 'wrong' | null;
+  streak:   number;
+  total:    number;
+  correct:  number;
+}
+
+interface Actions {
+  startGame:    () => void;
+  tap:          (choice: string) => void;
+  nextQuestion: () => void;
+}
+
+const INITIAL: State = {
+  phase: 'menu', q: makeLetterQ(), score: 0, best: 0,
+  timeLeft: GAME_TIME, feedback: null, streak: 0, total: 0, correct: 0,
+};
+
+export const useLetterRaceStore = makePersistStore<State & Actions>(
+  'LetterRaceStore',
+  'letter-race-best',
+  (set, get) => {
+    const timer = setupGameTimer({
+      name: 'letterRace',
+      set,
+      get,
+      onEnd: () => {
+        const { score, best } = get();
+        set({ timeLeft: 0, phase: 'dead', best: Math.max(best, score) }, false, 'letterRace/gameOver');
+      },
+    });
+
+    return {
+      ...INITIAL,
+
+      startGame: () => {
+        const diff = useGameDifficulty.getState().difficulty;
+        timer.stop();
+        set({ ...INITIAL, phase: 'playing', best: get().best, q: makeLetterQ(), timeLeft: DIFFICULTY_TIME[diff] }, false, 'letterRace/startGame');
+        timer.start();
+      },
+
+      tap: (choice: string) => {
+        const { phase, feedback, q, score, streak, total, correct } = get();
+        if (phase !== 'playing' || feedback !== null) return;
+        const newTotal = total + 1;
+        if (choice === q.answer) {
+          const newStreak = streak + 1;
+          const pts = newStreak >= 3 ? 20 : 10;
+          set({ score: score + pts, streak: newStreak, total: newTotal, correct: correct + 1, feedback: 'correct' }, false, 'letterRace/correct');
+        } else {
+          set({ streak: 0, total: newTotal, feedback: 'wrong' }, false, 'letterRace/wrong');
+        }
+      },
+
+      nextQuestion: () => {
+        set({ feedback: null, q: makeLetterQ() }, false, 'letterRace/nextQ');
+      },
+    };
+  },
+  { partialize: (s) => ({ best: s.best }) },
+);

--- a/gamesformykids/app/games/letter-race/useLetterRaceGame.ts
+++ b/gamesformykids/app/games/letter-race/useLetterRaceGame.ts
@@ -1,0 +1,28 @@
+'use client';
+import { useEffect } from 'react';
+import { createPhaseGameHook } from '@/hooks/shared/progress/createPhaseGameHook';
+import { useLetterRaceStore } from './letterRaceStore';
+
+export type { LetterQuestion } from './letterRaceStore';
+export { GAME_TIME } from './letterRaceStore';
+
+const _useBase = createPhaseGameHook(
+  useLetterRaceStore,
+  'letter-race',
+  (s) => ({ score: s.score, level: 1 }),
+  ['dead'],
+);
+
+export function useLetterRaceGame() {
+  const state = _useBase();
+  const accuracy = state.total > 0 ? Math.round((state.correct / state.total) * 100) : 0;
+
+  useEffect(() => {
+    if (!state.feedback) return;
+    const id = setTimeout(state.nextQuestion, 600);
+    return () => clearTimeout(id);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [state.feedback]);
+
+  return { ...state, accuracy };
+}

--- a/gamesformykids/lib/constants/gameCategories.ts
+++ b/gamesformykids/lib/constants/gameCategories.ts
@@ -30,7 +30,7 @@ export const GAME_CATEGORIES: Record<string, GameCategory> = {
     icon: Book,
     color: "bg-blue-500",
     gradient: "from-blue-400 to-blue-600",
-    gameIds: ["letters","hebrew-letters","numbers","shapes","colored-shapes","colors","advanced-colors","shapes-3d","phonics","rhyming","nikud","gender","final-letters","alphabet-order"],
+    gameIds: ["letters","hebrew-letters","numbers","shapes","colored-shapes","colors","advanced-colors","shapes-3d","phonics","rhyming","nikud","gender","final-letters","alphabet-order","letter-race"],
   },
   creative: {
     title: "יצירתיות ואומנות",

--- a/gamesformykids/lib/registry/registryData/batch4.ts
+++ b/gamesformykids/lib/registry/registryData/batch4.ts
@@ -849,7 +849,7 @@ export const gamesRegistryBatch4: GameRegistration[] = [
     color: "bg-pink-500 hover:bg-pink-600",
     href: "/games/dice",
     available: true,
-    contentType: "tool",
+    contentType: "tool" as const,
     order: 196,
   },
   {
@@ -861,7 +861,18 @@ export const gamesRegistryBatch4: GameRegistration[] = [
     color: "bg-indigo-500 hover:bg-indigo-600",
     href: "/games/timer",
     available: true,
-    contentType: "tool",
+    contentType: "tool" as const,
     order: 197,
+  },
+  {
+    id: "letter-race",
+    title: "מרוץ אותיות",
+    description: "ראה תמונה — בחר את האות הראשונה! מרוץ נגד השעון לזיהוי אותיות עבריות.",
+    icon: Type,
+    emoji: "🔤",
+    color: "bg-violet-500 hover:bg-violet-600",
+    href: "/games/letter-race",
+    available: true,
+    order: 198,
   },
 ];

--- a/gamesformykids/lib/types/core/base.ts
+++ b/gamesformykids/lib/types/core/base.ts
@@ -251,4 +251,6 @@ export type GameType =
   // Digital dice roller classroom tool
   | 'dice'
   // Classroom countdown timer
-  | 'timer';
+  | 'timer'
+  // Hebrew first-letter racing game
+  | 'letter-race';


### PR DESCRIPTION
## Summary

Adds **מרוץ אותיות** (letter-race) at `/games/letter-race`. Players see an emoji + Hebrew word and must select the correct first Hebrew letter from 4 choices, racing against a countdown timer. Streak bonuses (×3 = 20 pts) reward consistency. Forks the proven math-race architecture to minimise new code.

## Changes
- `app/games/letter-race/letterRaceStore.ts` — Zustand store with 42-word Hebrew dataset covering all 22 letters, timer, streak logic
- `app/games/letter-race/useLetterRaceGame.ts` — phase hook via `createPhaseGameHook`
- `app/games/letter-race/LetterRaceClient.tsx` + `LetterRaceGame.tsx` — entry points
- `app/games/letter-race/components/` — menu (difficulty picker), play (question + choices), result screens
- `app/games/[gameType]/gamePageConstants.ts` — adds to `SUPPORTED_GAMES` + `CUSTOM_GAME_TYPES`
- `app/games/[gameType]/CustomGameRenderer.tsx` — dynamic import
- `lib/types/core/base.ts` — adds `'letter-race'` to `GameType`
- `lib/registry/registryData/batch4.ts` — registry entry
- `lib/constants/gameCategories.ts` — adds to `basic` category

## Testing
- [ ] `/games/letter-race` loads and shows difficulty menu
- [ ] Question shows emoji + Hebrew word with 4 letter choices
- [ ] Correct choice scores 10 pts (20 pts on 3+ streak)
- [ ] Timer counts down and triggers result screen
- [ ] TTS button reads the question (emoji tap)
- [ ] RTL layout correct on mobile
- [ ] `npx tsc --noEmit` passes

Closes #1197

🤖 Generated with [Claude Code](https://claude.com/claude-code)