### PR TITLE
feat(tech): colorblind-friendly palette mode (closes #1169)

### DIFF
--- a/gamesformykids/app/globals.css
+++ b/gamesformykids/app/globals.css
@@ -389,3 +389,68 @@ body {
 .animate-fade-in-up {
   animation: fade-in-up 0.4s ease-out both;
 }
+
+/* ═══════════════════════════════════════════════════════
+   Colorblind-friendly mode (deuteranopia / protanopia)
+   Paul Tol palette: correct = #0077BB (blue), wrong = #EE7733 (orange)
+   Activated by [data-colorblind] on <html>
+   ═══════════════════════════════════════════════════════ */
+[data-colorblind="true"] .bg-green-400,
+[data-colorblind="true"] .bg-green-500,
+[data-colorblind="true"] .bg-green-600,
+[data-colorblind="true"] .from-green-400,
+[data-colorblind="true"] .from-green-500,
+[data-colorblind="true"] .to-green-400,
+[data-colorblind="true"] .to-green-500,
+[data-colorblind="true"] .to-green-600 {
+  --tw-bg-opacity: 1;
+  background-color: #0077BB !important;
+}
+
+[data-colorblind="true"] .bg-red-400,
+[data-colorblind="true"] .bg-red-500,
+[data-colorblind="true"] .bg-red-600,
+[data-colorblind="true"] .from-red-400,
+[data-colorblind="true"] .from-red-500,
+[data-colorblind="true"] .to-red-400,
+[data-colorblind="true"] .to-red-500,
+[data-colorblind="true"] .to-red-600 {
+  --tw-bg-opacity: 1;
+  background-color: #EE7733 !important;
+}
+
+[data-colorblind="true"] .text-green-400,
+[data-colorblind="true"] .text-green-500,
+[data-colorblind="true"] .text-green-600,
+[data-colorblind="true"] .text-green-700 {
+  color: #0077BB !important;
+}
+
+[data-colorblind="true"] .text-red-400,
+[data-colorblind="true"] .text-red-500,
+[data-colorblind="true"] .text-red-600,
+[data-colorblind="true"] .text-red-700 {
+  color: #EE7733 !important;
+}
+
+[data-colorblind="true"] .border-green-400,
+[data-colorblind="true"] .border-green-500,
+[data-colorblind="true"] .border-green-600 {
+  border-color: #0077BB !important;
+}
+
+[data-colorblind="true"] .border-red-400,
+[data-colorblind="true"] .border-red-500,
+[data-colorblind="true"] .border-red-600 {
+  border-color: #EE7733 !important;
+}
+
+[data-colorblind="true"] .ring-green-400,
+[data-colorblind="true"] .ring-green-500 {
+  --tw-ring-color: #0077BB !important;
+}
+
+[data-colorblind="true"] .ring-red-400,
+[data-colorblind="true"] .ring-red-500 {
+  --tw-ring-color: #EE7733 !important;
+}

--- a/gamesformykids/app/layout.tsx
+++ b/gamesformykids/app/layout.tsx
@@ -33,6 +33,12 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
             __html: `try{var t=localStorage.getItem('gfk_theme');if(t==='dark'||(!t&&matchMedia('(prefers-color-scheme:dark)').matches))document.documentElement.classList.add('dark')}catch{}`,
           }}
         />
