### PR TITLE
feat(gamification): championship mode — 3-round tournament (closes #1151)

### DIFF
--- a/gamesformykids/app/championship/[categoryId]/ChampionshipClient.tsx
+++ b/gamesformykids/app/championship/[categoryId]/ChampionshipClient.tsx
@@ -1,0 +1,167 @@
+'use client';
+
+import { useEffect } from 'react';
+import { useRouter } from 'next/navigation';
+import Link from 'next/link';
+import { useChampionshipStore } from '@/lib/stores/championshipStore';
+
+const ROUND_LABELS = ['סיבוב א׳', 'סיבוב ב׳', 'סיבוב ג׳'];
+const ROUND_EMOJIS = ['1️⃣', '2️⃣', '3️⃣'];
+
+interface Props {
+  categoryId: string;
+}
+
+export default function ChampionshipClient({ categoryId }: Props) {
+  const router = useRouter();
+  const { active, categoryId: storedCat, categoryTitle, gameIds, round, scores, resetChampionship } =
+    useChampionshipStore();
+
+  // Redirect home if no championship active for this category
+  useEffect(() => {
+    if (!active || storedCat !== categoryId) {
+      router.replace('/');
+    }
+  }, [active, storedCat, categoryId, router]);
+
+  if (!active || storedCat !== categoryId || !gameIds) return null;
+
+  const isDone = round === 4;
+  const totalScore = scores.reduce<number>((sum, s) => sum + (s ?? 0), 0);
+
+  if (isDone) {
+    return (
+      <div
+        className="min-h-screen flex flex-col items-center justify-center bg-linear-to-br from-yellow-100 to-amber-200 p-6 text-center"
+        dir="rtl"
+      >
+        <div className="text-8xl mb-4 motion-safe:animate-bounce">🏆</div>
+        <h1 className="text-4xl font-black text-amber-800 mb-2">
+          אלוף{categoryTitle ? ` ה${categoryTitle}` : ''}!
+        </h1>
+        <p className="text-2xl font-bold text-amber-700 mb-1">
+          ניקוד כולל: <span className="text-amber-900">{totalScore}</span> נקודות
+        </p>
+
+        <div className="mt-6 grid grid-cols-3 gap-4 w-full max-w-sm">
+          {gameIds.map((gid, i) => (
+            <div
+              key={gid}
+              className="bg-white rounded-2xl p-3 shadow flex flex-col items-center gap-1"
+            >
+              <span className="text-2xl">{ROUND_EMOJIS[i]}</span>
+              <span className="text-xs text-gray-500 font-medium">{ROUND_LABELS[i]}</span>
+              <span className="text-lg font-black text-purple-700">{scores[i] ?? 0}</span>
+            </div>
+          ))}
+        </div>
+
+        <div className="mt-8 flex flex-col gap-3 w-full max-w-xs">
+          <button
+            onClick={() => {
+              resetChampionship();
+              router.push('/');
+            }}
+            className="w-full py-4 rounded-2xl bg-linear-to-l from-amber-500 to-yellow-400 text-white font-black text-lg hover:opacity-90 active:scale-95 transition-[transform,opacity]"
+          >
+            🏠 חזור לדף הבית
+          </button>
+          <button
+            onClick={() => router.back()}
+            className="w-full py-3 rounded-2xl border-2 border-amber-300 text-amber-700 font-semibold hover:bg-amber-50 active:scale-95 transition-[transform,background-color]"
+          >
+            שחק שוב אליפות
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  // Active championship — show rounds progress + play button
+  const currentGameId = round >= 1 && round <= 3 ? gameIds[round - 1] : null;
+
+  return (
+    <div
+      className="min-h-screen bg-linear-to-br from-yellow-50 to-amber-100 p-6"
+      dir="rtl"
+    >
+      <div className="max-w-md mx-auto">
+        {/* Header */}
+        <div className="text-center mb-8">
+          <div className="text-6xl mb-2">🏆</div>
+          <h1 className="text-3xl font-black text-amber-800">
+            אליפות{categoryTitle ? ` ${categoryTitle}` : ''}
+          </h1>
+          <p className="text-amber-600 mt-1 text-sm">3 סיבובים — ניקוד מצטבר</p>
+        </div>
+
+        {/* Round cards */}
+        <div className="space-y-3 mb-8">
+          {gameIds.map((gid, i) => {
+            const roundNum = i + 1;
+            const isCurrentRound = round === roundNum;
+            const isCompleted = (round - 1) > i;
+            const isPending = round < roundNum;
+
+            return (
+              <div
+                key={gid}
+                className={`
+                  rounded-2xl p-4 flex items-center justify-between shadow-sm
+                  ${isCurrentRound ? 'bg-amber-400 shadow-amber-200 shadow-md' : ''}
+                  ${isCompleted ? 'bg-green-100 border-2 border-green-300' : ''}
+                  ${isPending ? 'bg-white opacity-60' : ''}
+                `}
+              >
+                <div className="flex items-center gap-3">
+                  <span className="text-3xl">{ROUND_EMOJIS[i]}</span>
+                  <div>
+                    <p className={`font-bold ${isCurrentRound ? 'text-white' : 'text-gray-800'}`}>
+                      {ROUND_LABELS[i]}
+                    </p>
+                    <p className={`text-xs ${isCurrentRound ? 'text-amber-100' : 'text-gray-500'}`}>
+                      {gid}
+                    </p>
+                  </div>
+                </div>
+                <div className="text-left">
+                  {isCompleted && (
+                    <span className="text-green-700 font-black text-lg">
+                      ✓ {scores[i]} נ׳
+                    </span>
+                  )}
+                  {isPending && <span className="text-gray-400 text-xl">⏳</span>}
+                  {isCurrentRound && (
+                    <span className="text-white font-bold text-sm">עכשיו!</span>
+                  )}
+                </div>
+              </div>
+            );
+          })}
+        </div>
+
+        {/* CTA */}
+        {currentGameId && (
+          <Link
+            href={`/games/${currentGameId}`}
+            className="block w-full py-5 rounded-2xl bg-linear-to-l from-purple-500 to-indigo-600 text-white font-black text-xl text-center hover:opacity-90 active:scale-95 transition-[transform,opacity] shadow-lg"
+          >
+            ▶ שחק סיבוב {round}
+          </Link>
+        )}
+
+        <button
+          onClick={() => {
+            if (window.confirm('לבטל את האליפות?')) {
+              resetChampionship();
+              router.push('/');
+            }
+          }}
+          className="mt-4 w-full py-3 rounded-xl text-gray-400 text-sm hover:text-red-400 transition-colors"
+        >
+          ביטול אליפות
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/gamesformykids/app/championship/[categoryId]/page.tsx
+++ b/gamesformykids/app/championship/[categoryId]/page.tsx
@@ -1,0 +1,10 @@
+import ChampionshipClient from './ChampionshipClient';
+
+interface Props {
+  params: Promise<{ categoryId: string }>;
+}
+
+export default async function ChampionshipPage({ params }: Props) {
+  const { categoryId } = await params;
+  return <ChampionshipClient categoryId={categoryId} />;
+}

--- a/gamesformykids/app/games/layout.tsx
+++ b/gamesformykids/app/games/layout.tsx
@@ -1,6 +1,7 @@
 import UniversalGameNavigation from '@/components/game/universal/navigation/UniversalGameNavigation';
 import SwipeNavigator from '@/components/game/shared/SwipeNavigator';
 import ScreenTimeOverlay from '@/components/game/shared/ScreenTimeOverlay';
+import ChampionshipOverlay from '@/components/game/shared/ChampionshipOverlay';
 import { ReactNode } from 'react';
 
 interface GamesLayoutProps {
@@ -22,6 +23,9 @@ export default function GamesLayout({ children }: GamesLayoutProps) {
 
       {/* Screen time overlay — only renders when limit is set and reached */}
       <ScreenTimeOverlay />
+
+      {/* Championship mode bottom bar — only renders when a championship is active */}
+      <ChampionshipOverlay />
 
       {/* Game Content — pt reserves space below the fixed nav bar (~56px = top-4 + button height) */}
       <div className="pt-16 md:pt-20">

--- a/gamesformykids/components/game/CategoryGamesView.tsx
+++ b/gamesformykids/components/game/CategoryGamesView.tsx
@@ -1,18 +1,35 @@
 "use client";
 
-import { useMemo } from "react";
+import { useMemo, useCallback } from "react";
+import { useRouter } from "next/navigation";
 import GameCard from "./GameCard";
 import { useHomePageStore } from "@/lib/stores";
 import { GAME_CATEGORIES } from "@/lib/constants/gameCategories";
 import { GamesRegistry } from "@/lib/registry/gamesRegistry";
 import { useGridFillers } from "@/hooks";
 import { useAgeFilterStore, isAgeAppropriate } from "@/lib/stores/ageFilterStore";
+import { useChampionshipStore } from "@/lib/stores/championshipStore";
+
+const MIN_GAMES_FOR_CHAMPIONSHIP = 3;
+
+function pickThreeRandom(ids: string[]): [string, string, string] {
+  const pool = [...ids];
+  const result: string[] = [];
+  for (let i = 0; i < 3; i++) {
+    const idx = Math.floor(Math.random() * pool.length);
+    const removed = pool.splice(idx, 1);
+    result.push(removed[0]!);
+  }
+  return result as [string, string, string];
+}
 
 export default function CategoryGamesView() {
+  const router = useRouter();
   const selectedCategory = useHomePageStore((s) => s.selectedCategory);
   const backToCategories = useHomePageStore((s) => s.backToCategories);
   const allGameRegistrations = useMemo(() => GamesRegistry.getAllGameRegistrations(), []);
   const ageRange = useAgeFilterStore((s) => s.ageRange);
+  const { startChampionship } = useChampionshipStore();
 
   const category = selectedCategory ? GAME_CATEGORIES[selectedCategory] : null;
   const categoryGames = useMemo(
@@ -26,9 +43,19 @@ export default function CategoryGamesView() {
         : [],
     [category, allGameRegistrations, ageRange],
   );
+  const availableGames = useMemo(() => categoryGames.filter(g => g.available), [categoryGames]);
   const fillerCount = useGridFillers(categoryGames.length);
 
+  const handleStartChampionship = useCallback(() => {
+    if (!selectedCategory || !category || availableGames.length < MIN_GAMES_FOR_CHAMPIONSHIP) return;
+    const pickedIds = pickThreeRandom(availableGames.map(g => g.id));
+    startChampionship(selectedCategory, category.title, pickedIds);
+    router.push(`/championship/${selectedCategory}`);
+  }, [selectedCategory, category, availableGames, startChampionship, router]);
+
   if (!selectedCategory || !category) return null;
+
+  const canStartChampionship = availableGames.length >= MIN_GAMES_FOR_CHAMPIONSHIP;
 
   return (
     <div>
@@ -45,14 +72,24 @@ export default function CategoryGamesView() {
         <p className="text-sm md:text-lg text-gray-600 mb-2 md:mb-3 hidden sm:block">
           {category.description}
         </p>
-        <div className="inline-block bg-blue-100 rounded-full px-3 py-1 md:px-4 md:py-2">
-          <span className="text-blue-800 font-semibold text-sm md:text-base">
-            {categoryGames.length} משחקים 
-            ({categoryGames.filter(g => g.available).length} זמינים)
-          </span>
+        <div className="flex flex-wrap items-center justify-center gap-3 mb-1">
+          <div className="inline-block bg-blue-100 rounded-full px-3 py-1 md:px-4 md:py-2">
+            <span className="text-blue-800 font-semibold text-sm md:text-base">
+              {categoryGames.length} משחקים
+              ({availableGames.length} זמינים)
+            </span>
+          </div>
+          {canStartChampionship && (
+            <button
+              onClick={handleStartChampionship}
+              className="inline-flex items-center gap-1.5 px-4 py-2 rounded-full bg-linear-to-l from-amber-500 to-yellow-400 text-amber-900 font-bold text-sm hover:opacity-90 active:scale-95 transition-[transform,opacity] shadow"
+            >
+              🏆 התחל אליפות
+            </button>
+          )}
         </div>
       </div>
-      
+
       <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-3 md:gap-4 lg:gap-6">
         {categoryGames.length > 0 ? (
           <>

--- a/gamesformykids/components/game/shared/ChampionshipOverlay.tsx
+++ b/gamesformykids/components/game/shared/ChampionshipOverlay.tsx
@@ -1,0 +1,50 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { useChampionshipStore } from '@/lib/stores/championshipStore';
+import { useGameProgressStore } from '@/lib/stores/gameProgressStore';
+
+const ROUND_EMOJIS = ['1️⃣', '2️⃣', '3️⃣'];
+
+export default function ChampionshipOverlay() {
+  const router = useRouter();
+  const { active, categoryId, categoryTitle, gameIds, round, scores, recordRoundScore } =
+    useChampionshipStore();
+  const score = useGameProgressStore((s) => s.score);
+
+  if (!active || round < 1 || round > 3 || !gameIds) return null;
+
+  const roundIdx = round - 1;
+  const totalSoFar = scores.reduce<number>((sum, s) => sum + (s ?? 0), 0);
+
+  const handleFinishRound = () => {
+    recordRoundScore(score);
+    router.push(`/championship/${categoryId}`);
+  };
+
+  return (
+    <div
+      className="fixed bottom-0 inset-x-0 z-[150] flex items-center justify-between gap-3 bg-linear-to-l from-amber-500 to-yellow-400 px-4 py-3 shadow-lg"
+      dir="rtl"
+    >
+      <div className="flex items-center gap-2 min-w-0">
+        <span className="text-2xl">🏆</span>
+        <div className="min-w-0">
+          <p className="text-amber-900 font-black text-sm leading-tight truncate">
+            אליפות {categoryTitle}
+          </p>
+          <p className="text-amber-800 text-xs">
+            {ROUND_EMOJIS[roundIdx]} סיבוב {round}/3 &middot; סה&quot;כ: {totalSoFar} נקודות
+          </p>
+        </div>
+      </div>
+
+      <button
+        onClick={handleFinishRound}
+        className="shrink-0 px-4 py-2 rounded-xl bg-white text-amber-700 font-bold text-sm hover:bg-amber-50 active:scale-95 transition-[transform,background-color]"
+      >
+        סיים סיבוב ✓
+      </button>
+    </div>
+  );
+}

--- a/gamesformykids/lib/stores/championshipStore.ts
+++ b/gamesformykids/lib/stores/championshipStore.ts
@@ -1,0 +1,58 @@
+'use client';
+
+import { makePersistStore } from './createStore';
+
+export interface ChampionshipState {
+  active: boolean;
+  categoryId: string | null;
+  categoryTitle: string | null;
+  /** Exactly 3 gameIds chosen at start */
+  gameIds: [string, string, string] | null;
+  /** 0 = not started, 1-3 = current round, 4 = done */
+  round: 0 | 1 | 2 | 3 | 4;
+  /** Score captured at end of each round (null = not yet played) */
+  scores: [number | null, number | null, number | null];
+}
+
+export interface ChampionshipActions {
+  startChampionship: (categoryId: string, categoryTitle: string, gameIds: [string, string, string]) => void;
+  recordRoundScore: (score: number) => void;
+  resetChampionship: () => void;
+}
+
+const INITIAL: ChampionshipState = {
+  active: false,
+  categoryId: null,
+  categoryTitle: null,
+  gameIds: null,
+  round: 0,
+  scores: [null, null, null],
+};
+
+export const useChampionshipStore = makePersistStore<ChampionshipState & ChampionshipActions>(
+  'ChampionshipStore',
+  'gfk-championship',
+  (set, get) => ({
+    ...INITIAL,
+
+    startChampionship: (categoryId, categoryTitle, gameIds) =>
+      set(
+        { active: true, categoryId, categoryTitle, gameIds, round: 1, scores: [null, null, null] },
+        false,
+        'championship/start',
+      ),
+
+    recordRoundScore: (score) => {
+      const { round, scores } = get();
+      if (round < 1 || round > 3) return;
+      const idx = round - 1;
+      const newScores: [number | null, number | null, number | null] = [...scores] as [number | null, number | null, number | null];
+      newScores[idx] = score;
+      const nextRound = (round + 1) as 1 | 2 | 3 | 4;
+      set({ scores: newScores, round: nextRound }, false, 'championship/recordScore');
+    },
+
+    resetChampionship: () => set({ ...INITIAL }, false, 'championship/reset'),
+  }),
+  { version: 1 },
+);


### PR DESCRIPTION
## What
Adds a championship mode (אליפות) that lets children play 3 consecutive games from the same category and accumulates their score.

**New files:**
- `lib/stores/championshipStore.ts` — persisted Zustand store tracking active championship, picked game IDs, per-round scores, and current round (1→2→3→trophy)
- `app/championship/[categoryId]/page.tsx` + `ChampionshipClient.tsx` — standalone championship page showing round progression, scores so far, and a trophy screen on completion
- `components/game/shared/ChampionshipOverlay.tsx` — fixed bottom bar that appears on every game page while a championship is active; shows round counter, cumulative score, and "סיים סיבוב" button that captures the current game score and returns to the championship page

**Modified files:**
- `components/game/CategoryGamesView.tsx` — adds "🏆 התחל אליפות" button when a category has ≥3 available games; randomly picks 3 and navigates to `/championship/[categoryId]`
- `app/games/layout.tsx` — mounts `<ChampionshipOverlay />` so it appears above all game pages

## Why
Closes #1151

## Merge notes
- `app/games/layout.tsx` will conflict with #1028 (screen time overlay) — both add components to the layout. Resolve by keeping both `<ChampionshipOverlay />` and `<ScreenTimeOverlay />`.

## Test plan
- [ ] Open any category (e.g. "מתמטיקה") on the home page → "🏆 התחל אליפות" button appears in the stats bar
- [ ] Click it → redirected to `/championship/math`; 3 random games shown with round indicators
- [ ] Click "שחק סיבוב 1" → game opens with championship bottom bar showing round 1/3
- [ ] Play for a while, click "סיים סיבוב ✓" → redirected back to championship page with round 1 score recorded
- [ ] Repeat for rounds 2 and 3
- [ ] After round 3, trophy screen appears with cumulative score and individual round breakdown
- [ ] "חזור לדף הבית" resets championship store and navigates home
- [ ] Categories with < 3 available games do NOT show the button

🤖 Generated with [Claude Code](https://claude.com/claude-code)