### PR TITLE
feat(tech): pre-cache top 10 games on service worker install (closes #1008)

### DIFF
--- a/gamesformykids/public/sw.js
+++ b/gamesformykids/public/sw.js
@@ -1,12 +1,17 @@
 // GamesForMyKids Service Worker
 // Bump CACHE_VERSION on each deploy to invalidate old caches.
-const CACHE_VERSION = 'v2';
+const CACHE_VERSION = 'v3';
 const STATIC_CACHE  = `gfk-static-${CACHE_VERSION}`;   // _next/static/* — content-addressed, cache forever
 const PAGES_CACHE   = `gfk-pages-${CACHE_VERSION}`;    // HTML navigation — stale-while-revalidate
 const ASSETS_CACHE  = `gfk-assets-${CACHE_VERSION}`;   // images / audio — cache-first
 const ALL_CACHES    = [STATIC_CACHE, PAGES_CACHE, ASSETS_CACHE];
 
-const PRECACHE_URLS = ['/', '/offline', '/manifest.json', '/favicon.ico'];
+const PRECACHE_URLS = [
+  '/', '/offline', '/manifest.json', '/favicon.ico',
+  '/games/animals', '/games/colors', '/games/numbers',
+  '/games/fruits', '/games/letters', '/games/shapes',
+  '/games/memory', '/games/math', '/games/counting', '/games/vehicles',
+];
 
 // ── Install: pre-cache critical pages ────────────────────────────────────────
 self.addEventListener('install', (event) => {


### PR DESCRIPTION
## What
Extended `PRECACHE_URLS` in `public/sw.js` to include the 10 most-played game pages and bumped `CACHE_VERSION` from `v2` to `v3` so existing clients invalidate their old cache on deploy.

## Why
Closes #1008

Games previously only became available offline after the user had visited them at least once. Now the top 10 games (animals, colors, numbers, fruits, letters, shapes, memory, math, counting, vehicles) are pre-cached during service worker install and work offline on first PWA launch.

## Test plan
- [ ] Install PWA in a clean browser profile
- [ ] Go offline immediately after install
- [ ] Navigate to `/games/animals` — page loads from cache
- [ ] Confirm old `gfk-pages-v2` cache is deleted and `gfk-pages-v3` is created

🤖 Generated with [Claude Code](https://claude.com/claude-code)