### PR TITLE
feat(content): sound effect theme packs — default/farm/space/jungle (closes #1160)

### DIFF
--- a/gamesformykids/app/settings/SettingsClient.tsx
+++ b/gamesformykids/app/settings/SettingsClient.tsx
@@ -12,6 +12,7 @@ import { AvatarSection } from '@/components/settings/AvatarSection';
 import { ScreenTimeSection } from '@/components/settings/ScreenTimeSection';
 import { AgeFilterSection } from '@/components/settings/AgeFilterSection';
 import { HolidaySection } from '@/components/settings/HolidaySection';
+import { SoundThemeSection } from '@/components/settings/SoundThemeSection';
 import GameSpinnerScreen from '@/components/ui/GameSpinnerScreen';
 
 export default function SettingsClient() {
@@ -76,6 +77,7 @@ export default function SettingsClient() {
             disabled={saving}
           />
           <ColorblindSection />
+          <SoundThemeSection />
           <AvatarSection />
           <AgeFilterSection />
           <ScreenTimeSection />

--- a/gamesformykids/components/settings/SoundThemeSection.tsx
+++ b/gamesformykids/components/settings/SoundThemeSection.tsx
@@ -1,0 +1,60 @@
+'use client';
+
+import { useSoundThemeStore, type SoundTheme } from '@/lib/stores/soundThemeStore';
+import { useGameAudioStore } from '@/lib/stores/gameAudioStore';
+import { playThemedSound } from '@/lib/utils/game/soundThemes';
+import { SectionContainer } from './SectionContainer';
+
+const THEMES: { value: SoundTheme; label: string; emoji: string; desc: string }[] = [
+  { value: 'default', label: 'ברירת מחדל', emoji: '🎵', desc: 'אקורד מוזיקלי' },
+  { value: 'farm',    label: 'חווה',       emoji: '🐄', desc: 'פעמון + רזוננס' },
+  { value: 'space',   label: 'חלל',        emoji: '🚀', desc: 'לייזר' },
+  { value: 'jungle',  label: 'ג\'ונגל',    emoji: '🦜', desc: 'ציוץ ציפורים' },
+];
+
+export function SoundThemeSection() {
+  const theme = useSoundThemeStore((s) => s.theme);
+  const setTheme = useSoundThemeStore((s) => s.setTheme);
+  const audioContext = useGameAudioStore((s) => s.audioContext);
+
+  const handleSelect = (value: SoundTheme) => {
+    setTheme(value);
+    // Preview the sound
+    if (audioContext) {
+      playThemedSound(audioContext, 'success', value);
+    }
+  };
+
+  return (
+    <SectionContainer title="ערכת צלילים" emoji="🎶">
+      <div className="space-y-3">
+        <p className="text-sm text-gray-500">
+          בחר ערכת צלילים לאפקטי המשחק. לחץ על כפתור לתצוגה מקדימה.
+        </p>
+        <div className="grid grid-cols-2 gap-2">
+          {THEMES.map(({ value, label, emoji, desc }) => (
+            <button
+              key={value}
+              type="button"
+              onClick={() => handleSelect(value)}
+              className={`
+                flex items-center gap-2 px-3 py-3 rounded-xl border-2 text-right transition-all
+                ${theme === value
+                  ? 'bg-purple-500 border-purple-600 text-white shadow-md'
+                  : 'bg-white border-gray-200 text-gray-700 hover:border-purple-300'}
+              `}
+            >
+              <span className="text-2xl shrink-0">{emoji}</span>
+              <div className="min-w-0">
+                <p className="text-sm font-bold truncate">{label}</p>
+                <p className={`text-xs truncate ${theme === value ? 'text-purple-200' : 'text-gray-400'}`}>
+                  {desc}
+                </p>
+              </div>
+            </button>
+          ))}
+        </div>
+      </div>
+    </SectionContainer>
+  );
+}

--- a/gamesformykids/hooks/shared/audio/useGameAudio.ts
+++ b/gamesformykids/hooks/shared/audio/useGameAudio.ts
@@ -1,9 +1,10 @@
 'use client';
 
-import { useEffect } from "react";
+import { useEffect, useCallback } from "react";
 import { initSpeechAndAudio } from "@/lib/utils/speech/enhancedSpeechUtils";
-import { playSuccessSound as playSound } from "@/lib/utils/game/gameUtils";
 import { useGameAudioStore } from "@/lib/stores/gameAudioStore";
+import { useSoundThemeStore } from "@/lib/stores/soundThemeStore";
+import { playThemedSound } from "@/lib/utils/game/soundThemes";
 
 /**
  * Hook לניהול אודיו ודיבור במשחקים
@@ -14,6 +15,7 @@ export function useGameAudio() {
   const speechEnabled = useGameAudioStore((s) => s.speechEnabled);
   const setAudioContext = useGameAudioStore((s) => s.setAudioContext);
   const setSpeechEnabled = useGameAudioStore((s) => s.setSpeechEnabled);
+  const theme = useSoundThemeStore((s) => s.theme);
 
   useEffect(() => {
     if (!audioContext && !speechEnabled) {
@@ -21,13 +23,23 @@ export function useGameAudio() {
     }
   }, [audioContext, speechEnabled, setSpeechEnabled, setAudioContext]);
 
-  const playSuccessSound = () => {
-    playSound(audioContext);
-  };
+  const playSuccessSound = useCallback(() => {
+    playThemedSound(audioContext, 'success', theme);
+  }, [audioContext, theme]);
+
+  const playWrongSound = useCallback(() => {
+    playThemedSound(audioContext, 'wrong', theme);
+  }, [audioContext, theme]);
+
+  const playLevelUpSound = useCallback(() => {
+    playThemedSound(audioContext, 'levelUp', theme);
+  }, [audioContext, theme]);
 
   return {
     audioContext,
     speechEnabled,
     playSuccessSound,
+    playWrongSound,
+    playLevelUpSound,
   };
 }

--- a/gamesformykids/lib/stores/soundThemeStore.ts
+++ b/gamesformykids/lib/stores/soundThemeStore.ts
@@ -1,0 +1,23 @@
+'use client';
+
+import { makePersistStore } from './createStore';
+
+export type SoundTheme = 'default' | 'farm' | 'space' | 'jungle';
+
+export interface SoundThemeState {
+  theme: SoundTheme;
+}
+
+export interface SoundThemeActions {
+  setTheme: (theme: SoundTheme) => void;
+}
+
+export const useSoundThemeStore = makePersistStore<SoundThemeState & SoundThemeActions>(
+  'SoundThemeStore',
+  'gfk-sound-theme',
+  (set) => ({
+    theme: 'default',
+    setTheme: (theme) => set({ theme }, false, 'soundTheme/set'),
+  }),
+  { version: 1 },
+);

--- a/gamesformykids/lib/utils/game/soundThemes.ts
+++ b/gamesformykids/lib/utils/game/soundThemes.ts
@@ -1,0 +1,128 @@
+/**
+ * Synthesized sound theme packs using Web Audio API.
+ * No audio files — all sounds are generated in real-time.
+ */
+
+import type { SoundTheme } from '@/lib/stores/soundThemeStore';
+
+function osc(
+  ctx: AudioContext,
+  freq: number,
+  type: OscillatorType,
+  gain: number,
+  startAt: number,
+  duration: number,
+  freqEnd?: number,
+) {
+  const o = ctx.createOscillator();
+  const g = ctx.createGain();
+  o.connect(g);
+  g.connect(ctx.destination);
+  o.type = type;
+  o.frequency.setValueAtTime(freq, startAt);
+  if (freqEnd !== undefined) {
+    o.frequency.linearRampToValueAtTime(freqEnd, startAt + duration);
+  }
+  g.gain.setValueAtTime(0, startAt);
+  g.gain.linearRampToValueAtTime(gain, startAt + 0.03);
+  g.gain.exponentialRampToValueAtTime(0.001, startAt + duration);
+  o.start(startAt);
+  o.stop(startAt + duration + 0.01);
+}
+
+// ── Default: C-major chord (existing behaviour) ────────────────────────────
+function defaultSuccess(ctx: AudioContext) {
+  const notes = [261.63, 329.63, 392.0]; // C4 E4 G4
+  notes.forEach((freq, i) => osc(ctx, freq, 'sine', 0.1, ctx.currentTime + i * 0.1, 0.3));
+}
+
+function defaultWrong(ctx: AudioContext) {
+  osc(ctx, 180, 'sawtooth', 0.08, ctx.currentTime, 0.25, 120);
+}
+
+function defaultLevelUp(ctx: AudioContext) {
+  [261.63, 329.63, 392.0, 523.25].forEach(
+    (freq, i) => osc(ctx, freq, 'sine', 0.12, ctx.currentTime + i * 0.12, 0.35),
+  );
+}
+
+// ── Farm: Cowbell-like ding + muted thud ──────────────────────────────────
+function farmSuccess(ctx: AudioContext) {
+  const t = ctx.currentTime;
+  osc(ctx, 587, 'triangle', 0.12, t, 0.4);       // cowbell high
+  osc(ctx, 440, 'triangle', 0.08, t + 0.05, 0.35); // cowbell low
+  osc(ctx, 220, 'sine',     0.06, t + 0.1,  0.5);  // warm resonance
+}
+
+function farmWrong(ctx: AudioContext) {
+  osc(ctx, 110, 'square', 0.06, ctx.currentTime, 0.3, 90); // low oink-ish thud
+}
+
+function farmLevelUp(ctx: AudioContext) {
+  const t = ctx.currentTime;
+  [392, 523, 659, 784].forEach(
+    (freq, i) => osc(ctx, freq, 'triangle', 0.1, t + i * 0.1, 0.4),
+  );
+}
+
+// ── Space: Laser sweep ─────────────────────────────────────────────────────
+function spaceSuccess(ctx: AudioContext) {
+  const t = ctx.currentTime;
+  osc(ctx, 300, 'sawtooth', 0.07, t,       0.25, 900); // laser up
+  osc(ctx, 600, 'sine',     0.06, t + 0.2, 0.3,  600); // sparkle
+}
+
+function spaceWrong(ctx: AudioContext) {
+  osc(ctx, 800, 'sawtooth', 0.07, ctx.currentTime, 0.25, 200); // laser down
+}
+
+function spaceLevelUp(ctx: AudioContext) {
+  const t = ctx.currentTime;
+  osc(ctx, 200, 'sawtooth', 0.08, t,       0.6, 1200);
+  osc(ctx, 400, 'sine',     0.06, t + 0.15, 0.5, 800);
+  osc(ctx, 800, 'sine',     0.04, t + 0.3,  0.4, 1600);
+}
+
+// ── Jungle: Bird chirp ─────────────────────────────────────────────────────
+function jungleSuccess(ctx: AudioContext) {
+  const t = ctx.currentTime;
+  osc(ctx, 1200, 'sine', 0.08, t,       0.12, 1800); // chirp up
+  osc(ctx, 1000, 'sine', 0.07, t + 0.15, 0.12, 1400); // second chirp
+  osc(ctx, 800,  'sine', 0.06, t + 0.3,  0.15, 1000); // echo
+}
+
+function jungleWrong(ctx: AudioContext) {
+  osc(ctx, 600, 'sine', 0.07, ctx.currentTime, 0.2, 300); // descending hoot
+}
+
+function jungleLevelUp(ctx: AudioContext) {
+  const t = ctx.currentTime;
+  [1200, 1400, 1600, 2000].forEach(
+    (freq, i) => osc(ctx, freq, 'sine', 0.07, t + i * 0.1, 0.2, freq * 1.3),
+  );
+}
+
+// ── Dispatch table ─────────────────────────────────────────────────────────
+type SoundFn = (ctx: AudioContext) => void;
+
+const THEMES: Record<SoundTheme, { success: SoundFn; wrong: SoundFn; levelUp: SoundFn }> = {
+  default: { success: defaultSuccess, wrong: defaultWrong, levelUp: defaultLevelUp },
+  farm:    { success: farmSuccess,    wrong: farmWrong,    levelUp: farmLevelUp },
+  space:   { success: spaceSuccess,   wrong: spaceWrong,   levelUp: spaceLevelUp },
+  jungle:  { success: jungleSuccess,  wrong: jungleWrong,  levelUp: jungleLevelUp },
+};
+
+export type SoundType = 'success' | 'wrong' | 'levelUp';
+
+export function playThemedSound(
+  ctx: AudioContext | null,
+  type: SoundType,
+  theme: SoundTheme,
+): void {
+  if (!ctx) return;
+  try {
+    THEMES[theme][type](ctx);
+  } catch {
+    // Ignore AudioContext errors (e.g. closed context)
+  }
+}


### PR DESCRIPTION
## What
Adds 4 synthesized sound theme packs that replace game sound effects using Web Audio API — no audio files needed.

**New files:**
- `lib/stores/soundThemeStore.ts` — persisted Zustand store with `theme: 'default' | 'farm' | 'space' | 'jungle'`
- `lib/utils/game/soundThemes.ts` — synthesized sound generators per theme (success, wrong, levelUp):
  - **Default** 🎵 — existing C-major chord (sine waves)
  - **Farm** 🐄 — cowbell-like triangle waves + warm resonance
  - **Space** 🚀 — laser sweep (sawtooth, frequency ramp)
  - **Jungle** 🦜 — bird chirp (fast-rising sine tones)
- `components/settings/SoundThemeSection.tsx` — 2×2 button grid in Settings; clicking a theme previews it immediately

**Modified files:**
- `hooks/shared/audio/useGameAudio.ts` — reads active theme from store; exposes `playSuccessSound`, `playWrongSound`, `playLevelUpSound` (all theme-aware)
- `app/settings/SettingsClient.tsx` — adds `<SoundThemeSection />` after ColorblindSection

## Why
Closes #1160

## Merge notes
- `app/settings/SettingsClient.tsx` will conflict with #1028/#1042 — add `SoundThemeSection` alongside those imports.

## Test plan
- [ ] Settings → "ערכת צלילים" shows 4 options; selected is highlighted
- [ ] Clicking a theme immediately plays its success sound as a preview
- [ ] Play any card game → correct answer plays the active theme's success sound
- [ ] Theme persists across page refresh (localStorage key `gfk-sound-theme`)
- [ ] Works on iOS Safari (AudioContext created on user gesture)

🤖 Generated with [Claude Code](https://claude.com/claude-code)