### PR TITLE
feat(engagement): emoji avatar picker for child profile (closes #1039)

### DIFF
--- a/gamesformykids/app/settings/SettingsClient.tsx
+++ b/gamesformykids/app/settings/SettingsClient.tsx
@@ -8,6 +8,7 @@ import { AudioSection } from '@/components/settings/AudioSection';
 import { AppearanceSection } from '@/components/settings/AppearanceSection';
 import { AccountSection } from '@/components/settings/AccountSection';
 import { ColorblindSection } from '@/components/settings/ColorblindSection';
+import { AvatarSection } from '@/components/settings/AvatarSection';
 import GameSpinnerScreen from '@/components/ui/GameSpinnerScreen';
 
 export default function SettingsClient() {
@@ -72,6 +73,7 @@ export default function SettingsClient() {
             disabled={saving}
           />
           <ColorblindSection />
+          <AvatarSection />
           <AccountSection onSignOut={handleSignOut} />
         </div>
 

--- a/gamesformykids/components/game/shared/GameCompletionCelebration.tsx
+++ b/gamesformykids/components/game/shared/GameCompletionCelebration.tsx
@@ -5,6 +5,7 @@ import { useParams } from 'next/navigation';
 import { useGameAudio } from '@/hooks/shared/audio/useGameAudio';
 import { speakHebrew } from '@/lib/utils/speech/speaker';
 import { getGameConfettiEmojis } from '@/lib/utils/game/getGameConfettiEmojis';
+import { useAvatarEmoji } from '@/hooks/shared/user/useAvatarEmoji';
 
 const CELEBRATION_PHRASES = [
   'כל הכבוד! עשית עבודה מדהימה!',
@@ -40,6 +41,7 @@ export function GameCompletionCelebration({ isPerfect = false }: Props) {
   const { playSuccessSound } = useGameAudio();
   const params = useParams();
   const gameType = typeof params?.gameType === 'string' ? params.gameType : undefined;
+  const { emoji: avatarEmoji } = useAvatarEmoji();
 
   const emojis = getGameConfettiEmojis(gameType) ?? getSeasonalEmojis();
   const particles = Array.from({ length: 20 }, (_, i) => ({
@@ -85,6 +87,14 @@ export function GameCompletionCelebration({ isPerfect = false }: Props) {
             {emoji}
           </span>
         ))}
+        {avatarEmoji && (
+          <span
+            className="absolute top-1/4 left-1/2 -translate-x-1/2 motion-safe:animate-bounce"
+            style={{ fontSize: '4rem' }}
+          >
+            {avatarEmoji}
+          </span>
+        )}
       </div>
     </>
   );

--- a/gamesformykids/components/marketing/ContinueBanner.tsx
+++ b/gamesformykids/components/marketing/ContinueBanner.tsx
@@ -4,9 +4,11 @@ import Link from 'next/link';
 import { X } from 'lucide-react';
 import { GamesRegistry } from '@/lib/registry/gamesRegistry';
 import { useContinueBanner } from '@/hooks/shared/marketing/useContinueBanner';
+import { useAvatarEmoji } from '@/hooks/shared/user/useAvatarEmoji';
 
 export default function ContinueBanner() {
   const { data, dismissed, dismiss } = useContinueBanner();
+  const { emoji: avatarEmoji } = useAvatarEmoji();
 
   if (!data || dismissed) return null;
 
@@ -15,7 +17,11 @@ export default function ContinueBanner() {
 
   return (
     <div dir="rtl" className="mx-4 mt-3 rounded-2xl bg-linear-to-l from-purple-500 to-indigo-600 text-white shadow-lg flex items-center gap-3 px-4 py-3">
-      <span className="text-3xl">{reg.emoji}</span>
+      {avatarEmoji ? (
+        <span className="text-3xl">{avatarEmoji}</span>
+      ) : (
+        <span className="text-3xl">{reg.emoji}</span>
+      )}
       <div className="flex-1 min-w-0">
         <p className="text-xs opacity-80 font-medium">ממשיכים מאיפה שעצרת</p>
         <p className="font-bold truncate">{reg.title}</p>

--- a/gamesformykids/components/settings/AvatarSection.tsx
+++ b/gamesformykids/components/settings/AvatarSection.tsx
@@ -1,0 +1,52 @@
+'use client';
+
+import { useState } from 'react';
+import { useAvatarEmoji } from '@/hooks/shared/user/useAvatarEmoji';
+import EmojiAvatarPicker from '@/components/shared/EmojiAvatarPicker';
+import { SectionContainer } from './SectionContainer';
+
+export function AvatarSection() {
+  const { emoji, setEmoji, clearEmoji } = useAvatarEmoji();
+  const [showPicker, setShowPicker] = useState(false);
+
+  return (
+    <SectionContainer title="אוואטר" emoji="🦁">
+      <div className="flex items-center justify-between gap-4">
+        <div>
+          <p className="font-medium text-gray-800">האוואטר שלי</p>
+          <p className="text-sm text-gray-500 mt-0.5">
+            מופיע בחגיגות ובבאנר ההמשך
+          </p>
+        </div>
+        <div className="flex items-center gap-2">
+          {emoji && (
+            <span className="text-4xl">{emoji}</span>
+          )}
+          <button
+            type="button"
+            onClick={() => setShowPicker(true)}
+            className="px-3 py-2 rounded-xl bg-purple-100 text-purple-700 font-semibold text-sm hover:bg-purple-200 transition-colors"
+          >
+            {emoji ? 'שנה' : 'בחר אוואטר'}
+          </button>
+          {emoji && (
+            <button
+              type="button"
+              onClick={clearEmoji}
+              className="px-3 py-2 rounded-xl bg-gray-100 text-gray-500 font-semibold text-sm hover:bg-gray-200 transition-colors"
+            >
+              הסר
+            </button>
+          )}
+        </div>
+      </div>
+      {showPicker && (
+        <EmojiAvatarPicker
+          current={emoji}
+          onSelect={setEmoji}
+          onClose={() => setShowPicker(false)}
+        />
+      )}
+    </SectionContainer>
+  );
+}

--- a/gamesformykids/components/shared/EmojiAvatarPicker.tsx
+++ b/gamesformykids/components/shared/EmojiAvatarPicker.tsx
@@ -1,0 +1,51 @@
+'use client';
+
+import { AVATAR_LIST } from '@/hooks/shared/user/useAvatarEmoji';
+
+interface Props {
+  current: string;
+  onSelect: (emoji: string) => void;
+  onClose: () => void;
+}
+
+export default function EmojiAvatarPicker({ current, onSelect, onClose }: Props) {
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60"
+      dir="rtl"
+      onClick={onClose}
+    >
+      <div
+        className="bg-white rounded-3xl shadow-2xl p-6 max-w-xs w-full mx-4"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <h3 className="text-xl font-black text-center text-gray-800 mb-4">בחר אוואטר</h3>
+        <div className="grid grid-cols-5 gap-2">
+          {AVATAR_LIST.map((e) => (
+            <button
+              key={e}
+              type="button"
+              onClick={() => { onSelect(e); onClose(); }}
+              className={`
+                text-3xl p-2 rounded-2xl transition-all duration-150 active:scale-90
+                ${current === e
+                  ? 'bg-purple-100 ring-2 ring-purple-500 scale-110'
+                  : 'hover:bg-gray-100'}
+              `}
+              aria-label={e}
+            >
+              {e}
+            </button>
+          ))}
+        </div>
+        <button
+          type="button"
+          onClick={onClose}
+          className="mt-4 w-full py-2 rounded-2xl border-2 border-gray-200 text-gray-500 font-semibold text-sm hover:bg-gray-50"
+        >
+          ביטול
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/gamesformykids/hooks/shared/user/useAvatarEmoji.ts
+++ b/gamesformykids/hooks/shared/user/useAvatarEmoji.ts
@@ -1,0 +1,34 @@
+'use client';
+
+import { useState, useCallback } from 'react';
+
+const LS_KEY = 'gfk_avatar_emoji';
+
+export const AVATAR_OPTIONS = [
+  '🦁', '🦊', '🐼', '🦋', '🐸', '🦄',
+  '🐶', '🐱', '🦖', '🚀', '🐬', '🦅',
+  '🐨', '🦞', '🦓', '🌟', '🐯', '🦒',
+  '🐙', '🦁',
+];
+
+// Deduplicated avatar list
+export const AVATAR_LIST = [...new Set(AVATAR_OPTIONS)];
+
+export function useAvatarEmoji() {
+  const [emoji, setEmojiState] = useState<string>(() => {
+    if (typeof window === 'undefined') return '';
+    return localStorage.getItem(LS_KEY) ?? '';
+  });
+
+  const setEmoji = useCallback((e: string) => {
+    setEmojiState(e);
+    localStorage.setItem(LS_KEY, e);
+  }, []);
+
+  const clearEmoji = useCallback(() => {
+    setEmojiState('');
+    localStorage.removeItem(LS_KEY);
+  }, []);
+
+  return { emoji, setEmoji, clearEmoji };
+}


### PR DESCRIPTION
## What
Lets children pick a personal emoji avatar that appears in celebration screens and the home page "continue" banner.

- **`useAvatarEmoji`** (new): reads/writes `gfk_avatar_emoji` in localStorage — no auth required, works for guests
- **`EmojiAvatarPicker`** (new): modal with a 5-column grid of 19 emoji options (animals, nature, space)
- **`GameCompletionCelebration`**: shows the chosen avatar bouncing in the center of the confetti shower
- **`ContinueBanner`**: replaces the generic game emoji with the child's avatar when one is set
- **`AvatarSection`** (new): settings section with preview, "שנה" (change) and "הסר" (remove) buttons

## Why
Closes #1039

## Conflicts note
`SettingsClient.tsx` — this branch adds `AvatarSection`. PR #1148 (holiday themes) adds `HolidaySection` to the same file — expect a trivial import/render conflict when the two branches merge to main.

## Test plan
- [ ] Go to `/settings` → see "אוואטר" section → click "בחר אוואטר" → pick 🦁
- [ ] Finish a game → see 🦁 bouncing in center of confetti
- [ ] Return to home page → ContinueBanner shows 🦁 instead of game emoji
- [ ] Refresh page → avatar persists
- [ ] Go to settings → "שנה" opens picker again; "הסר" clears it
- [ ] `npx tsc --noEmit` passes ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)