### PR TITLE
feat(engagement): mistake review mode — re-practice wrong answers after session

### DIFF
--- a/gamesformykids/components/game/universal/ultimate-game/GameLogicSync.tsx
+++ b/gamesformykids/components/game/universal/ultimate-game/GameLogicSync.tsx
@@ -30,6 +30,8 @@ function GameLogicSyncInner() {
       hasMoreHints: gameHookResult.hasMoreHints ?? false,
       showNextHint: gameHookResult.showNextHint ?? (() => {}),
       currentAccuracy: gameHookResult.currentAccuracy ?? 0,
+      lastMistakeItems: (gameHookResult.lastMistakeItems as import('@/lib/types/core/base').BaseGameItem[]) ?? [],
+      startMistakeReview: gameHookResult.startMistakeReview ?? (() => {}),
     });
   });
 

--- a/gamesformykids/components/shared/screens/AutoStartScreen.tsx
+++ b/gamesformykids/components/shared/screens/AutoStartScreen.tsx
@@ -11,7 +11,7 @@ import PrintWorksheetButton from '../buttons/PrintWorksheetButton';
 import { REAL_PHOTO_CARD_MAP } from '../GameCardMap';
 
 export default function AutoStartScreen() {
-  const { config, speakItemName, gameType, items, startGame } = useUniversalGame();
+  const { config, speakItemName, gameType, items, startGame, lastMistakeItems, startMistakeReview } = useUniversalGame();
   const [studyMode, setStudyMode] = useState(false);
   const [inStudy, setInStudy] = useState(false);
 
@@ -76,6 +76,14 @@ export default function AutoStartScreen() {
           </button>
           {gameType && gameType in REAL_PHOTO_CARD_MAP && <RealPhotoToggleButton />}
           <PrintWorksheetButton items={items as BaseGameItem[]} title={config.title ?? gameType ?? ''} />
+          {lastMistakeItems.length >= 2 && (
+            <button
+              onClick={() => startMistakeReview()}
+              className="flex items-center gap-2 px-4 py-2 rounded-xl text-sm font-semibold transition-all border-2 bg-rose-400 border-rose-500 text-white hover:bg-rose-500 shadow-md"
+            >
+              🔁 תרגל טעויות ({lastMistakeItems.length})
+            </button>
+          )}
         </div>
       }
     />

--- a/gamesformykids/hooks/shared/game-state/gameHooksMap.ts
+++ b/gamesformykids/hooks/shared/game-state/gameHooksMap.ts
@@ -22,6 +22,8 @@ type AnyGameHookFn = () => {
   hasMoreHints?: boolean;
   showNextHint?: () => void;
   currentAccuracy?: number;
+  lastMistakeItems?: BaseGameItem[];
+  startMistakeReview?: () => void | Promise<void>;
 };
 
 // טיפוס עבור משחקים שתומכים ב-AutoGamePage בלבד

--- a/gamesformykids/hooks/shared/game-state/useBaseGame.ts
+++ b/gamesformykids/hooks/shared/game-state/useBaseGame.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState, useCallback } from "react";
 import { BaseGameItem, BaseGameState } from "@/lib/types/core/base";
 import { UseBaseGameConfig } from "@/lib/types/hooks/game-state";
 import { useGameAudio } from "../audio/useGameAudio";
@@ -8,12 +8,14 @@ import { useGameOptions } from "./useGameOptions";
 import { useGameHints } from "../ui/useGameHints";
 import { useSessionStats } from "../progress/useSessionStats";
 import { useGameCompletion } from "../progress/useGameCompletion";
