### PR TITLE
feat(voice): speech recognition answer input for card games (closes #1161)

### DIFF
--- a/gamesformykids/components/game/universal/auto-game/AutoGameBody.tsx
+++ b/gamesformykids/components/game/universal/auto-game/AutoGameBody.tsx
@@ -5,6 +5,7 @@ import { useAutoGame } from "@/hooks";
 import { GameCardGrid } from "../../../shared";
 import { GameHints } from "../../../shared";
 import { TipsBox } from "../../../shared";
+import VoiceAnswerButton from "../../../shared/buttons/VoiceAnswerButton";
 
 interface AutoGameBodyProps {
   renderCard?: ((item: BaseGameItem, onClick: (item: BaseGameItem) => void) => React.ReactNode) | undefined;
@@ -54,8 +55,9 @@ export function AutoGameBody({ renderCard }: AutoGameBodyProps) {
         />
       )}
 
-      {/* כפתור סטטיסטיקות */}
-      <div className="text-center mt-4">
+      {/* כפתורי פעולה */}
+      <div className="flex items-center justify-center gap-3 mt-4 flex-wrap">
+        <VoiceAnswerButton options={options || []} onMatch={handleItemClick} />
         <button
           onClick={() => setShowProgressModal(true)}
           className="

--- a/gamesformykids/components/shared/buttons/VoiceAnswerButton.tsx
+++ b/gamesformykids/components/shared/buttons/VoiceAnswerButton.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+import { useCallback } from "react";
+import { Mic, MicOff } from "lucide-react";
+import { BaseGameItem } from "@/lib/types/core/base";
+import { useSpeechRecognition } from "@/hooks/shared/audio/useSpeechRecognition";
+
+interface VoiceAnswerButtonProps {
+  options: BaseGameItem[];
+  onMatch: (item: BaseGameItem) => void;
+}
+
+function stripNikud(text: string): string {
+  return text.replace(/[ְ-ׇ׳״]/g, "").trim();
+}
+
+function findBestMatch(transcript: string, options: BaseGameItem[]): BaseGameItem | null {
+  const normalized = stripNikud(transcript.toLowerCase());
+  if (!normalized) return null;
+
+  // Exact match first (Hebrew or English)
+  const exact = options.find((item) => {
+    const h = stripNikud(item.hebrew.toLowerCase());
+    const e = item.english.toLowerCase();
+    return normalized === h || normalized === e;
+  });
+  if (exact) return exact;
+
+  // Contains match
+  return options.find((item) => {
+    const h = stripNikud(item.hebrew.toLowerCase());
+    return normalized.includes(h) || h.includes(normalized);
+  }) ?? null;
+}
+
+export default function VoiceAnswerButton({ options, onMatch }: VoiceAnswerButtonProps) {
+  const handleResult = useCallback(
+    ({ transcript }: { transcript: string }) => {
+      const match = findBestMatch(transcript, options);
+      if (match) onMatch(match);
+    },
+    [options, onMatch],
+  );
+
+  const { isListening, isSupported, permissionDenied, startListening, stopListening } =
+    useSpeechRecognition({ onResult: handleResult });
+
+  if (!isSupported || permissionDenied) return null;
+
+  return (
+    <button
+      type="button"
+      onPointerDown={startListening}
+      onPointerUp={stopListening}
+      onPointerLeave={stopListening}
+      aria-label={isListening ? "מפסיק להאזין" : "דבר את התשובה"}
+      title={isListening ? "מפסיק להאזין" : "לחץ וחזק — דבר את התשובה בעברית"}
+      className={`
+        flex items-center gap-2 px-4 py-3 min-h-11 rounded-xl font-bold text-base
+        transition-[transform,background-color] duration-150 select-none border-2
+        ${isListening
+          ? "bg-red-500 text-white border-red-600 scale-105 animate-pulse"
+          : "bg-white/80 text-indigo-700 border-indigo-300 hover:bg-indigo-50"
+        }
+      `}
+    >
+      {isListening ? (
+        <>
+          <MicOff className="w-5 h-5" aria-hidden="true" />
+          <span>מאזין...</span>
+        </>
+      ) : (
+        <>
+          <Mic className="w-5 h-5" aria-hidden="true" />
+          <span>דבר</span>
+        </>
+      )}
+    </button>
+  );
+}

--- a/gamesformykids/hooks/shared/audio/useSpeechRecognition.ts
+++ b/gamesformykids/hooks/shared/audio/useSpeechRecognition.ts
@@ -1,0 +1,92 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+export interface SpeechRecognitionResult {
+  transcript: string;
+  isFinal: boolean;
+}
+
+interface UseSpeechRecognitionOptions {
+  lang?: string;
+  onResult?: (result: SpeechRecognitionResult) => void;
+  onError?: (error: string) => void;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type AnySpeechRecognition = any;
+
+function getSpeechRecognitionCtor(): (new () => AnySpeechRecognition) | null {
+  if (typeof window === 'undefined') return null;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const w = window as any;
+  return w.SpeechRecognition ?? w.webkitSpeechRecognition ?? null;
+}
+
+export function useSpeechRecognition({
+  lang = 'he-IL',
+  onResult,
+  onError,
+}: UseSpeechRecognitionOptions = {}) {
+  const [isListening, setIsListening] = useState(false);
+  const [isSupported, setIsSupported] = useState(false);
+  const [permissionDenied, setPermissionDenied] = useState(false);
+  const recognitionRef = useRef<AnySpeechRecognition>(null);
+
+  useEffect(() => {
+    setIsSupported(getSpeechRecognitionCtor() !== null);
+  }, []);
+
+  const startListening = useCallback(() => {
+    const Ctor = getSpeechRecognitionCtor();
+    if (!Ctor) return;
+
+    const recognition = new Ctor();
+    recognition.lang = lang;
+    recognition.continuous = false;
+    recognition.interimResults = false;
+    recognition.maxAlternatives = 3;
+
+    recognition.onstart = () => setIsListening(true);
+    recognition.onend = () => setIsListening(false);
+
+    recognition.onresult = (event: AnySpeechRecognition) => {
+      const results = Array.from(event.results as ArrayLike<AnySpeechRecognition>);
+      const best = results[results.length - 1] as AnySpeechRecognition;
+      if (best) {
+        onResult?.({
+          transcript: best[0].transcript as string,
+          isFinal: best.isFinal as boolean,
+        });
+      }
+    };
+
+    recognition.onerror = (event: AnySpeechRecognition) => {
+      setIsListening(false);
+      if (event.error === 'not-allowed' || event.error === 'service-not-allowed') {
+        setPermissionDenied(true);
+      }
+      onError?.(event.error as string);
+    };
+
+    recognitionRef.current = recognition;
+    try {
+      recognition.start();
+    } catch {
+      setIsListening(false);
+    }
+  }, [lang, onResult, onError]);
+
+  const stopListening = useCallback(() => {
+    recognitionRef.current?.stop();
+    setIsListening(false);
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      recognitionRef.current?.abort();
+    };
+  }, []);
+
+  return { isListening, isSupported, permissionDenied, startListening, stopListening };
+}


### PR DESCRIPTION
## What
Adds an optional press-and-hold microphone button to all card games. The child speaks the Hebrew item name, and the Web Speech API transcribes it — if the transcript matches one of the current answer choices, that item is automatically selected.

## Changes
- **`useSpeechRecognition`** hook (`hooks/shared/audio/`) — wraps `window.SpeechRecognition` / `webkitSpeechRecognition` with `lang='he-IL'`, handles permission denial and API absence
- **`VoiceAnswerButton`** (`components/shared/buttons/`) — press-and-hold mic with animated pulse while listening; strips nikud before fuzzy-matching against current `options`; invisible when API or permission is unavailable
- **`AutoGameBody`** — renders the button beside the accuracy stats button

## Why
Closes #1161

## Test plan
- [ ] Open any card game (e.g. `/games/animals`) and start playing
- [ ] A mic button labeled **דבר** appears below the answer grid
- [ ] Press and hold the button — it pulses red and says **מאזין...**
- [ ] Speak a Hebrew item name (e.g. **כלב**) — the matching card is selected automatically
- [ ] Release without speaking — nothing happens; game continues normally
- [ ] Deny mic permission — button disappears gracefully
- [ ] Firefox — button is hidden (no SpeechRecognition support)
- [ ] `npx tsc --noEmit` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)