### PR TITLE
feat(ux): first-time per-game tutorial overlay for chess, simon, memory (closes #1159)

### DIFF
--- a/gamesformykids/app/games/chess/components/ChessGame.tsx
+++ b/gamesformykids/app/games/chess/components/ChessGame.tsx
@@ -8,6 +8,13 @@ import ChessBoard from './ChessBoard';
 import ChessStatusBar from './ChessStatusBar';
 import ChessCaptured from './ChessCaptured';
 import ChessMoveHistory from './ChessMoveHistory';
+import { GameTutorial } from '@/components/game/GameTutorial';
+
+const CHESS_TUTORIAL = [
+  { emoji: '♟️', title: 'שחמט — הכרת הכלים', body: 'לכל כלי תנועה ייחודית: הרץ זז באלכסון, הצריח בקווים ישרים, הפרש קופץ בצורת L.' },
+  { emoji: '🎯', title: 'איך מנצחים?', body: 'לכודו את המלך של היריב — כשהמלך תחת מתקפה ואין לו מנוס, זה "מט".' },
+  { emoji: '🤖', title: 'משחק נגד AI', body: 'לחצו על כלי כדי לראות את הזזות האפשריות שלו, ואז לחצו על המשבצת הרצויה.' },
+];
 
 export default function ChessGame() {
   const { phase, message } = useChessGame();
@@ -31,6 +38,7 @@ export default function ChessGame() {
         }}
       />
 
+      <GameTutorial steps={CHESS_TUTORIAL} storageKey="gfk_tutorial_chess" />
       {phase === 'menu' && <ChessMenu />}
 
       {phase === 'checkmate' && <ChessGameOver />}

--- a/gamesformykids/app/games/memory/MemoryClient.tsx
+++ b/gamesformykids/app/games/memory/MemoryClient.tsx
@@ -7,12 +7,19 @@ import MemoryGameBoard from './components/MemoryGameBoard';
 import MemoryStartScreen from './components/MemoryStartScreen';
 import { useMemoryGameContent } from './useMemoryGameContent';
 import { useMemoryGame } from './useMemoryGame';
+import { GameTutorial } from '@/components/game/GameTutorial';
+
+const MEMORY_TUTORIAL = [
+  { emoji: '🃏', title: 'משחק זיכרון', body: 'כל הכרטיסים הפוכים על הגב. לחצו על כרטיס כדי לגלות מה מאחוריו.' },
+  { emoji: '👀', title: 'זכרו היכן כל דבר', body: 'מצאו שני כרטיסים זהים ברצף — הם יישארו פתוחים!' },
+  { emoji: '⏱️', title: 'חסכו לחיצות', body: 'כמה פחות ניסיונות — כך טוב יותר. שכלו את הזיכרון!' },
+];
 
 export default function MemoryClient() {
   useMemoryGameContent();
   const { phase } = useMemoryGame();
 
-  if (phase === 'menu')    return <MemoryStartScreen />;
+  if (phase === 'menu')    return <><GameTutorial steps={MEMORY_TUTORIAL} storageKey="gfk_tutorial_memory" /><MemoryStartScreen /></>;
   if (phase === 'won')     return <GameWinMessage />;
   if (phase === 'timeout') return <GameTimeoutScreen />;
 

--- a/gamesformykids/app/games/simon/SimonGame.tsx
+++ b/gamesformykids/app/games/simon/SimonGame.tsx
@@ -3,12 +3,20 @@ import { useSimonGame } from './useSimonGame';
 import SimonMenuScreen from './components/SimonMenuScreen';
 import SimonBoard from './components/SimonBoard';
 import SimonGameOverScreen from './components/SimonGameOverScreen';
+import { GameTutorial } from '@/components/game/GameTutorial';
+
+const SIMON_TUTORIAL = [
+  { emoji: '🎨', title: 'סיימון אומר', body: 'הלוח יאיר צבעים ברצף. הקשיבו לצליל וראו את הסדר.' },
+  { emoji: '👆', title: 'עכשיו התורך!', body: 'חזרו על הרצף בדיוק באותו סדר — לחצו על כל צבע בתורו.' },
+  { emoji: '📈', title: 'הרצף מתארך', body: 'כל סיבוב מוסיף צבע נוסף. כמה סיבובים תצליחו?' },
+];
 
 export default function SimonGame() {
   const { phase, handleTap, startGame } = useSimonGame();
 
   return (
     <div className="min-h-screen bg-gray-900 flex flex-col items-center justify-center p-4 select-none">
+      <GameTutorial steps={SIMON_TUTORIAL} storageKey="gfk_tutorial_simon" />
       {phase === 'menu' && <SimonMenuScreen />}
       {(phase === 'showing' || phase === 'input') && <SimonBoard onTap={handleTap} />}
       {phase === 'dead' && <SimonGameOverScreen onRestart={startGame} />}

--- a/gamesformykids/components/game/GameTutorial.tsx
+++ b/gamesformykids/components/game/GameTutorial.tsx
@@ -1,0 +1,89 @@
+'use client';
+import { useState, useEffect, useCallback } from 'react';
+
+export interface TutorialStep {
+  emoji: string;
+  title: string;
+  body: string;
+}
+
+interface Props {
+  steps: TutorialStep[];
+  storageKey: string;
+}
+
+export function GameTutorial({ steps, storageKey }: Props) {
+  const [visible, setVisible] = useState(false);
+  const [step, setStep] = useState(0);
+
+  useEffect(() => {
+    try {
+      if (!localStorage.getItem(storageKey)) setVisible(true);
+    } catch {}
+  }, [storageKey]);
+
+  const close = useCallback(() => {
+    try { localStorage.setItem(storageKey, '1'); } catch {}
+    setVisible(false);
+  }, [storageKey]);
+
+  const next = useCallback(() => {
+    if (step < steps.length - 1) setStep(s => s + 1);
+    else close();
+  }, [step, steps.length, close]);
+
+  const prev = useCallback(() => setStep(s => Math.max(0, s - 1)), []);
+
+  if (!visible) return null;
+
+  const current = steps[step]!;
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/50 backdrop-blur-sm"
+      dir="rtl"
+      role="dialog"
+      aria-modal="true"
+      aria-label="הדרכה"
+    >
+      <div className="bg-white rounded-3xl shadow-2xl p-8 max-w-sm w-full text-center">
+        <div className="text-6xl mb-4">{current.emoji}</div>
+        <h2 className="text-2xl font-bold text-gray-800 mb-3">{current.title}</h2>
+        <p className="text-gray-600 leading-relaxed mb-6">{current.body}</p>
+
+        <div className="flex justify-center gap-2 mb-6">
+          {steps.map((_, i) => (
+            <div
+              key={i}
+              className={`w-2.5 h-2.5 rounded-full transition-colors ${i === step ? 'bg-indigo-600' : 'bg-gray-200'}`}
+            />
+          ))}
+        </div>
+
+        <div className="flex gap-3">
+          {step > 0 && (
+            <button
+              onClick={prev}
+              className="flex-1 py-3 rounded-2xl border-2 border-gray-200 text-gray-500 font-semibold hover:bg-gray-50 transition-colors"
+            >
+              ← אחורה
+            </button>
+          )}
+          <button
+            onClick={next}
+            className="flex-1 py-3 rounded-2xl bg-indigo-600 text-white font-bold hover:bg-indigo-700 transition-colors"
+          >
+            {step < steps.length - 1 ? 'הבא ←' : '🎮 הבנתי!'}
+          </button>
+        </div>
+
+        <button
+          onClick={close}
+          className="mt-3 text-sm text-gray-400 hover:text-gray-600 underline w-full"
+        >
+          דלג על ההדרכה
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/gamesformykids/e2e/game-memory.spec.ts
+++ b/gamesformykids/e2e/game-memory.spec.ts
@@ -1,6 +1,13 @@
 import { test, expect } from '@playwright/test';
 
 test.describe('Memory game', () => {
+  test.beforeEach(async ({ page }) => {
+    // Pre-seed localStorage so the first-time tutorial overlay does not appear
+    await page.addInitScript(() => {
+      localStorage.setItem('gfk_tutorial_memory', '1');
+    });
+  });
+
   test('menu page loads with title', async ({ page }) => {
     await page.goto('/games/memory');
     await expect(page.getByText('משחק הזיכרון')).toBeVisible({ timeout: 10_000 });


### PR DESCRIPTION
## What
A generic `GameTutorial` component shows a 3-step modal overlay on a game's first visit. After dismissal it never shows again (per-game `localStorage` key).

**Rollout games:** Chess ♟️, Simon 🎨, Memory 🃏

**Component API:**
```tsx
<GameTutorial
  steps={[{ emoji, title, body }, ...]}
  storageKey="gfk_tutorial_chess"
/>
```

**Features:**
- Dot-pagination (1 / 2 / 3)
- Forward/back navigation
- "🎮 הבנתי!" final step button
- "דלג על ההדרכה" skip link
- `role="dialog" aria-modal` for accessibility

## Why
Closes #1159

## Test plan
- [ ] Visit chess/simon/memory for the first time → tutorial appears
- [ ] Navigate through all 3 steps
- [ ] Click "הבנתי!" → tutorial dismisses, game works normally
- [ ] Refresh → tutorial does NOT appear again
- [ ] "דלג" → dismisses immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)