### PR TITLE
feat(hub): dedicated landing pages for /tools, /creative, /riddles

### DIFF
--- a/gamesformykids/app/creative/CreativePageClient.tsx
+++ b/gamesformykids/app/creative/CreativePageClient.tsx
@@ -1,0 +1,28 @@
+'use client';
+
+import Header from '@/components/layout/Header';
+import Footer from '@/components/layout/Footer';
+import ContentTypeGrid from '@/components/marketing/ContentTypeGrid';
+import Link from 'next/link';
+
+export default function CreativePageClient() {
+  return (
+    <div className="min-h-screen bg-linear-to-br from-pink-50 via-purple-50 to-rose-50 dark:from-gray-900 dark:via-gray-800 dark:to-gray-900">
+      <Header />
+      <div className="max-w-6xl mx-auto px-4 pt-6 pb-2" dir="rtl">
+        <div className="text-center mb-6">
+          <div className="text-5xl mb-3">🎨</div>
+          <h1 className="text-3xl md:text-4xl font-bold text-purple-800 dark:text-purple-200 mb-2">יצירה ואומנות</h1>
+          <p className="text-purple-600 dark:text-purple-400 text-base md:text-lg mb-4">
+            ציור, צביעה, מוזיקה ויצירה חופשית לכל גיל
+          </p>
+          <Link href="/" className="text-sm text-purple-500 hover:text-purple-700 underline underline-offset-2 transition-colors">
+            ← חזרה לדף הבית
+          </Link>
+        </div>
+      </div>
+      <ContentTypeGrid contentType="creative" />
+      <Footer />
+    </div>
+  );
+}

--- a/gamesformykids/app/creative/page.tsx
+++ b/gamesformykids/app/creative/page.tsx
@@ -1,0 +1,12 @@
+import type { Metadata } from 'next';
+import CreativePageClient from './CreativePageClient';
+
+export const metadata: Metadata = {
+  title: 'יצירה ואומנות — GamesForMyKids',
+  description: 'משחקי יצירה לילדים: ציור, צביעה, מוזיקה, בניית אווטאר ועוד.',
+  keywords: 'יצירה לילדים, ציור, צביעה, מוזיקה, אמנות לילדים',
+};
+
+export default function CreativePage() {
+  return <CreativePageClient />;
+}

--- a/gamesformykids/app/riddles/RiddlesPageClient.tsx
+++ b/gamesformykids/app/riddles/RiddlesPageClient.tsx
@@ -1,0 +1,28 @@
+'use client';
+
+import Header from '@/components/layout/Header';
+import Footer from '@/components/layout/Footer';
+import ContentTypeGrid from '@/components/marketing/ContentTypeGrid';
+import Link from 'next/link';
+
+export default function RiddlesPageClient() {
+  return (
+    <div className="min-h-screen bg-linear-to-br from-yellow-50 via-orange-50 to-amber-50 dark:from-gray-900 dark:via-gray-800 dark:to-gray-900">
+      <Header />
+      <div className="max-w-6xl mx-auto px-4 pt-6 pb-2" dir="rtl">
+        <div className="text-center mb-6">
+          <div className="text-5xl mb-3">🤣</div>
+          <h1 className="text-3xl md:text-4xl font-bold text-orange-800 dark:text-orange-200 mb-2">חידות ובדיחות</h1>
+          <p className="text-orange-600 dark:text-orange-400 text-base md:text-lg mb-4">
+            חידות, טריוויה ובדיחות לאתגר את המוח
+          </p>
+          <Link href="/" className="text-sm text-orange-500 hover:text-orange-700 underline underline-offset-2 transition-colors">
+            ← חזרה לדף הבית
+          </Link>
+        </div>
+      </div>
+      <ContentTypeGrid contentType="riddles" />
+      <Footer />
+    </div>
+  );
+}

--- a/gamesformykids/app/riddles/page.tsx
+++ b/gamesformykids/app/riddles/page.tsx
@@ -1,0 +1,12 @@
+import type { Metadata } from 'next';
+import RiddlesPageClient from './RiddlesPageClient';
+
+export const metadata: Metadata = {
+  title: 'חידות ובדיחות — GamesForMyKids',
+  description: 'חידות, טריוויה ובדיחות לילדים: חידות לגיל הרך, ניחוש, שאלות ותשובות ועוד.',
+  keywords: 'חידות לילדים, טריוויה, בדיחות, שאלות ותשובות, ניחוש',
+};
+
+export default function RiddlesPage() {
+  return <RiddlesPageClient />;
+}

