### PR TITLE
feat(game): letter-slicer — tap flying Hebrew word bubbles to slice the target (closes #1181)

### DIFF
--- a/gamesformykids/app/games/[gameType]/CustomGameRenderer.tsx
+++ b/gamesformykids/app/games/[gameType]/CustomGameRenderer.tsx
@@ -82,6 +82,7 @@ const GAME_CLIENTS: Record<string, ComponentType> = {
   'syllable-drums':    dynamic(() => import('../syllable-drums/DrumsClient'),                          { ssr: false }),
   'dress-up':          dynamic(() => import('../dress-up/DressUpClient'),                              { ssr: false }),
   'letter-bubble-shooter': dynamic(() => import('../letter-bubble-shooter/BubbleShooterClient'),      { ssr: false }),
+  'letter-slicer':         dynamic(() => import('../letter-slicer/LetterSlicerClient'),                { ssr: false }),
 };
 
 interface Props { gameType: string; }

--- a/gamesformykids/app/games/[gameType]/gamePageConstants.ts
+++ b/gamesformykids/app/games/[gameType]/gamePageConstants.ts
@@ -104,6 +104,7 @@ export const SUPPORTED_GAMES = [
   'syllable-drums',
   'dress-up',
   'letter-bubble-shooter',
+  'letter-slicer',
 ] as const;
 
 export type SupportedGameType = typeof SUPPORTED_GAMES[number];
@@ -118,7 +119,7 @@ export const CUSTOM_GAME_TYPES = new Set([
   'word-builder', 'word-scramble', 'maze', 'letter-defender', 'puppet-story', 'number-slide', 'snakes-ladders',
 
 
-  'escape-room', 'robot-coder', 'find-in-scene', 'hangman', 'choose-adventure', 'picture-dictionary', 'word-search', 'israel-map', 'kids-songs', 'melody-maker', 'kids-encyclopedia', 'age-calculator', 'craft-guide', 'jokes-browser', 'word-maze', 'avatar-maker', 'sound-quiz', 'spinner', 'team-picker', 'dice', 'timer', 'letter-race', 'drag-sort', 'answer-cannon', 'typing-race', 'word-fishing', 'letter-grow', 'letter-slingshot', 'syllable-drums', 'dress-up', 'letter-bubble-shooter',
+  'escape-room', 'robot-coder', 'find-in-scene', 'hangman', 'choose-adventure', 'picture-dictionary', 'word-search', 'israel-map', 'kids-songs', 'melody-maker', 'kids-encyclopedia', 'age-calculator', 'craft-guide', 'jokes-browser', 'word-maze', 'avatar-maker', 'sound-quiz', 'spinner', 'team-picker', 'dice', 'timer', 'letter-race', 'drag-sort', 'answer-cannon', 'typing-race', 'word-fishing', 'letter-grow', 'letter-slingshot', 'syllable-drums', 'dress-up', 'letter-bubble-shooter', 'letter-slicer',
   
   
 ]);

--- a/gamesformykids/app/games/letter-slicer/LetterSlicerClient.tsx
+++ b/gamesformykids/app/games/letter-slicer/LetterSlicerClient.tsx
@@ -1,0 +1,368 @@
+'use client';
+import { useState, useCallback, useRef, useEffect } from 'react';
+import { useCanvasLoop } from '@/hooks/canvas/useCanvasLoop';
+import { speakHebrew } from '@/lib/utils/speech/speaker';
+
+const WORDS = [
+  { word: 'כלב',    color: '#3b82f6' },
+  { word: 'חתול',   color: '#ef4444' },
+  { word: 'דג',     color: '#22c55e' },
+  { word: 'ציפור',  color: '#f97316' },
+  { word: 'פרח',    color: '#a855f7' },
+  { word: 'תפוח',   color: '#14b8a6' },
+  { word: 'ספר',    color: '#f59e0b' },
+  { word: 'בית',    color: '#ec4899' },
+  { word: 'כוכב',   color: '#6366f1' },
+  { word: 'ירח',    color: '#84cc16' },
+  { word: 'שמש',    color: '#eab308' },
+  { word: 'עץ',     color: '#16a34a' },
+  { word: 'אוטו',   color: '#0ea5e9' },
+  { word: 'ספינה',  color: '#8b5cf6' },
+  { word: 'עוגה',   color: '#fb7185' },
+];
+
+const R = 40;
+const MAX_BUBBLES = 7;
+const HEARTS_MAX = 3;
+const GRAVITY = 0.10;
+
+const SPEED_MAP = { slow: 0.65, medium: 1.0, fast: 1.5 } as const;
+type Difficulty = keyof typeof SPEED_MAP;
+
+interface Bubble { id: number; word: string; color: string; x: number; y: number; vx: number; vy: number; }
+interface Pop    { x: number; y: number; color: string; t: number; }
+
+type Phase = 'menu' | 'playing' | 'result';
+
+let _nextId = 0;
+
+export default function LetterSlicerClient() {
+  const [phase, setPhase]   = useState<Phase>('menu');
+  const [score, setScore]   = useState(0);
+  const [hearts, setHearts] = useState(HEARTS_MAX);
+  const [target, setTarget] = useState('');
+  const [diff, setDiff]     = useState<Difficulty>('medium');
+
+  const bubblesRef    = useRef<Bubble[]>([]);
+  const popsRef       = useRef<Pop[]>([]);
+  const targetRef     = useRef('');
+  const heartsRef     = useRef(HEARTS_MAX);
+  const scoreRef      = useRef(0);
+  const phaseRef      = useRef<Phase>('menu');
+  const diffRef       = useRef<Difficulty>('medium');
+  const spawnTimer    = useRef(0);
+  const targetTimer   = useRef(0);
+  const flashTimer    = useRef(0);
+  const successTimer  = useRef(0);
+
+  const pickTarget = useCallback(() => {
+    const pool = bubblesRef.current;
+    if (!pool.length) return;
+    const t = pool[Math.floor(Math.random() * pool.length)]!.word;
+    targetRef.current = t;
+    setTarget(t);
+    speakHebrew(`חתוך את: ${t}`);
+  }, []);
+
+  const startGame = useCallback((d: Difficulty) => {
+    bubblesRef.current  = [];
+    popsRef.current     = [];
+    targetRef.current   = '';
+    heartsRef.current   = HEARTS_MAX;
+    scoreRef.current    = 0;
+    spawnTimer.current  = 0;
+    targetTimer.current = 0;
+    flashTimer.current  = 0;
+    successTimer.current = 0;
+    phaseRef.current    = 'playing';
+    diffRef.current     = d;
+    setPhase('playing');
+    setHearts(HEARTS_MAX);
+    setScore(0);
+    setTarget('');
+    setDiff(d);
+  }, []);
+
+  const endGame = useCallback(() => {
+    phaseRef.current = 'result';
+    setPhase('result');
+    setTimeout(() => speakHebrew(`כל הכבוד! קיבלת ${scoreRef.current} נקודות!`), 300);
+  }, []);
+
+  const canvasRef = useCanvasLoop(useCallback((ctx: CanvasRenderingContext2D, dt: number) => {
+    if (phaseRef.current !== 'playing') return;
+    const W = ctx.canvas.width;
+    const H = ctx.canvas.height;
+    const spd = SPEED_MAP[diffRef.current];
+
+    // Background
+    const bg = ctx.createLinearGradient(0, 0, 0, H);
+    bg.addColorStop(0, '#0f172a');
+    bg.addColorStop(1, '#1e1b4b');
+    ctx.fillStyle = bg;
+    ctx.fillRect(0, 0, W, H);
+
+    // Stars background
+    ctx.fillStyle = 'rgba(255,255,255,0.15)';
+    for (let i = 0; i < 40; i++) {
+      const sx = ((i * 137 + W * 0.3) % W);
+      const sy = ((i * 97 + H * 0.2) % (H * 0.7));
+      ctx.fillRect(sx, sy, 1.5, 1.5);
+    }
+
+    // Wrong-tap red flash
+    if (flashTimer.current > 0) {
+      ctx.fillStyle = `rgba(239,68,68,${Math.min(flashTimer.current / 300, 0.45)})`;
+      ctx.fillRect(0, 0, W, H);
+      flashTimer.current = Math.max(0, flashTimer.current - dt);
+    }
+
+    // Correct green flash
+    if (successTimer.current > 0) {
+      ctx.fillStyle = `rgba(34,197,94,${Math.min(successTimer.current / 300, 0.30)})`;
+      ctx.fillRect(0, 0, W, H);
+      successTimer.current = Math.max(0, successTimer.current - dt);
+    }
+
+    // Spawn bubbles
+    spawnTimer.current -= dt;
+    if (spawnTimer.current <= 0 && bubblesRef.current.length < MAX_BUBBLES) {
+      const item = WORDS[Math.floor(Math.random() * WORDS.length)]!;
+      const fromLeft = Math.random() < 0.5;
+      const x = fromLeft ? -R : W + R;
+      const y = H * (0.45 + Math.random() * 0.35);
+      const vx = (fromLeft ? 1 : -1) * (2.5 + Math.random() * 2) * spd;
+      const vy = -(3.5 + Math.random() * 2.5) * spd;
+      bubblesRef.current.push({ id: ++_nextId, word: item.word, color: item.color, x, y, vx, vy });
+      spawnTimer.current = (900 + Math.random() * 600) / spd;
+    }
+
+    // Target refresh — pick if none or target fell off
+    const targetOnScreen = bubblesRef.current.some(b => b.word === targetRef.current);
+    targetTimer.current -= dt;
+    if (!targetOnScreen || targetTimer.current <= 0) {
+      if (bubblesRef.current.length > 0) {
+        pickTarget();
+        targetTimer.current = 6000 / spd;
+      }
+    }
+
+    // Update + draw bubbles
+    bubblesRef.current = bubblesRef.current.filter(b => {
+      b.vy += GRAVITY;
+      b.x += b.vx;
+      b.y += b.vy;
+      if (b.y > H + R * 2 || b.x < -R * 4 || b.x > W + R * 4) return false;
+
+      const isTarget = b.word === targetRef.current;
+
+      // Glow on target
+      ctx.save();
+      if (isTarget) {
+        ctx.shadowColor = '#fbbf24';
+        ctx.shadowBlur = 24;
+      } else {
+        ctx.shadowColor = 'rgba(0,0,0,0.4)';
+        ctx.shadowBlur = 8;
+      }
+      ctx.beginPath();
+      ctx.arc(b.x, b.y, R, 0, Math.PI * 2);
+      ctx.fillStyle = b.color;
+      ctx.fill();
+      if (isTarget) {
+        ctx.strokeStyle = '#fbbf24';
+        ctx.lineWidth = 3;
+        ctx.stroke();
+      }
+      ctx.restore();
+
+      // Label
+      const fontSize = b.word.length > 4 ? 16 : b.word.length > 3 ? 19 : 22;
+      ctx.font = `bold ${fontSize}px Arial, sans-serif`;
+      ctx.fillStyle = '#ffffff';
+      ctx.textAlign = 'center';
+      ctx.textBaseline = 'middle';
+      ctx.fillText(b.word, b.x, b.y);
+
+      return true;
+    });
+
+    // Pop animations
+    popsRef.current = popsRef.current.filter(p => {
+      p.t += dt / 450;
+      if (p.t >= 1) return false;
+      const alpha = 1 - p.t;
+      // Expanding ring
+      ctx.beginPath();
+      ctx.arc(p.x, p.y, R * (1 + p.t * 1.8), 0, Math.PI * 2);
+      ctx.strokeStyle = `rgba(255,255,255,${alpha * 0.8})`;
+      ctx.lineWidth = 3;
+      ctx.stroke();
+      // 8 flying particles
+      for (let i = 0; i < 8; i++) {
+        const angle = (i / 8) * Math.PI * 2;
+        const pr = R * 2 * p.t;
+        const px = p.x + Math.cos(angle) * pr;
+        const py = p.y + Math.sin(angle) * pr;
+        const pr2 = 5 * (1 - p.t);
+        if (pr2 < 0.5) continue;
+        ctx.beginPath();
+        ctx.arc(px, py, pr2, 0, Math.PI * 2);
+        const hex = Math.round(alpha * 255).toString(16).padStart(2, '0');
+        ctx.fillStyle = `${p.color}${hex}`;
+        ctx.fill();
+      }
+      return true;
+    });
+  }, [pickTarget]));
+
+  // Resize canvas to match CSS layout
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const obs = new ResizeObserver(entries => {
+      const e = entries[0];
+      if (!e) return;
+      canvas.width  = e.contentRect.width;
+      canvas.height = e.contentRect.height;
+    });
+    obs.observe(canvas);
+    return () => obs.disconnect();
+  }, [canvasRef]);
+
+  const handlePointer = useCallback((e: React.PointerEvent<HTMLElement>) => {
+    if (phaseRef.current !== 'playing') return;
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const rect = canvas.getBoundingClientRect();
+    const sx = canvas.width  / rect.width;
+    const sy = canvas.height / rect.height;
+    const tx = (e.clientX - rect.left) * sx;
+    const ty = (e.clientY - rect.top)  * sy;
+
+    for (let i = bubblesRef.current.length - 1; i >= 0; i--) {
+      const b = bubblesRef.current[i]!;
+      if (Math.hypot(b.x - tx, b.y - ty) > R + 10) continue;
+
+      if (b.word === targetRef.current) {
+        popsRef.current.push({ x: b.x, y: b.y, color: b.color, t: 0 });
+        bubblesRef.current.splice(i, 1);
+        scoreRef.current += 10;
+        setScore(scoreRef.current);
+        successTimer.current = 350;
+        speakHebrew(`כן! ${b.word}!`);
+        targetRef.current = '';
+        setTarget('');
+      } else {
+        flashTimer.current = 400;
+        heartsRef.current -= 1;
+        setHearts(heartsRef.current);
+        speakHebrew('לא נכון!');
+        if (heartsRef.current <= 0) setTimeout(endGame, 500);
+      }
+      break;
+    }
+  }, [canvasRef, endGame]);
+
+  if (phase === 'menu') {
+    return (
+      <div className="min-h-screen flex flex-col items-center justify-center bg-gradient-to-br from-slate-900 via-indigo-950 to-slate-900 p-4">
+        <div className="text-center mb-8">
+          <div className="text-7xl mb-4">✂️</div>
+          <h1 className="text-4xl font-bold text-white mb-2">חותך מילים</h1>
+          <p className="text-indigo-300 text-lg">הקשב למילה — חתוך את הבועה הנכונה!</p>
+        </div>
+        <div className="bg-white/10 rounded-2xl p-6 mb-8 text-white text-sm space-y-2 max-w-xs w-full">
+          <p>👂 TTS אומר מילה</p>
+          <p>🎯 לחץ על הבועה הנכונה</p>
+          <p>❌ 3 טעויות = סוף המשחק</p>
+          <p>💫 +10 נקודות לכל פגיעה</p>
+        </div>
+        <p className="text-indigo-300 mb-3 font-semibold">בחר רמת קושי:</p>
+        <div className="flex gap-3 mb-6">
+          {(['slow', 'medium', 'fast'] as Difficulty[]).map(d => (
+            <button
+              key={d}
+              onClick={() => setDiff(d)}
+              className={`px-4 py-2 rounded-xl font-bold text-sm transition-all ${diff === d ? 'bg-indigo-500 text-white scale-110' : 'bg-white/20 text-white hover:bg-white/30'}`}
+            >
+              {d === 'slow' ? '🐢 איטי' : d === 'medium' ? '🚶 בינוני' : '🐇 מהיר'}
+            </button>
+          ))}
+        </div>
+        <button
+          onClick={() => startGame(diff)}
+          className="bg-gradient-to-r from-indigo-500 to-purple-500 text-white font-bold text-xl px-10 py-4 rounded-2xl shadow-lg hover:scale-105 active:scale-95 transition-all"
+        >
+          התחל! ✂️
+        </button>
+      </div>
+    );
+  }
+
+  if (phase === 'result') {
+    const stars = score >= 100 ? 3 : score >= 50 ? 2 : 1;
+    return (
+      <div className="min-h-screen flex flex-col items-center justify-center bg-gradient-to-br from-slate-900 via-indigo-950 to-slate-900 p-4">
+        <div className="bg-white/10 backdrop-blur rounded-3xl p-8 text-center max-w-sm w-full">
+          <div className="text-6xl mb-4">{stars === 3 ? '🏆' : stars === 2 ? '🥈' : '🥉'}</div>
+          <h2 className="text-3xl font-bold text-white mb-2">כל הכבוד!</h2>
+          <div className="text-5xl font-bold text-yellow-400 mb-2">{score}</div>
+          <p className="text-indigo-300 mb-1">נקודות</p>
+          <div className="flex justify-center gap-1 text-3xl mb-6">
+            {Array.from({ length: 3 }, (_, i) => <span key={i}>{i < stars ? '⭐' : '☆'}</span>)}
+          </div>
+          <div className="flex gap-3 justify-center">
+            <button
+              onClick={() => startGame(diff)}
+              className="bg-indigo-500 text-white font-bold px-6 py-3 rounded-xl hover:bg-indigo-600 transition"
+            >
+              שחק שוב ✂️
+            </button>
+            <button
+              onClick={() => setPhase('menu')}
+              className="bg-white/20 text-white font-bold px-6 py-3 rounded-xl hover:bg-white/30 transition"
+            >
+              תפריט
+            </button>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  // Playing
+  return (
+    <div
+      className="relative w-full min-h-screen bg-slate-900 overflow-hidden"
+      onPointerDown={handlePointer}
+      style={{ touchAction: 'none' }}
+    >
+      <canvas ref={canvasRef} className="absolute inset-0 w-full h-full" />
+
+      {/* HUD */}
+      <div className="absolute top-3 inset-x-3 flex items-center justify-between pointer-events-none z-10">
+        {/* Hearts */}
+        <div className="flex gap-1 text-2xl">
+          {Array.from({ length: HEARTS_MAX }, (_, i) => (
+            <span key={i}>{i < hearts ? '❤️' : '🖤'}</span>
+          ))}
+        </div>
+        {/* Target */}
+        {target ? (
+          <div className="bg-yellow-400/90 text-slate-900 font-bold px-4 py-1 rounded-full text-lg shadow">
+            ✂️ {target}
+          </div>
+        ) : (
+          <div className="bg-white/20 text-white px-4 py-1 rounded-full text-sm">
+            מחכה...
+          </div>
+        )}
+        {/* Score */}
+        <div className="bg-white/20 text-white font-bold px-3 py-1 rounded-full text-lg">
+          {score}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/gamesformykids/lib/constants/gameCategories.ts
+++ b/gamesformykids/lib/constants/gameCategories.ts
@@ -122,7 +122,7 @@ export const GAME_CATEGORIES: Record<string, GameCategory> = {
       "flappy-bird","snake","dino-runner","catch-fruit","space-defender",
       "whack-a-mole","brick-breaker","balloon-pop","pong","meteor-dodge",
       "frogger","stack","color-tap","jumper","simon",
-      "reflex","taki","checkers","chess","shesh-besh","maze","letter-defender","snakes-ladders","escape-room","find-in-scene","answer-cannon","word-fishing","letter-grow","letter-slingshot","syllable-drums","letter-bubble-shooter",
+      "reflex","taki","checkers","chess","shesh-besh","maze","letter-defender","snakes-ladders","escape-room","find-in-scene","answer-cannon","word-fishing","letter-grow","letter-slingshot","syllable-drums","letter-bubble-shooter","letter-slicer",
     ],
   },
   educational: {

--- a/gamesformykids/lib/registry/registryData/batch4.ts
+++ b/gamesformykids/lib/registry/registryData/batch4.ts
@@ -41,6 +41,7 @@ import {
   Crosshair,
   Fish,
   Shirt,
+  Scissors,
 } from "lucide-react";
 import type { GameRegistration } from "@/lib/types/games/base";
 
@@ -999,5 +1000,16 @@ export const gamesRegistryBatch4: GameRegistration[] = [
     href: "/games/letter-bubble-shooter",
     available: true,
     order: 209,
+  },
+  {
+    id: "letter-slicer",
+    title: "חותך מילים",
+    description: "הקשב למילה ולחץ על הבועה הנכונה — בועות עפות בכל כיוון, חתוך את הנכונה!",
+    icon: Scissors,
+    emoji: "✂️",
+    color: "bg-violet-700 hover:bg-violet-800",
+    href: "/games/letter-slicer",
+    available: true,
+    order: 210,
   },
 ];

--- a/gamesformykids/lib/types/core/base.ts
+++ b/gamesformykids/lib/types/core/base.ts
@@ -275,4 +275,6 @@ export type GameType =
   // Dress-up — clothe the character with Hebrew vocabulary items
   | 'dress-up'
   // Letter bubble shooter — shoot letter bubbles to match 3+
-  | 'letter-bubble-shooter';
+  | 'letter-bubble-shooter'
+  // Letter slicer — tap flying Hebrew word bubbles to slice the target
+  | 'letter-slicer';


### PR DESCRIPTION
## What
Canvas arcade game: Hebrew words fly across the screen as colored bubbles. TTS announces a target word — tap it to slice it, gaining points. Tap the wrong bubble to lose a heart. 3 hearts, 3 difficulty levels.

## Why
Closes #1181

## Implementation
- Single-file canvas game using `useCanvasLoop` (RAF loop) and refs for game state
- Physics: bubbles launch from sides with gravity arcs, respawn continuously
- Slice animation: expanding ring + 8 particle burst on correct tap
- Red/green screen flash for feedback
- 15 Hebrew words across common vocabulary categories
- TTS via `speakHebrew` announces target and feedback
- ResizeObserver syncs canvas dimensions to CSS layout (mobile-responsive)
- Touch-safe: `touchAction: none` on wrapper, `PointerEvent` for unified mouse/touch

## Test plan
- [ ] Bubbles fly in from sides in arcs
- [ ] TTS announces target word on new target
- [ ] Correct tap: pop animation + green flash + new target
- [ ] Wrong tap: red flash + heart lost
- [ ] 0 hearts → result screen with score + stars
- [ ] Works on mobile touch
- [ ] Appears in arcade category on home page
- [ ] `npx tsc --noEmit` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)