### PR TITLE
feat(game): drag-sort — drag-and-drop category sorting with touch support

### DIFF
--- a/gamesformykids/app/games/[gameType]/CustomGameRenderer.tsx
+++ b/gamesformykids/app/games/[gameType]/CustomGameRenderer.tsx
@@ -73,6 +73,7 @@ const GAME_CLIENTS: Record<string, ComponentType> = {
   'dice':              dynamic(() => import('../dice/DiceClient'),                                    { ssr: false }),
   'timer':             dynamic(() => import('../timer/TimerClient'),                                  { ssr: false }),
   'letter-race':       dynamic(() => import('../letter-race/LetterRaceClient'),                      { ssr: false }),
+  'drag-sort':         dynamic(() => import('../drag-sort/DragSortClient'),                           { ssr: false }),
 };
 
 interface Props { gameType: string; }

--- a/gamesformykids/app/games/[gameType]/gamePageConstants.ts
+++ b/gamesformykids/app/games/[gameType]/gamePageConstants.ts
@@ -94,6 +94,7 @@ export const SUPPORTED_GAMES = [
   'timer',
   'letter-race',
   'city-builder',
+  'drag-sort',
 ] as const;
 
 export type SupportedGameType = typeof SUPPORTED_GAMES[number];
@@ -108,7 +109,7 @@ export const CUSTOM_GAME_TYPES = new Set([
   'word-builder', 'word-scramble', 'maze', 'letter-defender', 'puppet-story', 'number-slide', 'snakes-ladders',
 
 
-  'escape-room', 'robot-coder', 'find-in-scene', 'hangman', 'choose-adventure', 'picture-dictionary', 'word-search', 'israel-map', 'kids-songs', 'melody-maker', 'kids-encyclopedia', 'age-calculator', 'craft-guide', 'jokes-browser', 'word-maze', 'avatar-maker', 'sound-quiz', 'spinner', 'team-picker', 'dice', 'timer', 'letter-race',
+  'escape-room', 'robot-coder', 'find-in-scene', 'hangman', 'choose-adventure', 'picture-dictionary', 'word-search', 'israel-map', 'kids-songs', 'melody-maker', 'kids-encyclopedia', 'age-calculator', 'craft-guide', 'jokes-browser', 'word-maze', 'avatar-maker', 'sound-quiz', 'spinner', 'team-picker', 'dice', 'timer', 'letter-race', 'drag-sort',
   
   
 ]);

