### PR TITLE
fix(ux): dark mode for game card shells and quiz screen (closes #1091)

### DIFF
--- a/gamesformykids/components/game/quiz/QuizQuestionShell.tsx
+++ b/gamesformykids/components/game/quiz/QuizQuestionShell.tsx
@@ -35,11 +35,11 @@ export function QuizQuestionShell({
 }: Props) {
   const t = QUIZ_THEMES[theme];
   const cardCls = cardVariant === 'white'
-    ? 'bg-white shadow-xl rounded-2xl p-5 mb-5 text-center'
+    ? 'bg-white dark:bg-gray-700 shadow-xl rounded-2xl p-5 mb-5 text-center'
     : `${t.card} rounded-2xl p-5 mb-5 text-center`;
   return (
     <div className={`min-h-screen bg-gradient-to-br ${t.gradient} flex flex-col items-center justify-center p-4`} dir="rtl">
-      <div className="bg-white rounded-3xl shadow-2xl p-6 max-w-lg w-full">
+      <div className="bg-white dark:bg-gray-800 rounded-3xl shadow-2xl p-6 max-w-lg w-full">
         <QuizProgress theme={theme} />
         <div className={cardCls}>
           {children}

--- a/gamesformykids/components/game/shared/GameMenuCard.tsx
+++ b/gamesformykids/components/game/shared/GameMenuCard.tsx
@@ -52,11 +52,11 @@ export default function GameMenuCard({
       className={`min-h-screen bg-gradient-to-br ${gradientClass} flex items-center justify-center p-4`}
       dir="rtl"
     >
-      <div className="bg-white rounded-3xl p-8 text-center shadow-2xl max-w-sm w-full">
+      <div className="bg-white dark:bg-gray-800 rounded-3xl p-8 text-center shadow-2xl max-w-sm w-full">
         <div className={`text-6xl mb-4 ${animateEmoji ? 'motion-safe:animate-bounce' : ''}`}>{emoji}</div>
-        <h1 className="text-3xl font-black text-gray-700 mb-2">{title}</h1>
-        <p className="text-gray-500 text-base mb-2">{description}</p>
-        {hint && <p className="text-gray-400 text-sm mb-4">{hint}</p>}
+        <h1 className="text-3xl font-black text-gray-700 dark:text-gray-100 mb-2">{title}</h1>
+        <p className="text-gray-500 dark:text-gray-300 text-base mb-2">{description}</p>
+        {hint && <p className="text-gray-400 dark:text-gray-400 text-sm mb-4">{hint}</p>}
         {best !== undefined && best > 0 && (
           <p className="text-yellow-600 font-bold mb-4">🏆 שיא: {best}</p>
         )}
@@ -73,7 +73,7 @@ export default function GameMenuCard({
         {secondaryAction && (
           <button
             onClick={secondaryAction.onClick}
-            className="w-full mt-3 py-3 rounded-2xl border-2 border-gray-200 text-gray-600 font-semibold text-base hover:bg-gray-50 active:scale-95 transition-[transform,colors]"
+            className="w-full mt-3 py-3 rounded-2xl border-2 border-gray-200 dark:border-gray-600 text-gray-600 dark:text-gray-300 font-semibold text-base hover:bg-gray-50 dark:hover:bg-gray-700 active:scale-95 transition-[transform,colors]"
           >
             {secondaryAction.label}
           </button>

--- a/gamesformykids/components/game/shared/GameResultCard.tsx
+++ b/gamesformykids/components/game/shared/GameResultCard.tsx
@@ -94,9 +94,9 @@ export default function GameResultCard({
           </div>
         </div>
       )}
-      <div className="bg-white rounded-3xl shadow-2xl p-8 text-center max-w-sm w-full">
+      <div className="bg-white dark:bg-gray-800 rounded-3xl shadow-2xl p-8 text-center max-w-sm w-full">
         <div className={`text-6xl mb-3 ${animateEmoji ? 'motion-safe:animate-bounce' : ''}`}>{emoji}</div>
-        <h2 className="text-2xl font-bold text-gray-800 mb-4">{title}</h2>
+        <h2 className="text-2xl font-bold text-gray-800 dark:text-gray-100 mb-4">{title}</h2>
         {isNewRecord && (
           <div className="mb-4 px-4 py-2 rounded-2xl bg-linear-to-l from-yellow-400 to-amber-500 text-white font-black text-lg motion-safe:animate-bounce shadow-md">
             🏆 שיא חדש!
@@ -113,7 +113,7 @@ export default function GameResultCard({
           {secondaryAction && (
             <button
               onClick={secondaryAction.onClick}
-              className="flex-1 py-4 rounded-2xl border-2 border-gray-200 text-gray-600 font-semibold hover:bg-gray-50 transition-colors"
+              className="flex-1 py-4 rounded-2xl border-2 border-gray-200 dark:border-gray-600 text-gray-600 dark:text-gray-300 font-semibold hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors"
             >
               {secondaryAction.label}
             </button>
@@ -123,7 +123,7 @@ export default function GameResultCard({
           <>
             <button
               onClick={() => share(shareText)}
-              className="mt-3 w-full py-2.5 rounded-2xl border-2 border-gray-200 text-gray-500 font-semibold text-sm hover:bg-gray-50 active:scale-95 transition-[transform,colors]"
+              className="mt-3 w-full py-2.5 rounded-2xl border-2 border-gray-200 dark:border-gray-600 text-gray-500 dark:text-gray-400 font-semibold text-sm hover:bg-gray-50 dark:hover:bg-gray-700 active:scale-95 transition-[transform,colors]"
             >
               {copied ? '✅ הועתק!' : '📤 שתף את הניקוד'}
             </button>
@@ -148,14 +148,14 @@ export default function GameResultCard({
           </Link>
         )}
         {gameType && (
-          <div className="mt-4 pt-3 border-t border-gray-100">
+          <div className="mt-4 pt-3 border-t border-gray-100 dark:border-gray-700">
             {rating ? (
-              <p className="text-sm text-gray-400">
+              <p className="text-sm text-gray-400 dark:text-gray-500">
                 {rating === 'up' ? '😊 תודה על המשוב!' : '🙏 תודה! נמשיך להשתפר'}
               </p>
             ) : (
               <div className="flex items-center justify-center gap-3">
-                <span className="text-sm text-gray-400">איך היה המשחק?</span>
+                <span className="text-sm text-gray-400 dark:text-gray-500">איך היה המשחק?</span>
                 <button
                   onClick={() => rate('up')}
                   className="text-2xl hover:scale-125 transition-transform"

--- a/gamesformykids/components/shared/feedback/SimpleGameInstructions.tsx
+++ b/gamesformykids/components/shared/feedback/SimpleGameInstructions.tsx
@@ -14,11 +14,11 @@ export default function SimpleGameInstructions({
   }
 
   return (
-    <div className="bg-white rounded-3xl p-8 mb-8 shadow-xl">
-      <h3 className="text-2xl font-bold text-purple-800 mb-6 text-center">
+    <div className="bg-white dark:bg-gray-800 rounded-3xl p-8 mb-8 shadow-xl">
+      <h3 className="text-2xl font-bold text-purple-800 dark:text-purple-300 mb-6 text-center">
         {title}
       </h3>
-      
+
       {variant === "detailed" ? (
         <ol className="space-y-4">
           {instructions.map((instruction, index) => (
@@ -28,14 +28,14 @@ export default function SimpleGameInstructions({
                   {index + 1}
                 </span>
               )}
-              <span className="text-gray-700 leading-relaxed">{instruction}</span>
+              <span className="text-gray-700 dark:text-gray-300 leading-relaxed">{instruction}</span>
             </li>
           ))}
         </ol>
       ) : (
         <div className="space-y-3">
           {instructions.map((instruction, index) => (
-            <p key={index} className="text-gray-700 leading-relaxed">
+            <p key={index} className="text-gray-700 dark:text-gray-300 leading-relaxed">
               {instruction}
             </p>
           ))}


### PR DESCRIPTION
## What
Add `dark:` Tailwind variants to the four shared game screen components so they respect the OS/app dark mode preference instead of blasting white in dark environments.

**Files changed:**
- `GameMenuCard.tsx` — card bg, heading, description, secondary button
- `GameResultCard.tsx` — card bg, heading, secondary button, share button, rating section
- `QuizQuestionShell.tsx` — outer white card + inner white card variant
- `SimpleGameInstructions.tsx` — instructions card bg, heading, body text

## Why
Closes #1091

The site already has `darkMode: 'class'` in Tailwind config and a pre-hydration script to apply the `dark` class. The home page and body already use `dark:` variants. Game screens were missed, causing blinding white screens in dark environments.

## Test plan
- [ ] Enable OS dark mode or add `dark` class to `<html>` via DevTools
- [ ] Navigate to any card game (e.g. `/games/animals`) — menu screen is dark
- [ ] Answer a question — result card is dark
- [ ] Navigate to any quiz game (e.g. `/games/riddles`) — question shell is dark
- [ ] Navigate to a generic start screen — instructions card is dark
- [ ] Verify light mode still looks correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)