### PR TITLE
feat(ux): study-first vocabulary preview before card games (closes #1036)

### DIFF
--- a/gamesformykids/components/shared/screens/AutoStartScreen.tsx
+++ b/gamesformykids/components/shared/screens/AutoStartScreen.tsx
@@ -1,17 +1,39 @@
 'use client';
 
+import { useState, useCallback } from 'react';
 import { useUniversalGame } from '@/hooks/shared/game-state/useUniversalGame';
 import type { BaseGameItem } from '@/lib/types';
 import GenericStartScreen from "./GenericStartScreen";
 import UnifiedCard from "../cards/UnifiedCard";
+import { StudyFirstPhase } from './StudyFirstPhase';
 
 export default function AutoStartScreen() {
-  const { config, speakItemName, gameType } = useUniversalGame();
+  const { config, speakItemName, gameType, items, startGame } = useUniversalGame();
+  const [studyMode, setStudyMode] = useState(false);
+  const [inStudy, setInStudy] = useState(false);
+
+  const handleStartWithStudy = useCallback(() => setInStudy(true), []);
+  const handleStudyComplete = useCallback(() => {
+    setInStudy(false);
+    startGame();
+  }, [startGame]);
 
   if (!config) {
     return (
       <div className="text-center p-8">
         <p className="text-xl text-red-500">Game type not supported: {gameType}</p>
+      </div>
+    );
+  }
+
+  if (inStudy) {
+    return (
+      <div className="min-h-screen" style={{ background: config.colors?.background || 'linear-gradient(135deg, #667eea 0%, #764ba2 100%)' }}>
+        <StudyFirstPhase
+          items={(items as BaseGameItem[]).slice(0, 20)}
+          onSpeak={(name) => speakItemName?.(name)}
+          onComplete={handleStudyComplete}
+        />
       </div>
     );
   }
@@ -35,6 +57,22 @@ export default function AutoStartScreen() {
           />
         );
       }}
+      customOnStart={studyMode ? handleStartWithStudy : undefined}
+      extraControls={
+        <div className="flex justify-center mt-3">
+          <button
+            onClick={() => setStudyMode(v => !v)}
+            className={`flex items-center gap-2 px-4 py-2 rounded-xl text-sm font-semibold transition-all border-2 ${
+              studyMode
+                ? 'bg-amber-400 border-amber-500 text-amber-900 shadow-md'
+                : 'bg-white/30 border-white/50 text-white hover:bg-white/40'
+            }`}
+            aria-pressed={studyMode}
+          >
+            📖 {studyMode ? 'לימוד קודם ✓' : 'לימוד קודם'}
+          </button>
+        </div>
+      }
     />
   );
 }

