### PR TITLE
feat(ux): timer anxiety hide — toggle timer visibility in timed games (closes #1156)

### DIFF
--- a/gamesformykids/components/game/shared/ScoreTimeLivesHUD.tsx
+++ b/gamesformykids/components/game/shared/ScoreTimeLivesHUD.tsx
@@ -1,5 +1,6 @@
 'use client';
 import LivesDisplay from './LivesDisplay';
+import { useTimerVisibility } from '@/hooks/shared/useTimerVisibility';
 
 interface Props {
   score: number;
@@ -9,6 +10,7 @@ interface Props {
 }
 
 export default function ScoreTimeLivesHUD({ score, lives, timeLeft, mb = 'mb-3' }: Props) {
+  const { timerHidden, toggleTimer } = useTimerVisibility();
   return (
     <div className={`flex gap-5 ${mb} text-white text-center`}>
       <div>
@@ -19,8 +21,21 @@ export default function ScoreTimeLivesHUD({ score, lives, timeLeft, mb = 'mb-3' 
         <LivesDisplay lives={lives} />
         <p className="text-sm text-red-400">חיים</p>
       </div>
-      <div>
-        <p className="text-2xl font-black text-blue-200">{timeLeft} שנ׳</p>
+      <div className="flex flex-col items-center">
+        <div className="flex items-center gap-1">
+          {timerHidden
+            ? <p className="text-2xl font-black text-blue-200">⏱️</p>
+            : <p className="text-2xl font-black text-blue-200">{timeLeft} שנ׳</p>
+          }
+          <button
+            onClick={toggleTimer}
+            title={timerHidden ? 'הצג שעון' : 'הסתר שעון'}
+            aria-label={timerHidden ? 'הצג שעון ספירה לאחור' : 'הסתר שעון ספירה לאחור'}
+            className="text-blue-300 hover:text-blue-100 transition-colors text-base leading-none opacity-70 hover:opacity-100"
+          >
+            {timerHidden ? '👁️' : '🙈'}
+          </button>
+        </div>
         <p className="text-sm text-blue-400">זמן</p>
       </div>
     </div>

--- a/gamesformykids/hooks/shared/useTimerVisibility.ts
+++ b/gamesformykids/hooks/shared/useTimerVisibility.ts
@@ -1,0 +1,27 @@
+'use client';
+import { useState, useEffect, useCallback } from 'react';
+
+const LS_KEY = 'gfk_timer_hidden';
+
+export function useTimerVisibility() {
+  const [timerHidden, setTimerHidden] = useState(false);
+
+  useEffect(() => {
+    try {
+      setTimerHidden(localStorage.getItem(LS_KEY) === 'true');
+    } catch {}
+  }, []);
+
+  const toggleTimer = useCallback(() => {
+    setTimerHidden(prev => {
+      const next = !prev;
+      try {
+        if (next) localStorage.setItem(LS_KEY, 'true');
+        else localStorage.removeItem(LS_KEY);
+      } catch {}
+      return next;
+    });
+  }, []);
+
+  return { timerHidden, toggleTimer };
+}


### PR DESCRIPTION
## What
A 🙈/👁️ toggle button next to the timer in `ScoreTimeLivesHUD` lets children hide the countdown number. The timer still runs in the background — the game still ends when time is up. Preference is persisted in `localStorage`.

**Implementation:**
- `hooks/shared/useTimerVisibility.ts` — reads/writes `gfk_timer_hidden` in localStorage
- `ScoreTimeLivesHUD.tsx` — shows `⏱️` placeholder instead of number when hidden; 🙈/👁️ toggle button with `aria-label`

## Why
Closes #1156

## Test plan
- [ ] Open a timed game (color-tap, emoji-math, math-race) → see 🙈 button next to the timer
- [ ] Click 🙈 → timer number hides, ⏱️ shown, 👁️ appears
- [ ] Game still ends when time runs out (timer is just invisible)
- [ ] Refresh page → timer stays hidden (localStorage persisted)
- [ ] Click 👁️ → timer number reappears

🤖 Generated with [Claude Code](https://claude.com/claude-code)