### PR TITLE
feat(game): city-builder — Hebrew city panorama quiz with building animation (closes #1200)

### DIFF
--- a/gamesformykids/app/games/[gameType]/gamePageConstants.ts
+++ b/gamesformykids/app/games/[gameType]/gamePageConstants.ts
@@ -93,6 +93,7 @@ export const SUPPORTED_GAMES = [
   'dice',
   'timer',
   'letter-race',
+  'city-builder',
 ] as const;
 
 export type SupportedGameType = typeof SUPPORTED_GAMES[number];

--- a/gamesformykids/components/game/quiz/screens/CityBuilderStage.tsx
+++ b/gamesformykids/components/game/quiz/screens/CityBuilderStage.tsx
@@ -1,0 +1,75 @@
+'use client';
+
+import { QuizQuestionShell } from '@/components/game/quiz';
+import { useQuizGameStore } from '@/lib/stores/quizGameStore';
+import type { CityBuilderQuestion } from '@/lib/quiz/data/city-builder';
+
+const BUILDINGS = ['🏠', '🏢', '🏛️', '🏪', '🏬', '🏦', '🏨', '🏰', '⛪', '🗼'] as const;
+
+function CityPanorama() {
+  const score     = useQuizGameStore(s => s.score);
+  const isCorrect = useQuizGameStore(s => s.isCorrect);
+  const total     = useQuizGameStore(s => s.total);
+
+  return (
+    <div dir="rtl" className="mb-4">
+      {/* Sky + city strip */}
+      <div className="rounded-xl bg-gradient-to-b from-sky-300 to-sky-100 p-3 relative overflow-hidden">
+        <p className="text-xs font-bold text-sky-700 mb-2 text-center">
+          🏙️ העיר שלי — {score} / {total} בניינים
+        </p>
+        <div className="flex gap-1 justify-center items-end min-h-[3rem]">
+          {BUILDINGS.map((building, i) => {
+            const isBuilt = i < score;
+            const isNewest = isBuilt && i === score - 1 && isCorrect === true;
+            return (
+              <span
+                key={i}
+                className={`text-2xl leading-none transition-all duration-300 ${
+                  isBuilt
+                    ? isNewest
+                      ? 'opacity-100 scale-125 animate-bounce'
+                      : 'opacity-100 scale-100'
+                    : 'opacity-20 grayscale'
+                }`}
+                title={isBuilt ? undefined : 'עוד לא נבנה'}
+              >
+                {isBuilt ? building : '🏗️'}
+              </span>
+            );
+          })}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+interface Props {
+  current: CityBuilderQuestion;
+  choices: string[];
+  onSelect: (choice: string) => void;
+}
+
+export default function CityBuilderStage({ current, choices, onSelect }: Props) {
+  return (
+    <QuizQuestionShell
+      theme="sky"
+      choices={choices}
+      correctLabel={current.answer}
+      onSelect={onSelect}
+      correctMsg={`✅ נכון! בניין חדש נוסף לעיר! 🏙️`}
+      wrongMsg={`כמעט! התשובה הנכונה: ${current.answer}`}
+    >
+      <CityPanorama />
+
+      {/* Question */}
+      <div className="flex items-center justify-center gap-2 mb-2">
+        <span className="text-3xl">{current.emoji}</span>
+        <span className="text-xs font-semibold text-sky-500 bg-sky-100 rounded-full px-2 py-0.5">
+          {current.category}
+        </span>
+      </div>
+      <p className="text-base font-bold text-sky-900 leading-snug">{current.question}</p>
+    </QuizQuestionShell>
+  );
+}

--- a/gamesformykids/lib/constants/gameCategories.ts
+++ b/gamesformykids/lib/constants/gameCategories.ts
@@ -132,6 +132,6 @@ export const GAME_CATEGORIES: Record<string, GameCategory> = {
     color: "bg-teal-500",
     gradient: "from-teal-400 to-cyan-600",
 
-    gameIds: ["true-false","emoji-math","math-race","number-bubbles","word-scramble","word-builder","word-chain","trivia","trivia-categories","clock","spelling","opposites","world-languages","riddles","riddles-pro","english-words","singular-plural","adjectives","verbs","visual-opposites","english-cards","proverbs","story-builder","robot-coder","hangman","choose-adventure","picture-dictionary","word-search","kids-songs","kids-encyclopedia","age-calculator","jokes-browser","word-maze"],
+    gameIds: ["true-false","emoji-math","math-race","number-bubbles","word-scramble","word-builder","word-chain","trivia","trivia-categories","clock","spelling","opposites","world-languages","riddles","riddles-pro","english-words","singular-plural","adjectives","verbs","visual-opposites","english-cards","proverbs","story-builder","robot-coder","hangman","choose-adventure","picture-dictionary","word-search","kids-songs","kids-encyclopedia","age-calculator","jokes-browser","word-maze","city-builder"],
   },
 };

--- a/gamesformykids/lib/quiz/data/city-builder.ts
+++ b/gamesformykids/lib/quiz/data/city-builder.ts
@@ -1,0 +1,46 @@
+export type CityBuilderQuestion = {
+  id: number;
+  question: string;
+  answer: string;
+  emoji: string;
+  wrongOptions: [string, string, string];
+  category: string;
+};
+
+export const CITY_BUILDER_QUESTIONS: CityBuilderQuestion[] = [
+  // מדע וטבע
+  { id: 1, question: 'מה הצבע של השמיים ביום בהיר?', answer: 'כחול', emoji: '🌤️', wrongOptions: ['ירוק', 'אדום', 'צהוב'], category: 'טבע' },
+  { id: 2, question: 'איזה חיה נובחת?', answer: 'כלב', emoji: '🐕', wrongOptions: ['חתול', 'פרה', 'סוס'], category: 'בעלי חיים' },
+  { id: 3, question: 'מה יש בתוך ביצה שבוקעת ממנה אפרוח?', answer: 'אפרוח קטן', emoji: '🐣', wrongOptions: ['דגיג', 'צב', 'שועל'], category: 'בעלי חיים' },
+  { id: 4, question: 'כמה רגליים יש לעכביש?', answer: 'שמונה', emoji: '🕷️', wrongOptions: ['שש', 'ארבע', 'עשר'], category: 'מדע' },
+  { id: 5, question: 'מה זורח ביום ומאיר אותנו?', answer: 'שמש', emoji: '☀️', wrongOptions: ['ירח', 'כוכב', 'ענן'], category: 'טבע' },
+  { id: 6, question: 'איזה פרי הוא צהוב וחמוץ?', answer: 'לימון', emoji: '🍋', wrongOptions: ['תפוח', 'בננה', 'ענב'], category: 'אוכל' },
+  { id: 7, question: 'מה מרכיב את הגשם?', answer: 'מים', emoji: '🌧️', wrongOptions: ['חול', 'חלב', 'שמן'], category: 'מדע' },
+  { id: 8, question: 'כמה צבעים ביש בקשת בענן?', answer: 'שבעה', emoji: '🌈', wrongOptions: ['חמישה', 'שלושה', 'עשרה'], category: 'מדע' },
+  { id: 9, question: 'איזה חיה קופצת הכי גבוה?', answer: 'קנגורו', emoji: '🦘', wrongOptions: ['פיל', 'דג', 'צב'], category: 'בעלי חיים' },
+  { id: 10, question: 'מה הצמח שממנו מכינים שוקולד?', answer: 'קקאו', emoji: '🍫', wrongOptions: ['קפה', 'סוכר', 'חיטה'], category: 'טבע' },
+  // גיאוגרפיה וישראל
+  { id: 11, question: 'מה בירת ישראל?', answer: 'ירושלים', emoji: '🏙️', wrongOptions: ['תל אביב', 'חיפה', 'אילת'], category: 'ישראל' },
+  { id: 12, question: 'איזה ים נמצא בצפון ישראל?', answer: 'הכינרת', emoji: '🏞️', wrongOptions: ['ים המלח', 'הים התיכון', 'ים סוף'], category: 'ישראל' },
+  { id: 13, question: 'כמה ימים בשבוע?', answer: 'שבעה', emoji: '📅', wrongOptions: ['חמישה', 'שישה', 'שמונה'], category: 'ידע כללי' },
+  { id: 14, question: 'כמה חודשים בשנה?', answer: 'שנים עשר', emoji: '🗓️', wrongOptions: ['עשרה', 'שמונה', 'ארבעה עשר'], category: 'ידע כללי' },
+  { id: 15, question: 'מה הבניין הכי גבוה בעולם נקרא?', answer: 'בורג\'  ח\'ליפה', emoji: '🏗️', wrongOptions: ['מגדל אייפל', 'ביג בן', 'פירמידה'], category: 'גיאוגרפיה' },
+  // מתמטיקה ומספרים
+  { id: 16, question: 'כמה זה 5 + 3?', answer: '8', emoji: '🔢', wrongOptions: ['7', '9', '6'], category: 'מתמטיקה' },
+  { id: 17, question: 'כמה זה 10 - 4?', answer: '6', emoji: '➖', wrongOptions: ['5', '7', '8'], category: 'מתמטיקה' },
+  { id: 18, question: 'כמה זה 2 × 5?', answer: '10', emoji: '✖️', wrongOptions: ['8', '12', '7'], category: 'מתמטיקה' },
+  { id: 19, question: 'מה מספר זוגי?', answer: '4', emoji: '🔢', wrongOptions: ['3', '7', '9'], category: 'מתמטיקה' },
+  { id: 20, question: 'כמה זה 3 + 3 + 3?', answer: '9', emoji: '➕', wrongOptions: ['6', '12', '8'], category: 'מתמטיקה' },
+  // שפה ועברית
+  { id: 21, question: 'מה ניגוד של "גדול"?', answer: 'קטן', emoji: '📏', wrongOptions: ['עגול', 'שמן', 'חזק'], category: 'שפה' },
+  { id: 22, question: 'מה ניגוד של "יום"?', answer: 'לילה', emoji: '🌙', wrongOptions: ['שמש', 'ענן', 'שחר'], category: 'שפה' },
+  { id: 23, question: 'מה ניגוד של "חם"?', answer: 'קר', emoji: '🌡️', wrongOptions: ['רטוב', 'שקט', 'גדול'], category: 'שפה' },
+  { id: 24, question: 'כמה אותיות יש באלפבית העברי?', answer: 'עשרים ושתיים', emoji: '🔤', wrongOptions: ['עשרים', 'עשרים וארבע', 'שמונה עשרה'], category: 'שפה' },
+  { id: 25, question: 'איזו אות באה ראשונה באלפבית?', answer: 'אלף', emoji: 'א', wrongOptions: ['בית', 'גימל', 'דלת'], category: 'שפה' },
+  // ידע כללי לילדים
+  { id: 26, question: 'מה עושים כשיש אש?', answer: 'מתקשרים ל-102', emoji: '🚒', wrongOptions: ['שותים מים', 'ישנים', 'מחכים'], category: 'בטיחות' },
+  { id: 27, question: 'כמה שנות לימוד בבית ספר יסודי?', answer: 'שש', emoji: '🏫', wrongOptions: ['ארבע', 'שמונה', 'שלוש'], category: 'ידע כללי' },
+  { id: 28, question: 'מה עושה שוטר?', answer: 'שומר על הסדר', emoji: '👮', wrongOptions: ['מבשל אוכל', 'בונה בתים', 'מרפא חולים'], category: 'מקצועות' },
+  { id: 29, question: 'מה צבע תנור אדום ברמזור?', answer: 'עצור!', emoji: '🚦', wrongOptions: ['לך!', 'היזהר', 'האט'], category: 'בטיחות' },
+  { id: 30, question: 'מה נחוץ לצמח לגדול?', answer: 'מים ואור שמש', emoji: '🌱', wrongOptions: ['חול ואבנים', 'קרח ורוח', 'חשיכה ומלח'], category: 'טבע' },
+];

--- a/gamesformykids/lib/quiz/registry/customQuizGames.tsx
+++ b/gamesformykids/lib/quiz/registry/customQuizGames.tsx
@@ -8,6 +8,7 @@ import { useDivisionGame } from '@/lib/quiz/useDivisionGame';
 import { useStoryBuilderGame } from '@/lib/quiz/useStoryBuilderGame';
 import { useRiddlesProGame } from '@/lib/quiz/useRiddlesProGame';
 import { useTriviaCategoriesGame } from '@/lib/quiz/useTriviaCategoriesGame';
+import { useCityBuilderGame } from '@/lib/quiz/useCityBuilderGame';
 
 // Hooks — small, kept static so tree-shaking inlines only what's used
 import { useClockGame } from '@/lib/quiz/useClockGame';
@@ -63,6 +64,7 @@ const NikudQuestion        = dynamic(() => import('@/components/game/quiz/screen
 const DivisionQuestion     = dynamic(() => import('@/components/game/quiz/screens/DivisionQuestion'), { loading: () => <GameSpinnerScreen /> });
 const StoryBuilderQuestion = dynamic(() => import('@/components/game/quiz/screens/StoryBuilderQuestion'), { loading: () => <GameSpinnerScreen /> });
 const StoryBuilderResult   = dynamic(() => import('@/components/game/quiz/screens/StoryBuilderResult'), { loading: () => <GameSpinnerScreen /> });
+const CityBuilderStage     = dynamic(() => import('@/components/game/quiz/screens/CityBuilderStage'),   { loading: () => <GameSpinnerScreen /> });
 
 /**
  * Games built with makeQuizGame — custom hooks + lazy-loaded screen components.
@@ -219,6 +221,15 @@ export const CUSTOM_QUIZ_GAMES: Record<string, ComponentType> = {
       menu:     <QuizMenuScreen emoji="➗" title="חילוק" description="12 ÷ 3 = ? — חלק פריטים לקבוצות שוות!" theme="blue" buttonLabel="➗ בואו נחלק!" onStart={startGame} />,
       question: current ? <DivisionQuestion current={current} choices={choices as string[]} onSelect={selectAnswer} /> : null,
       result:   <QuizResultScreen onRestart={restart} theme="blue" />,
+    }),
+  ),
+
+  'city-builder': makeQuizGame(
+    useCityBuilderGame,
+    ({ current, choices, startGame, selectAnswer, restart }) => ({
+      menu:     <QuizMenuScreen emoji="🏙️" title="בנה את העיר" description="ענה נכון — ובנה בניין חדש בעיר! 10 שאלות מכל התחומים." theme="sky" buttonLabel="🏗️ בואו לבנות!" onStart={startGame} />,
+      question: current ? <CityBuilderStage current={current} choices={choices as string[]} onSelect={selectAnswer} /> : null,
+      result:   <QuizResultScreen onRestart={restart} theme="sky" title="העיר שלך מוכנה!" subtitle="כל הכבוד על הבניין!" />,
     }),
   ),
 

--- a/gamesformykids/lib/quiz/useCityBuilderGame.ts
+++ b/gamesformykids/lib/quiz/useCityBuilderGame.ts
@@ -1,0 +1,36 @@
+'use client';
+import { useCallback, useMemo } from 'react';
+import { CITY_BUILDER_QUESTIONS, type CityBuilderQuestion } from '@/lib/quiz/data/city-builder';
+import { QUESTIONS_PER_GAME } from '@/lib/quiz/constants';
+import { useQuizSession } from '@/lib/quiz/useQuizSession';
+import { useQuizGameStore } from '@/lib/stores/quizGameStore';
+import { shuffle } from '@/lib/utils';
+
+export function useCityBuilderGame() {
+  const { phase, current, begin, answer, reset } = useQuizSession<CityBuilderQuestion>('city-builder');
+
+  const buildingsBuilt = useQuizGameStore(s => s.score);
+  const isCorrect      = useQuizGameStore(s => s.isCorrect);
+  const questionIndex  = useQuizGameStore(s => s.index);
+  const total          = useQuizGameStore(s => s.total);
+
+  const choices = useMemo(
+    () => current ? shuffle([current.answer, ...current.wrongOptions]) : [],
+    [current],
+  );
+
+  const startGame = useCallback(() => {
+    begin(shuffle(CITY_BUILDER_QUESTIONS).slice(0, QUESTIONS_PER_GAME));
+  }, [begin]);
+
+  const selectAnswer = useCallback((choice: string) => {
+    if (!current) return;
+    answer(choice, choice === current.answer);
+  }, [answer, current]);
+
+  const restart = useCallback(() => {
+    reset(shuffle(CITY_BUILDER_QUESTIONS).slice(0, QUESTIONS_PER_GAME));
+  }, [reset]);
+
+  return { phase, current, choices, buildingsBuilt, isCorrect, questionIndex, total, startGame, selectAnswer, restart };
+}

--- a/gamesformykids/lib/registry/registryData/batch4.ts
+++ b/gamesformykids/lib/registry/registryData/batch4.ts
@@ -37,6 +37,7 @@ import {
   RotateCw,
   Users,
   Dice6,
+  Building2,
 } from "lucide-react";
 import type { GameRegistration } from "@/lib/types/games/base";
 
@@ -874,5 +875,16 @@ export const gamesRegistryBatch4: GameRegistration[] = [
     href: "/games/letter-race",
     available: true,
     order: 198,
+  },
+  {
+    id: "city-builder",
+    title: "בנה את העיר",
+    description: "ענה על שאלות מכל התחומים ובנה עיר מגדלים שלמה — 10 שאלות, 10 בניינים!",
+    icon: Building2,
+    emoji: "🏙️",
+    color: "bg-sky-500 hover:bg-sky-600",
+    href: "/games/city-builder",
+    available: true,
+    order: 199,
   },
 ];

--- a/gamesformykids/lib/types/core/base.ts
+++ b/gamesformykids/lib/types/core/base.ts
@@ -253,4 +253,6 @@ export type GameType =
   // Classroom countdown timer
   | 'timer'
   // Hebrew first-letter racing game
-  | 'letter-race';
+  | 'letter-race'
+  // City builder quiz game
+  | 'city-builder';


### PR DESCRIPTION
## What
Adds a new educational quiz game **city-builder** (🏙️ בנה את העיר) where each correct answer adds an animated building to a growing Hebrew city skyline.

## Implementation
- **Style C** (makeQuizGame) — custom question screen with city panorama, standard menu/result phases
- 30 cross-category questions (ages 5–9): science, nature, animals, math, geography, Hebrew language, safety
- City panorama renders up to 10 buildings as emoji (🏠🏢🏛️…🗼) above each question
- Newest building bounces + scales on correct answer using existing `animate-bounce` CSS
- Disabled slots show grayed 🏗️ scaffolding icons
- Uses `QuizQuestionShell` + `QuizFeedback` for answer flow (zero custom store logic)
- `building2` icon from lucide-react for registry card

## Files changed
| File | Type |
|---|---|
| `lib/quiz/data/city-builder.ts` | NEW — 30 quiz questions |
| `lib/quiz/useCityBuilderGame.ts` | NEW — game hook via useQuizSession |
| `components/game/quiz/screens/CityBuilderStage.tsx` | NEW — question screen with city panorama |
| `lib/quiz/registry/customQuizGames.tsx` | ADD — register game |
| `lib/types/core/base.ts` | ADD — `'city-builder'` to GameType |
| `app/games/[gameType]/gamePageConstants.ts` | ADD — SUPPORTED_GAMES |
| `lib/registry/registryData/batch4.ts` | ADD — registry card (order 199) |
| `lib/constants/gameCategories.ts` | ADD — educational category |

## Why
Closes #1200

## Test plan
- [ ] Visit `/games/city-builder` — menu screen shows
- [ ] Start game — first question appears with empty city (10 gray scaffolds)
- [ ] Correct answer → building bounces in, city grows
- [ ] Wrong answer → no building added, city stays same
- [ ] After 10 questions → result screen with city panorama
- [ ] Works on mobile (touch targets ≥ 44px)
- [ ] RTL layout correct
- [ ] Game appears in educational category on home page

🤖 Generated with [Claude Code](https://claude.com/claude-code)