--- a/gamesformykids/app/tools/ToolsPageClient.tsx
+++ b/gamesformykids/app/tools/ToolsPageClient.tsx
@@ -1,0 +1,28 @@
+'use client';
+
+import Header from '@/components/layout/Header';
+import Footer from '@/components/layout/Footer';
+import ContentTypeGrid from '@/components/marketing/ContentTypeGrid';
+import Link from 'next/link';
+
+export default function ToolsPageClient() {
+  return (
+    <div className="min-h-screen bg-linear-to-br from-teal-50 via-green-50 to-cyan-50 dark:from-gray-900 dark:via-gray-800 dark:to-gray-900">
+      <Header />
+      <div className="max-w-6xl mx-auto px-4 pt-6 pb-2" dir="rtl">
+        <div className="text-center mb-6">
+          <div className="text-5xl mb-3">🎲</div>
+          <h1 className="text-3xl md:text-4xl font-bold text-teal-800 dark:text-teal-200 mb-2">כלי כיתה</h1>
+          <p className="text-teal-600 dark:text-teal-400 text-base md:text-lg mb-4">
+            כלים שימושיים למורים, להורים ולילדים
+          </p>
+          <Link href="/" className="text-sm text-teal-500 hover:text-teal-700 underline underline-offset-2 transition-colors">
+            ← חזרה לדף הבית
+          </Link>
+        </div>
+      </div>
+      <ContentTypeGrid contentType="tools" />
+      <Footer />
+    </div>
+  );
+}

--- a/gamesformykids/app/tools/page.tsx
+++ b/gamesformykids/app/tools/page.tsx
@@ -1,0 +1,12 @@
+import type { Metadata } from 'next';
+import ToolsPageClient from './ToolsPageClient';
+
+export const metadata: Metadata = {
+  title: 'כלי כיתה — GamesForMyKids',
+  description: 'כלים חינוכיים לכיתה ולבית: גלגל מזל, מחלק קבוצות, מחשבון גיל ועוד.',
+  keywords: 'כלי כיתה, גלגל מזל, מחלק קבוצות, כלים חינוכיים, כלים למורים',
+};
+
+export default function ToolsPage() {
+  return <ToolsPageClient />;
+}

--- a/gamesformykids/components/layout/Footer.tsx
+++ b/gamesformykids/components/layout/Footer.tsx
@@ -1,3 +1,4 @@
+import Link from "next/link";
 import { GamesRegistry } from "@/lib/registry/gamesRegistry";
 
 function Footer() {
@@ -44,6 +45,14 @@ function Footer() {
             <span className="bg-blue-100 px-2 md:px-3 py-1 rounded-full">📱 נייד</span>
             <span className="bg-green-100 px-2 md:px-3 py-1 rounded-full">🎯 חינוכי</span>
             <span className="bg-yellow-100 px-2 md:px-3 py-1 rounded-full">🎮 מהנה</span>
+          </div>
+
+          {/* Section links */}
+          <div className="flex flex-wrap justify-center gap-3 md:gap-5 text-sm mt-5 md:mt-6">
+            <Link href="/tools"    className="text-teal-600 hover:text-teal-800 font-medium transition-colors">🎲 כלי כיתה</Link>
+            <Link href="/creative" className="text-purple-600 hover:text-purple-800 font-medium transition-colors">🎨 יצירה</Link>
+            <Link href="/riddles"  className="text-orange-600 hover:text-orange-800 font-medium transition-colors">🤣 חידות</Link>
+            <Link href="/"         className="text-blue-600 hover:text-blue-800 font-medium transition-colors">🎮 משחקים</Link>
           </div>
           
           {/* Developer credit */}


### PR DESCRIPTION
## What
Adds three dedicated section pages, each with a coloured hero, grid of relevant games, and back-to-home link:
- `/tools` — כלי כיתה (teal, classroom tools)
- `/creative` — יצירה ואומנות (purple, art/creative games)
- `/riddles` — חידות ובדיחות (orange, riddles/trivia)

Footer updated with navigation links to all four sections (tools/creative/riddles/home).

Each page uses a `'use client'` wrapper to satisfy Next.js's `ssr:false` constraint on `Header.tsx`.

## Why
Closes #1209

## Test plan
- [ ] `/tools` renders with teal gradient and shows spinner, team-picker, age-calculator etc.
- [ ] `/creative` renders with purple gradient and shows drawing, coloring, melody-maker etc.
- [ ] `/riddles` renders with orange gradient and shows riddles, trivia, jokes-browser etc.
- [ ] Footer shows section nav links on all pages
- [ ] All pages link back to `/` correctly
- [ ] RTL layout correct on mobile

🤖 Generated with [Claude Code](https://claude.com/claude-code)