### PR TITLE
feat(engagement): quick multi-child profile switcher (closes #1152)

### DIFF
--- a/gamesformykids/app/HomePageClient.tsx
+++ b/gamesformykids/app/HomePageClient.tsx
@@ -23,6 +23,7 @@ import CategoryJumpBar from "@/components/marketing/CategoryJumpBar";
 import ContentTypeTabBar, { type ContentType } from "@/components/marketing/ContentTypeTabBar";
 import ContentTypeGrid from "@/components/marketing/ContentTypeGrid";
 import HolidayLane from "@/components/marketing/HolidayLane";
+import ChildProfileSwitcher from "@/components/marketing/ChildProfileSwitcher";
 import { useHomePage } from "./useHomePage";
 
 const SESSION_KEY = 'home-content-tab';
@@ -51,6 +52,7 @@ export default function HomePageClient() {
     <div className="min-h-screen bg-linear-to-br from-blue-100 via-purple-100 to-pink-100 dark:from-gray-900 dark:via-gray-800 dark:to-gray-900">
       <VocabularyOfTheDay />
       <Header />
+      <ChildProfileSwitcher />
       <CategoryJumpBar />
       <ContentTypeTabBar active={activeTab} onChange={handleTabChange} />
       <main>

--- a/gamesformykids/components/marketing/ChildProfileSwitcher.tsx
+++ b/gamesformykids/components/marketing/ChildProfileSwitcher.tsx
@@ -1,0 +1,201 @@
+'use client';
+
+import { useState, useRef, useEffect } from 'react';
+import { useChildProfileStore, type ChildProfile } from '@/lib/stores/childProfileStore';
+import { AVATAR_LIST } from '@/hooks/shared/user/useAvatarEmoji';
+
+const MAX_PROFILES = 4;
+
+function AddProfileModal({ onAdd, onClose }: { onAdd: (name: string, emoji: string) => void; onClose: () => void }) {
+  const [name, setName] = useState('');
+  const [emoji, setEmoji] = useState(AVATAR_LIST[0]!);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    inputRef.current?.focus();
+  }, []);
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (name.trim()) {
+      onAdd(name.trim(), emoji);
+      onClose();
+    }
+  }
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-end sm:items-center justify-center bg-black/40"
+      onClick={onClose}
+      dir="rtl"
+    >
+      <div
+        className="w-full sm:max-w-sm bg-white dark:bg-gray-800 rounded-t-3xl sm:rounded-2xl p-6 shadow-2xl"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <h2 className="text-lg font-bold text-gray-800 dark:text-gray-100 mb-4">הוסף פרופיל ילד</h2>
+        <form onSubmit={handleSubmit}>
+          <input
+            ref={inputRef}
+            type="text"
+            placeholder="שם הילד"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            maxLength={20}
+            className="w-full border border-gray-300 dark:border-gray-600 rounded-xl px-4 py-2 mb-4 text-right bg-white dark:bg-gray-700 text-gray-800 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-purple-400"
+          />
+          <p className="text-sm text-gray-500 dark:text-gray-400 mb-2">בחר אייקון</p>
+          <div className="grid grid-cols-6 gap-2 mb-5">
+            {AVATAR_LIST.map((av) => (
+              <button
+                key={av}
+                type="button"
+                onClick={() => setEmoji(av)}
+                className={`text-2xl p-1 rounded-xl transition-transform active:scale-90 ${
+                  emoji === av
+                    ? 'ring-2 ring-purple-500 bg-purple-50 dark:bg-purple-900'
+                    : 'hover:bg-gray-100 dark:hover:bg-gray-700'
+                }`}
+              >
+                {av}
+              </button>
+            ))}
+          </div>
+          <div className="flex gap-3">
+            <button
+              type="submit"
+              disabled={!name.trim()}
+              className="flex-1 bg-purple-600 hover:bg-purple-700 disabled:bg-gray-300 dark:disabled:bg-gray-600 text-white font-bold py-2.5 rounded-xl transition-colors"
+            >
+              הוסף
+            </button>
+            <button
+              type="button"
+              onClick={onClose}
+              className="flex-1 bg-gray-100 dark:bg-gray-700 hover:bg-gray-200 dark:hover:bg-gray-600 text-gray-700 dark:text-gray-200 font-bold py-2.5 rounded-xl transition-colors"
+            >
+              ביטול
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}
+
+interface ProfileBubbleProps {
+  profile: ChildProfile | null;
+  isActive: boolean;
+  isManaging: boolean;
+  onClick: () => void;
+  onDelete?: () => void;
+}
+
+function ProfileBubble({ profile, isActive, isManaging, onClick, onDelete }: ProfileBubbleProps) {
+  const emoji = profile?.emoji ?? '👨‍👩‍👧';
+  const name = profile?.name ?? 'הכל';
+
+  return (
+    <div className="relative flex flex-col items-center gap-1 shrink-0">
+      <button
+        onClick={onClick}
+        className={`w-12 h-12 rounded-full text-2xl flex items-center justify-center transition-all active:scale-90 ${
+          isActive
+            ? 'ring-4 ring-purple-500 ring-offset-2 ring-offset-white dark:ring-offset-gray-900 scale-110 shadow-md'
+            : 'ring-2 ring-gray-200 dark:ring-gray-600 hover:ring-purple-300'
+        } bg-white dark:bg-gray-700 shadow`}
+        aria-label={`עבור לפרופיל ${name}`}
+        aria-pressed={isActive}
+      >
+        {emoji}
+      </button>
+      <span className={`text-xs font-medium truncate max-w-14 text-center ${isActive ? 'text-purple-600 dark:text-purple-400' : 'text-gray-500 dark:text-gray-400'}`}>
+        {name}
+      </span>
+      {isManaging && onDelete && (
+        <button
+          onClick={onDelete}
+          className="absolute -top-1 -left-1 w-5 h-5 bg-red-500 text-white rounded-full text-xs flex items-center justify-center shadow hover:bg-red-600 active:scale-90"
+          aria-label={`מחק פרופיל ${name}`}
+        >
+          ×
+        </button>
+      )}
+    </div>
+  );
+}
+
+export default function ChildProfileSwitcher() {
+  const { profiles, activeProfileId, addProfile, removeProfile, switchProfile } = useChildProfileStore();
+  const [showAdd, setShowAdd] = useState(false);
+  const [isManaging, setIsManaging] = useState(false);
+
+  if (profiles.length === 0 && !showAdd) {
+    return (
+      <div className="flex justify-center my-2" dir="rtl">
+        <button
+          onClick={() => setShowAdd(true)}
+          className="inline-flex items-center gap-2 px-4 py-2 rounded-full bg-purple-50 dark:bg-purple-900/30 border border-purple-200 dark:border-purple-700 text-purple-700 dark:text-purple-300 text-sm font-medium hover:bg-purple-100 dark:hover:bg-purple-900/50 transition-colors"
+        >
+          <span>+</span>
+          <span>הוסף פרופיל ילד</span>
+        </button>
+        {showAdd && (
+          <AddProfileModal onAdd={(n, e) => addProfile(n, e)} onClose={() => setShowAdd(false)} />
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <>
+      <div className="px-4 my-3" dir="rtl">
+        <div className="flex items-center gap-1 mb-2">
+          <span className="text-xs font-semibold text-gray-500 dark:text-gray-400">מי משחק עכשיו?</span>
+          {profiles.length > 0 && (
+            <button
+              onClick={() => setIsManaging((m) => !m)}
+              className="mr-auto text-xs text-purple-500 dark:text-purple-400 hover:text-purple-700 dark:hover:text-purple-300 transition-colors"
+            >
+              {isManaging ? 'סיים עריכה' : '✏️ ערוך'}
+            </button>
+          )}
+        </div>
+        <div className="flex gap-4 overflow-x-auto scrollbar-hide pb-1">
+          {/* Default / parent bubble */}
+          <ProfileBubble
+            profile={null}
+            isActive={activeProfileId === null}
+            isManaging={false}
+            onClick={() => { switchProfile(null); setIsManaging(false); }}
+          />
+          {profiles.map((p) => (
+            <ProfileBubble
+              key={p.id}
+              profile={p}
+              isActive={p.id === activeProfileId}
+              isManaging={isManaging}
+              onClick={() => { switchProfile(p.id); setIsManaging(false); }}
+              onDelete={() => removeProfile(p.id)}
+            />
+          ))}
+          {profiles.length < MAX_PROFILES && !isManaging && (
+            <div className="flex flex-col items-center gap-1 shrink-0">
+              <button
+                onClick={() => setShowAdd(true)}
+                className="w-12 h-12 rounded-full text-2xl flex items-center justify-center ring-2 ring-dashed ring-gray-300 dark:ring-gray-600 hover:ring-purple-400 bg-gray-50 dark:bg-gray-800 transition-all active:scale-90 text-gray-400 dark:text-gray-500"
+                aria-label="הוסף פרופיל"
+              >
+                +
+              </button>
+              <span className="text-xs text-gray-400 dark:text-gray-500">הוסף</span>
+            </div>
+          )}
+        </div>
+      </div>
+      {showAdd && (
+        <AddProfileModal onAdd={(n, e) => { addProfile(n, e); }} onClose={() => setShowAdd(false)} />
+      )}
+    </>
+  );
+}

--- a/gamesformykids/components/marketing/DailyStreakBadge.tsx
+++ b/gamesformykids/components/marketing/DailyStreakBadge.tsx
@@ -1,14 +1,16 @@
 'use client';
 import { useState, useEffect } from 'react';
 import { getDailyLoginStreak } from '@/lib/utils/engagement/trackDailyLogin';
+import { useChildProfileStore } from '@/lib/stores/childProfileStore';
 
 export default function DailyStreakBadge() {
+  const activeProfileId = useChildProfileStore((s) => s.activeProfileId);
   const [streak, setStreak] = useState(0);
 
   useEffect(() => {
-    const { count } = getDailyLoginStreak();
+    const { count } = getDailyLoginStreak(activeProfileId);
     setStreak(count);
-  }, []);
+  }, [activeProfileId]);
 
   if (streak < 2) return null;
 

--- a/gamesformykids/hooks/shared/marketing/useRecentlyPlayed.ts
+++ b/gamesformykids/hooks/shared/marketing/useRecentlyPlayed.ts
@@ -2,6 +2,7 @@
 import { useState, useEffect } from 'react';
 import { getRecentGames, type RecentGameEntry } from '@/lib/utils/engagement/trackGameVisit';
 import { GamesRegistry } from '@/lib/registry/gamesRegistry';
+import { useChildProfileStore } from '@/lib/stores/childProfileStore';
 
 export interface RecentItem {
   gameType: string;
@@ -11,10 +12,11 @@ export interface RecentItem {
 }
 
 export function useRecentlyPlayed(): RecentItem[] {
+  const activeProfileId = useChildProfileStore((s) => s.activeProfileId);
   const [items, setItems] = useState<RecentItem[]>([]);
 
   useEffect(() => {
-    const recent: RecentGameEntry[] = getRecentGames();
+    const recent: RecentGameEntry[] = getRecentGames(activeProfileId);
     const resolved = recent
       .map((entry) => {
         const reg = GamesRegistry.getGameById(entry.gameType);
@@ -23,7 +25,7 @@ export function useRecentlyPlayed(): RecentItem[] {
       })
       .filter((x): x is RecentItem => x !== null);
     setItems(resolved);
-  }, []);
+  }, [activeProfileId]);
 
   return items;
 }

--- a/gamesformykids/hooks/shared/progress/useSessionStats.ts
+++ b/gamesformykids/hooks/shared/progress/useSessionStats.ts
@@ -9,6 +9,7 @@ import { useState, useCallback } from 'react';
 import { BaseGameItem, GameType } from '@/lib/types/core/base';
 import { GameSession } from '@/lib/types/hooks/progress';
 import { useProgressTrackingStore } from '@/lib/stores/progressTrackingStore';
+import { useChildProfileStore } from '@/lib/stores/childProfileStore';
 import { recordGameSession } from '@/lib/utils/engagement/masteryStars';
 
 export function useSessionStats(gameType: GameType) {
@@ -73,9 +74,11 @@ export function useSessionStats(gameType: GameType) {
   // End current session and save progress
   const endSession = useCallback(() => {
     if (currentSession) {
+      const childProfileId = useChildProfileStore.getState().activeProfileId;
       const completedSession: GameSession = {
         ...currentSession,
         endTime: new Date(),
+        ...(childProfileId ? { childProfileId } : {}),
       };
       addSession(completedSession);
       const accuracy = completedSession.totalAnswers > 0

--- a/gamesformykids/hooks/shared/user/useAvatarEmoji.ts
+++ b/gamesformykids/hooks/shared/user/useAvatarEmoji.ts
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState, useCallback } from 'react';
+import { useChildProfileStore } from '@/lib/stores/childProfileStore';
 
 const LS_KEY = 'gfk_avatar_emoji';
 
@@ -15,20 +16,35 @@ export const AVATAR_OPTIONS = [
 export const AVATAR_LIST = [...new Set(AVATAR_OPTIONS)];
 
 export function useAvatarEmoji() {
-  const [emoji, setEmojiState] = useState<string>(() => {
+  const activeProfileId = useChildProfileStore((s) => s.activeProfileId);
+  const profiles = useChildProfileStore((s) => s.profiles);
+  const { updateProfile } = useChildProfileStore();
+
+  const [localEmoji, setLocalEmojiState] = useState<string>(() => {
     if (typeof window === 'undefined') return '';
     return localStorage.getItem(LS_KEY) ?? '';
   });
 
+  const activeProfile = profiles.find((p) => p.id === activeProfileId);
+  const emoji = activeProfile ? activeProfile.emoji : localEmoji;
+
   const setEmoji = useCallback((e: string) => {
-    setEmojiState(e);
-    localStorage.setItem(LS_KEY, e);
-  }, []);
+    if (activeProfileId && activeProfile) {
+      updateProfile(activeProfileId, { emoji: e });
+    } else {
+      setLocalEmojiState(e);
+      localStorage.setItem(LS_KEY, e);
+    }
+  }, [activeProfileId, activeProfile, updateProfile]);
 
   const clearEmoji = useCallback(() => {
-    setEmojiState('');
-    localStorage.removeItem(LS_KEY);
-  }, []);
+    if (activeProfileId && activeProfile) {
+      updateProfile(activeProfileId, { emoji: '' });
+    } else {
+      setLocalEmojiState('');
+      localStorage.removeItem(LS_KEY);
+    }
+  }, [activeProfileId, activeProfile, updateProfile]);
 
   return { emoji, setEmoji, clearEmoji };
 }

--- a/gamesformykids/lib/stores/childProfileStore.ts
+++ b/gamesformykids/lib/stores/childProfileStore.ts
@@ -1,0 +1,63 @@
+'use client';
+import { makePersistStore } from './createStore';
+
+export interface ChildProfile {
+  id: string;
+  name: string;
+  emoji: string;
+}
+
+interface ChildProfileState {
+  profiles: ChildProfile[];
+  activeProfileId: string | null;
+}
+
+interface ChildProfileActions {
+  addProfile: (name: string, emoji: string) => void;
+  removeProfile: (id: string) => void;
+  updateProfile: (id: string, changes: Partial<Omit<ChildProfile, 'id'>>) => void;
+  switchProfile: (id: string | null) => void;
+}
+
+function generateId(): string {
+  return Math.random().toString(36).slice(2, 10);
+}
+
+export const useChildProfileStore = makePersistStore<ChildProfileState & ChildProfileActions>(
+  'ChildProfileStore',
+  'gfk-child-profiles',
+  (set) => ({
+    profiles: [],
+    activeProfileId: null,
+
+    addProfile: (name, emoji) =>
+      set(
+        (s) => ({ profiles: [...s.profiles, { id: generateId(), name, emoji }] }),
+        false,
+        'childProfile/add',
+      ),
+
+    removeProfile: (id) =>
+      set(
+        (s) => ({
+          profiles: s.profiles.filter((p) => p.id !== id),
+          activeProfileId: s.activeProfileId === id ? null : s.activeProfileId,
+        }),
+        false,
+        'childProfile/remove',
+      ),
+
+    updateProfile: (id, changes) =>
+      set(
+        (s) => ({
+          profiles: s.profiles.map((p) => (p.id === id ? { ...p, ...changes } : p)),
+        }),
+        false,
+        'childProfile/update',
+      ),
+
+    switchProfile: (id) =>
+      set({ activeProfileId: id }, false, 'childProfile/switch'),
+  }),
+  { version: 1 },
+);

--- a/gamesformykids/lib/stores/index.ts
+++ b/gamesformykids/lib/stores/index.ts
@@ -77,6 +77,10 @@ export { useFavoritesStore } from './favoritesStore';
 export { useCountingChallengeStore } from './countingChallengeStore';
 export { useMathChallengeStore } from './mathChallengeStore';
 
+// Child Profiles (multi-child switcher — persisted)
+export { useChildProfileStore } from './childProfileStore';
+export type { ChildProfile } from './childProfileStore';
+
 // Store utilities
 export type { RemoteDataSlice } from './utils/RemoteDataSlice';
 export type { ChallengeStoreState } from './utils/createChallengeStore';

--- a/gamesformykids/lib/types/hooks/progress.ts
+++ b/gamesformykids/lib/types/hooks/progress.ts
@@ -23,6 +23,7 @@ export interface GameSession {
     attempts: number;
   }>;
   completed: boolean;
+  childProfileId?: string;
 }
 
 

--- a/gamesformykids/lib/utils/engagement/trackDailyLogin.ts
+++ b/gamesformykids/lib/utils/engagement/trackDailyLogin.ts
@@ -1,14 +1,14 @@
-const STREAK_KEY = 'gfk_login_streak';
-const LAST_DATE_KEY = 'gfk_login_last_date';
-
 export interface LoginStreak {
   count: number;
   isNew: boolean;
 }
 
 /** Reads and updates the daily login streak in localStorage. Call once on home page mount. */
-export function getDailyLoginStreak(): LoginStreak {
+export function getDailyLoginStreak(profileId?: string | null): LoginStreak {
   if (typeof window === 'undefined') return { count: 0, isNew: false };
+  const s = profileId ? `_${profileId}` : '';
+  const STREAK_KEY = `gfk_login_streak${s}`;
+  const LAST_DATE_KEY = `gfk_login_last_date${s}`;
   try {
     const today = new Date().toISOString().slice(0, 10);
     const lastDate = localStorage.getItem(LAST_DATE_KEY);

--- a/gamesformykids/lib/utils/engagement/trackGameVisit.ts
+++ b/gamesformykids/lib/utils/engagement/trackGameVisit.ts
@@ -1,6 +1,4 @@
-const LAST_PLAYED_KEY = 'gfk_last_played';
-const RECENT_KEY = 'gfk_recent';
-const TODAY_COUNT_KEY = 'gfk_today_count';
+import { useChildProfileStore } from '@/lib/stores/childProfileStore';
 
 export interface LastPlayedData {
   gameType: string;
@@ -17,24 +15,39 @@ export interface TodayCountData {
   count: number;
 }
 
+function profileKeys(profileId: string | null) {
+  const s = profileId ? `_${profileId}` : '';
+  return {
+    recent: `gfk_recent${s}`,
+    lastPlayed: `gfk_last_played${s}`,
+    todayCount: `gfk_today_count${s}`,
+  };
+}
+
+function activeId(): string | null {
+  if (typeof window === 'undefined') return null;
+  try {
+    return useChildProfileStore.getState().activeProfileId;
+  } catch {
+    return null;
+  }
+}
+
 export function trackGameVisit(gameType: string): void {
   if (typeof window === 'undefined') return;
+  const keys = profileKeys(activeId());
   const now = Date.now();
 
-  // Last played
-  const entry: LastPlayedData = { gameType, timestamp: now };
-  localStorage.setItem(LAST_PLAYED_KEY, JSON.stringify(entry));
+  localStorage.setItem(keys.lastPlayed, JSON.stringify({ gameType, timestamp: now } as LastPlayedData));
 
-  // Recent list (max 5, deduplicated)
   const prev = getRecentGames().filter((g) => g.gameType !== gameType);
   prev.unshift({ gameType, timestamp: now });
-  localStorage.setItem(RECENT_KEY, JSON.stringify(prev.slice(0, 5)));
+  localStorage.setItem(keys.recent, JSON.stringify(prev.slice(0, 5)));
 
-  // Games played today
   const today = new Date().toISOString().slice(0, 10);
   let todayData: TodayCountData;
   try {
-    todayData = JSON.parse(localStorage.getItem(TODAY_COUNT_KEY) ?? '{}') as TodayCountData;
+    todayData = JSON.parse(localStorage.getItem(keys.todayCount) ?? '{}') as TodayCountData;
   } catch {
     todayData = { date: '', count: 0 };
   }
@@ -43,32 +56,35 @@ export function trackGameVisit(gameType: string): void {
   } else {
     todayData = { date: today, count: 1 };
   }
-  localStorage.setItem(TODAY_COUNT_KEY, JSON.stringify(todayData));
+  localStorage.setItem(keys.todayCount, JSON.stringify(todayData));
 }
 
-export function getLastPlayed(): LastPlayedData | null {
+export function getLastPlayed(profileId?: string | null): LastPlayedData | null {
   if (typeof window === 'undefined') return null;
+  const id = profileId !== undefined ? profileId : activeId();
   try {
-    const raw = localStorage.getItem(LAST_PLAYED_KEY);
+    const raw = localStorage.getItem(profileKeys(id).lastPlayed);
     return raw ? (JSON.parse(raw) as LastPlayedData) : null;
   } catch {
     return null;
   }
 }
 
-export function getRecentGames(): RecentGameEntry[] {
+export function getRecentGames(profileId?: string | null): RecentGameEntry[] {
   if (typeof window === 'undefined') return [];
+  const id = profileId !== undefined ? profileId : activeId();
   try {
-    return JSON.parse(localStorage.getItem(RECENT_KEY) ?? '[]') as RecentGameEntry[];
+    return JSON.parse(localStorage.getItem(profileKeys(id).recent) ?? '[]') as RecentGameEntry[];
   } catch {
     return [];
   }
 }
 
-export function getGamesTodayCount(): number {
+export function getGamesTodayCount(profileId?: string | null): number {
   if (typeof window === 'undefined') return 0;
+  const id = profileId !== undefined ? profileId : activeId();
   try {
-    const data = JSON.parse(localStorage.getItem(TODAY_COUNT_KEY) ?? '{}') as TodayCountData;
+    const data = JSON.parse(localStorage.getItem(profileKeys(id).todayCount) ?? '{}') as TodayCountData;
     const today = new Date().toISOString().slice(0, 10);
     return data.date === today ? (data.count ?? 0) : 0;
   } catch {


### PR DESCRIPTION
## What
Adds a multi-child profile switcher to the home page. Parents can create up to 4 named child profiles (each with a custom emoji avatar), and switching profiles isolates: recently played games, daily streak counter, and game session history.

## Implementation
- New `useChildProfileStore` (Zustand + persist) stores 1–4 `ChildProfile` entries and the active profile ID
- `trackGameVisit` + `getRecentGames` + `getDailyLoginStreak` are now profile-namespaced (key suffix `_profileId`)
- `useRecentlyPlayed` reacts to active profile changes
- `useAvatarEmoji` returns the active profile's emoji when a profile is selected
- `GameSession` type gains optional `childProfileId` field; `useSessionStats` tags each completed session
- `ChildProfileSwitcher` component renders below the header on the home page: avatar row, "+add", "edit" (to delete profiles), and a modal for adding a new profile

## Why
Closes #1152

## Test plan
- [ ] Visit `/` — see "הוסף פרופיל ילד" button below header
- [ ] Add a profile named "מיה" with a lion emoji — appears in the row
- [ ] Switch to מיה — avatar ring highlights, "מי משחק עכשיו?" shows her name active
- [ ] Play a game under מיה — "שיחקת לאחרונה" row shows her games
- [ ] Switch back to "הכל" — recently played shows global history
- [ ] Add/delete profiles up to 4 max
- [ ] Works on mobile (RTL, touch)
- [ ] `tsc --noEmit` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)