### PR TITLE
feat(tech): in-game loading skeletons for canvas and quiz games (closes #1173)

### DIFF
--- a/gamesformykids/app/games/[gameType]/CustomGameRenderer.tsx
+++ b/gamesformykids/app/games/[gameType]/CustomGameRenderer.tsx
@@ -3,7 +3,7 @@
 import { Suspense } from 'react';
 import dynamic from 'next/dynamic';
 import type { ComponentType } from 'react';
-import GameSpinnerScreen from '@/components/ui/GameSpinnerScreen';
+import CanvasGameSkeleton from '@/components/ui/CanvasGameSkeleton';
 
 const GAME_CLIENTS: Record<string, ComponentType> = {
   arithmetic:        dynamic(() => import('../arithmetic/ArithmeticGameClient'),              { ssr: false }),
@@ -93,7 +93,7 @@ export default function CustomGameRenderer({ gameType }: Props) {
   const Component = GAME_CLIENTS[gameType];
   if (!Component) return null;
   return (
-    <Suspense fallback={<GameSpinnerScreen />}>
+    <Suspense fallback={<CanvasGameSkeleton />}>
       <Component />
     </Suspense>
   );

--- a/gamesformykids/components/ui/CanvasGameSkeleton.tsx
+++ b/gamesformykids/components/ui/CanvasGameSkeleton.tsx
@@ -1,0 +1,23 @@
+export default function CanvasGameSkeleton() {
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-indigo-50 to-purple-50 flex flex-col p-4 gap-4 animate-pulse" dir="rtl">
+      {/* Header bar */}
+      <div className="flex items-center justify-between">
+        <div className="h-8 w-32 bg-indigo-200 rounded-xl" />
+        <div className="flex gap-2">
+          <div className="h-8 w-16 bg-purple-200 rounded-xl" />
+          <div className="h-8 w-16 bg-pink-200 rounded-xl" />
+        </div>
+      </div>
+      {/* Canvas placeholder */}
+      <div className="flex-1 min-h-[60vh] bg-white/60 rounded-3xl border-2 border-indigo-100 flex items-center justify-center">
+        <div className="text-6xl opacity-20">🎮</div>
+      </div>
+      {/* Controls row */}
+      <div className="flex justify-center gap-3">
+        <div className="h-12 w-24 bg-indigo-200 rounded-2xl" />
+        <div className="h-12 w-24 bg-purple-200 rounded-2xl" />
+      </div>
+    </div>
+  );
+}

--- a/gamesformykids/components/ui/QuizGameSkeleton.tsx
+++ b/gamesformykids/components/ui/QuizGameSkeleton.tsx
@@ -1,0 +1,19 @@
+export default function QuizGameSkeleton() {
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-violet-50 to-pink-50 flex flex-col items-center justify-center p-6 gap-6 animate-pulse" dir="rtl">
+      {/* Question card */}
+      <div className="w-full max-w-md bg-white/70 rounded-3xl p-6 flex flex-col gap-4">
+        <div className="h-4 w-24 bg-violet-200 rounded-full mx-auto" />
+        <div className="h-6 w-full bg-violet-100 rounded-xl" />
+        <div className="h-6 w-3/4 bg-violet-100 rounded-xl" />
+        <div className="text-5xl text-center opacity-20">❓</div>
+      </div>
+      {/* 4 answer buttons */}
+      <div className="w-full max-w-md grid grid-cols-2 gap-3">
+        {[0, 1, 2, 3].map(i => (
+          <div key={i} className="h-16 bg-white/60 rounded-2xl border-2 border-violet-100" />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/gamesformykids/lib/quiz/registry/complexQuizGames.tsx
+++ b/gamesformykids/lib/quiz/registry/complexQuizGames.tsx
@@ -1,14 +1,14 @@
 'use client';
 import dynamic from 'next/dynamic';
 import type { ComponentType } from 'react';
-import GameSpinnerScreen from '@/components/ui/GameSpinnerScreen';
+import QuizGameSkeleton from '@/components/ui/QuizGameSkeleton';
 
 /**
  * Games with their own store / multi-phase rendering — loaded lazily.
  */
 export const COMPLEX_QUIZ_GAMES: Record<string, ComponentType> = {
-  'transport':  dynamic(() => import('@/app/games/transport/TransportGame'),   { ssr: false, loading: () => <GameSpinnerScreen /> }),
-  'holidays':   dynamic(() => import('@/app/games/holidays/HolidaysGame'),     { ssr: false, loading: () => <GameSpinnerScreen /> }),
-  'tzadikim':   dynamic(() => import('@/app/games/tzadikim/TzadikimGame'),     { ssr: false, loading: () => <GameSpinnerScreen /> }),
-  'word-chain': dynamic(() => import('@/app/games/word-chain/WordChainGame'),  { ssr: false, loading: () => <GameSpinnerScreen /> }),
+  'transport':  dynamic(() => import('@/app/games/transport/TransportGame'),   { ssr: false, loading: () => <QuizGameSkeleton /> }),
+  'holidays':   dynamic(() => import('@/app/games/holidays/HolidaysGame'),     { ssr: false, loading: () => <QuizGameSkeleton /> }),
+  'tzadikim':   dynamic(() => import('@/app/games/tzadikim/TzadikimGame'),     { ssr: false, loading: () => <QuizGameSkeleton /> }),
+  'word-chain': dynamic(() => import('@/app/games/word-chain/WordChainGame'),  { ssr: false, loading: () => <QuizGameSkeleton /> }),
 };

--- a/gamesformykids/lib/quiz/registry/customQuizGames.tsx
+++ b/gamesformykids/lib/quiz/registry/customQuizGames.tsx
@@ -33,40 +33,40 @@ import { CATEGORY_COLORS as NATURE_COLORS } from '@/lib/quiz/data/nature';
 import type { IsraelCategory } from '@/lib/quiz/data/israel';
 import { CATEGORY_COLORS as ISRAEL_COLORS } from '@/lib/quiz/data/israel';
 
-import GameSpinnerScreen from '@/components/ui/GameSpinnerScreen';
+import QuizGameSkeleton from '@/components/ui/QuizGameSkeleton';
 
 // Screen components — lazy-loaded so each game page only downloads its own screens
 // Options must be object literals (Turbopack static analysis requirement)
-const WordWheelQuestion    = dynamic(() => import('@/components/game/quiz/screens/WordWheelQuestion'),   { loading: () => <GameSpinnerScreen /> });
-const RiddleProQuestion  = dynamic(() => import('@/components/game/quiz/screens/RiddleProQuestion'), { loading: () => <GameSpinnerScreen /> });
-const TriviaCategoryPicker = dynamic(() => import('@/components/game/quiz/screens/TriviaCategoryPicker'), { loading: () => <GameSpinnerScreen /> });
-const TriviaCategoriesQuestion = dynamic(() => import('@/components/game/quiz/screens/TriviaCategoriesQuestion'), { loading: () => <GameSpinnerScreen /> });
-const ClockMenuScreen    = dynamic(() => import('@/components/game/quiz/screens/ClockMenuScreen'), { loading: () => <GameSpinnerScreen /> });
-const ClockQuestion      = dynamic(() => import('@/components/game/quiz/screens/ClockQuestion'), { loading: () => <GameSpinnerScreen /> });
-const ClockResultScreen  = dynamic(() => import('@/components/game/quiz/screens/ClockResultScreen'), { loading: () => <GameSpinnerScreen /> });
-const ColorMixQuestion   = dynamic(() => import('@/components/game/quiz/screens/ColorMixQuestion'), { loading: () => <GameSpinnerScreen /> });
-const SequencesMenuScreen = dynamic(() => import('@/components/game/quiz/screens/SequencesMenuScreen'), { loading: () => <GameSpinnerScreen /> });
-const SequencesQuestion  = dynamic(() => import('@/components/game/quiz/screens/SequencesQuestion'), { loading: () => <GameSpinnerScreen /> });
-const HumanBodyMenuScreen = dynamic(() => import('@/components/game/quiz/screens/HumanBodyMenuScreen'), { loading: () => <GameSpinnerScreen /> });
-const HumanBodyQuestion  = dynamic(() => import('@/components/game/quiz/screens/HumanBodyQuestion'), { loading: () => <GameSpinnerScreen /> });
-const TriviaMenuScreen   = dynamic(() => import('@/components/game/quiz/screens/TriviaMenuScreen'), { loading: () => <GameSpinnerScreen /> });
-const TriviaQuestion     = dynamic(() => import('@/components/game/quiz/screens/TriviaQuestion'), { loading: () => <GameSpinnerScreen /> });
-const ScienceMenuScreen  = dynamic(() => import('@/components/game/quiz/screens/ScienceMenuScreen'), { loading: () => <GameSpinnerScreen /> });
-const ScienceQuestion    = dynamic(() => import('@/components/game/quiz/screens/ScienceQuestion'), { loading: () => <GameSpinnerScreen /> });
-const NatureMenuScreen   = dynamic(() => import('@/components/game/quiz/screens/NatureMenuScreen'), { loading: () => <GameSpinnerScreen /> });
-const IsraelMenuScreen   = dynamic(() => import('@/components/game/quiz/screens/IsraelMenuScreen'), { loading: () => <GameSpinnerScreen /> });
-const SoccerMenuScreen   = dynamic(() => import('@/app/games/soccer/components/SoccerMenuScreen'), { loading: () => <GameSpinnerScreen /> });
-const SoccerQuestion     = dynamic(() => import('@/app/games/soccer/components/SoccerQuestion'), { loading: () => <GameSpinnerScreen /> });
-const SoccerResultScreen = dynamic(() => import('@/app/games/soccer/components/SoccerResultScreen'), { loading: () => <GameSpinnerScreen /> });
-const PhonicsQuestion    = dynamic(() => import('@/components/game/quiz/screens/PhonicsQuestion'), { loading: () => <GameSpinnerScreen /> });
-const SortingQuestion    = dynamic(() => import('@/components/game/quiz/screens/SortingQuestion'), { loading: () => <GameSpinnerScreen /> });
-const PatternQuestion    = dynamic(() => import('@/components/game/quiz/screens/PatternQuestion'), { loading: () => <GameSpinnerScreen /> });
-const LifeCyclesQuestion = dynamic(() => import('@/components/game/quiz/screens/LifeCyclesQuestion'), { loading: () => <GameSpinnerScreen /> });
-const NikudQuestion        = dynamic(() => import('@/components/game/quiz/screens/NikudQuestion'), { loading: () => <GameSpinnerScreen /> });
-const DivisionQuestion     = dynamic(() => import('@/components/game/quiz/screens/DivisionQuestion'), { loading: () => <GameSpinnerScreen /> });
-const StoryBuilderQuestion = dynamic(() => import('@/components/game/quiz/screens/StoryBuilderQuestion'), { loading: () => <GameSpinnerScreen /> });
-const StoryBuilderResult   = dynamic(() => import('@/components/game/quiz/screens/StoryBuilderResult'), { loading: () => <GameSpinnerScreen /> });
-const CityBuilderStage     = dynamic(() => import('@/components/game/quiz/screens/CityBuilderStage'),   { loading: () => <GameSpinnerScreen /> });
+const WordWheelQuestion    = dynamic(() => import('@/components/game/quiz/screens/WordWheelQuestion'),   { loading: () => <QuizGameSkeleton /> });
+const RiddleProQuestion  = dynamic(() => import('@/components/game/quiz/screens/RiddleProQuestion'), { loading: () => <QuizGameSkeleton /> });
+const TriviaCategoryPicker = dynamic(() => import('@/components/game/quiz/screens/TriviaCategoryPicker'), { loading: () => <QuizGameSkeleton /> });
+const TriviaCategoriesQuestion = dynamic(() => import('@/components/game/quiz/screens/TriviaCategoriesQuestion'), { loading: () => <QuizGameSkeleton /> });
+const ClockMenuScreen    = dynamic(() => import('@/components/game/quiz/screens/ClockMenuScreen'), { loading: () => <QuizGameSkeleton /> });
+const ClockQuestion      = dynamic(() => import('@/components/game/quiz/screens/ClockQuestion'), { loading: () => <QuizGameSkeleton /> });
+const ClockResultScreen  = dynamic(() => import('@/components/game/quiz/screens/ClockResultScreen'), { loading: () => <QuizGameSkeleton /> });
+const ColorMixQuestion   = dynamic(() => import('@/components/game/quiz/screens/ColorMixQuestion'), { loading: () => <QuizGameSkeleton /> });
+const SequencesMenuScreen = dynamic(() => import('@/components/game/quiz/screens/SequencesMenuScreen'), { loading: () => <QuizGameSkeleton /> });
+const SequencesQuestion  = dynamic(() => import('@/components/game/quiz/screens/SequencesQuestion'), { loading: () => <QuizGameSkeleton /> });
+const HumanBodyMenuScreen = dynamic(() => import('@/components/game/quiz/screens/HumanBodyMenuScreen'), { loading: () => <QuizGameSkeleton /> });
+const HumanBodyQuestion  = dynamic(() => import('@/components/game/quiz/screens/HumanBodyQuestion'), { loading: () => <QuizGameSkeleton /> });
+const TriviaMenuScreen   = dynamic(() => import('@/components/game/quiz/screens/TriviaMenuScreen'), { loading: () => <QuizGameSkeleton /> });
+const TriviaQuestion     = dynamic(() => import('@/components/game/quiz/screens/TriviaQuestion'), { loading: () => <QuizGameSkeleton /> });
+const ScienceMenuScreen  = dynamic(() => import('@/components/game/quiz/screens/ScienceMenuScreen'), { loading: () => <QuizGameSkeleton /> });
+const ScienceQuestion    = dynamic(() => import('@/components/game/quiz/screens/ScienceQuestion'), { loading: () => <QuizGameSkeleton /> });
+const NatureMenuScreen   = dynamic(() => import('@/components/game/quiz/screens/NatureMenuScreen'), { loading: () => <QuizGameSkeleton /> });
+const IsraelMenuScreen   = dynamic(() => import('@/components/game/quiz/screens/IsraelMenuScreen'), { loading: () => <QuizGameSkeleton /> });
+const SoccerMenuScreen   = dynamic(() => import('@/app/games/soccer/components/SoccerMenuScreen'), { loading: () => <QuizGameSkeleton /> });
+const SoccerQuestion     = dynamic(() => import('@/app/games/soccer/components/SoccerQuestion'), { loading: () => <QuizGameSkeleton /> });
+const SoccerResultScreen = dynamic(() => import('@/app/games/soccer/components/SoccerResultScreen'), { loading: () => <QuizGameSkeleton /> });
+const PhonicsQuestion    = dynamic(() => import('@/components/game/quiz/screens/PhonicsQuestion'), { loading: () => <QuizGameSkeleton /> });
+const SortingQuestion    = dynamic(() => import('@/components/game/quiz/screens/SortingQuestion'), { loading: () => <QuizGameSkeleton /> });
+const PatternQuestion    = dynamic(() => import('@/components/game/quiz/screens/PatternQuestion'), { loading: () => <QuizGameSkeleton /> });
+const LifeCyclesQuestion = dynamic(() => import('@/components/game/quiz/screens/LifeCyclesQuestion'), { loading: () => <QuizGameSkeleton /> });
+const NikudQuestion        = dynamic(() => import('@/components/game/quiz/screens/NikudQuestion'), { loading: () => <QuizGameSkeleton /> });
+const DivisionQuestion     = dynamic(() => import('@/components/game/quiz/screens/DivisionQuestion'), { loading: () => <QuizGameSkeleton /> });
+const StoryBuilderQuestion = dynamic(() => import('@/components/game/quiz/screens/StoryBuilderQuestion'), { loading: () => <QuizGameSkeleton /> });
+const StoryBuilderResult   = dynamic(() => import('@/components/game/quiz/screens/StoryBuilderResult'), { loading: () => <QuizGameSkeleton /> });
+const CityBuilderStage     = dynamic(() => import('@/components/game/quiz/screens/CityBuilderStage'),   { loading: () => <QuizGameSkeleton /> });
 
 /**
  * Games built with makeQuizGame — custom hooks + lazy-loaded screen components.


### PR DESCRIPTION
## What
Replaces the generic `GameSpinnerScreen` fallback with purpose-built animated skeletons while game JS bundles load:

- **`CanvasGameSkeleton`** — used by `CustomGameRenderer` for all 39+ arcade/canvas games. Shows a header bar, large canvas placeholder, and control row, all pulsing with `animate-pulse`.
- **`QuizGameSkeleton`** — used by `complexQuizGames` and `customQuizGames` registries. Shows a question card with shimmer text lines and a 2×2 grid of answer button placeholders.

Both skeletons are RTL-aware and match the approximate layout shape of the game that will appear, eliminating the jarring white-flash/spinner between navigation and first render.

## Why
Closes #1173

## Test plan
- [ ] Navigate to any arcade game (e.g. `/games/flappy-bird`) — canvas skeleton appears briefly then game loads
- [ ] Navigate to any quiz game (e.g. `/games/clock`) — quiz skeleton appears briefly then game loads
- [ ] Skeletons use `animate-pulse` shimmer (visible on slow connections)
- [ ] RTL layout is correct (items flow right-to-left)
- [ ] No layout shift once game loads

🤖 Generated with [Claude Code](https://claude.com/claude-code)