--- a/gamesformykids/components/shared/screens/GenericStartScreen.tsx
+++ b/gamesformykids/components/shared/screens/GenericStartScreen.tsx
@@ -36,6 +36,7 @@ export default function GenericStartScreen<T>({
   customItemsRenderer,
   showAudioCheck = true,
   className = "",
+  extraControls,
 }: GenericStartScreenProps<T>) {
   const { config, items: hookItems, startGame, gameType } = useUniversalGame();
   const prevBest = useGameStore((s) => s.highScores[gameType ?? ""] ?? 0);
@@ -96,6 +97,9 @@ export default function GenericStartScreen<T>({
 
         {/* כפתור בדיקת שמע */}
         {showAudioCheck && <ButtonCheckAudio />}
+
+        {/* פקדים נוספים (למשל כפתור לימוד קודם) */}
+        {extraControls}
 
         {/* דוגמת פריטים */}
         <div className="mt-12">

--- a/gamesformykids/components/shared/screens/StudyFirstPhase.tsx
+++ b/gamesformykids/components/shared/screens/StudyFirstPhase.tsx
@@ -1,0 +1,82 @@
+'use client';
+import { useState, useEffect, useCallback } from 'react';
+import type { BaseGameItem } from '@/lib/types/core/base';
+
+interface Props {
+  items: BaseGameItem[];
+  onSpeak: (name: string) => void;
+  onComplete: () => void;
+}
+
+export function StudyFirstPhase({ items, onSpeak, onComplete }: Props) {
+  const [idx, setIdx] = useState(0);
+
+  const current = items[idx];
+
+  // Speak current item on mount and on index change
+  useEffect(() => {
+    if (current) onSpeak(current.name);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [idx]);
+
+  // Auto-advance every 2.5 seconds
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      if (idx < items.length - 1) setIdx(i => i + 1);
+      else onComplete();
+    }, 2500);
+    return () => clearTimeout(timer);
+  }, [idx, items.length, onComplete]);
+
+  const next = useCallback(() => {
+    if (idx < items.length - 1) setIdx(i => i + 1);
+    else onComplete();
+  }, [idx, items.length, onComplete]);
+
+  if (!current) return null;
+
+  return (
+    <div className="min-h-screen flex flex-col items-center justify-center p-6 gap-6 text-center" dir="rtl">
+      {/* Progress */}
+      <div className="text-white/80 text-sm font-semibold">
+        {idx + 1} / {items.length}
+      </div>
+
+      {/* Progress bar */}
+      <div className="w-48 h-1.5 bg-white/20 rounded-full">
+        <div
+          className="h-full bg-white/70 rounded-full transition-all duration-300"
+          style={{ width: `${((idx + 1) / items.length) * 100}%` }}
+        />
+      </div>
+
+      {/* Item display */}
+      <div className="bg-white/20 backdrop-blur-sm rounded-3xl p-8 max-w-xs w-full flex flex-col items-center gap-4 shadow-xl">
+        <span className="text-8xl">{current.emoji || '🎯'}</span>
+        <p className="text-3xl font-bold text-white drop-shadow">{current.hebrew}</p>
+        <button
+          onClick={() => onSpeak(current.name)}
+          className="text-white/70 hover:text-white text-sm underline"
+          aria-label="שמע שוב"
+        >
+          🔊 שמע שוב
+        </button>
+      </div>
+
+      <div className="flex gap-3 mt-2">
+        <button
+          onClick={next}
+          className="px-6 py-3 bg-white/20 hover:bg-white/30 text-white font-bold rounded-2xl transition-colors"
+        >
+          {idx < items.length - 1 ? 'הבא ←' : '🎮 התחל משחק!'}
+        </button>
+        <button
+          onClick={onComplete}
+          className="px-4 py-3 text-white/60 hover:text-white text-sm transition-colors"
+        >
+          דלג →
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/gamesformykids/lib/types/components/screens.ts
+++ b/gamesformykids/lib/types/components/screens.ts
@@ -50,6 +50,9 @@ export interface GenericStartScreenProps<T> {
   // Layout options
   showAudioCheck?: boolean | undefined;
   className?: string | undefined;
+
+  // Extra controls below the start button (e.g. study-first toggle)
+  extraControls?: React.ReactNode;
 }
 
 export interface GameErrorScreenProps {


### PR DESCRIPTION
## What
Adds an optional study-first mode to card games. Before starting, players can toggle a \"📖 לימוד קודם\" (Study First) button on the start screen. When enabled, the game shows each vocabulary item one-by-one with automatic TTS playback (auto-advancing every 2.5 s), then transitions directly into the game.

**New / changed files:**
- `components/shared/screens/StudyFirstPhase.tsx` — new component: scrolls through items with emoji + Hebrew label, progress bar, "next" and "skip" buttons, auto-TTS
- `components/shared/screens/AutoStartScreen.tsx` — wires the study toggle and phase transition
- `components/shared/screens/GenericStartScreen.tsx` — accepts and renders the new `extraControls` prop below the audio-check button
- `lib/types/components/screens.ts` — adds `extraControls?: React.ReactNode` to `GenericStartScreenProps`

## Why
Closes #1036

## Test plan
- [ ] Open any card game (e.g. `/games/animals`)
- [ ] Tap "📖 לימוד קודם" — button highlights; "Start" now says it will launch study first
- [ ] Tap Start — items cycle one-by-one with TTS; tap "הבא" to advance manually or "דלג" to skip to game
- [ ] After last item, game starts automatically
- [ ] Without toggling study mode, start behaves as before (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)