### PR TITLE
feat(gamification): personal best chip on QuizMenuScreen

### DIFF
--- a/gamesformykids/components/game/quiz/QuizMenuScreen.tsx
+++ b/gamesformykids/components/game/quiz/QuizMenuScreen.tsx
@@ -2,6 +2,8 @@
 
 import { type ReactNode } from 'react';
 import { QUIZ_THEMES, type QuizTheme } from './quizTheme';
+import { useGameStore } from '@/lib/stores/gameStore';
+import { useGameTypeStore } from '@/lib/stores/gameTypeStore';
 
 interface Props {
   emoji: string;
@@ -24,6 +26,9 @@ export function QuizMenuScreen({
   onStart,
 }: Props) {
   const t = QUIZ_THEMES[theme];
+  const gameType = useGameTypeStore((s) => s.currentGameType);
+  const prevBest = useGameStore((s) => s.highScores[gameType ?? ''] ?? 0);
+
   return (
     <div className={`min-h-screen bg-gradient-to-br ${t.gradient} flex flex-col items-center justify-center p-4`} dir="rtl">
       <div className="bg-white rounded-3xl shadow-2xl p-8 max-w-md w-full text-center">
@@ -37,6 +42,11 @@ export function QuizMenuScreen({
         >
           {emoji} {buttonLabel}
         </button>
+        {prevBest > 0 && (
+          <p className={`mt-4 text-sm font-medium ${t.text} opacity-75`}>
+            🏅 השיא שלך: {prevBest} — אפשר יותר?
+          </p>
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary

Extends the \"beat your best\" feature to quiz games. Card games already show a personal-best chip via \`GenericStartScreen\`. This PR adds the same chip to \`QuizMenuScreen\` (used by all custom and generic quiz games).

When a player has a stored high score for the current game, they now see:
> 🏅 השיא שלך: 12 — אפשר יותר?

below the start button. The chip is hidden on first play (no stored score yet).

## Changes

- \`components/game/quiz/QuizMenuScreen.tsx\` — reads \`gameStore.highScores[currentGameType]\` via \`useGameTypeStore\` and renders the personal-best chip

## Testing

- [x] \`npx tsc --noEmit\` passes (0 errors)
- [ ] Play any quiz game to end → return to menu → verify chip appears with correct score
- [ ] Verify chip is absent on first-ever play

Closes #1026

🤖 Generated with [Claude Code](https://claude.com/claude-code)