### PR TITLE
feat(gamification): category completion trophy overlay

### DIFF
--- a/gamesformykids/components/game/shared/GameResultCard.tsx
+++ b/gamesformykids/components/game/shared/GameResultCard.tsx
@@ -1,5 +1,5 @@
 'use client';
-import { ReactNode, useMemo } from 'react';
+import { ReactNode, useMemo, useState, useEffect } from 'react';
 import Link from 'next/link';
 import { GameCompletionCelebration } from './GameCompletionCelebration';
 import { useShareScore } from '@/hooks/shared/social/useShareScore';
@@ -7,6 +7,7 @@ import { useGameRating } from '@/hooks/shared/social/useGameRating';
 import { printCertificate } from '@/lib/utils/game/printCertificate';
 import { getNextGameInCategory } from '@/lib/utils/game/getNextGameInCategory';
 import WhatsAppShareButton from '@/components/shared/buttons/WhatsAppShareButton';
+import { useCategoryCompletion } from '@/hooks/shared/progress/useCategoryCompletion';
 
 interface SecondaryAction {
   label: string;
@@ -64,12 +65,35 @@ export default function GameResultCard({
   const isNewRecord = score !== undefined && best !== undefined && score > 0 && score === best;
   const showCertificate = scorePercent !== undefined && scorePercent >= 80;
 
+  const categoryTrophy = useCategoryCompletion(gameType);
+  const [showTrophyOverlay, setShowTrophyOverlay] = useState(false);
+  useEffect(() => {
+    if (!categoryTrophy) return;
+    setShowTrophyOverlay(true);
+    const t = setTimeout(() => setShowTrophyOverlay(false), 4000);
+    return () => clearTimeout(t);
+  }, [categoryTrophy]);
+
   return (
     <div
       className={`min-h-screen bg-linear-to-br ${gradientClass} flex items-center justify-center p-4`}
       dir="rtl"
     >
       {(score === undefined || score > 0) && <GameCompletionCelebration />}
+      {showTrophyOverlay && categoryTrophy && (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 cursor-pointer"
+          onClick={() => setShowTrophyOverlay(false)}
+        >
+          <div className="bg-linear-to-br from-yellow-300 to-amber-500 rounded-3xl p-10 text-center shadow-2xl max-w-sm mx-4 motion-safe:animate-bounce">
+            <div className="text-7xl mb-4">🏆</div>
+            <h2 className="text-3xl font-black text-white mb-2">כל הכבוד!</h2>
+            <p className="text-xl text-white/90 font-bold">השלמת את כל משחקי הקטגוריה</p>
+            <p className="text-lg text-white mt-1 font-semibold">{categoryTrophy.title}</p>
+            <p className="text-sm text-white/75 mt-4">🥇 🌟 🎉</p>
+          </div>
+        </div>
+      )}
       <div className="bg-white rounded-3xl shadow-2xl p-8 text-center max-w-sm w-full">
         <div className={`text-6xl mb-3 ${animateEmoji ? 'motion-safe:animate-bounce' : ''}`}>{emoji}</div>
         <h2 className="text-2xl font-bold text-gray-800 mb-4">{title}</h2>

--- a/gamesformykids/hooks/shared/progress/useCategoryCompletion.ts
+++ b/gamesformykids/hooks/shared/progress/useCategoryCompletion.ts
@@ -1,0 +1,68 @@
+'use client';
+import { useState, useEffect, useRef } from 'react';
+import { useProgressTrackingStore } from '@/lib/stores/progressTrackingStore';
+import { GAME_CATEGORIES } from '@/lib/constants/gameCategories';
+import { GamesRegistry } from '@/lib/registry/gamesRegistry';
+
+const TROPHY_LS_KEY = 'gfk_category_trophies';
+
+function getTrophiedCategories(): Set<string> {
+  try {
+    const raw = localStorage.getItem(TROPHY_LS_KEY);
+    return new Set<string>(raw ? JSON.parse(raw) : []);
+  } catch {
+    return new Set<string>();
+  }
+}
+
+function markTrophied(categoryKey: string) {
+  try {
+    const existing = getTrophiedCategories();
+    existing.add(categoryKey);
+    localStorage.setItem(TROPHY_LS_KEY, JSON.stringify([...existing]));
+  } catch {
+    // localStorage unavailable
+  }
+}
+
+/**
+ * Detects when a game completion finishes a full category for the first time.
+ * Returns `{ title }` of the completed category on the first completion — null otherwise.
+ * Each category can only trigger a trophy once (stored in localStorage).
+ */
+export function useCategoryCompletion(gameType: string | undefined): { title: string } | null {
+  const allSessions = useProgressTrackingStore(s => s.allSessions);
+  const [trophy, setTrophy] = useState<{ title: string } | null>(null);
+  const checkedRef = useRef(false);
+
+  useEffect(() => {
+    if (checkedRef.current || !gameType) return;
+    checkedRef.current = true;
+
+    const categoryEntry = Object.entries(GAME_CATEGORIES).find(([, cat]) =>
+      cat.gameIds.includes(gameType)
+    );
+    if (!categoryEntry) return;
+    const [categoryKey, category] = categoryEntry;
+
+    if (getTrophiedCategories().has(categoryKey)) return;
+
+    const allRegistrations = GamesRegistry.getAllGameRegistrations();
+    const availableIds = new Set(
+      allRegistrations
+        .filter(g => g.available && category.gameIds.includes(g.id))
+        .map(g => g.id)
+    );
+    if (availableIds.size === 0) return;
+
+    const playedIds = new Set(allSessions.map(s => s.gameType as string));
+    const allPlayed = [...availableIds].every(id => playedIds.has(id));
+
+    if (allPlayed) {
+      markTrophied(categoryKey);
+      setTrophy({ title: category.title });
+    }
+  }, [gameType, allSessions]);
+
+  return trophy;
+}


### PR DESCRIPTION
## Summary

When a player finishes the last available game in a category for the first time, a gold trophy overlay appears over the result screen for 4 seconds: **🏆 כל הכבוד! השלמת את כל משחקי הקטגוריה {category name}**. Each category is celebrated exactly once — completed categories are persisted in \`localStorage\` under \`gfk_category_trophies\`. The overlay can also be dismissed early by tapping anywhere.

## Changes

- **`hooks/shared/progress/useCategoryCompletion.ts`** (new) — reads \`progressTrackingStore.allSessions\`, finds the game's category in \`GAME_CATEGORIES\`, checks all available game IDs have been played, marks the trophy as awarded in \`localStorage\`
- **`components/game/shared/GameResultCard.tsx`** — calls \`useCategoryCompletion(gameType)\` and renders a fixed amber overlay that auto-dismisses after 4 s

## Testing

- [x] \`npx tsc --noEmit\` passes (0 errors)
- [ ] Play every game in a small category (e.g. "special" has ~9 games) → after the last one, verify the trophy overlay appears on the result screen
- [ ] Verify it does not appear again on re-plays of the same category
- [ ] Verify it does not appear when the category is not yet complete

Closes #1003

🤖 Generated with [Claude Code](https://claude.com/claude-code)