+        {/* Colorblind mode — apply before hydration to avoid flash */}
+        <script
+          dangerouslySetInnerHTML={{
+            __html: `try{if(localStorage.getItem('gfk_colorblind')==='true')document.documentElement.dataset.colorblind='true'}catch{}`,
+          }}
+        />
       </head>
       <body className={`${rubik.className} dark:bg-gray-900 dark:text-white`}>
         {process.env.NODE_ENV === 'production' && process.env.NEXT_PUBLIC_GA_ID && (

--- a/gamesformykids/app/settings/SettingsClient.tsx
+++ b/gamesformykids/app/settings/SettingsClient.tsx
@@ -7,6 +7,7 @@ import { useAuth } from '@/hooks/shared/auth/useAuth';
 import { AudioSection } from '@/components/settings/AudioSection';
 import { AppearanceSection } from '@/components/settings/AppearanceSection';
 import { AccountSection } from '@/components/settings/AccountSection';
+import { ColorblindSection } from '@/components/settings/ColorblindSection';
 import GameSpinnerScreen from '@/components/ui/GameSpinnerScreen';
 
 export default function SettingsClient() {
@@ -70,6 +71,7 @@ export default function SettingsClient() {
             onChange={handleSettingChange}
             disabled={saving}
           />
+          <ColorblindSection />
           <AccountSection onSignOut={handleSignOut} />
         </div>
 

--- a/gamesformykids/components/settings/ColorblindSection.tsx
+++ b/gamesformykids/components/settings/ColorblindSection.tsx
@@ -1,0 +1,54 @@
+'use client';
+import { useState, useEffect } from 'react';
+import { SectionContainer } from './SectionContainer';
+
+const LS_KEY = 'gfk_colorblind';
+
+export function ColorblindSection() {
+  const [enabled, setEnabled] = useState(false);
+
+  useEffect(() => {
+    try {
+      const stored = localStorage.getItem(LS_KEY);
+      const on = stored === 'true';
+      setEnabled(on);
+      document.documentElement.dataset.colorblind = on ? 'true' : '';
+    } catch {}
+  }, []);
+
+  const toggle = () => {
+    const next = !enabled;
+    setEnabled(next);
+    try {
+      if (next) {
+        localStorage.setItem(LS_KEY, 'true');
+        document.documentElement.dataset.colorblind = 'true';
+      } else {
+        localStorage.removeItem(LS_KEY);
+        document.documentElement.dataset.colorblind = '';
+      }
+    } catch {}
+  };
+
+  return (
+    <SectionContainer title="נגישות" emoji="♿">
+      <div className="flex items-center justify-between p-3 bg-white rounded-xl border border-gray-200">
+        <div>
+          <p className="font-medium text-gray-800">מצב עיוורי צבעים 🎨</p>
+          <p className="text-sm text-gray-500">מחליף ירוק/אדום לכחול/כתום (מותאם לדאוטרנופיה ופרוטנופיה)</p>
+        </div>
+        <button
+          onClick={toggle}
+          role="switch"
+          aria-checked={enabled}
+          className={`relative w-12 h-6 rounded-full transition-colors ${enabled ? 'bg-blue-500' : 'bg-gray-300'}`}
+          aria-label="הפעל מצב עיוורי צבעים"
+        >
+          <span
+            className={`absolute top-0.5 w-5 h-5 bg-white rounded-full shadow transition-transform ${enabled ? 'translate-x-6' : 'translate-x-0.5'}`}
+          />
+        </button>
+      </div>
+    </SectionContainer>
+  );
+}


### PR DESCRIPTION
## What
Adds a colorblind-friendly mode toggle in the Settings page that swaps the site's red/green feedback colors to a deuteranopia/protanopia-safe blue/orange palette (Paul Tol safe palette).

**Implementation:**
- `ColorblindSection` component in Settings — a `localStorage`-persisted toggle (key: `gfk_colorblind`), independent of the Supabase settings system
- Inline `<script>` in `layout.tsx` applies `data-colorblind="true"` to `<html>` before hydration (same pattern as dark mode) — no flash of wrong colors on page load
- `globals.css` overrides: under `[data-colorblind="true"]` selector, replaces Tailwind `bg-green-*`, `text-green-*`, `bg-red-*`, `text-red-*`, `border-*`, and `ring-*` classes with `#0077BB` (blue) and `#EE7733` (orange) respectively

## Why
Closes #1169

## Test plan
- [ ] Go to `/settings` — "נגישות" section with colorblind toggle appears
- [ ] Toggle ON — button turns blue, page feedback colors shift
- [ ] Reload page with toggle ON — colorblind mode persists (no flash)
- [ ] Toggle OFF — feedback colors revert to green/red
- [ ] Navigate to any quiz game — correct answer shows blue instead of green
- [ ] Wrong answer shows orange instead of red
- [ ] Works on mobile (iOS Safari / Android Chrome)

🤖 Generated with [Claude Code](https://claude.com/claude-code)