### PR TITLE
feat(engagement): adaptive auto-difficulty for card games (closes #1149)

### DIFF
--- a/gamesformykids/components/game/shared/AdaptiveDifficultyBanner.tsx
+++ b/gamesformykids/components/game/shared/AdaptiveDifficultyBanner.tsx
@@ -1,0 +1,31 @@
+'use client';
+
+import { useAdaptiveDifficulty } from '@/hooks/shared/game-state/useAdaptiveDifficulty';
+
+export default function AdaptiveDifficultyBanner() {
+  const { banner } = useAdaptiveDifficulty();
+
+  if (!banner) return null;
+
+  return (
+    <div
+      className={`
+        fixed top-16 inset-x-0 z-40 flex justify-center pointer-events-none
+      `}
+      dir="rtl"
+    >
+      <div
+        className={`
+          px-5 py-2.5 rounded-full shadow-xl text-white font-bold text-sm
+          motion-safe:animate-bounce
+          ${banner.positive
+            ? 'bg-linear-to-l from-emerald-500 to-teal-500'
+            : 'bg-linear-to-l from-orange-500 to-amber-500'
+          }
+        `}
+      >
+        {banner.text}
+      </div>
+    </div>
+  );
+}

--- a/gamesformykids/components/game/universal/ultimate-game/UltimateGamePage.tsx
+++ b/gamesformykids/components/game/universal/ultimate-game/UltimateGamePage.tsx
@@ -25,6 +25,7 @@ import { ContextProgressDisplay } from "../../../shared";
 import { UltimateStartScreen } from "./UltimateStartScreen";
 import SpeedBurstTimer from "../../shared/SpeedBurstTimer";
 import { useSpeedBurstStore } from '@/lib/stores/speedBurstStore';
+import AdaptiveDifficultyBanner from "../../shared/AdaptiveDifficultyBanner";
 
 // Re-export co-located components for convenience
 export { GameLogicSync } from './GameLogicSync';
@@ -81,6 +82,7 @@ function CardGamePage() {
       style={{ background: game.config.colors?.background || DEFAULT_BG }}
     >
       {speedEnabled && <SpeedBurstTimer gameType={String(game.gameType)} />}
+      <AdaptiveDifficultyBanner />
       <div className={`max-w-5xl mx-auto ${speedEnabled ? 'pt-8' : ''}`}>
         <GameHeaderSection />
         <GameMainContent />

--- a/gamesformykids/hooks/shared/game-state/useAdaptiveDifficulty.ts
+++ b/gamesformykids/hooks/shared/game-state/useAdaptiveDifficulty.ts
@@ -1,0 +1,88 @@
+'use client';
+
+import { useState, useRef, useEffect } from 'react';
+import { useGameProgressStore } from '@/lib/stores/gameProgressStore';
+
+const WINDOW_SIZE = 10;
+const HIGH_ACCURACY = 0.85;  // bump up when accuracy > 85%
+const LOW_ACCURACY  = 0.40;  // bump down when accuracy < 40%
+const LEVEL_JUMP    = 3;     // steps to skip when adjusting
+
+export interface AdaptiveBanner {
+  text: string;
+  positive: boolean;
+}
+
+/**
+ * Watches the last WINDOW_SIZE answers and automatically adjusts
+ * the game level after every 10 attempts.
+ *
+ * Only runs while the game is active (isGameActive = true).
+ * Returns a transient banner to show the child.
+ */
+export function useAdaptiveDifficulty() {
+  const [banner, setBanner] = useState<AdaptiveBanner | null>(null);
+
+  const windowRef  = useRef<boolean[]>([]);
+  const prevRef    = useRef({ attempts: 0, correctAnswers: 0 });
+  const timerRef   = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const showBanner = (text: string, positive: boolean) => {
+    if (timerRef.current) clearTimeout(timerRef.current);
+    setBanner({ text, positive });
+    timerRef.current = setTimeout(() => setBanner(null), 3000);
+  };
+
+  useEffect(() => {
+    const unsub = useGameProgressStore.subscribe((state) => {
+      if (!state.isGameActive) return;
+      if (state.attempts === prevRef.current.attempts) return;
+
+      const wasCorrect = state.correctAnswers > prevRef.current.correctAnswers;
+      prevRef.current = { attempts: state.attempts, correctAnswers: state.correctAnswers };
+
+      windowRef.current.push(wasCorrect);
+      if (windowRef.current.length > WINDOW_SIZE) windowRef.current.shift();
+
+      if (windowRef.current.length < WINDOW_SIZE) return;
+      if (state.attempts % WINDOW_SIZE !== 0) return;
+
+      const accuracy = windowRef.current.filter(Boolean).length / WINDOW_SIZE;
+
+      if (accuracy > HIGH_ACCURACY) {
+        const next = Math.min(state.level + LEVEL_JUMP, 30);
+        if (next > state.level) {
+          useGameProgressStore.getState().updateProgress({ level: next });
+          showBanner('🌟 מעולה! עלית לרמה קשה יותר', true);
+        }
+      } else if (accuracy < LOW_ACCURACY) {
+        const next = Math.max(state.level - LEVEL_JUMP, 1);
+        if (next < state.level) {
+          useGameProgressStore.getState().updateProgress({ level: next });
+          showBanner('💪 המשך להתאמן! חזרת לרמה קלה יותר', false);
+        }
+      }
+    });
+
+    return () => {
+      unsub();
+      windowRef.current = [];
+      prevRef.current = { attempts: 0, correctAnswers: 0 };
+      if (timerRef.current) clearTimeout(timerRef.current);
+    };
+  }, []);
+
+  // Reset window when a new game starts (attempts reset to 0)
+  useEffect(() => {
+    const unsub = useGameProgressStore.subscribe((state, prev) => {
+      if (state.attempts === 0 && prev.attempts > 0) {
+        windowRef.current = [];
+        prevRef.current = { attempts: 0, correctAnswers: 0 };
+        setBanner(null);
+      }
+    });
+    return () => unsub();
+  }, []);
+
+  return { banner };
+}


### PR DESCRIPTION
## What
After every 10 answers, the game automatically adjusts difficulty based on a sliding accuracy window — no child input needed.

- **`useAdaptiveDifficulty`** (new hook): subscribes to `gameProgressStore`, tracks the last 10 answers in a boolean window, bumps `level` by ±3 when accuracy crosses 85% (up) or 40% (down)
- **`AdaptiveDifficultyBanner`** (new component): floating pill that animates in for 3 seconds when the level adjusts — "🌟 עלית לרמה קשה יותר" or "💪 חזרת לרמה קלה יותר"
- **`UltimateGamePage`**: renders the banner during gameplay (sits alongside the existing SpeedBurstTimer)

## Why
Closes #1149

## Conflicts resolved
`UltimateGamePage.tsx` conflicted with #1040 (SpeedBurstTimer); merged both — SpeedBurstTimer + AdaptiveDifficultyBanner coexist.

## Test plan
- [ ] Play a card game and answer 10 questions correctly in a row — see green "עלית לרמה" banner and harder item pool
- [ ] Answer 10 questions mostly wrong — see orange "חזרת לרמה" banner and easier pool
- [ ] Banner disappears after 3 seconds without any user interaction
- [ ] Level never goes below 1 or above 30
- [ ] `npx tsc --noEmit` passes ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)