### PR TITLE
feat(photos): real photo toggle for card games — animals & fruits (closes #1163)

### DIFF
--- a/gamesformykids/components/game/universal/auto-game/AutoGameBody.tsx
+++ b/gamesformykids/components/game/universal/auto-game/AutoGameBody.tsx
@@ -6,6 +6,8 @@ import { GameCardGrid } from "../../../shared";
 import { GameHints } from "../../../shared";
 import { TipsBox } from "../../../shared";
 import VoiceAnswerButton from "../../../shared/buttons/VoiceAnswerButton";
+import { REAL_PHOTO_CARD_MAP } from "../../../shared/GameCardMap";
+import { useAudioSettingsStore } from "@/lib/stores/audioSettingsStore";
 
 interface AutoGameBodyProps {
   renderCard?: ((item: BaseGameItem, onClick: (item: BaseGameItem) => void) => React.ReactNode) | undefined;
@@ -24,7 +26,12 @@ export function AutoGameBody({ renderCard }: AutoGameBodyProps) {
     currentAccuracy,
     setShowProgressModal,
     CardComponent,
+    gameType,
   } = useAutoGame();
+
+  const showRealPhotos = useAudioSettingsStore((s) => s.showRealPhotos);
+  const PhotoCard = showRealPhotos && gameType ? REAL_PHOTO_CARD_MAP[gameType] : undefined;
+  const EffectiveCard = PhotoCard ?? CardComponent;
 
   return (
     <div className="space-y-6">
@@ -37,7 +44,7 @@ export function AutoGameBody({ renderCard }: AutoGameBodyProps) {
         maxWidth="max-w-2xl"
         renderCustomCard={(item) => (
           renderCard ? renderCard(item, handleItemClick) : (
-            <CardComponent item={item} onClick={handleItemClick} />
+            <EffectiveCard item={item} onClick={handleItemClick} />
           )
         )}
       />

--- a/gamesformykids/components/shared/GameCardMap.tsx
+++ b/gamesformykids/components/shared/GameCardMap.tsx
@@ -125,4 +125,13 @@ export const GameCardMap: Partial<Record<GameType, ComponentType<GameItemCardPro
   'english-cards': DefaultGameCard,
 };
 
+/**
+ * Photo card components available for the "real photos" toggle.
+ * Only includes games that have photo data in photoCardConfigs.
+ */
+export const REAL_PHOTO_CARD_MAP: Partial<Record<GameType, ComponentType<GameItemCardProps>>> = {
+  animals: createPhotoCard('animals'),
+  fruits: createPhotoCard('fruits'),
+};
+
 export default GameCardMap;

--- a/gamesformykids/components/shared/buttons/RealPhotoToggleButton.tsx
+++ b/gamesformykids/components/shared/buttons/RealPhotoToggleButton.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import { useAudioSettingsStore } from "@/lib/stores/audioSettingsStore";
+
+export default function RealPhotoToggleButton() {
+  const showRealPhotos = useAudioSettingsStore((s) => s.showRealPhotos);
+  const toggleRealPhotos = useAudioSettingsStore((s) => s.toggleRealPhotos);
+
+  return (
+    <button
+      type="button"
+      onClick={toggleRealPhotos}
+      title={showRealPhotos ? "חזור לאמוג׳י" : "הצג תמונות אמיתיות"}
+      aria-label={showRealPhotos ? "חזור לאמוג׳י" : "הצג תמונות אמיתיות"}
+      aria-pressed={showRealPhotos}
+      className={`
+        px-3 py-2 rounded-xl font-bold text-sm min-h-11
+        transition-[transform,background-color] duration-150 select-none
+        border-2
+        ${showRealPhotos
+          ? "bg-emerald-500 text-white border-emerald-600 shadow-lg scale-105"
+          : "bg-white/80 text-emerald-700 border-emerald-300 hover:bg-emerald-50"
+        }
+      `}
+    >
+      {showRealPhotos ? "📷" : "🖼️"}
+    </button>
+  );
+}

--- a/gamesformykids/components/shared/headers/GameHeaderSection.tsx
+++ b/gamesformykids/components/shared/headers/GameHeaderSection.tsx
@@ -4,14 +4,21 @@ import GameHeader from "./GameHeader";
 import GameStatsButton from "../buttons/GameStatsButton";
 import SlowSpeechButton from "../buttons/SlowSpeechButton";
 import NikudToggleButton from "../buttons/NikudToggleButton";
+import RealPhotoToggleButton from "../buttons/RealPhotoToggleButton";
 import GameChallengeSection from "../GameChallengeSection";
+import { useGameTypeStore } from "@/lib/stores/gameTypeStore";
+import { REAL_PHOTO_CARD_MAP } from "../GameCardMap";
 
 export default function GameHeaderSection() {
+  const gameType = useGameTypeStore((s) => s.currentGameType);
+  const hasRealPhotos = !!gameType && gameType in REAL_PHOTO_CARD_MAP;
+
   return (
     <div className="text-center mb-8">
       <div className="flex justify-between items-center mb-6">
         <GameHeader />
         <div className="flex items-center gap-2">
+          {hasRealPhotos && <RealPhotoToggleButton />}
           <NikudToggleButton />
           <SlowSpeechButton />
           <GameStatsButton />

--- a/gamesformykids/components/shared/screens/AutoStartScreen.tsx
+++ b/gamesformykids/components/shared/screens/AutoStartScreen.tsx
@@ -6,6 +6,8 @@ import type { BaseGameItem } from '@/lib/types';
 import GenericStartScreen from "./GenericStartScreen";
 import UnifiedCard from "../cards/UnifiedCard";
 import { StudyFirstPhase } from './StudyFirstPhase';
+import RealPhotoToggleButton from '../buttons/RealPhotoToggleButton';
+import { REAL_PHOTO_CARD_MAP } from '../GameCardMap';
 
 export default function AutoStartScreen() {
   const { config, speakItemName, gameType, items, startGame } = useUniversalGame();
@@ -59,7 +61,7 @@ export default function AutoStartScreen() {
       }}
       customOnStart={studyMode ? handleStartWithStudy : undefined}
       extraControls={
-        <div className="flex justify-center mt-3">
+        <div className="flex justify-center gap-3 mt-3 flex-wrap">
           <button
             onClick={() => setStudyMode(v => !v)}
             className={`flex items-center gap-2 px-4 py-2 rounded-xl text-sm font-semibold transition-all border-2 ${
@@ -71,6 +73,7 @@ export default function AutoStartScreen() {
           >
             📖 {studyMode ? 'לימוד קודם ✓' : 'לימוד קודם'}
           </button>
+          {gameType && gameType in REAL_PHOTO_CARD_MAP && <RealPhotoToggleButton />}
         </div>
       }
     />

--- a/gamesformykids/lib/constants/ui/photoCardConfigs.ts
+++ b/gamesformykids/lib/constants/ui/photoCardConfigs.ts
@@ -18,6 +18,8 @@ import { TECH_LOGOS_URLS, TECH_BG_MAP } from './photoCardData/techLogos';
 import { SOCCER_LOGOS_URLS }   from './photoCardData/soccerLogos';
 import { CAR_BRANDS_URLS }     from './photoCardData/carBrands';
 import { DINOSAURS_URLS }      from './photoCardData/dinosaurs';
+import { ANIMALS_URLS }        from './photoCardData/animals';
+import { FRUITS_URLS }         from './photoCardData/fruits';
 
 export interface PhotoCardConfig {
   imageUrls: Record<string, string>;
@@ -97,6 +99,17 @@ export const PHOTO_CARD_CONFIGS = {
     imageUrls: DINOSAURS_URLS, objectFit: "cover",
     cardBg: "bg-stone-100", selectedBorder: "border-emerald-500 ring-4 ring-emerald-500 ring-offset-4",
     defaultBorder: "border-stone-300", labelBg: "bg-stone-100", labelText: "text-stone-800",
+  },
+  // Real-photo toggle targets (emoji cards by default; these activate when showRealPhotos is on)
+  "animals": {
+    imageUrls: ANIMALS_URLS, objectFit: "cover",
+    cardBg: "bg-green-50", selectedBorder: "border-green-400 ring-4 ring-green-400 ring-offset-4",
+    defaultBorder: "border-green-200", labelBg: "bg-green-50", labelText: "text-green-900",
+  },
+  "fruits": {
+    imageUrls: FRUITS_URLS, objectFit: "cover",
+    cardBg: "bg-yellow-50", selectedBorder: "border-yellow-400 ring-4 ring-yellow-400 ring-offset-4",
+    defaultBorder: "border-yellow-200", labelBg: "bg-yellow-50", labelText: "text-yellow-900",
   },
 } as const satisfies Record<string, PhotoCardConfig>;
 

--- a/gamesformykids/lib/constants/ui/photoCardData/animals.ts
+++ b/gamesformykids/lib/constants/ui/photoCardData/animals.ts
@@ -1,0 +1,14 @@
+// Wikimedia Commons CC-licensed images for the animals card game.
+// Keys match the `name` field from ANIMALS in natureData/animals.ts.
+export const ANIMALS_URLS: Record<string, string> = {
+  dog:      "https://upload.wikimedia.org/wikipedia/commons/thumb/2/26/YellowLabradorLooking_new.jpg/320px-YellowLabradorLooking_new.jpg",
+  cat:      "https://upload.wikimedia.org/wikipedia/commons/thumb/4/4d/Cat_November_2010-1a.jpg/320px-Cat_November_2010-1a.jpg",
+  cow:      "https://upload.wikimedia.org/wikipedia/commons/thumb/0/0a/Cow_female_black_white.jpg/320px-Cow_female_black_white.jpg",
+  horse:    "https://upload.wikimedia.org/wikipedia/commons/thumb/d/de/Nokota_Horses_cropped.jpg/320px-Nokota_Horses_cropped.jpg",
+  sheep:    "https://upload.wikimedia.org/wikipedia/commons/thumb/2/27/Kauai_Sheep.jpg/320px-Kauai_Sheep.jpg",
+  pig:      "https://upload.wikimedia.org/wikipedia/commons/thumb/1/14/Pig_portrait.jpg/320px-Pig_portrait.jpg",
+  chicken:  "https://upload.wikimedia.org/wikipedia/commons/thumb/9/9b/Chicken_portrait.jpg/320px-Chicken_portrait.jpg",
+  duck:     "https://upload.wikimedia.org/wikipedia/commons/thumb/b/bf/Bucephala-albeola-010.jpg/320px-Bucephala-albeola-010.jpg",
+  rabbit:   "https://upload.wikimedia.org/wikipedia/commons/thumb/1/1f/Oryctolagus_cuniculus_Rcdo.jpg/320px-Oryctolagus_cuniculus_Rcdo.jpg",
+  frog:     "https://upload.wikimedia.org/wikipedia/commons/thumb/3/30/Rana_temporaria.jpg/320px-Rana_temporaria.jpg",
+};

--- a/gamesformykids/lib/constants/ui/photoCardData/fruits.ts
+++ b/gamesformykids/lib/constants/ui/photoCardData/fruits.ts
@@ -1,0 +1,14 @@
+// Wikimedia Commons CC-licensed images for the fruits card game.
+// Keys match the `name` field from FRUITS in natureData/fruits.ts.
+export const FRUITS_URLS: Record<string, string> = {
+  apple:      "https://upload.wikimedia.org/wikipedia/commons/thumb/1/15/Red_Apple.jpg/320px-Red_Apple.jpg",
+  banana:     "https://upload.wikimedia.org/wikipedia/commons/thumb/4/44/Bananas_white_background_DS.jpg/320px-Bananas_white_background_DS.jpg",
+  orange:     "https://upload.wikimedia.org/wikipedia/commons/thumb/4/43/Oranges_and_orange_juice.jpg/320px-Oranges_and_orange_juice.jpg",
+  grapes:     "https://upload.wikimedia.org/wikipedia/commons/thumb/3/36/Kyoho-grape.jpg/320px-Kyoho-grape.jpg",
+  strawberry: "https://upload.wikimedia.org/wikipedia/commons/thumb/2/29/PerfectStrawberry.jpg/320px-PerfectStrawberry.jpg",
+  watermelon: "https://upload.wikimedia.org/wikipedia/commons/thumb/4/4c/Watermelon_photo.jpg/320px-Watermelon_photo.jpg",
+  peach:      "https://upload.wikimedia.org/wikipedia/commons/thumb/9/9e/Autumn_Red_peach.jpg/320px-Autumn_Red_peach.jpg",
+  pear:       "https://upload.wikimedia.org/wikipedia/commons/thumb/d/d7/Pears.jpg/320px-Pears.jpg",
+  pineapple:  "https://upload.wikimedia.org/wikipedia/commons/thumb/c/cb/Pineapple_and_cross_section.jpg/320px-Pineapple_and_cross_section.jpg",
+  cherry:     "https://upload.wikimedia.org/wikipedia/commons/thumb/b/bb/Cherry_Stella444.jpg/320px-Cherry_Stella444.jpg",
+};

--- a/gamesformykids/lib/stores/audioSettingsStore.ts
+++ b/gamesformykids/lib/stores/audioSettingsStore.ts
@@ -20,6 +20,7 @@ export interface AudioSettingsState {
   volume: number;
   enabled: boolean;
   showNikud: boolean;
+  showRealPhotos: boolean;
 }
 
 export interface AudioSettingsActions {
@@ -28,6 +29,7 @@ export interface AudioSettingsActions {
   updateVolume: (volume: number) => void;
   toggleEnabled: () => void;
   toggleNikud: () => void;
+  toggleRealPhotos: () => void;
   saveSettings: (partial: Partial<AudioSettingsState>) => void;
   resetToDefaults: () => void;
 }
@@ -38,6 +40,7 @@ const DEFAULTS: AudioSettingsState = {
   volume: 0.8,        // AUDIO_CONSTANTS.SPEECH.DEFAULT_VOLUME
   enabled: true,
   showNikud: false,
+  showRealPhotos: false,
 };
 
 // ── Store ──────────────────────────────────────────────────
@@ -76,6 +79,9 @@ export const useAudioSettingsStore = makePersistStore<AudioSettingsState & Audio
 
     toggleNikud: () =>
       set((s) => ({ showNikud: !s.showNikud }), false, 'audio/toggleNikud'),
+
+    toggleRealPhotos: () =>
+      set((s) => ({ showRealPhotos: !s.showRealPhotos }), false, 'audio/toggleRealPhotos'),
 
     resetToDefaults: () => set(DEFAULTS, false, 'audio/resetToDefaults'),
   }),


### PR DESCRIPTION
## What
Adds a 🖼️/📷 toggle button to card games that replaces emoji cards with real CC-licensed photographs from Wikimedia Commons. Currently supports **animals** and **fruits** (the two most-played categories).

## Changes
- **Photo URL maps** for animals (10 images) and fruits (10 images) in `lib/constants/ui/photoCardData/`
- **Photo card configs** for `animals` and `fruits` added to `photoCardConfigs.ts`
- **`showRealPhotos`** boolean + `toggleRealPhotos` action added to `audioSettingsStore` (persisted)
- **`REAL_PHOTO_CARD_MAP`** exported from `GameCardMap.tsx` — maps game types to photo card components
- **`AutoGameBody`** reads `showRealPhotos` and swaps to the photo card when the current game has photos
- **`RealPhotoToggleButton`** (🖼️ → 📷) — only renders for games with photo data
- **`AutoStartScreen`** shows the photo toggle beside the study-mode button on start screen
- **`GameHeaderSection`** shows the photo toggle in the header during play (for photo-capable games only)
- All photos have emoji fallback via `onError` in existing `PhotoGameCard` — no broken UI if a URL fails

## Why
Closes #1163

## Test plan
- [ ] Open `/games/animals` start screen → 🖼️ button visible
- [ ] Click toggle → becomes 📷; start game → animal cards show real photographs
- [ ] Image load fails for any card → gracefully falls back to emoji
- [ ] Open `/games/fruits` — same toggle works
- [ ] Open `/games/colors` — toggle button is **not** shown (no photo data)
- [ ] Refresh page — `showRealPhotos` persists from localStorage
- [ ] `npx tsc --noEmit` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)