--- a/gamesformykids/app/games/drag-sort/DragSortClient.tsx
+++ b/gamesformykids/app/games/drag-sort/DragSortClient.tsx
@@ -1,0 +1,284 @@
+'use client';
+
+import { useRef, useState, useEffect, useCallback } from 'react';
+import Link from 'next/link';
+import { useDragSortStore } from './dragSortStore';
+import { DRAG_LEVELS, type DragItem } from './dragSortData';
+import { speakHebrew } from '@/lib/utils/speech/speaker';
+
+type DragState = { item: DragItem; x: number; y: number };
+type Toast = { text: string; ok: boolean };
+
+// ─── Menu ─────────────────────────────────────────────────────────────────────
+
+function MenuScreen({ onStart }: { onStart: (i: number) => void }) {
+  return (
+    <div
+      dir="rtl"
+      className="min-h-screen flex flex-col items-center justify-center p-6"
+      style={{ background: 'linear-gradient(135deg, #a78bfa 0%, #f472b6 100%)' }}
+    >
+      <div className="bg-white rounded-3xl shadow-2xl p-8 max-w-sm w-full text-center">
+        <div className="text-6xl mb-3">🗂️</div>
+        <h1 className="text-3xl font-black text-purple-800 mb-1">מיון גרירה</h1>
+        <p className="text-gray-500 text-sm mb-6">גרור כל פריט לקטגוריה הנכונה!</p>
+        <div className="flex flex-col gap-3">
+          {DRAG_LEVELS.map((level, i) => (
+            <button
+              key={level.id}
+              onClick={() => onStart(i)}
+              className="bg-purple-500 hover:bg-purple-600 text-white font-bold py-3 px-4 rounded-xl text-sm transition-all active:scale-95"
+            >
+              {i + 1}. {level.title}
+            </button>
+          ))}
+        </div>
+        <Link href="/" className="mt-5 inline-block text-sm text-gray-400 hover:text-gray-600">
+          ← חזרה לבית
+        </Link>
+      </div>
+    </div>
+  );
+}
+
+// ─── Result ───────────────────────────────────────────────────────────────────
+
+function ResultScreen({
+  score, total, errors, levelIndex,
+  onRestart, onNext, onMenu,
+}: {
+  score: number; total: number; errors: number; levelIndex: number;
+  onRestart: () => void; onNext: () => void; onMenu: () => void;
+}) {
+  const perfect = errors === 0;
+  const hasNext = levelIndex < DRAG_LEVELS.length - 1;
+  return (
+    <div
+      dir="rtl"
+      className="min-h-screen flex flex-col items-center justify-center p-6"
+      style={{ background: 'linear-gradient(135deg, #a78bfa 0%, #f472b6 100%)' }}
+    >
+      <div className="bg-white rounded-3xl shadow-2xl p-8 max-w-sm w-full text-center">
+        <div className="text-6xl mb-2">{perfect ? '🏆' : '🎉'}</div>
+        <h2 className="text-2xl font-black text-purple-800 mb-4">
+          {perfect ? 'מושלם!' : 'כל הכבוד!'}
+        </h2>
+        <div className="bg-purple-50 rounded-2xl p-4 grid grid-cols-3 gap-3 mb-5">
+          <div>
+            <div className="text-2xl font-black text-purple-700">{score}</div>
+            <div className="text-xs text-gray-500">נכון</div>
+          </div>
+          <div>
+            <div className="text-2xl font-black text-gray-600">{total}</div>
+            <div className="text-xs text-gray-500">סה&quot;כ</div>
+          </div>
+          <div>
+            <div className="text-2xl font-black text-red-500">{errors}</div>
+            <div className="text-xs text-gray-500">שגיאות</div>
+          </div>
+        </div>
+        <div className="flex flex-col gap-2">
+          {hasNext && (
+            <button
+              onClick={onNext}
+              className="bg-purple-500 hover:bg-purple-600 text-white font-bold py-3 rounded-xl transition-all active:scale-95"
+            >
+              ➡️ רמה הבאה
+            </button>
+          )}
+          <button
+            onClick={onRestart}
+            className="bg-gray-100 hover:bg-gray-200 text-gray-700 font-semibold py-3 rounded-xl transition-all"
+          >
+            🔄 שחק שוב
+          </button>
+          <button
+            onClick={onMenu}
+            className="bg-gray-50 hover:bg-gray-100 text-gray-500 font-semibold py-2 rounded-xl transition-all text-sm"
+          >
+            ← תפריט
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ─── Playing ──────────────────────────────────────────────────────────────────
+
+export default function DragSortClient() {
+  const {
+    phase, currentLevel, itemStates, score, errors, levelIndex,
+    startLevel, placeItem, restart, goToMenu,
+  } = useDragSortStore();
+
+  const [drag, setDrag] = useState<DragState | null>(null);
+  const [hoverZone, setHoverZone] = useState<string | null>(null);
+  const [toast, setToast] = useState<Toast | null>(null);
+
+  const dragRef = useRef<DragState | null>(null);
+  const hoverZoneRef = useRef<string | null>(null);
+  const zoneRefs = useRef<Record<string, HTMLElement | null>>({});
+  const ghostRef = useRef<HTMLDivElement>(null);
+
+  // Keep refs in sync
+  useEffect(() => { dragRef.current = drag; }, [drag]);
+  useEffect(() => { hoverZoneRef.current = hoverZone; }, [hoverZone]);
+
+  const showToast = useCallback((text: string, ok: boolean) => {
+    setToast({ text, ok });
+    setTimeout(() => setToast(null), 1000);
+  }, []);
+
+  // Document-level pointer listeners while dragging
+  useEffect(() => {
+    if (!drag) return;
+
+    const findZone = (x: number, y: number): string | null =>
+      Object.entries(zoneRefs.current).find(([, el]) => {
+        if (!el) return false;
+        const r = el.getBoundingClientRect();
+        return x >= r.left && x <= r.right && y >= r.top && y <= r.bottom;
+      })?.[0] ?? null;
+
+    const onMove = (e: PointerEvent) => {
+      // Update ghost directly (no re-render)
+      if (ghostRef.current) {
+        ghostRef.current.style.left = `${e.clientX - 44}px`;
+        ghostRef.current.style.top  = `${e.clientY - 44}px`;
+      }
+      const zone = findZone(e.clientX, e.clientY);
+      if (zone !== hoverZoneRef.current) {
+        hoverZoneRef.current = zone;
+        setHoverZone(zone);
+      }
+    };
+
+    const onUp = (e: PointerEvent) => {
+      const currentDrag = dragRef.current;
+      if (!currentDrag) { setDrag(null); return; }
+      const zone = findZone(e.clientX, e.clientY);
+      if (zone) {
+        const ok = placeItem(currentDrag.item.id, zone);
+        const cat = currentLevel?.categories.find(c => c.id === zone);
+        showToast(ok ? `✅ ${currentDrag.item.label} — ${cat?.label}!` : '❌ נסה שוב!', ok);
+        if (ok) speakHebrew(`כל הכבוד! ${currentDrag.item.label}`);
+      }
+      setDrag(null);
+      hoverZoneRef.current = null;
+      setHoverZone(null);
+    };
+
+    document.addEventListener('pointermove', onMove, { passive: true });
+    document.addEventListener('pointerup', onUp);
+    return () => {
+      document.removeEventListener('pointermove', onMove);
+      document.removeEventListener('pointerup', onUp);
+    };
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [drag?.item.id]);
+
+  const handlePointerDown = useCallback((e: React.PointerEvent<HTMLDivElement>, item: DragItem) => {
+    e.preventDefault();
+    speakHebrew(item.label);
+    setDrag({ item, x: e.clientX - 44, y: e.clientY - 44 });
+  }, []);
+
+  if (phase === 'menu') return <MenuScreen onStart={startLevel} />;
+
+  if (phase === 'result') {
+    return (
+      <ResultScreen
+        score={score}
+        total={currentLevel?.items.length ?? 0}
+        errors={errors}
+        levelIndex={levelIndex}
+        onRestart={restart}
+        onNext={() => startLevel(levelIndex + 1)}
+        onMenu={goToMenu}
+      />
+    );
+  }
+
+  if (!currentLevel) return null;
+
+  const unplaced = currentLevel.items.filter(i => !itemStates[i.id]?.placed);
+  const catCols = currentLevel.categories.length <= 3 ? `grid-cols-${currentLevel.categories.length}` : 'grid-cols-2 md:grid-cols-4';
+
+  return (
+    <div dir="rtl" className="min-h-screen flex flex-col select-none" style={{ background: 'linear-gradient(135deg, #ede9fe 0%, #fce7f3 100%)' }}>
+      {/* Header */}
+      <div className="flex items-center justify-between px-4 py-3 bg-white/80 backdrop-blur">
+        <span className="text-lg font-black text-purple-700">🗂️ {currentLevel.title}</span>
+        <span className="text-sm font-semibold text-gray-500">✅ {score} / {currentLevel.items.length}</span>
+      </div>
+
+      {/* Toast feedback */}
+      {toast && (
+        <div className={`fixed top-16 left-1/2 -translate-x-1/2 z-50 px-5 py-2 rounded-full text-white font-bold text-sm shadow-lg transition-all ${toast.ok ? 'bg-green-500' : 'bg-red-400'}`}>
+          {toast.text}
+        </div>
+      )}
+
+      {/* Category zones */}
+      <div className={`grid ${catCols} gap-3 p-3`}>
+        {currentLevel.categories.map(cat => {
+          const placedHere = currentLevel.items.filter(i => itemStates[i.id]?.placed && i.categoryId === cat.id);
+          const isHover = hoverZone === cat.id;
+          return (
+            <div
+              key={cat.id}
+              ref={el => { zoneRefs.current[cat.id] = el; }}
+              className={`rounded-2xl border-4 p-3 min-h-28 transition-all duration-150 ${cat.bg} ${isHover ? `${cat.border} scale-105 shadow-lg` : 'border-transparent'}`}
+            >
+              <div className="flex items-center gap-1 mb-2">
+                <span className="text-xl">{cat.emoji}</span>
+                <span className={`text-xs font-black ${cat.text}`}>{cat.label}</span>
+              </div>
+              <div className="flex flex-wrap gap-1">
+                {placedHere.map(i => (
+                  <span key={i.id} className="text-2xl leading-none animate-bounce" style={{ animationDuration: '0.4s', animationIterationCount: 1 }}>
+                    {i.emoji}
+                  </span>
+                ))}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+
+      {/* Items to sort */}
+      <div className="flex-1 p-3">
+        <p className="text-xs text-gray-500 text-center mb-3 font-medium">גרור כל פריט לקטגוריה הנכונה</p>
+        <div className="flex flex-wrap gap-3 justify-center">
+          {unplaced.map(item => (
+            <div
+              key={item.id}
+              className="bg-white rounded-2xl shadow-md p-3 text-center w-20 cursor-grab active:cursor-grabbing"
+              style={{ touchAction: 'none', userSelect: 'none' }}
+              onPointerDown={e => handlePointerDown(e, item)}
+            >
+              <div className="text-3xl leading-none mb-1">{item.emoji}</div>
+              <div className="text-xs font-bold text-gray-600 leading-tight">{item.label}</div>
+            </div>
+          ))}
+          {unplaced.length === 0 && (
+            <p className="text-gray-400 text-sm mt-4">כל הפריטים מוינו! 🎉</p>
+          )}
+        </div>
+      </div>
+
+      {/* Floating ghost */}
+      {drag && (
+        <div
+          ref={ghostRef}
+          className="fixed z-50 pointer-events-none bg-white rounded-2xl shadow-2xl p-3 text-center w-22"
+          style={{ left: drag.x, top: drag.y, width: 88, opacity: 0.95, transform: 'scale(1.1)' }}
+        >
+          <div className="text-3xl leading-none mb-1">{drag.item.emoji}</div>
+          <div className="text-xs font-bold text-gray-600 leading-tight">{drag.item.label}</div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/gamesformykids/app/games/drag-sort/dragSortData.ts
+++ b/gamesformykids/app/games/drag-sort/dragSortData.ts
@@ -1,0 +1,164 @@
+export type DragCategory = {
+  id: string;
+  label: string;
+  emoji: string;
+  bg: string;
+  border: string;
+  text: string;
+};
+
+export type DragItem = {
+  id: string;
+  label: string;
+  emoji: string;
+  categoryId: string;
+};
+
+export type DragLevel = {
+  id: string;
+  title: string;
+  categories: DragCategory[];
+  items: DragItem[];
+};
+
+export const DRAG_LEVELS: DragLevel[] = [
+  {
+    id: 'basics',
+    title: 'בסיסי — פירות / ירקות / חיות / תחבורה',
+    categories: [
+      { id: 'fruits',   label: 'פירות',       emoji: '🍎', bg: 'bg-red-50',    border: 'border-red-400',    text: 'text-red-700'    },
+      { id: 'veggies',  label: 'ירקות',       emoji: '🥕', bg: 'bg-green-50',  border: 'border-green-400',  text: 'text-green-700'  },
+      { id: 'animals',  label: 'בעלי חיים',   emoji: '🐕', bg: 'bg-amber-50',  border: 'border-amber-400',  text: 'text-amber-700'  },
+      { id: 'vehicles', label: 'תחבורה',      emoji: '🚗', bg: 'bg-blue-50',   border: 'border-blue-400',   text: 'text-blue-700'   },
+    ],
+    items: [
+      { id: 'apple',    label: 'תפוח',     emoji: '🍎', categoryId: 'fruits'   },
+      { id: 'banana',   label: 'בננה',     emoji: '🍌', categoryId: 'fruits'   },
+      { id: 'grape',    label: 'ענבים',    emoji: '🍇', categoryId: 'fruits'   },
+      { id: 'carrot',   label: 'גזר',      emoji: '🥕', categoryId: 'veggies'  },
+      { id: 'cucumber', label: 'מלפפון',   emoji: '🥒', categoryId: 'veggies'  },
+      { id: 'tomato',   label: 'עגבנייה',  emoji: '🍅', categoryId: 'veggies'  },
+      { id: 'dog',      label: 'כלב',      emoji: '🐕', categoryId: 'animals'  },
+      { id: 'cat',      label: 'חתול',     emoji: '🐱', categoryId: 'animals'  },
+      { id: 'rabbit',   label: 'ארנב',     emoji: '🐰', categoryId: 'animals'  },
+      { id: 'car',      label: 'מכונית',   emoji: '🚗', categoryId: 'vehicles' },
+      { id: 'bus',      label: 'אוטובוס',  emoji: '🚌', categoryId: 'vehicles' },
+      { id: 'bike',     label: 'אופניים',  emoji: '🚲', categoryId: 'vehicles' },
+    ],
+  },
+  {
+    id: 'habitat',
+    title: 'בית גר — ים / יבשה / אוויר',
+    categories: [
+      { id: 'sea',  label: 'ים',    emoji: '🌊', bg: 'bg-blue-50',  border: 'border-blue-400',  text: 'text-blue-700'  },
+      { id: 'land', label: 'יבשה', emoji: '🌿', bg: 'bg-green-50', border: 'border-green-400', text: 'text-green-700' },
+      { id: 'sky',  label: 'אוויר', emoji: '☁️', bg: 'bg-sky-50',   border: 'border-sky-400',   text: 'text-sky-700'   },
+    ],
+    items: [
+      { id: 'shark',    label: 'כריש',    emoji: '🦈', categoryId: 'sea'  },
+      { id: 'dolphin',  label: 'דולפין',  emoji: '🐬', categoryId: 'sea'  },
+      { id: 'turtle',   label: 'צב ים',   emoji: '🐢', categoryId: 'sea'  },
+      { id: 'fish',     label: 'דג',      emoji: '🐟', categoryId: 'sea'  },
+      { id: 'lion',     label: 'אריה',    emoji: '🦁', categoryId: 'land' },
+      { id: 'elephant', label: 'פיל',     emoji: '🐘', categoryId: 'land' },
+      { id: 'giraffe',  label: 'ג׳ירפה',  emoji: '🦒', categoryId: 'land' },
+      { id: 'zebra',    label: 'זברה',    emoji: '🦓', categoryId: 'land' },
+      { id: 'eagle',    label: 'נשר',     emoji: '🦅', categoryId: 'sky'  },
+      { id: 'parrot',   label: 'תוכי',    emoji: '🦜', categoryId: 'sky'  },
+      { id: 'owl',      label: 'ינשוף',   emoji: '🦉', categoryId: 'sky'  },
+      { id: 'duck',     label: 'ברווז',   emoji: '🦆', categoryId: 'sky'  },
+    ],
+  },
+  {
+    id: 'clothes-food-tools',
+    title: 'אוכל / לבוש / כלים',
+    categories: [
+      { id: 'food',    label: 'אוכל', emoji: '🍕', bg: 'bg-orange-50', border: 'border-orange-400', text: 'text-orange-700' },
+      { id: 'clothes', label: 'לבוש', emoji: '👕', bg: 'bg-pink-50',   border: 'border-pink-400',   text: 'text-pink-700'   },
+      { id: 'tools',   label: 'כלים', emoji: '🔨', bg: 'bg-gray-100',  border: 'border-gray-400',   text: 'text-gray-700'   },
+    ],
+    items: [
+      { id: 'bread',    label: 'לחם',      emoji: '🍞', categoryId: 'food'    },
+      { id: 'pizza',    label: 'פיצה',     emoji: '🍕', categoryId: 'food'    },
+      { id: 'rice',     label: 'אורז',     emoji: '🍚', categoryId: 'food'    },
+      { id: 'egg',      label: 'ביצה',     emoji: '🥚', categoryId: 'food'    },
+      { id: 'shirt',    label: 'חולצה',    emoji: '👕', categoryId: 'clothes' },
+      { id: 'pants',    label: 'מכנסיים',  emoji: '👖', categoryId: 'clothes' },
+      { id: 'shoe',     label: 'נעל',      emoji: '👟', categoryId: 'clothes' },
+      { id: 'hat',      label: 'כובע',     emoji: '🎩', categoryId: 'clothes' },
+      { id: 'hammer',   label: 'פטיש',     emoji: '🔨', categoryId: 'tools'   },
+      { id: 'wrench',   label: 'מברג',     emoji: '🔧', categoryId: 'tools'   },
+      { id: 'key',      label: 'מפתח',     emoji: '🔑', categoryId: 'tools'   },
+      { id: 'scissors', label: 'מספריים',  emoji: '✂️', categoryId: 'tools'   },
+    ],
+  },
+  {
+    id: 'transport-medium',
+    title: 'תחבורה — כביש / ים / אוויר',
+    categories: [
+      { id: 'road', label: 'כביש',  emoji: '🛣️', bg: 'bg-gray-100',  border: 'border-gray-400',  text: 'text-gray-700'  },
+      { id: 'sea2', label: 'ים',    emoji: '🌊', bg: 'bg-blue-50',   border: 'border-blue-400',  text: 'text-blue-700'  },
+      { id: 'air',  label: 'אוויר', emoji: '✈️', bg: 'bg-sky-50',    border: 'border-sky-400',   text: 'text-sky-700'   },
+    ],
+    items: [
+      { id: 'car2',    label: 'מכונית',  emoji: '🚗', categoryId: 'road' },
+      { id: 'bus2',    label: 'אוטובוס', emoji: '🚌', categoryId: 'road' },
+      { id: 'train',   label: 'רכבת',    emoji: '🚂', categoryId: 'road' },
+      { id: 'truck',   label: 'משאית',   emoji: '🚚', categoryId: 'road' },
+      { id: 'ship',    label: 'ספינה',   emoji: '🚢', categoryId: 'sea2' },
+      { id: 'boat',    label: 'סירה',    emoji: '⛵', categoryId: 'sea2' },
+      { id: 'ferry',   label: 'מעבורת',  emoji: '🛥️', categoryId: 'sea2' },
+      { id: 'sub',     label: 'צוללת',   emoji: '🤿', categoryId: 'sea2' },
+      { id: 'plane',   label: 'מטוס',    emoji: '✈️', categoryId: 'air'  },
+      { id: 'heli',    label: 'מסוק',    emoji: '🚁', categoryId: 'air'  },
+      { id: 'balloon', label: 'בלון',    emoji: '🎈', categoryId: 'air'  },
+      { id: 'rocket',  label: 'רקטה',    emoji: '🚀', categoryId: 'air'  },
+    ],
+  },
+  {
+    id: 'sport-music-art',
+    title: 'ספורט / מוזיקה / אומנות',
+    categories: [
+      { id: 'sport', label: 'ספורט',  emoji: '⚽', bg: 'bg-green-50',  border: 'border-green-400',  text: 'text-green-700'  },
+      { id: 'music', label: 'מוזיקה', emoji: '🎵', bg: 'bg-purple-50', border: 'border-purple-400', text: 'text-purple-700' },
+      { id: 'art',   label: 'אומנות', emoji: '🎨', bg: 'bg-yellow-50', border: 'border-yellow-400', text: 'text-yellow-700' },
+    ],
+    items: [
+      { id: 'soccer',   label: 'כדורגל',  emoji: '⚽', categoryId: 'sport' },
+      { id: 'basket',   label: 'כדורסל',  emoji: '🏀', categoryId: 'sport' },
+      { id: 'tennis',   label: 'טניס',    emoji: '🎾', categoryId: 'sport' },
+      { id: 'swim',     label: 'שחייה',   emoji: '🏊', categoryId: 'sport' },
+      { id: 'guitar',   label: 'גיטרה',   emoji: '🎸', categoryId: 'music' },
+      { id: 'piano',    label: 'פסנתר',   emoji: '🎹', categoryId: 'music' },
+      { id: 'trumpet',  label: 'חצוצרה',  emoji: '🎺', categoryId: 'music' },
+      { id: 'drum',     label: 'תופים',   emoji: '🥁', categoryId: 'music' },
+      { id: 'brush',    label: 'מברשת',   emoji: '🖌️', categoryId: 'art'   },
+      { id: 'pencil',   label: 'עיפרון',  emoji: '✏️', categoryId: 'art'   },
+      { id: 'palette',  label: 'פלטה',    emoji: '🎨', categoryId: 'art'   },
+      { id: 'camera',   label: 'מצלמה',   emoji: '📷', categoryId: 'art'   },
+    ],
+  },
+  {
+    id: 'wild-pet-insect',
+    title: 'חיות בית / חיות בר / חרקים',
+    categories: [
+      { id: 'pet',    label: 'חיות בית', emoji: '🐾', bg: 'bg-amber-50',  border: 'border-amber-400',  text: 'text-amber-700'  },
+      { id: 'wild',   label: 'חיות בר',  emoji: '🌿', bg: 'bg-green-50',  border: 'border-green-400',  text: 'text-green-700'  },
+      { id: 'insect', label: 'חרקים',    emoji: '🦋', bg: 'bg-lime-50',   border: 'border-lime-400',   text: 'text-lime-700'   },
+    ],
+    items: [
+      { id: 'dog2',      label: 'כלב',      emoji: '🐕', categoryId: 'pet'    },
+      { id: 'cat2',      label: 'חתול',     emoji: '🐱', categoryId: 'pet'    },
+      { id: 'rabbit2',   label: 'ארנב',     emoji: '🐰', categoryId: 'pet'    },
+      { id: 'hamster',   label: 'אוגר',     emoji: '🐹', categoryId: 'pet'    },
+      { id: 'lion2',     label: 'אריה',     emoji: '🦁', categoryId: 'wild'   },
+      { id: 'bear',      label: 'דוב',      emoji: '🐻', categoryId: 'wild'   },
+      { id: 'wolf',      label: 'זאב',      emoji: '🐺', categoryId: 'wild'   },
+      { id: 'fox',       label: 'שועל',     emoji: '🦊', categoryId: 'wild'   },
+      { id: 'butterfly', label: 'פרפר',     emoji: '🦋', categoryId: 'insect' },
+      { id: 'ant',       label: 'נמלה',     emoji: '🐜', categoryId: 'insect' },
+      { id: 'bee',       label: 'דבורה',    emoji: '🐝', categoryId: 'insect' },
+      { id: 'ladybug',   label: 'פרת משה',  emoji: '🐞', categoryId: 'insect' },
+    ],
+  },
+];

--- a/gamesformykids/app/games/drag-sort/dragSortStore.ts
+++ b/gamesformykids/app/games/drag-sort/dragSortStore.ts
@@ -1,0 +1,73 @@
+'use client';
+import { create } from 'zustand';
+import { DRAG_LEVELS, type DragLevel } from './dragSortData';
+
+export interface ItemState {
+  id: string;
+  placed: boolean;
+}
+
+interface State {
+  phase: 'menu' | 'playing' | 'result';
+  levelIndex: number;
+  currentLevel: DragLevel | null;
+  itemStates: Record<string, ItemState>;
+  score: number;
+  errors: number;
+}
+
+interface Actions {
+  startLevel: (index: number) => void;
+  placeItem: (itemId: string, categoryId: string) => boolean;
+  restart: () => void;
+  goToMenu: () => void;
+}
+
+const INITIAL: State = {
+  phase: 'menu',
+  levelIndex: 0,
+  currentLevel: null,
+  itemStates: {},
+  score: 0,
+  errors: 0,
+};
+
+export const useDragSortStore = create<State & Actions>((set, get) => ({
+  ...INITIAL,
+
+  startLevel: (index) => {
+    const level = DRAG_LEVELS[index];
+    if (!level) return;
+    const itemStates: Record<string, ItemState> = {};
+    for (const item of level.items) {
+      itemStates[item.id] = { id: item.id, placed: false };
+    }
+    set({ phase: 'playing', levelIndex: index, currentLevel: level, itemStates, score: 0, errors: 0 });
+  },
+
+  placeItem: (itemId, categoryId) => {
+    const { currentLevel, itemStates } = get();
+    const item = currentLevel?.items.find(i => i.id === itemId);
+    if (!item) return false;
+    const correct = item.categoryId === categoryId;
+    if (correct) {
+      const newStates = { ...itemStates, [itemId]: { id: itemId, placed: true } };
+      const allPlaced = Object.values(newStates).every(s => s.placed);
+      set(s => ({
+        itemStates: newStates,
+        score: s.score + 1,
+        phase: allPlaced ? 'result' : 'playing',
+      }));
+    } else {
+      set(s => ({ errors: s.errors + 1 }));
+    }
+    return correct;
+  },
+
+  restart: () => {
+    const { levelIndex } = get();
+    get().startLevel(levelIndex);
+  },
+
+  goToMenu: () => set({ ...INITIAL }),
+}));

--- a/gamesformykids/lib/constants/gameCategories.ts
+++ b/gamesformykids/lib/constants/gameCategories.ts
@@ -132,6 +132,6 @@ export const GAME_CATEGORIES: Record<string, GameCategory> = {
     color: "bg-teal-500",
     gradient: "from-teal-400 to-cyan-600",
 
-    gameIds: ["true-false","emoji-math","math-race","number-bubbles","word-scramble","word-builder","word-chain","trivia","trivia-categories","clock","spelling","opposites","world-languages","riddles","riddles-pro","english-words","singular-plural","adjectives","verbs","visual-opposites","english-cards","proverbs","story-builder","robot-coder","hangman","choose-adventure","picture-dictionary","word-search","kids-songs","kids-encyclopedia","age-calculator","jokes-browser","word-maze","city-builder"],
+    gameIds: ["true-false","emoji-math","math-race","number-bubbles","word-scramble","word-builder","word-chain","trivia","trivia-categories","clock","spelling","opposites","world-languages","riddles","riddles-pro","english-words","singular-plural","adjectives","verbs","visual-opposites","english-cards","proverbs","story-builder","robot-coder","hangman","choose-adventure","picture-dictionary","word-search","kids-songs","kids-encyclopedia","age-calculator","jokes-browser","word-maze","city-builder","drag-sort"],
   },
 };

--- a/gamesformykids/lib/registry/registryData/batch4.ts
+++ b/gamesformykids/lib/registry/registryData/batch4.ts
@@ -887,4 +887,15 @@ export const gamesRegistryBatch4: GameRegistration[] = [
     available: true,
     order: 199,
   },
+  {
+    id: "drag-sort",
+    title: "מיון גרירה",
+    description: "גרור כל פריט לקטגוריה הנכונה — 6 נושאים: חיות, תחבורה, אוכל ועוד!",
+    icon: Layers,
+    emoji: "🗂️",
+    color: "bg-purple-500 hover:bg-purple-600",
+    href: "/games/drag-sort",
+    available: true,
+    order: 202,
+  },
 ];

--- a/gamesformykids/lib/types/core/base.ts
+++ b/gamesformykids/lib/types/core/base.ts
@@ -255,4 +255,6 @@ export type GameType =
   // Hebrew first-letter racing game
   | 'letter-race'
   // City builder quiz game
-  | 'city-builder';
+  | 'city-builder'
+  // Drag-and-drop sorting game
+  | 'drag-sort';


### PR DESCRIPTION
## What
Implements a drag-and-drop sorting game (Style D custom) where players drag emoji items into matching category bins. Works on both mouse and touch via the Pointer Events API.

## Features
- 6 themed levels: basics (fruit/veg/animals/vehicles), habitat (sea/land/sky), clothes-food-tools, transport by medium, sport-music-art, wild-pet-insect
- 12 items per level, 3-4 category zones per level
- Pointer Events API — unified mouse + touch drag with no library dependency
- Ghost element follows cursor directly via DOM style (no React re-renders per frame)
- Drop zone highlights on hover, visual bounce on correct placement
- TTS speaks item name on touch, congratulates on correct drop
- Toast feedback: ✅ / ❌ with 1s auto-dismiss
- Result screen with score, total, errors + next-level / replay / menu buttons

## Implementation
- `dragSortData.ts` — 6 level definitions with categories and items
- `dragSortStore.ts` — Zustand store (phase, itemStates, score, errors)
- `DragSortClient.tsx` — complete game with drag logic via `useEffect` + document listeners

## Why
Closes #1196

## Test plan
- [ ] Visit `/games/drag-sort` — menu with 6 level buttons
- [ ] Start level 1 — items appear at bottom, zones at top
- [ ] Drag (mouse) an item to correct zone → turns green, item disappears, ✅ toast
- [ ] Drag to wrong zone → stays, ❌ toast
- [ ] Touch-drag on mobile works identically
- [ ] Complete all 12 items → result screen with stats
- [ ] "רמה הבאה" advances to next level
- [ ] Game appears in "📚 משחקים חינוכיים" category

🤖 Generated with [Claude Code](https://claude.com/claude-code)