### PR TITLE
feat(engagement): parental screen time countdown timer (closes #1028)

### DIFF
--- a/gamesformykids/app/games/layout.tsx
+++ b/gamesformykids/app/games/layout.tsx
@@ -1,5 +1,6 @@
 import UniversalGameNavigation from '@/components/game/universal/navigation/UniversalGameNavigation';
 import SwipeNavigator from '@/components/game/shared/SwipeNavigator';
+import ScreenTimeOverlay from '@/components/game/shared/ScreenTimeOverlay';
 import { ReactNode } from 'react';
 
 interface GamesLayoutProps {
@@ -18,6 +19,9 @@ export default function GamesLayout({ children }: GamesLayoutProps) {
 
       {/* RTL swipe gesture handler + first-visit hint */}
       <SwipeNavigator />
+
+      {/* Screen time overlay — only renders when limit is set and reached */}
+      <ScreenTimeOverlay />
 
       {/* Game Content — pt reserves space below the fixed nav bar (~56px = top-4 + button height) */}
       <div className="pt-16 md:pt-20">

--- a/gamesformykids/app/settings/SettingsClient.tsx
+++ b/gamesformykids/app/settings/SettingsClient.tsx
@@ -9,6 +9,7 @@ import { AppearanceSection } from '@/components/settings/AppearanceSection';
 import { AccountSection } from '@/components/settings/AccountSection';
 import { ColorblindSection } from '@/components/settings/ColorblindSection';
 import { AvatarSection } from '@/components/settings/AvatarSection';
+import { ScreenTimeSection } from '@/components/settings/ScreenTimeSection';
 import GameSpinnerScreen from '@/components/ui/GameSpinnerScreen';
 
 export default function SettingsClient() {
@@ -74,6 +75,7 @@ export default function SettingsClient() {
           />
           <ColorblindSection />
           <AvatarSection />
+          <ScreenTimeSection />
           <AccountSection onSignOut={handleSignOut} />
         </div>
 

--- a/gamesformykids/components/game/shared/ScreenTimeOverlay.tsx
+++ b/gamesformykids/components/game/shared/ScreenTimeOverlay.tsx
@@ -1,0 +1,111 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { useScreenTimeStore } from '@/lib/stores/screenTimeStore';
+
+const CHECK_INTERVAL_MS = 60_000; // check every minute
+
+function getElapsedMinutes(startMs: number | null, extended: boolean): number {
+  if (!startMs) return 0;
+  const extraMs = extended ? 5 * 60_000 : 0;
+  return Math.floor((Date.now() - startMs + extraMs) / 60_000);
+}
+
+function getElapsedDisplay(startMs: number | null): string {
+  if (!startMs) return '0 דקות';
+  const mins = Math.floor((Date.now() - startMs) / 60_000);
+  if (mins < 60) return `${mins} דקות`;
+  const h = Math.floor(mins / 60);
+  const m = mins % 60;
+  return m > 0 ? `${h} שעות ו-${m} דקות` : `${h} שעות`;
+}
+
+export default function ScreenTimeOverlay() {
+  const router = useRouter();
+  const {
+    timeLimitMinutes,
+    sessionStartMs,
+    extended,
+    ensureSessionStart,
+    extend5Minutes,
+    resetSession,
+  } = useScreenTimeStore();
+
+  const [expired, setExpired] = useState(false);
+  const [dismissed, setDismissed] = useState(false);
+
+  // Ensure session start is recorded
+  useEffect(() => {
+    ensureSessionStart();
+  }, [ensureSessionStart]);
+
+  // Poll for expiry every minute
+  useEffect(() => {
+    if (!timeLimitMinutes || dismissed) return;
+
+    const check = () => {
+      const elapsed = getElapsedMinutes(
+        useScreenTimeStore.getState().sessionStartMs,
+        useScreenTimeStore.getState().extended,
+      );
+      if (elapsed >= timeLimitMinutes) {
+        setExpired(true);
+      }
+    };
+
+    check(); // immediate check on mount
+    const id = setInterval(check, CHECK_INTERVAL_MS);
+    return () => clearInterval(id);
+  }, [timeLimitMinutes, dismissed]);
+
+  if (!expired || dismissed) return null;
+
+  const elapsedDisplay = getElapsedDisplay(sessionStartMs);
+
+  const handleExtend = () => {
+    extend5Minutes();
+    setExpired(false);
+    setDismissed(false);
+  };
+
+  const handleFinish = () => {
+    resetSession();
+    setDismissed(true);
+    router.push('/');
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-[200] flex items-center justify-center bg-black/70"
+      dir="rtl"
+    >
+      <div className="bg-white rounded-3xl shadow-2xl p-8 text-center max-w-sm w-full mx-4">
+        <div className="text-6xl mb-4 motion-safe:animate-bounce">🕐</div>
+        <h2 className="text-2xl font-black text-gray-800 mb-2">הזמן הסתיים!</h2>
+        <p className="text-lg text-gray-600 mb-1">
+          שיחקת <span className="font-bold text-purple-600">{elapsedDisplay}</span> היום
+        </p>
+        <p className="text-sm text-gray-400 mb-6">כל הכבוד על המשחק! 🎉</p>
+
+        <div className="flex flex-col gap-3">
+          <button
+            onClick={handleFinish}
+            className="w-full py-4 rounded-2xl bg-linear-to-l from-purple-500 to-indigo-600 text-white font-bold text-lg hover:opacity-90 active:scale-95 transition-[transform,opacity]"
+          >
+            🏠 סיים ולדף הבית
+          </button>
+
+          {!extended && (
+            <button
+              onClick={handleExtend}
+              className="w-full py-3 rounded-2xl border-2 border-purple-200 text-purple-600 font-semibold hover:bg-purple-50 active:scale-95 transition-[transform,background-color]"
+            >
+              ⏱️ עוד 5 דקות
+            </button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/gamesformykids/components/settings/ScreenTimeSection.tsx
+++ b/gamesformykids/components/settings/ScreenTimeSection.tsx
@@ -1,0 +1,44 @@
+'use client';
+
+import { useScreenTimeStore } from '@/lib/stores/screenTimeStore';
+import { SectionContainer } from './SectionContainer';
+
+const OPTIONS: { label: string; value: number | null }[] = [
+  { label: 'אין הגבלה', value: null },
+  { label: '15 דקות', value: 15 },
+  { label: '30 דקות', value: 30 },
+  { label: '45 דקות', value: 45 },
+  { label: '60 דקות', value: 60 },
+];
+
+export function ScreenTimeSection() {
+  const timeLimitMinutes = useScreenTimeStore((s) => s.timeLimitMinutes);
+  const setTimeLimit = useScreenTimeStore((s) => s.setTimeLimit);
+
+  return (
+    <SectionContainer title="זמן משחק" emoji="⏱️">
+      <div className="space-y-3">
+        <p className="text-sm text-gray-500">
+          כשהזמן נגמר, מוצגת הודעה ידידותית. ניתן להאריך ב-5 דקות פעם אחת.
+        </p>
+        <div className="flex flex-wrap gap-2">
+          {OPTIONS.map(({ label, value }) => (
+            <button
+              key={String(value)}
+              type="button"
+              onClick={() => setTimeLimit(value)}
+              className={`
+                px-4 py-2 rounded-xl text-sm font-semibold border-2 transition-all
+                ${timeLimitMinutes === value
+                  ? 'bg-purple-500 border-purple-600 text-white shadow-md'
+                  : 'bg-white border-gray-200 text-gray-700 hover:border-purple-300'}
+              `}
+            >
+              {label}
+            </button>
+          ))}
+        </div>
+      </div>
+    </SectionContainer>
+  );
+}

--- a/gamesformykids/lib/stores/screenTimeStore.ts
+++ b/gamesformykids/lib/stores/screenTimeStore.ts
@@ -1,0 +1,57 @@
+'use client';
+
+import { makePersistStore } from './createStore';
+
+const MIDNIGHT_RESETS = true;
+
+function todayStart(): number {
+  const d = new Date();
+  d.setHours(0, 0, 0, 0);
+  return d.getTime();
+}
+
+interface ScreenTimeState {
+  /** null = no limit */
+  timeLimitMinutes: number | null;
+  /** timestamp when the current session started (resets at midnight) */
+  sessionStartMs: number | null;
+  /** whether the user has already used "5 more minutes" this session */
+  extended: boolean;
+}
+
+interface ScreenTimeActions {
+  setTimeLimit: (minutes: number | null) => void;
+  ensureSessionStart: () => void;
+  extend5Minutes: () => void;
+  resetSession: () => void;
+}
+
+export const useScreenTimeStore = makePersistStore<ScreenTimeState & ScreenTimeActions>(
+  'ScreenTimeStore',
+  'gfk-screen-time',
+  (set, get) => ({
+    timeLimitMinutes: null,
+    sessionStartMs: null,
+    extended: false,
+
+    setTimeLimit: (minutes) => set({ timeLimitMinutes: minutes }, false, 'screenTime/setLimit'),
+
+    ensureSessionStart: () => {
+      const { sessionStartMs } = get();
+      const now = Date.now();
+      if (!sessionStartMs) {
+        set({ sessionStartMs: now, extended: false }, false, 'screenTime/startSession');
+        return;
+      }
+      // Reset at midnight
+      if (MIDNIGHT_RESETS && sessionStartMs < todayStart()) {
+        set({ sessionStartMs: now, extended: false }, false, 'screenTime/midnightReset');
+      }
+    },
+
+    extend5Minutes: () => set({ extended: true }, false, 'screenTime/extend'),
+
+    resetSession: () => set({ sessionStartMs: Date.now(), extended: false }, false, 'screenTime/reset'),
+  }),
+  { version: 1 },
+);


### PR DESCRIPTION
## What
Adds a parental screen-time limit feature:

- **`lib/stores/screenTimeStore.ts`** — persisted Zustand store with `timeLimitMinutes`, `sessionStartMs`, `extended` state; auto-resets at midnight
- **`components/game/shared/ScreenTimeOverlay.tsx`** — full-screen overlay that appears when the limit is reached; polls every 60 s; shows elapsed time, "🏠 סיים ולדף הבית" (goes home + resets), and "⏱️ עוד 5 דקות" (one-time 5-minute extension)
- **`components/settings/ScreenTimeSection.tsx`** — radio-style selector (no limit / 15 / 30 / 45 / 60 min) in Settings
- **`app/games/layout.tsx`** — mounts `<ScreenTimeOverlay />` so it covers all game screens
- **`app/settings/SettingsClient.tsx`** — renders `<ScreenTimeSection />` after the Avatar section

## Why
Closes #1028

## Merge notes
Conflict with #1352 (avatar picker) in `SettingsClient.tsx` — resolved by keeping both `<AvatarSection />` and `<ScreenTimeSection />`.

## Test plan
- [ ] Go to Settings → set a 15-min limit
- [ ] Play any game for >15 min (or temporarily lower `CHECK_INTERVAL_MS` and manipulate `sessionStartMs` in DevTools)
- [ ] Overlay appears with correct elapsed time
- [ ] "עוד 5 דקות" extends once and hides itself
- [ ] "סיים ולדף הבית" redirects to `/` and resets the session
- [ ] No overlay when `timeLimitMinutes` is null

🤖 Generated with [Claude Code](https://claude.com/claude-code)