### PR TITLE
feat(gamification): category play-progress bar on category cards (closes #1038)

### DIFF
--- a/gamesformykids/components/game/CategoriesView.tsx
+++ b/gamesformykids/components/game/CategoriesView.tsx
@@ -6,6 +6,7 @@ import { useHomePageStore } from "@/lib/stores";
 import { GAME_CATEGORIES } from "@/lib/constants/gameCategories";
 import { GamesRegistry } from "@/lib/registry/gamesRegistry";
 import { useGridFillers } from "@/hooks";
+import { useCategoryProgress } from "@/hooks/shared/progress/useCategoryProgress";
 
 export default function CategoriesView() {
   const selectCategory = useHomePageStore((s) => s.selectCategory);
@@ -13,6 +14,7 @@ export default function CategoriesView() {
   const categories = GAME_CATEGORIES;
   const categoriesCount = Object.keys(categories).length;
   const fillerCount = useGridFillers(categoriesCount, { mobile: 2, tablet: 3, desktop: 3 });
+  const categoryProgress = useCategoryProgress();
 
   return (
     <div>
@@ -30,6 +32,7 @@ export default function CategoriesView() {
               <CategoryCard
                 category={category}
                 gamesCount={gamesCount}
+                playedCount={categoryProgress[key] ?? 0}
                 onClick={() => selectCategory(key)}
               />
             </div>

--- a/gamesformykids/components/game/CategoryCard.tsx
+++ b/gamesformykids/components/game/CategoryCard.tsx
@@ -5,15 +5,17 @@ import { ComponentTypes } from "@/lib/types";
 export default function CategoryCard({
   category,
   gamesCount,
+  playedCount = 0,
   onClick
 }: ComponentTypes.CategoryCardProps) {
   const Icon = category.icon;
+  const progressPct = gamesCount > 0 ? Math.round((playedCount / gamesCount) * 100) : 0;
 
   return (
     <button
       type="button"
       onClick={onClick}
-      aria-label={`${category.title} — ${gamesCount} משחקים`}
+      aria-label={`${category.title} — ${gamesCount} משחקים${playedCount > 0 ? `, שיחקת ${playedCount}` : ''}`}
       className={`w-full relative p-3 md:p-4 lg:p-6 rounded-2xl md:rounded-3xl shadow-lg md:shadow-xl transition-[transform,box-shadow] duration-300 hover:scale-105 cursor-pointer hover:shadow-2xl bg-gradient-to-br ${category.gradient}`}
     >
       <div className="text-center text-white">
@@ -31,6 +33,21 @@ export default function CategoryCard({
             {gamesCount} משחקים
           </span>
         </div>
+        {playedCount > 0 && (
+          <div className="mt-2 md:mt-3">
+            <div className="flex items-center justify-between px-1 mb-1">
+              <span className="text-white/80 text-xs">{playedCount}/{gamesCount}</span>
+              <span className="text-white/80 text-xs">{progressPct}%</span>
+            </div>
+            <div className="h-1.5 bg-black/25 rounded-full overflow-hidden">
+              <div
+                className="h-full bg-white/70 rounded-full transition-all"
+                style={{ width: `${progressPct}%` }}
+                aria-hidden
+              />
+            </div>
+          </div>
+        )}
       </div>
     </button>
   );

--- a/gamesformykids/hooks/shared/progress/useCategoryProgress.ts
+++ b/gamesformykids/hooks/shared/progress/useCategoryProgress.ts
@@ -1,0 +1,19 @@
+'use client';
+import { useMemo } from 'react';
+import { useProgressTrackingStore } from '@/lib/stores/progressTrackingStore';
+import { GAME_CATEGORIES } from '@/lib/constants/gameCategories';
+
+/** Returns a map of categoryKey → number of unique games played in that category */
+export function useCategoryProgress(): Record<string, number> {
+  const allSessions = useProgressTrackingStore(s => s.allSessions);
+
+  return useMemo(() => {
+    const playedByGame = new Set(allSessions.map(s => s.gameType as string));
+    const result: Record<string, number> = {};
+    for (const [key, cat] of Object.entries(GAME_CATEGORIES)) {
+      const count = cat.gameIds.filter(id => playedByGame.has(id)).length;
+      if (count > 0) result[key] = count;
+    }
+    return result;
+  }, [allSessions]);
+}

--- a/gamesformykids/lib/types/components/game.ts
+++ b/gamesformykids/lib/types/components/game.ts
@@ -26,6 +26,8 @@ export interface CategoryCardProps {
   category: Category;
   /** מספר כלל המשחקים בקטגוריה */
   gamesCount: number;
+  /** מספר משחקים שהילד שיחק בקטגוריה זו */
+  playedCount?: number;
   /** פונקציה שמתבצעת בלחיצה */
   onClick: () => void;
 }


### PR DESCRIPTION
## What
Shows a personal play-progress bar at the bottom of each category card when the child has played at least one game in that category.

**Implementation:**
- `useCategoryProgress` hook — reads `allSessions` from `progressTrackingStore`, returns `{ [categoryKey]: uniqueGamesPlayed }` per category
- `CategoryCard` — renders a thin white/translucent progress bar + `played/total` text when `playedCount > 0`; completely hidden for unstarted categories
- `CategoryCardProps` — new optional `playedCount` field
- `CategoriesView` — calls `useCategoryProgress()` and passes counts per card

## Why
Closes #1038

## Test plan
- [ ] Play a game, return to home page → category card shows progress bar
- [ ] Multiple games played → bar and count update correctly
- [ ] Category with 0 plays → no bar visible
- [ ] Bar fills proportionally (e.g. 7/16 = ~44%)
- [ ] Works in RTL layout on mobile

🤖 Generated with [Claude Code](https://claude.com/claude-code)