### PR TITLE
feat(ux): reduced-motion accessibility mode — CSS + settings toggle (closes #1155)

### DIFF
--- a/gamesformykids/app/globals.css
+++ b/gamesformykids/app/globals.css
@@ -454,3 +454,25 @@ body {
 [data-colorblind="true"] .ring-red-500 {
   --tw-ring-color: #EE7733 !important;
 }
+
+/* Reduced-motion mode — OS media query baseline */
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}
+
+/* Reduced-motion mode — manual override via data attribute */
+[data-reduced-motion="true"] *,
+[data-reduced-motion="true"] *::before,
+[data-reduced-motion="true"] *::after {
+  animation-duration: 0.01ms !important;
+  animation-iteration-count: 1 !important;
+  transition-duration: 0.01ms !important;
+  scroll-behavior: auto !important;
+}

--- a/gamesformykids/app/layout.tsx
+++ b/gamesformykids/app/layout.tsx
@@ -39,6 +39,12 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
             __html: `try{if(localStorage.getItem('gfk_colorblind')==='true')document.documentElement.dataset.colorblind='true'}catch{}`,
           }}
         />
+        {/* Reduced-motion mode — apply before hydration to avoid flash */}
+        <script
+          dangerouslySetInnerHTML={{
+            __html: `try{if(localStorage.getItem('gfk_reduced_motion')==='true'||matchMedia('(prefers-reduced-motion:reduce)').matches)document.documentElement.dataset.reducedMotion='true'}catch{}`,
+          }}
+        />
       </head>
       <body className={`${rubik.className} dark:bg-gray-900 dark:text-white`}>
         {process.env.NODE_ENV === 'production' && process.env.NEXT_PUBLIC_GA_ID && (

--- a/gamesformykids/components/settings/ColorblindSection.tsx
+++ b/gamesformykids/components/settings/ColorblindSection.tsx
@@ -2,52 +2,77 @@
 import { useState, useEffect } from 'react';
 import { SectionContainer } from './SectionContainer';
 
-const LS_KEY = 'gfk_colorblind';
+const CB_KEY = 'gfk_colorblind';
+const RM_KEY = 'gfk_reduced_motion';
+
+function Toggle({ enabled, onToggle, label }: { enabled: boolean; onToggle: () => void; label: string }) {
+  return (
+    <button
+      onClick={onToggle}
+      role="switch"
+      aria-checked={enabled}
+      aria-label={label}
+      className={`relative w-12 h-6 rounded-full transition-colors ${enabled ? 'bg-blue-500' : 'bg-gray-300'}`}
+    >
+      <span
+        className={`absolute top-0.5 w-5 h-5 bg-white rounded-full shadow transition-transform ${enabled ? 'translate-x-6' : 'translate-x-0.5'}`}
+      />
+    </button>
+  );
+}
 
 export function ColorblindSection() {
-  const [enabled, setEnabled] = useState(false);
+  const [colorblind, setColorblind] = useState(false);
+  const [reducedMotion, setReducedMotion] = useState(false);
 
   useEffect(() => {
     try {
-      const stored = localStorage.getItem(LS_KEY);
-      const on = stored === 'true';
-      setEnabled(on);
-      document.documentElement.dataset.colorblind = on ? 'true' : '';
+      const cb = localStorage.getItem(CB_KEY) === 'true';
+      setColorblind(cb);
+      document.documentElement.dataset.colorblind = cb ? 'true' : '';
+
+      const osReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+      const rm = localStorage.getItem(RM_KEY) === 'true' || osReducedMotion;
+      setReducedMotion(rm);
+      document.documentElement.dataset.reducedMotion = rm ? 'true' : '';
     } catch {}
   }, []);
 
-  const toggle = () => {
-    const next = !enabled;
-    setEnabled(next);
+  const toggleColorblind = () => {
+    const next = !colorblind;
+    setColorblind(next);
     try {
-      if (next) {
-        localStorage.setItem(LS_KEY, 'true');
-        document.documentElement.dataset.colorblind = 'true';
-      } else {
-        localStorage.removeItem(LS_KEY);
-        document.documentElement.dataset.colorblind = '';
-      }
+      if (next) { localStorage.setItem(CB_KEY, 'true'); document.documentElement.dataset.colorblind = 'true'; }
+      else { localStorage.removeItem(CB_KEY); document.documentElement.dataset.colorblind = ''; }
+    } catch {}
+  };
+
+  const toggleReducedMotion = () => {
+    const next = !reducedMotion;
+    setReducedMotion(next);
+    try {
+      if (next) { localStorage.setItem(RM_KEY, 'true'); document.documentElement.dataset.reducedMotion = 'true'; }
+      else { localStorage.removeItem(RM_KEY); document.documentElement.dataset.reducedMotion = ''; }
     } catch {}
   };
 
   return (
     <SectionContainer title="נגישות" emoji="♿">
-      <div className="flex items-center justify-between p-3 bg-white rounded-xl border border-gray-200">
-        <div>
-          <p className="font-medium text-gray-800">מצב עיוורי צבעים 🎨</p>
-          <p className="text-sm text-gray-500">מחליף ירוק/אדום לכחול/כתום (מותאם לדאוטרנופיה ופרוטנופיה)</p>
+      <div className="space-y-3">
+        <div className="flex items-center justify-between p-3 bg-white rounded-xl border border-gray-200">
+          <div>
+            <p className="font-medium text-gray-800">מצב עיוורי צבעים 🎨</p>
+            <p className="text-sm text-gray-500">מחליף ירוק/אדום לכחול/כתום (מותאם לדאוטרנופיה ופרוטנופיה)</p>
+          </div>
+          <Toggle enabled={colorblind} onToggle={toggleColorblind} label="הפעל מצב עיוורי צבעים" />
         </div>
-        <button
-          onClick={toggle}
-          role="switch"
-          aria-checked={enabled}
-          className={`relative w-12 h-6 rounded-full transition-colors ${enabled ? 'bg-blue-500' : 'bg-gray-300'}`}
-          aria-label="הפעל מצב עיוורי צבעים"
-        >
-          <span
-            className={`absolute top-0.5 w-5 h-5 bg-white rounded-full shadow transition-transform ${enabled ? 'translate-x-6' : 'translate-x-0.5'}`}
-          />
-        </button>
+        <div className="flex items-center justify-between p-3 bg-white rounded-xl border border-gray-200">
+          <div>
+            <p className="font-medium text-gray-800">הפחת תנועה 🧘</p>
+            <p className="text-sm text-gray-500">מבטל אנימציות ומעברים (מומלץ לרגישות חושית ו-ADHD)</p>
+          </div>
+          <Toggle enabled={reducedMotion} onToggle={toggleReducedMotion} label="הפחת תנועה" />
+        </div>
       </div>
     </SectionContainer>
   );


### PR DESCRIPTION
## What
Implements the OS-level `prefers-reduced-motion` media query and adds a manual toggle in settings.

**Changes:**
- `globals.css`: added `@media (prefers-reduced-motion: reduce)` baseline rule (disables all CSS animations/transitions globally)
- `globals.css`: added `[data-reduced-motion="true"]` data-attribute rule that mirrors the same overrides for the manual toggle
- `layout.tsx`: init script applied before hydration checks both `localStorage['gfk_reduced_motion']` and `matchMedia('(prefers-reduced-motion:reduce)')` — no flash
- `ColorblindSection.tsx`: added 🧘 reduced-motion toggle row in the existing Accessibility settings section; auto-detects OS preference on first visit

## Why
Closes #1155

## Test plan
- [ ] Enable "Reduce motion" in OS settings → animations disappear across all games without touching settings page
- [ ] Toggle "הפחת תנועה" in Settings → animations stop/resume in the same session
- [ ] Hard refresh with toggle on → reduced motion still active (no flash)
- [ ] Works on mobile (iOS Safari + Android Chrome)

🤖 Generated with [Claude Code](https://claude.com/claude-code)