### PR TITLE
feat: streak tracking + fullscreen toggle for card games

### DIFF
--- a/gamesformykids/components/shared/headers/GameHeaderSection.tsx
+++ b/gamesformykids/components/shared/headers/GameHeaderSection.tsx
@@ -8,6 +8,8 @@ import RealPhotoToggleButton from "../buttons/RealPhotoToggleButton";
 import GameChallengeSection from "../GameChallengeSection";
 import { useGameTypeStore } from "@/lib/stores/gameTypeStore";
 import { REAL_PHOTO_CARD_MAP } from "../GameCardMap";
+import { StreakBadge } from "@/components/game/shared/StreakBadge";
+import { FullscreenToggle } from "@/components/game/shared/FullscreenToggle";
 
 export default function GameHeaderSection() {
   const gameType = useGameTypeStore((s) => s.currentGameType);
@@ -18,9 +20,11 @@ export default function GameHeaderSection() {
       <div className="flex justify-between items-center mb-6">
         <GameHeader />
         <div className="flex items-center gap-2">
+          <StreakBadge />
           {hasRealPhotos && <RealPhotoToggleButton />}
           <NikudToggleButton />
           <SlowSpeechButton />
+          <FullscreenToggle />
           <GameStatsButton />
         </div>
       </div>

--- a/gamesformykids/hooks/shared/game-state/useBaseGame.ts
+++ b/gamesformykids/hooks/shared/game-state/useBaseGame.ts
@@ -173,6 +173,18 @@ export function useBaseGame<T extends BaseGameItem = BaseGameItem>(config: UseBa
       playSuccessSound();
       useGameSessionStore.getState().resetWrongAttempts();
 
+      // Update streak counter and award milestone bonus points
+      const { streakCount, bestStreak } = useGameProgressStore.getState();
+      const newStreak = streakCount + 1;
+      useGameProgressStore.getState().updateProgress({
+        streakCount: newStreak,
+        bestStreak: Math.max(newStreak, bestStreak),
+      });
+      // Milestone bonuses: 5→+5pts, 10→+10pts, 20→+20pts
+      const STREAK_BONUS: Record<number, number> = { 5: 5, 10: 10, 20: 20 };
+      const bonus = STREAK_BONUS[newStreak];
+      if (bonus) useGameProgressStore.getState().incrementScore(bonus);
+
       // Read current store values for progress tracking
       const { score: currentScore, level: currentLevel } = useGameProgressStore.getState();
       progressHooks.recordCorrectAnswer(
@@ -203,6 +215,8 @@ export function useBaseGame<T extends BaseGameItem = BaseGameItem>(config: UseBa
       // תשובה שגויה
       trackEvent('wrong_answer', { game_type: gameType });
       useGameSessionStore.getState().incrementWrongAttempts();
+      // Reset streak on wrong answer
+      useGameProgressStore.getState().updateProgress({ streakCount: 0 });
       progressHooks.recordMistake(currentChallenge, 1);
       
       await handleWrongGameAnswer(async () => {


### PR DESCRIPTION
## Summary

Adds two quality-of-life improvements to all card games (UltimateGamePage engine):

- **Streak tracking**: `useBaseGame.handleItemClick` now maintains `streakCount` and `bestStreak` in `gameProgressStore` on every answer. Correct answers increment the streak; wrong answers reset it to 0. Milestone bonuses (+5 pts at 5×, +10 pts at 10×, +20 pts at 20×) are awarded automatically.
- **StreakBadge + FullscreenToggle in header**: `GameHeaderSection` now includes the existing `StreakBadge` (shows 🔥 when streak ≥ 3) and `FullscreenToggle` (⛶/✕ button) in its toolbar, making them available across all card games without touching individual game files.

## Changes

- `hooks/shared/game-state/useBaseGame.ts` — streak increment/reset + bonus points in `handleItemClick`
- `components/shared/headers/GameHeaderSection.tsx` — added `StreakBadge` and `FullscreenToggle` imports and JSX

## Testing

- [x] `npx tsc --noEmit` passes (0 errors)
- [ ] Manually verify streak badge appears and increments on correct answers in any card game
- [ ] Verify fullscreen toggle works

Closes #993
Closes #1024

🤖 Generated with [Claude Code](https://claude.com/claude-code)