### PR TITLE
feat(engagement): seasonal / holiday visual themes (closes #1150)

### DIFF
--- a/gamesformykids/app/settings/SettingsClient.tsx
+++ b/gamesformykids/app/settings/SettingsClient.tsx
@@ -11,6 +11,7 @@ import { ColorblindSection } from '@/components/settings/ColorblindSection';
 import { AvatarSection } from '@/components/settings/AvatarSection';
 import { ScreenTimeSection } from '@/components/settings/ScreenTimeSection';
 import { AgeFilterSection } from '@/components/settings/AgeFilterSection';
+import { HolidaySection } from '@/components/settings/HolidaySection';
 import GameSpinnerScreen from '@/components/ui/GameSpinnerScreen';
 
 export default function SettingsClient() {
@@ -78,6 +79,7 @@ export default function SettingsClient() {
           <AvatarSection />
           <AgeFilterSection />
           <ScreenTimeSection />
+          <HolidaySection />
           <AccountSection onSignOut={handleSignOut} />
         </div>
 

--- a/gamesformykids/components/game/shared/GameCompletionCelebration.tsx
+++ b/gamesformykids/components/game/shared/GameCompletionCelebration.tsx
@@ -6,6 +6,8 @@ import { useGameAudio } from '@/hooks/shared/audio/useGameAudio';
 import { speakHebrew } from '@/lib/utils/speech/speaker';
 import { getGameConfettiEmojis } from '@/lib/utils/game/getGameConfettiEmojis';
 import { useAvatarEmoji } from '@/hooks/shared/user/useAvatarEmoji';
+import { getActiveHoliday } from '@/lib/constants/holidayLanes';
+import { useAudioSettingsStore } from '@/lib/stores/audioSettingsStore';
 
 const CELEBRATION_PHRASES = [
   'כל הכבוד! עשית עבודה מדהימה!',
@@ -42,8 +44,10 @@ export function GameCompletionCelebration({ isPerfect = false }: Props) {
   const params = useParams();
   const gameType = typeof params?.gameType === 'string' ? params.gameType : undefined;
   const { emoji: avatarEmoji } = useAvatarEmoji();
+  const holidayThemesEnabled = useAudioSettingsStore((s) => s.holidayThemesEnabled);
 
-  const emojis = getGameConfettiEmojis(gameType) ?? getSeasonalEmojis();
+  const holiday = holidayThemesEnabled ? getActiveHoliday() : null;
+  const emojis = getGameConfettiEmojis(gameType) ?? holiday?.confettiEmojis ?? getSeasonalEmojis();
   const particles = Array.from({ length: 20 }, (_, i) => ({
     id: i,
     emoji: emojis[i % emojis.length]!,

--- a/gamesformykids/components/game/shared/GameResultCard.tsx
+++ b/gamesformykids/components/game/shared/GameResultCard.tsx
@@ -8,6 +8,8 @@ import { printCertificate } from '@/lib/utils/game/printCertificate';
 import { getNextGameInCategory } from '@/lib/utils/game/getNextGameInCategory';
 import WhatsAppShareButton from '@/components/shared/buttons/WhatsAppShareButton';
 import { useCategoryCompletion } from '@/hooks/shared/progress/useCategoryCompletion';
+import { getActiveHoliday } from '@/lib/constants/holidayLanes';
+import { useAudioSettingsStore } from '@/lib/stores/audioSettingsStore';
 
 interface SecondaryAction {
   label: string;
@@ -64,6 +66,8 @@ export default function GameResultCard({
   const nextGame = useMemo(() => (gameType ? getNextGameInCategory(gameType) : null), [gameType]);
   const isNewRecord = score !== undefined && best !== undefined && score > 0 && score === best;
   const showCertificate = scorePercent !== undefined && scorePercent >= 80;
+  const holidayThemesEnabled = useAudioSettingsStore((s) => s.holidayThemesEnabled);
+  const holiday = useMemo(() => holidayThemesEnabled ? getActiveHoliday() : null, [holidayThemesEnabled]);
 
   const categoryTrophy = useCategoryCompletion(gameType);
   const [showTrophyOverlay, setShowTrophyOverlay] = useState(false);
@@ -95,6 +99,12 @@ export default function GameResultCard({
         </div>
       )}
       <div className="bg-white dark:bg-gray-800 rounded-3xl shadow-2xl p-8 text-center max-w-sm w-full">
+        {holiday && (
+          <div className="mb-3 inline-flex items-center gap-1.5 px-3 py-1 rounded-full bg-linear-to-l from-amber-400 to-yellow-300 text-amber-900 text-sm font-bold shadow-sm">
+            <span>{holiday.emoji}</span>
+            <span>חג שמח! {holiday.name}</span>
+          </div>
+        )}
         <div className={`text-6xl mb-3 ${animateEmoji ? 'motion-safe:animate-bounce' : ''}`}>{emoji}</div>
         <h2 className="text-2xl font-bold text-gray-800 dark:text-gray-100 mb-4">{title}</h2>
         {isNewRecord && (

--- a/gamesformykids/components/settings/HolidaySection.tsx
+++ b/gamesformykids/components/settings/HolidaySection.tsx
@@ -1,0 +1,47 @@
+'use client';
+
+import { useAudioSettingsStore } from '@/lib/stores/audioSettingsStore';
+import { HOLIDAY_CONFIGS } from '@/lib/constants/holidayLanes';
+import { SectionContainer } from './SectionContainer';
+
+export function HolidaySection() {
+  const holidayThemesEnabled = useAudioSettingsStore((s) => s.holidayThemesEnabled);
+  const toggleHolidayThemes = useAudioSettingsStore((s) => s.toggleHolidayThemes);
+
+  return (
+    <SectionContainer title="ערכות חג" emoji="🎉">
+      <div className="space-y-4">
+        <div className="flex items-start justify-between gap-4">
+          <div>
+            <p className="font-medium text-gray-800">עיצוב חגים אוטומטי</p>
+            <p className="text-sm text-gray-500 mt-0.5">
+              מציג קונפטי וקישוטים מיוחדים בחגים — חנוכה, פורים, פסח ועוד
+            </p>
+            <div className="flex flex-wrap gap-1 mt-2">
+              {HOLIDAY_CONFIGS.map((h) => (
+                <span key={h.id} className="text-base" title={h.name}>{h.emoji}</span>
+              ))}
+            </div>
+          </div>
+          <button
+            type="button"
+            onClick={toggleHolidayThemes}
+            aria-pressed={holidayThemesEnabled}
+            className={`
+              flex-shrink-0 relative inline-flex h-7 w-12 items-center rounded-full transition-colors duration-200
+              ${holidayThemesEnabled ? 'bg-purple-500' : 'bg-gray-300'}
+            `}
+          >
+            <span className="sr-only">{holidayThemesEnabled ? 'כבה עיצוב חגים' : 'הפעל עיצוב חגים'}</span>
+            <span
+              className={`
+                inline-block h-5 w-5 rounded-full bg-white shadow-md transform transition-transform duration-200
+                ${holidayThemesEnabled ? 'translate-x-6' : 'translate-x-1'}
+              `}
+            />
+          </button>
+        </div>
+      </div>
+    </SectionContainer>
+  );
+}

--- a/gamesformykids/lib/constants/holidayLanes.ts
+++ b/gamesformykids/lib/constants/holidayLanes.ts
@@ -3,6 +3,8 @@ export interface HolidayConfig {
   name: string;
   emoji: string;
   color: string;
+  /** Emojis used for confetti on result screens during this holiday */
+  confettiEmojis: string[];
   gameIds: string[];
   // Each occurrence: show lane from (start - 14 days) until (end + 1 day)
   occurrences: { start: string; end: string }[];
@@ -14,6 +16,7 @@ export const HOLIDAY_CONFIGS: HolidayConfig[] = [
     name: 'ראש השנה',
     emoji: '🍎',
     color: 'from-amber-400 to-yellow-500',
+    confettiEmojis: ['🍎', '🍯', '🌙', '✡️', '⭐', '🌟', '🎉', '💫'],
     gameIds: ['jewish-holidays', 'seasons-holidays', 'family', 'blessings', 'fruits', 'counting'],
     occurrences: [
       { start: '2025-09-22', end: '2025-09-24' },
@@ -26,6 +29,7 @@ export const HOLIDAY_CONFIGS: HolidayConfig[] = [
     name: 'סוכות',
     emoji: '🌿',
     color: 'from-green-400 to-emerald-500',
+    confettiEmojis: ['🌿', '🍊', '🌴', '🍋', '⭐', '🌟', '💫', '✨'],
     gameIds: ['jewish-holidays', 'seasons-holidays', 'garden-plants', 'nature', 'fruits', 'weather'],
     occurrences: [
       { start: '2025-09-27', end: '2025-10-04' },
@@ -38,6 +42,7 @@ export const HOLIDAY_CONFIGS: HolidayConfig[] = [
     name: 'חנוכה',
     emoji: '🕎',
     color: 'from-blue-500 to-indigo-600',
+    confettiEmojis: ['🕎', '🕯️', '✡️', '⭐', '💙', '❄️', '🌟', '💫'],
     gameIds: ['jewish-holidays', 'shapes', 'colors', 'counting', 'math', 'seasons-holidays'],
     occurrences: [
       { start: '2025-12-14', end: '2025-12-22' },
@@ -50,6 +55,7 @@ export const HOLIDAY_CONFIGS: HolidayConfig[] = [
     name: 'פורים',
     emoji: '🎭',
     color: 'from-purple-500 to-pink-500',
+    confettiEmojis: ['🎭', '👑', '🎉', '🎁', '🌟', '🎊', '💫', '✨'],
     gameIds: ['jewish-holidays', 'emotions', 'clothing', 'superheroes', 'art-craft', 'drawing'],
     occurrences: [
       { start: '2026-03-13', end: '2026-03-14' },
@@ -62,6 +68,7 @@ export const HOLIDAY_CONFIGS: HolidayConfig[] = [
     name: 'פסח',
     emoji: '🫓',
     color: 'from-yellow-400 to-orange-400',
+    confettiEmojis: ['🫓', '🌾', '🍷', '✡️', '⭐', '🏆', '🌟', '💫'],
     gameIds: ['jewish-holidays', 'family', 'seasons-holidays', 'food', 'healthy-food', 'world-food'],
     occurrences: [
       { start: '2026-04-01', end: '2026-04-09' },
@@ -74,6 +81,7 @@ export const HOLIDAY_CONFIGS: HolidayConfig[] = [
     name: 'יום העצמאות',
     emoji: '🇮🇱',
     color: 'from-blue-400 to-cyan-500',
+    confettiEmojis: ['🇮🇱', '⭐', '🌟', '🎉', '🎊', '💙', '💫', '✨'],
     gameIds: ['israel', 'israel-map', 'flags', 'world-landmarks', 'capitals', 'geography-flags'],
     occurrences: [
       { start: '2026-04-29', end: '2026-04-30' },
@@ -86,6 +94,7 @@ export const HOLIDAY_CONFIGS: HolidayConfig[] = [
     name: 'שבועות',
     emoji: '📜',
     color: 'from-emerald-400 to-teal-500',
+    confettiEmojis: ['📜', '🌸', '⭐', '🌟', '💫', '🌾', '🍀', '✨'],
     gameIds: ['jewish-holidays', 'letters', 'blessings', 'seasons-holidays', 'hebrew-letters', 'fruits'],
     occurrences: [
       { start: '2026-05-21', end: '2026-05-23' },

--- a/gamesformykids/lib/stores/audioSettingsStore.ts
+++ b/gamesformykids/lib/stores/audioSettingsStore.ts
@@ -22,6 +22,7 @@ export interface AudioSettingsState {
   showNikud: boolean;
   showRealPhotos: boolean;
   showEnglish: boolean;
+  holidayThemesEnabled: boolean;
 }
 
 export interface AudioSettingsActions {
@@ -32,6 +33,7 @@ export interface AudioSettingsActions {
   toggleNikud: () => void;
   toggleRealPhotos: () => void;
   toggleEnglish: () => void;
+  toggleHolidayThemes: () => void;
   saveSettings: (partial: Partial<AudioSettingsState>) => void;
   resetToDefaults: () => void;
 }
@@ -44,6 +46,7 @@ const DEFAULTS: AudioSettingsState = {
   showNikud: false,
   showRealPhotos: false,
   showEnglish: false,
+  holidayThemesEnabled: true,
 };
 
 // ── Store ──────────────────────────────────────────────────
@@ -88,6 +91,9 @@ export const useAudioSettingsStore = makePersistStore<AudioSettingsState & Audio
 
     toggleEnglish: () =>
       set((s) => ({ showEnglish: !s.showEnglish }), false, 'audio/toggleEnglish'),
+
+    toggleHolidayThemes: () =>
+      set((s) => ({ holidayThemesEnabled: !s.holidayThemesEnabled }), false, 'audio/toggleHolidayThemes'),
 
     resetToDefaults: () => set(DEFAULTS, false, 'audio/resetToDefaults'),
   }),


### PR DESCRIPTION
## What
Implements auto-activating holiday visual themes for Hanukkah, Purim, Passover, and 4 other Jewish holidays.

- **`holidayLanes.ts`**: added `confettiEmojis[]` field to each `HolidayConfig` (7 holidays covered)
- **`audioSettingsStore`**: added `holidayThemesEnabled` toggle (persist v2) with `toggleHolidayThemes` action
- **`GameCompletionCelebration`**: uses holiday-specific confetti emojis when a holiday is active and themes are enabled; falls back to game-type or seasonal emojis otherwise
- **`GameResultCard`**: shows a "חג שמח! [holiday name]" badge above the result emoji during active holidays
- **`HolidaySection`** (new): settings toggle card so parents can enable/disable the feature and preview all holiday emojis

## Why
Closes #1150

## Conflicts resolved
Merged dark-mode classes from #1091 (already on main) into `GameResultCard.tsx`.

## Test plan
- [ ] Visit `/games/animals` and finish a game — in Hanukkah season confetti should show 🕎🕯️✡️ etc.
- [ ] Toggle holiday themes OFF in `/settings` — confetti reverts to game-type or seasonal
- [ ] Result card shows "חג שמח! חנוכה" badge during holiday window
- [ ] `/settings` shows the new "ערכות חג" section with a toggle and all 7 holiday emojis
- [ ] `npx tsc --noEmit` passes ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)