### PR TITLE
feat(audio): slow speech toggle (🐢) halves TTS rate for young learners (closes #1124)

### DIFF
--- a/gamesformykids/components/shared/buttons/SlowSpeechButton.tsx
+++ b/gamesformykids/components/shared/buttons/SlowSpeechButton.tsx
@@ -1,0 +1,22 @@
+'use client';
+import { useSlowSpeech } from '@/hooks/shared/audio/useSlowSpeech';
+
+export default function SlowSpeechButton() {
+  const { slowMode, toggle } = useSlowSpeech();
+  return (
+    <button
+      onClick={toggle}
+      title={slowMode ? 'חזור למהירות רגילה' : 'דיבור איטי לילדים צעירים'}
+      aria-label={slowMode ? 'מהירות רגילה' : 'דיבור איטי'}
+      aria-pressed={slowMode}
+      className={`
+        px-3 py-2 rounded-xl font-bold text-base shadow transition-all
+        ${slowMode
+          ? 'bg-amber-400 text-amber-900 ring-2 ring-amber-500 scale-110'
+          : 'bg-white/80 text-gray-600 hover:bg-amber-50 hover:text-amber-700'}
+      `}
+    >
+      🐢
+    </button>
+  );
+}

--- a/gamesformykids/components/shared/headers/GameHeaderSection.tsx
+++ b/gamesformykids/components/shared/headers/GameHeaderSection.tsx
@@ -2,6 +2,7 @@
 
 import GameHeader from "./GameHeader";
 import GameStatsButton from "../buttons/GameStatsButton";
+import SlowSpeechButton from "../buttons/SlowSpeechButton";
 import GameChallengeSection from "../GameChallengeSection";
 
 export default function GameHeaderSection() {
@@ -9,7 +10,10 @@ export default function GameHeaderSection() {
     <div className="text-center mb-8">
       <div className="flex justify-between items-center mb-6">
         <GameHeader />
-        <GameStatsButton />
+        <div className="flex items-center gap-2">
+          <SlowSpeechButton />
+          <GameStatsButton />
+        </div>
       </div>
       <GameChallengeSection />
     </div>

--- a/gamesformykids/hooks/shared/audio/useSlowSpeech.ts
+++ b/gamesformykids/hooks/shared/audio/useSlowSpeech.ts
@@ -1,0 +1,22 @@
+'use client';
+import { useState, useCallback, useEffect } from 'react';
+import { setSlowModeActive } from '@/lib/audio/slowSpeechMode';
+
+export function useSlowSpeech() {
+  const [slowMode, setSlowMode] = useState(false);
+
+  const toggle = useCallback(() => {
+    setSlowMode(prev => {
+      const next = !prev;
+      setSlowModeActive(next);
+      return next;
+    });
+  }, []);
+
+  // Reset slow mode when the game session unmounts
+  useEffect(() => {
+    return () => setSlowModeActive(false);
+  }, []);
+
+  return { slowMode, toggle };
+}

--- a/gamesformykids/lib/audio/slowSpeechMode.ts
+++ b/gamesformykids/lib/audio/slowSpeechMode.ts
@@ -1,0 +1,13 @@
+/**
+ * Module-level singleton for session-scoped slow speech mode.
+ * Readable by non-React utility functions (voiceSelector, speaker).
+ */
+let _slowMode = false;
+
+export function isSlowModeActive(): boolean {
+  return _slowMode;
+}
+
+export function setSlowModeActive(v: boolean): void {
+  _slowMode = v;
+}

--- a/gamesformykids/lib/utils/speech/voiceSelector.ts
+++ b/gamesformykids/lib/utils/speech/voiceSelector.ts
@@ -1,4 +1,5 @@
 import { AUDIO_CONSTANTS } from "../../constants/core";
+import { isSlowModeActive } from "../../audio/slowSpeechMode";
 
 export interface SpeechOptions {
   lang?: string;
@@ -89,7 +90,7 @@ export function getOptimizedSpeechSettings(options: SpeechOptions = {}) {
 
   return {
     lang: options.lang || "he-IL",
-    rate: options.rate || savedSettings?.speechRate || AUDIO_CONSTANTS.SPEECH.HEBREW_RATE,
+    rate: options.rate || ((savedSettings?.speechRate || AUDIO_CONSTANTS.SPEECH.HEBREW_RATE) * (isSlowModeActive() ? 0.5 : 1)),
     pitch: options.pitch || savedSettings?.speechPitch || AUDIO_CONSTANTS.SPEECH.DEFAULT_PITCH,
     volume: options.volume || savedSettings?.volume || AUDIO_CONSTANTS.SPEECH.DEFAULT_VOLUME,
   };


### PR DESCRIPTION
## What
A 🐢 toggle button in the game header that halves the TTS speech rate (0.85 → 0.42) for the current session. Pressing again restores normal speed. The button appears next to the stats button in every card game.

**Implementation:**
- `lib/audio/slowSpeechMode.ts` — module-level singleton readable outside React hooks
- `hooks/shared/audio/useSlowSpeech.ts` — React hook with toggle + auto-reset on unmount (session-scoped)
- `components/shared/buttons/SlowSpeechButton.tsx` — 🐢 button with amber active state, `aria-pressed`
- `voiceSelector.getOptimizedSpeechSettings` — multiplies base rate × 0.5 when slow mode is active
- Injected into `GameHeaderSection` next to the stats button

## Why
Closes #1124

## Test plan
- [ ] Press 🐢 in any card game → TTS speaks at half speed
- [ ] Press 🐢 again → TTS returns to normal speed
- [ ] Button shows amber highlight when active
- [ ] Navigate away from game → slow mode resets (next game starts at normal speed)
- [ ] Works on mobile (iOS Safari + Android Chrome)

🤖 Generated with [Claude Code](https://claude.com/claude-code)