### PR TITLE
feat(a11y): keyboard navigation audit — Escape key for modals + ARIA roles (closes #1172)

### DIFF
--- a/gamesformykids/app/games/puzzles/custom/CustomHelpModal.tsx
+++ b/gamesformykids/app/games/puzzles/custom/CustomHelpModal.tsx
@@ -2,9 +2,11 @@
 
 import { RotateCcw, Eye, Settings, Upload, Shuffle } from 'lucide-react';
 import { usePuzzleGame } from '../usePuzzleGame';
+import { useEscapeKey } from '@/hooks/shared/useEscapeKey';
 
 export default function CustomHelpModal() {
   const { showHelp, toggleHelp } = usePuzzleGame();
+  useEscapeKey(toggleHelp, showHelp);
   if (!showHelp) return null;
   return (
     <div
@@ -13,6 +15,9 @@ export default function CustomHelpModal() {
     >
       <div
         className="bg-white rounded-2xl p-8 max-w-2xl mx-4 max-h-[80vh] overflow-y-auto"
+        role="dialog"
+        aria-modal="true"
+        aria-label="איך לשחק?"
         onClick={(e) => e.stopPropagation()}
       >
         <div className="flex justify-between items-center mb-6">

--- a/gamesformykids/app/games/puzzles/simple/SimpleHelpModal.tsx
+++ b/gamesformykids/app/games/puzzles/simple/SimpleHelpModal.tsx
@@ -2,9 +2,11 @@
 
 import { X, Mouse, RotateCcw, HelpCircle, Eye, Settings } from 'lucide-react';
 import { usePuzzleGame } from '../usePuzzleGame';
+import { useEscapeKey } from '@/hooks/shared/useEscapeKey';
 
 export default function SimpleHelpModal() {
   const { showHelp, toggleHelp } = usePuzzleGame();
+  useEscapeKey(toggleHelp, showHelp);
   if (!showHelp) return null;
   return (
     <div
@@ -13,6 +15,9 @@ export default function SimpleHelpModal() {
     >
       <div
         className="bg-white rounded-lg p-6 max-w-md w-full mx-4"
+        role="dialog"
+        aria-modal="true"
+        aria-label="איך לשחק?"
         onClick={(e) => e.stopPropagation()}
       >
         <div className="flex justify-between items-center mb-4">

--- a/gamesformykids/components/game/QRButton.tsx
+++ b/gamesformykids/components/game/QRButton.tsx
@@ -2,6 +2,7 @@
 import { useState, useCallback, useRef } from 'react';
 import QRCode from 'react-qr-code';
 import { QrCode, X, Copy, Download, Check } from 'lucide-react';
+import { useEscapeKey } from '@/hooks/shared/useEscapeKey';
 
 interface Props {
   gameType: string;
@@ -11,6 +12,7 @@ export default function QRButton({ gameType }: Props) {
   const [open, setOpen] = useState(false);
   const [copied, setCopied] = useState(false);
   const wrapperRef = useRef<HTMLDivElement>(null);
+  useEscapeKey(() => setOpen(false), open);
 
   const gameUrl = typeof window !== 'undefined'
     ? `${window.location.origin}/games/${gameType}?utm_source=qr`
@@ -59,7 +61,7 @@ export default function QRButton({ gameType }: Props) {
           className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm p-4"
           onClick={(e) => { if (e.target === e.currentTarget) setOpen(false); }}
         >
-          <div className="bg-white rounded-3xl p-6 max-w-xs w-full shadow-2xl text-center" dir="rtl">
+          <div className="bg-white rounded-3xl p-6 max-w-xs w-full shadow-2xl text-center" dir="rtl" role="dialog" aria-modal="true" aria-label="שתף את המשחק">
             <div className="flex justify-between items-center mb-4">
               <h2 className="text-lg font-bold text-indigo-900">שתף את המשחק</h2>
               <button onClick={() => setOpen(false)} className="text-gray-400 hover:text-gray-600">

--- a/gamesformykids/components/shared/displays/ContextProgressDisplay.tsx
+++ b/gamesformykids/components/shared/displays/ContextProgressDisplay.tsx
@@ -9,19 +9,20 @@
 "use client";
 
 import { useUniversalGame } from '@/hooks/shared/game-state/useUniversalGame';
+import { useEscapeKey } from '@/hooks/shared/useEscapeKey';
 
 /**
  * 🎯 ContextProgressDisplay עם קונטקסט - ללא props!
  */
 export function ContextProgressDisplay() {
-  const { 
-    currentAccuracy, 
-    showProgressModal, 
+  const {
+    currentAccuracy,
+    showProgressModal,
     setShowProgressModal,
     score,
     level
   } = useUniversalGame();
-  
+  useEscapeKey(() => setShowProgressModal(false), showProgressModal);
   if (!showProgressModal) return null;
 
   const getAccuracyColor = (accuracy: number) => {
@@ -39,7 +40,7 @@ export function ContextProgressDisplay() {
 
   return (
     <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center p-4 z-50">
-      <div className="bg-white rounded-2xl p-6 max-w-md w-full mx-4 max-h-[80vh] overflow-y-auto shadow-2xl">
+      <div className="bg-white rounded-2xl p-6 max-w-md w-full mx-4 max-h-[80vh] overflow-y-auto shadow-2xl" role="dialog" aria-modal="true" aria-label="הסטטיסטיקות שלך">
         {/* Header */}
         <div className="flex justify-between items-center mb-6">
           <h2 className="text-2xl font-bold text-gray-800">📊 הסטטיסטיקות שלך</h2>

--- a/gamesformykids/hooks/shared/useEscapeKey.ts
+++ b/gamesformykids/hooks/shared/useEscapeKey.ts
@@ -1,0 +1,24 @@
+'use client';
+import { useEffect, useRef } from 'react';
+
+/**
+ * Calls `onClose` when the Escape key is pressed, while the element is `enabled`.
+ * Registers in the capture phase so it intercepts Escape before the global
+ * "Escape → go home" handler in useUniversalGameNavigation.
+ */
+export function useEscapeKey(onClose: () => void, enabled: boolean) {
+  const onCloseRef = useRef(onClose);
+  onCloseRef.current = onClose;
+
+  useEffect(() => {
+    if (!enabled) return;
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.stopImmediatePropagation();
+        onCloseRef.current();
+      }
+    };
+    window.addEventListener('keydown', handler, true);
+    return () => window.removeEventListener('keydown', handler, true);
+  }, [enabled]);
+}


### PR DESCRIPTION
## What
- New shared `useEscapeKey` hook that registers in the **capture phase** so it intercepts Escape before the global "Escape → go home" handler in `useUniversalGameNavigation`
- Escape key closes: QR code modal (`QRButton`), puzzle help modals (`SimpleHelpModal`, `CustomHelpModal`), and the progress stats modal (`ContextProgressDisplay`)
- Added `role="dialog"` + `aria-modal="true"` + `aria-label` on all overlay modals (WCAG 2.1 AA)
- Quiz answer keyboard shortcuts (1–4, Arrow keys, Enter/Space) were already implemented in `useKeyboardAnswerSelect` — no new work needed
- Card game arrow-key navigation was already implemented in `GameMainContent` via the same hook — no new work needed

## Why
Closes #1172

## Test plan
- [ ] Press Escape while QR code modal is open → modal closes (not navigate home)
- [ ] Press Escape while puzzles help modal is open → modal closes
- [ ] Press Escape while progress stats modal is open → modal closes
- [ ] Press 1–4 in any quiz game → selects that answer option
- [ ] Press arrow keys in any card game → moves keyboard focus between cards
- [ ] Press Enter/Space on focused card → selects it
- [ ] `npx tsc --noEmit` passes with zero errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)