### PR TITLE
feat(ux): parent age-range filter for home page games (closes #1042)

### DIFF
--- a/gamesformykids/app/settings/SettingsClient.tsx
+++ b/gamesformykids/app/settings/SettingsClient.tsx
@@ -10,6 +10,7 @@ import { AccountSection } from '@/components/settings/AccountSection';
 import { ColorblindSection } from '@/components/settings/ColorblindSection';
 import { AvatarSection } from '@/components/settings/AvatarSection';
 import { ScreenTimeSection } from '@/components/settings/ScreenTimeSection';
+import { AgeFilterSection } from '@/components/settings/AgeFilterSection';
 import GameSpinnerScreen from '@/components/ui/GameSpinnerScreen';
 
 export default function SettingsClient() {
@@ -75,6 +76,7 @@ export default function SettingsClient() {
           />
           <ColorblindSection />
           <AvatarSection />
+          <AgeFilterSection />
           <ScreenTimeSection />
           <AccountSection onSignOut={handleSignOut} />
         </div>

--- a/gamesformykids/components/game/CategoryGamesView.tsx
+++ b/gamesformykids/components/game/CategoryGamesView.tsx
@@ -6,16 +6,25 @@ import { useHomePageStore } from "@/lib/stores";
 import { GAME_CATEGORIES } from "@/lib/constants/gameCategories";
 import { GamesRegistry } from "@/lib/registry/gamesRegistry";
 import { useGridFillers } from "@/hooks";
+import { useAgeFilterStore, isAgeAppropriate } from "@/lib/stores/ageFilterStore";
 
 export default function CategoryGamesView() {
   const selectedCategory = useHomePageStore((s) => s.selectedCategory);
   const backToCategories = useHomePageStore((s) => s.backToCategories);
   const allGameRegistrations = useMemo(() => GamesRegistry.getAllGameRegistrations(), []);
+  const ageRange = useAgeFilterStore((s) => s.ageRange);
 
   const category = selectedCategory ? GAME_CATEGORIES[selectedCategory] : null;
   const categoryGames = useMemo(
-    () => (category ? allGameRegistrations.filter(game => category.gameIds.includes(game.id)) : []),
-    [category, allGameRegistrations]
+    () =>
+      category
+        ? allGameRegistrations.filter(
+            (game) =>
+              category.gameIds.includes(game.id) &&
+              isAgeAppropriate(game.ageMin, ageRange),
+          )
+        : [],
+    [category, allGameRegistrations, ageRange],
   );
   const fillerCount = useGridFillers(categoryGames.length);
 

--- a/gamesformykids/components/game/GameSearchBar.tsx
+++ b/gamesformykids/components/game/GameSearchBar.tsx
@@ -2,6 +2,14 @@
 
 import { Search, X } from 'lucide-react';
 import { GAME_CATEGORIES } from '@/lib/constants/gameCategories';
+import { useAgeFilterStore, type AgeRange } from '@/lib/stores/ageFilterStore';
+
+const AGE_LABELS: Record<AgeRange, string> = {
+  all: 'כל הגילאים',
+  '3-4': 'גיל 3-4',
+  '5-7': 'גיל 5-7',
+  '8-10': 'גיל 8-10',
+};
 
 interface Props {
   query: string;
@@ -20,6 +28,9 @@ export function GameSearchBar({
   hasFilter,
   onClear,
 }: Props) {
+  const ageRange = useAgeFilterStore((s) => s.ageRange);
+  const setAgeRange = useAgeFilterStore((s) => s.setAgeRange);
+
   return (
     <div dir="rtl" className="mb-4 md:mb-6 space-y-3">
       <div className="relative max-w-md mx-auto">
@@ -44,6 +55,21 @@ export function GameSearchBar({
           </button>
         )}
       </div>
+
+      {/* Age filter active badge */}
+      {ageRange !== 'all' && (
+        <div className="flex justify-center">
+          <button
+            onClick={() => setAgeRange('all')}
+            className="inline-flex items-center gap-1.5 px-3 py-1 rounded-full bg-purple-100 text-purple-700 text-xs font-semibold hover:bg-purple-200 transition-colors"
+            aria-label="הסר סינון גיל"
+          >
+            <span>🔧</span>
+            <span>מסנן: {AGE_LABELS[ageRange]}</span>
+            <X className="w-3 h-3" />
+          </button>
+        </div>
+      )}
 
       <div
         className="flex gap-2 overflow-x-auto pb-1 px-1"

--- a/gamesformykids/components/settings/AgeFilterSection.tsx
+++ b/gamesformykids/components/settings/AgeFilterSection.tsx
@@ -1,0 +1,49 @@
+'use client';
+
+import { useAgeFilterStore, type AgeRange } from '@/lib/stores/ageFilterStore';
+import { SectionContainer } from './SectionContainer';
+
+const OPTIONS: { label: string; desc: string; value: AgeRange }[] = [
+  { label: 'הכל', desc: 'הצג את כל המשחקים', value: 'all' },
+  { label: '3-4', desc: 'גן טרום-חובה', value: '3-4' },
+  { label: '5-7', desc: 'גן וכיתות א-ב', value: '5-7' },
+  { label: '8-10', desc: 'כיתות ג-ה', value: '8-10' },
+];
+
+export function AgeFilterSection() {
+  const ageRange = useAgeFilterStore((s) => s.ageRange);
+  const setAgeRange = useAgeFilterStore((s) => s.setAgeRange);
+
+  return (
+    <SectionContainer title="מסנן גיל" emoji="🎂">
+      <div className="space-y-3">
+        <p className="text-sm text-gray-500">
+          הגבל את רשימת המשחקים בדף הבית לגיל הילד שלך.
+        </p>
+        <div className="flex flex-wrap gap-2">
+          {OPTIONS.map(({ label, desc, value }) => (
+            <button
+              key={value}
+              type="button"
+              onClick={() => setAgeRange(value)}
+              title={desc}
+              className={`
+                px-4 py-2 rounded-xl text-sm font-semibold border-2 transition-all
+                ${ageRange === value
+                  ? 'bg-purple-500 border-purple-600 text-white shadow-md'
+                  : 'bg-white border-gray-200 text-gray-700 hover:border-purple-300'}
+              `}
+            >
+              {label}
+            </button>
+          ))}
+        </div>
+        {ageRange !== 'all' && (
+          <p className="text-xs text-purple-600 font-medium">
+            🔧 פעיל: מוצגים רק משחקים לגיל {ageRange}
+          </p>
+        )}
+      </div>
+    </SectionContainer>
+  );
+}

--- a/gamesformykids/hooks/shared/search/useGameSearch.ts
+++ b/gamesformykids/hooks/shared/search/useGameSearch.ts
@@ -4,10 +4,12 @@ import { useRouter } from 'next/navigation';
 import { GamesRegistry, GameRegistration } from '@/lib/registry/gamesRegistry';
 import { GAME_CATEGORIES } from '@/lib/constants/gameCategories';
 import { useHomePageStore } from '@/lib/stores';
+import { useAgeFilterStore, isAgeAppropriate } from '@/lib/stores/ageFilterStore';
 
 export function useGameSearch() {
   const router = useRouter();
   const showAllGamesView = useHomePageStore((s) => s.showAllGamesView);
+  const ageRange = useAgeFilterStore((s) => s.ageRange);
   const [query, setQueryState] = useState('');
   const [activeCat, setActiveCatState] = useState<string | null>(null);
 
@@ -62,7 +64,8 @@ export function useGameSearch() {
   const allGames = useMemo(() => GamesRegistry.getAllGameRegistrations(), []);
 
   const filteredGames = useMemo((): GameRegistration[] => {
-    let games = allGames;
+    let games = allGames.filter((g) => isAgeAppropriate(g.ageMin, ageRange));
+
     if (activeCat && GAME_CATEGORIES[activeCat]) {
       const ids = new Set(GAME_CATEGORIES[activeCat].gameIds);
       games = games.filter((g) => ids.has(g.id));
@@ -89,7 +92,7 @@ export function useGameSearch() {
     }, []);
 
     return scored.sort((a, b) => b.score - a.score).map(({ game }) => game);
-  }, [allGames, query, activeCat]);
+  }, [allGames, query, activeCat, ageRange]);
 
   return {
     query,
@@ -98,6 +101,7 @@ export function useGameSearch() {
     setActiveCat,
     filteredGames,
     hasFilter: Boolean(query || activeCat),
+    ageRange,
     clearFilters,
   };
 }

--- a/gamesformykids/lib/stores/ageFilterStore.ts
+++ b/gamesformykids/lib/stores/ageFilterStore.ts
@@ -1,0 +1,32 @@
+'use client';
+
+import { makePersistStore } from './createStore';
+
+export type AgeRange = 'all' | '3-4' | '5-7' | '8-10';
+
+export interface AgeFilterState {
+  ageRange: AgeRange;
+}
+
+export interface AgeFilterActions {
+  setAgeRange: (range: AgeRange) => void;
+}
+
+export const useAgeFilterStore = makePersistStore<AgeFilterState & AgeFilterActions>(
+  'AgeFilterStore',
+  'gfk-age-filter',
+  (set) => ({
+    ageRange: 'all',
+    setAgeRange: (range) => set({ ageRange: range }, false, 'ageFilter/setRange'),
+  }),
+  { version: 1 },
+);
+
+/** Returns true if a game's ageMin is compatible with the selected range. */
+export function isAgeAppropriate(ageMin: number | undefined, range: AgeRange): boolean {
+  if (range === 'all' || ageMin === undefined) return true;
+  if (range === '3-4') return ageMin <= 4;
+  if (range === '5-7') return ageMin <= 7;
+  if (range === '8-10') return ageMin >= 5;
+  return true;
+}


### PR DESCRIPTION
## What
Adds a parent-controlled age filter that hides age-inappropriate games from the home page.

**New files:**
- `lib/stores/ageFilterStore.ts` — persisted Zustand store with `ageRange: 'all' | '3-4' | '5-7' | '8-10'`; `isAgeAppropriate(ageMin, range)` helper
- `components/settings/AgeFilterSection.tsx` — 4-button selector in Settings page

**Modified files:**
- `hooks/shared/search/useGameSearch.ts` — applies age filter to all game search results (including AllGamesView)
- `components/game/CategoryGamesView.tsx` — applies age filter within category game lists
- `components/game/GameSearchBar.tsx` — shows "🔧 מסנן: גיל 3-4 ×" active badge that clears the filter on click
- `app/settings/SettingsClient.tsx` — adds `<AgeFilterSection />` to settings page

## Age range logic
- `3-4`: show games where `ageMin <= 4` (simplest games only)
- `5-7`: show games where `ageMin <= 7` (broad range for school-age beginners)
- `8-10`: show games where `ageMin >= 5` (hide the very simplest games)
- `all`: no filter (default)

Note: All 205 registry entries already have `ageMin` populated (3–8), so no data migration needed.

## Why
Closes #1042

## Merge notes
- `app/settings/SettingsClient.tsx` conflicts with #1028 (ScreenTimeSection) — resolved by keeping both sections.

## Test plan
- [ ] Settings page → "מסנן גיל" section shows 4 options; selected option is highlighted
- [ ] Choose "3-4" → home page category game counts drop; hard games (chess, capitals, algebra) disappear
- [ ] "🔧 מסנן: גיל 3-4 ×" badge appears in search bar; clicking it clears the filter
- [ ] Choose "8-10" → baby games (animals-basic, shapes-3d) are hidden; harder games remain
- [ ] Search results also respect the active age filter
- [ ] Setting persists across page refresh (localStorage)
- [ ] "הכל" shows all games again

🤖 Generated with [Claude Code](https://claude.com/claude-code)