-import { 
-  delay, 
+import {
+  delay,
   speakItemName as speakItemNameUtil,
   handleWrongGameAnswer,
   handleCorrectGameAnswer,
-  speakStartMessage
+  speakStartMessage,
+  getRandomItem,
+  generateOptions,
 } from "@/lib/utils/game/gameUtils";
 import { GAME_CONSTANTS } from "@/lib/constants";
 import { useGameProgressStore, useGameStore } from "@/lib/stores";
@@ -26,6 +28,13 @@ import { trackEvent } from "@/lib/analytics/trackEvent";
  */
 export function useBaseGame<T extends BaseGameItem = BaseGameItem>(config: UseBaseGameConfig) {
   const { gameType, items, pronunciations, gameConstants, customAudio, uniqueByField } = config;
+
+  // Mistakes from the last completed session — persists until the next startGame
+  const [lastMistakeItems, setLastMistakeItems] = useState<T[]>([]);
+  // When set, the game uses only these items (mistake review mode)
+  const [reviewItems, setReviewItems] = useState<T[] | null>(null);
+
+  const effectiveItems = (reviewItems ?? items) as T[];
 
   // ── Zustand store reads (score / level / isPlaying) ─────
   const score          = useGameProgressStore((s) => s.score);
@@ -81,7 +90,7 @@ export function useBaseGame<T extends BaseGameItem = BaseGameItem>(config: UseBa
   }, []);
   
   const { getRandomChallenge, getOptionsForChallenge } = useGameOptions({
-    allItems: items,
+    allItems: effectiveItems,
     level,
     baseCount: gameConstants.BASE_COUNT,
     increment: gameConstants.INCREMENT,
@@ -112,36 +121,47 @@ export function useBaseGame<T extends BaseGameItem = BaseGameItem>(config: UseBa
     }
   };
 
-  // התחלת משחק
-  const startGame = async () => {
-    // Save previous session score before resetting (user may replay without navigating away)
+  // Helper shared by startGame and startMistakeReview
+  const _beginSession = async (firstChallenge: T, firstOptions: T[]) => {
     const progressStore = useGameProgressStore.getState();
     const { score: prevScore, level: prevLevel, isGameActive } = progressStore;
     if (isGameActive && (prevScore > 0 || prevLevel > 1)) {
       const durationSeconds = Math.round((Date.now() - sessionStartRef.current) / 1000);
       saveGameResultRef.current({ score: prevScore, level: prevLevel, durationSeconds });
     }
-
     progressStore.resetProgress();
     progressStore.setGameActive(true);
     sessionStartRef.current = Date.now();
     useGameStore.getState().startGame(gameType);
     trackEvent('game_start', { game_type: gameType });
-
     useGameSessionStore.getState().resetSession();
     progressHooks.startSession();
-
     await delay(GAME_CONSTANTS.DELAYS.START_GAME_DELAY);
     await speakStartMessage();
-    
+    useGameSessionStore.getState().setChallengeAndOptions(firstChallenge, firstOptions);
+    await delay(GAME_CONSTANTS.DELAYS.NEXT_ITEM_DELAY);
+    await speakItemNameFunc(firstChallenge.name);
+  };
+
+  // התחלת משחק
+  const startGame = async () => {
+    setReviewItems(null); // reset to full item pool
     const challenge = getRandomChallenge() as T;
     const newOptions = getOptionsForChallenge(challenge) as T[];
-
-    useGameSessionStore.getState().setChallengeAndOptions(challenge, newOptions);
-
-    await delay(GAME_CONSTANTS.DELAYS.NEXT_ITEM_DELAY);
-    await speakItemNameFunc(challenge.name);
+    await _beginSession(challenge, newOptions);
   };
+
+  // התחלת סשן תרגול טעויות — משחק רק עם הפריטים שהמשתמש פספס
+  const startMistakeReview = useCallback(async () => {
+    if (lastMistakeItems.length < 2) return;
+    setReviewItems(lastMistakeItems);
+    // Pick first challenge directly from lastMistakeItems (reviewItems update is async)
+    const challenge = getRandomItem(lastMistakeItems) as T;
+    const pool = lastMistakeItems as T[];
+    const newOptions = generateOptions(challenge, pool, GAME_CONSTANTS.OPTIONS_COUNT, 'name') as T[];
+    await _beginSession(challenge, newOptions);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [lastMistakeItems]);
 
   // טיפול בלחיצה על פריט
   const handleItemClick = async (selectedItem: T) => {
@@ -198,6 +218,12 @@ export function useBaseGame<T extends BaseGameItem = BaseGameItem>(config: UseBa
     // Capture final score/level before resetting local state
     const { score: finalScore, level: finalLevel } = useGameProgressStore.getState();
 
+    // Preserve mistake items so the start screen can offer a review round
+    const mistakeNames = progressHooks.currentSession?.mistakes?.map((m) => m.item) ?? [];
+    const capturedMistakes = (items as T[]).filter((item) => mistakeNames.includes(item.name));
+    setLastMistakeItems(capturedMistakes);
+    setReviewItems(null);
+
     progressHooks.endSession();
     useGameStore.getState().endGame();
     useGameProgressStore.getState().setGameActive(false);
@@ -224,5 +250,8 @@ export function useBaseGame<T extends BaseGameItem = BaseGameItem>(config: UseBa
     hasMoreHints: hintsHooks.hasMoreHints || false,
     showNextHint: hintsHooks.showNextHint || (() => {}),
     currentAccuracy: progressHooks.getCurrentAccuracy() || 0,
+    // תרגול טעויות
+    lastMistakeItems,
+    startMistakeReview,
   };
 }

--- a/gamesformykids/hooks/shared/game-state/useGameLogic.ts
+++ b/gamesformykids/hooks/shared/game-state/useGameLogic.ts
@@ -125,11 +125,13 @@ export function useGameState() {
 }
 
 export function useGameActions() {
-  const startGame       = useGameActionsStore((s) => s.startGame)
-  const resetGame       = useGameActionsStore((s) => s.resetGame)
-  const handleItemClick = useGameActionsStore((s) => s.handleItemClick)
-  const speakItemName   = useGameActionsStore((s) => s.speakItemName)
-  return { startGame, resetGame, handleItemClick, speakItemName }
+  const startGame          = useGameActionsStore((s) => s.startGame)
+  const resetGame          = useGameActionsStore((s) => s.resetGame)
+  const handleItemClick    = useGameActionsStore((s) => s.handleItemClick)
+  const speakItemName      = useGameActionsStore((s) => s.speakItemName)
+  const lastMistakeItems   = useGameActionsStore((s) => s.lastMistakeItems)
+  const startMistakeReview = useGameActionsStore((s) => s.startMistakeReview)
+  return { startGame, resetGame, handleItemClick, speakItemName, lastMistakeItems, startMistakeReview }
 }
 
 export function useGameUI() {

--- a/gamesformykids/hooks/shared/game-state/useUniversalGame.ts
+++ b/gamesformykids/hooks/shared/game-state/useUniversalGame.ts
@@ -36,7 +36,7 @@ export function useUniversalGame(): UniversalGameContextValue {
   const { isReady, error } = useGameLogic()
   const { gameState, isPlaying, showCelebration, currentChallenge, options, score, level } =
     useGameState()
-  const { startGame, resetGame, handleItemClick, speakItemName } = useGameActions()
+  const { startGame, resetGame, handleItemClick, speakItemName, lastMistakeItems, startMistakeReview } = useGameActions()
   const { config, items, CardComponent, gameType } = useGameConfigFromLogic()
   const { hints, hasMoreHints, showNextHint, currentAccuracy } = useHintActions()
   const { showProgressModal, setShowProgressModal } = useGameUI()
@@ -55,6 +55,8 @@ export function useUniversalGame(): UniversalGameContextValue {
     resetGame,
     handleItemClick,
     speakItemName,
+    lastMistakeItems: lastMistakeItems || [],
+    startMistakeReview: startMistakeReview || (() => {}),
     config: config!,
     items: items || [],
     CardComponent: CardComponent!,

--- a/gamesformykids/lib/stores/gameActionsStore.ts
+++ b/gamesformykids/lib/stores/gameActionsStore.ts
@@ -25,6 +25,8 @@ export interface GameActionsState {
   hasMoreHints: boolean;
   showNextHint: () => void;
   currentAccuracy: number;
+  lastMistakeItems: BaseGameItem[];
+  startMistakeReview: () => void | Promise<void>;
 }
 
 export interface GameActionsStoreActions {
@@ -40,6 +42,8 @@ export const useGameActionsStore = makeStore<GameActionsState & GameActionsStore
       hasMoreHints: false,
       showNextHint: NOOP,
       currentAccuracy: 0,
+      lastMistakeItems: [],
+      startMistakeReview: ASYNC_NOOP,
 
       setGameActions: (actions) => set(actions, false, 'gameActions/setGameActions'),
     }));

--- a/gamesformykids/lib/types/contexts/universal-game.ts
+++ b/gamesformykids/lib/types/contexts/universal-game.ts
@@ -53,6 +53,8 @@ interface BasicGameActions {
   readonly resetGame: () => void;
   readonly handleItemClick: (item: BaseGameItem) => void;
   readonly speakItemName: (itemName: string) => void;
+  readonly lastMistakeItems: readonly BaseGameItem[];
+  readonly startMistakeReview: () => void;
 }
 
 /**


### PR DESCRIPTION
## Summary
After a card game session ends, the child is offered a focused mini-round with only the items they got wrong. This turns failure into an immediate retry loop rather than a discouraging signal.

## Changes
- **`lib/stores/gameActionsStore.ts`** — added `lastMistakeItems` and `startMistakeReview` slots
- **`hooks/shared/game-state/useBaseGame.ts`** — captures mistake items before `endSession`, exposes `startMistakeReview`; introduces `reviewItems` state so only missed items are used during review
- **`hooks/shared/game-state/gameHooksMap.ts`** — extended `AnyGameHookFn` with optional new fields
- **`hooks/shared/game-state/useGameLogic.ts`** — `useGameActions()` reads the two new store fields
- **`hooks/shared/game-state/useUniversalGame.ts`** — forwards `lastMistakeItems` + `startMistakeReview`
- **`components/game/universal/ultimate-game/GameLogicSync.tsx`** — syncs new fields from hook result into the store every render
- **`lib/types/contexts/universal-game.ts`** — added fields to `BasicGameActions`
- **`components/shared/screens/AutoStartScreen.tsx`** — shows a `🔁 תרגל טעויות (N)` button when `lastMistakeItems.length >= 2`

## Testing
- [x] `npx tsc --noEmit` passes (0 errors)
- [ ] Play a card game, deliberately get some wrong → after reset, verify the button appears with the correct count
- [ ] Click the button → verify only the missed items appear as challenges
- [ ] Complete the review session → button should disappear (no new mistakes)
- [ ] Click normal "Start" → verify full item pool is used (review mode resets)

Closes #1148

🤖 Generated with [Claude Code](https://claude.com/claude-code)