### PR TITLE
feat(game): Hebrew letter-trace canvas game for ages 3-6 (closes #1226)

### DIFF
--- a/gamesformykids/app/games/[gameType]/CustomGameRenderer.tsx
+++ b/gamesformykids/app/games/[gameType]/CustomGameRenderer.tsx
@@ -85,6 +85,7 @@ const GAME_CLIENTS: Record<string, ComponentType> = {
   'letter-slicer':         dynamic(() => import('../letter-slicer/LetterSlicerClient'),                { ssr: false }),
   'cooking-game':          dynamic(() => import('../cooking-game/CookingClient'),                     { ssr: false }),
   'spot-the-difference':   dynamic(() => import('../spot-the-difference/SpotClient'),                 { ssr: false }),
+  'letter-trace':          dynamic(() => import('../letter-trace/LetterTraceClient'),                  { ssr: false }),
 };
 
 interface Props { gameType: string; }

--- a/gamesformykids/app/games/[gameType]/gamePageConstants.ts
+++ b/gamesformykids/app/games/[gameType]/gamePageConstants.ts
@@ -33,7 +33,7 @@ export const SUPPORTED_GAMES = [
   'math-race', 'memory', 'meteor-dodge', 'multiplication', 'number-bubbles', 'pong',
   'puzzles', 'reflex', 'shesh-besh', 'simon', 'snake', 'space-defender',
   'stack', 'taki', 'tetris', 'true-false', 'tzedakah', 'whack-a-mole',
-  'word-builder', 'word-scramble', 'snakes-ladders',
+  'word-builder', 'word-scramble', 'snakes-ladders', 'letter-trace',
 
   // ── משחקי חידון (QuizGameRouter) ──────────────────────────────────────────
   'riddles', 'capitals', 'fractions', 'spelling',
@@ -122,7 +122,7 @@ export const CUSTOM_GAME_TYPES = new Set([
   'word-builder', 'word-scramble', 'maze', 'letter-defender', 'puppet-story', 'number-slide', 'snakes-ladders',
 
 
-  'escape-room', 'robot-coder', 'find-in-scene', 'hangman', 'choose-adventure', 'picture-dictionary', 'word-search', 'israel-map', 'kids-songs', 'melody-maker', 'kids-encyclopedia', 'age-calculator', 'craft-guide', 'jokes-browser', 'word-maze', 'avatar-maker', 'sound-quiz', 'spinner', 'team-picker', 'dice', 'timer', 'letter-race', 'drag-sort', 'answer-cannon', 'typing-race', 'word-fishing', 'letter-grow', 'letter-slingshot', 'syllable-drums', 'dress-up', 'letter-bubble-shooter', 'letter-slicer', 'cooking-game', 'spot-the-difference',
+  'escape-room', 'robot-coder', 'find-in-scene', 'hangman', 'choose-adventure', 'picture-dictionary', 'word-search', 'israel-map', 'kids-songs', 'melody-maker', 'kids-encyclopedia', 'age-calculator', 'craft-guide', 'jokes-browser', 'word-maze', 'avatar-maker', 'sound-quiz', 'spinner', 'team-picker', 'dice', 'timer', 'letter-race', 'drag-sort', 'answer-cannon', 'typing-race', 'word-fishing', 'letter-grow', 'letter-slingshot', 'syllable-drums', 'dress-up', 'letter-bubble-shooter', 'letter-slicer', 'cooking-game', 'spot-the-difference', 'letter-trace',
   
   
 ]);

--- a/gamesformykids/app/games/letter-trace/LetterTraceClient.tsx
+++ b/gamesformykids/app/games/letter-trace/LetterTraceClient.tsx
@@ -1,0 +1,118 @@
+'use client';
+
+import { useCallback, useRef } from 'react';
+import { useLetterTraceStore } from './letterTraceStore';
+import LetterTraceMenu from './components/LetterTraceMenu';
+import LetterCanvas from './components/LetterCanvas';
+import { speakHebrew } from '@/lib/utils/speech/speaker';
+
+const SUCCESS_THRESHOLD = 0.60;
+
+export default function LetterTraceClient() {
+  const { phase, difficulty, letters, currentIndex, score, total, startGame, nextLetter, restart } =
+    useLetterTraceStore();
+  const resultRef = useRef<number | null>(null);
+  const current = letters[currentIndex];
+
+  const handleComplete = useCallback(
+    (accuracy: number) => {
+      resultRef.current = accuracy;
+    },
+    [],
+  );
+
+  function handleNext() {
+    const acc = resultRef.current ?? 0;
+    const success = acc >= SUCCESS_THRESHOLD;
+    if (current) {
+      speakHebrew(current.sound);
+    }
+    nextLetter(success);
+    resultRef.current = null;
+  }
+
+  if (phase === 'menu') {
+    return <LetterTraceMenu onStart={startGame} />;
+  }
+
+  if (phase === 'result') {
+    const pct = total > 0 ? Math.round((score / total) * 100) : 0;
+    return (
+      <div
+        dir="rtl"
+        className="min-h-screen flex flex-col items-center justify-center bg-linear-to-br from-green-100 to-teal-200 p-6"
+      >
+        <div className="bg-white rounded-3xl shadow-2xl p-8 max-w-sm w-full text-center">
+          <div className="text-6xl mb-4">🏆</div>
+          <h2 className="text-3xl font-extrabold text-green-800 mb-2">כל הכבוד!</h2>
+          <p className="text-gray-600 mb-2">סיימת את כל 22 האותיות!</p>
+          <div className="text-5xl font-black text-green-600 mb-6">{pct}%</div>
+          <div className="text-gray-500 text-sm mb-6">
+            {score} מתוך {total} אותיות הצלחת
+          </div>
+          <button
+            onClick={restart}
+            className="bg-green-500 hover:bg-green-600 active:scale-95 text-white font-bold py-4 px-8 rounded-2xl text-lg transition-all w-full"
+          >
+            🔄 שחק שוב
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  if (!current) return null;
+
+  return (
+    <div
+      dir="rtl"
+      className="min-h-screen flex flex-col items-center justify-center bg-linear-to-br from-blue-50 to-purple-100 p-4"
+    >
+      {/* Progress bar */}
+      <div className="w-full max-w-sm mb-4">
+        <div className="flex justify-between text-xs text-gray-500 mb-1">
+          <span>אות {currentIndex + 1} מתוך {letters.length}</span>
+          <span>✅ {score} הצלחות</span>
+        </div>
+        <div className="h-2 bg-gray-200 rounded-full overflow-hidden">
+          <div
+            className="h-full bg-blue-500 rounded-full transition-all duration-500"
+            style={{ width: `${(currentIndex / letters.length) * 100}%` }}
+          />
+        </div>
+      </div>
+
+      <div className="bg-white rounded-3xl shadow-xl p-6 max-w-sm w-full text-center">
+        {/* Letter header */}
+        <div className={`text-8xl font-black bg-linear-to-br ${current.color} bg-clip-text text-transparent mb-1`}>
+          {current.char}
+        </div>
+        <div className="text-base font-semibold text-gray-600 mb-4">{current.name}</div>
+
+        {/* Canvas */}
+        <LetterCanvas
+          key={`${current.char}-${currentIndex}`}
+          letter={current}
+          difficulty={difficulty}
+          onComplete={handleComplete}
+        />
+
+        {/* Buttons */}
+        <div className="mt-5 flex gap-3">
+          <button
+            onClick={handleNext}
+            className="flex-1 bg-blue-500 hover:bg-blue-600 active:scale-95 text-white font-bold py-3 rounded-2xl transition-all"
+          >
+            הבאה ←
+          </button>
+          <button
+            onClick={restart}
+            className="px-4 bg-gray-100 hover:bg-gray-200 active:scale-95 text-gray-600 font-bold py-3 rounded-2xl transition-all"
+          >
+            🏠
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/gamesformykids/app/games/letter-trace/components/LetterCanvas.tsx
+++ b/gamesformykids/app/games/letter-trace/components/LetterCanvas.tsx
@@ -184,7 +184,6 @@ export default function LetterCanvas({ letter, difficulty, onComplete }: Props) 
     setAccuracy(acc);
     setDone(true);
     onComplete(acc);
-  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [onComplete]);
 
   return (

--- a/gamesformykids/app/games/letter-trace/components/LetterCanvas.tsx
+++ b/gamesformykids/app/games/letter-trace/components/LetterCanvas.tsx
@@ -1,0 +1,215 @@
+'use client';
+
+import { useRef, useEffect, useState, useCallback } from 'react';
+import type { HebrewLetterPath } from '@/lib/constants/gameData/hebrewLetterPaths';
+
+interface Props {
+  letter: HebrewLetterPath;
+  difficulty: 'guided' | 'free';
+  onComplete: (accuracy: number) => void;
+}
+
+const WAYPOINT_RADIUS = 12; // px — how close the user must be to "capture" a waypoint
+const SUCCESS_THRESHOLD = 0.60; // 60% of waypoints captured = success
+const CANVAS_SIZE = 280; // logical px
+
+function flattenStrokes(strokes: Array<Array<[number, number]>>): Array<[number, number]> {
+  return strokes.flatMap((s) => s);
+}
+
+function toCanvasPx(norm: [number, number], size: number): [number, number] {
+  return [norm[0] * size / 100, norm[1] * size / 100];
+}
+
+export default function LetterCanvas({ letter, difficulty, onComplete }: Props) {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const isDrawing = useRef(false);
+  const drawnPoints = useRef<Array<[number, number]>>([]);
+  const capturedCount = useRef(0);
+  const totalWaypoints = useRef(0);
+  const [done, setDone] = useState(false);
+  const [accuracy, setAccuracy] = useState(0);
+
+  // Flatten all waypoints into a single ordered list for capture tracking
+  const allWaypoints = flattenStrokes(letter.strokes);
+  const nextWaypointIdx = useRef(0);
+
+  function resetState() {
+    drawnPoints.current = [];
+    capturedCount.current = 0;
+    nextWaypointIdx.current = 0;
+    totalWaypoints.current = allWaypoints.length;
+    setDone(false);
+    setAccuracy(0);
+  }
+
+  useEffect(() => {
+    resetState();
+    drawBackground();
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [letter, difficulty]);
+
+  function drawBackground() {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+    const size = canvas.width;
+
+    ctx.clearRect(0, 0, size, size);
+
+    if (difficulty === 'guided') {
+      // Draw ghost letter path
+      ctx.strokeStyle = 'rgba(200, 200, 200, 0.8)';
+      ctx.lineWidth = 18;
+      ctx.lineCap = 'round';
+      ctx.lineJoin = 'round';
+
+      for (const stroke of letter.strokes) {
+        if (stroke.length < 2) continue;
+        ctx.beginPath();
+        const [sx, sy] = toCanvasPx(stroke[0]!, size);
+        ctx.moveTo(sx, sy);
+        for (let i = 1; i < stroke.length; i++) {
+          const [x, y] = toCanvasPx(stroke[i]!, size);
+          ctx.lineTo(x, y);
+        }
+        ctx.stroke();
+      }
+    }
+
+    // Draw waypoints
+    allWaypoints.forEach(([nx, ny], i) => {
+      const [px, py] = toCanvasPx([nx, ny], size);
+      const isStart = i === 0;
+      ctx.beginPath();
+      ctx.arc(px, py, isStart ? 14 : 8, 0, Math.PI * 2);
+      ctx.fillStyle = isStart ? '#22c55e' : 'rgba(148,163,184,0.6)';
+      ctx.fill();
+      if (isStart) {
+        // Arrow pointing down
+        ctx.fillStyle = 'white';
+        ctx.font = 'bold 12px sans-serif';
+        ctx.textAlign = 'center';
+        ctx.textBaseline = 'middle';
+        ctx.fillText('▼', px, py);
+      }
+    });
+  }
+
+  function drawUserPath() {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+    const size = canvas.width;
+
+    // Redraw background first
+    drawBackground();
+
+    // Draw captured waypoints highlighted
+    allWaypoints.slice(0, nextWaypointIdx.current).forEach(([nx, ny]) => {
+      const [px, py] = toCanvasPx([nx, ny], size);
+      ctx.beginPath();
+      ctx.arc(px, py, 10, 0, Math.PI * 2);
+      ctx.fillStyle = '#22c55e';
+      ctx.fill();
+    });
+
+    // Draw user path
+    const points = drawnPoints.current;
+    if (points.length < 2) return;
+    ctx.beginPath();
+    ctx.strokeStyle = '#3b82f6';
+    ctx.lineWidth = 8;
+    ctx.lineCap = 'round';
+    ctx.lineJoin = 'round';
+    const [fx, fy] = points[0]!;
+    ctx.moveTo(fx, fy);
+    for (let i = 1; i < points.length; i++) {
+      const [x, y] = points[i]!;
+      ctx.lineTo(x, y);
+    }
+    ctx.stroke();
+  }
+
+  function getCanvasPos(e: React.PointerEvent<HTMLCanvasElement>): [number, number] {
+    const canvas = canvasRef.current!;
+    const rect = canvas.getBoundingClientRect();
+    const scaleX = canvas.width / rect.width;
+    const scaleY = canvas.height / rect.height;
+    return [(e.clientX - rect.left) * scaleX, (e.clientY - rect.top) * scaleY];
+  }
+
+  function checkWaypointCapture(pos: [number, number]) {
+    const size = canvasRef.current?.width ?? CANVAS_SIZE;
+    while (nextWaypointIdx.current < allWaypoints.length) {
+      const wp = allWaypoints[nextWaypointIdx.current]!;
+      const [wpx, wpy] = toCanvasPx(wp, size);
+      const dist = Math.hypot(pos[0] - wpx, pos[1] - wpy);
+      if (dist <= WAYPOINT_RADIUS * 1.5) {
+        capturedCount.current += 1;
+        nextWaypointIdx.current += 1;
+      } else {
+        break;
+      }
+    }
+  }
+
+  const handlePointerDown = useCallback((e: React.PointerEvent<HTMLCanvasElement>) => {
+    if (done) return;
+    isDrawing.current = true;
+    (e.target as HTMLCanvasElement).setPointerCapture(e.pointerId);
+    const pos = getCanvasPos(e);
+    drawnPoints.current = [pos];
+    checkWaypointCapture(pos);
+    drawUserPath();
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [done, letter, difficulty]);
+
+  const handlePointerMove = useCallback((e: React.PointerEvent<HTMLCanvasElement>) => {
+    if (!isDrawing.current || done) return;
+    const pos = getCanvasPos(e);
+    drawnPoints.current.push(pos);
+    checkWaypointCapture(pos);
+    drawUserPath();
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [done, letter, difficulty]);
+
+  const handlePointerUp = useCallback(() => {
+    if (!isDrawing.current) return;
+    isDrawing.current = false;
+    if (drawnPoints.current.length < 5) return; // too short — ignore accidental taps
+    const acc = capturedCount.current / Math.max(totalWaypoints.current, 1);
+    setAccuracy(acc);
+    setDone(true);
+    onComplete(acc);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [onComplete]);
+
+  return (
+    <div className="flex flex-col items-center gap-3">
+      <canvas
+        ref={canvasRef}
+        width={CANVAS_SIZE}
+        height={CANVAS_SIZE}
+        className="touch-none rounded-2xl shadow-lg border-2 border-gray-200 bg-white cursor-crosshair"
+        style={{ maxWidth: '100%', width: CANVAS_SIZE, height: CANVAS_SIZE }}
+        onPointerDown={handlePointerDown}
+        onPointerMove={handlePointerMove}
+        onPointerUp={handlePointerUp}
+        onPointerLeave={handlePointerUp}
+      />
+      {done && (
+        <div className={`text-lg font-bold px-5 py-2 rounded-full ${
+          accuracy >= SUCCESS_THRESHOLD
+            ? 'bg-green-100 text-green-700 border border-green-300'
+            : 'bg-orange-100 text-orange-700 border border-orange-300'
+        }`}>
+          {accuracy >= SUCCESS_THRESHOLD ? '✅ יפה מאוד!' : '💪 נסה שוב!'}
+          {' '}{Math.round(accuracy * 100)}%
+        </div>
+      )}
+    </div>
+  );
+}

--- a/gamesformykids/app/games/letter-trace/components/LetterTraceMenu.tsx
+++ b/gamesformykids/app/games/letter-trace/components/LetterTraceMenu.tsx
@@ -1,0 +1,45 @@
+'use client';
+
+import type { TraceDifficulty } from '../letterTraceStore';
+
+interface Props {
+  onStart: (difficulty: TraceDifficulty) => void;
+}
+
+export default function LetterTraceMenu({ onStart }: Props) {
+  return (
+    <div
+      dir="rtl"
+      className="min-h-screen flex flex-col items-center justify-center bg-linear-to-br from-blue-100 to-purple-200 p-6"
+    >
+      <div className="bg-white rounded-3xl shadow-2xl p-8 max-w-sm w-full text-center">
+        <div className="text-6xl mb-4">✏️</div>
+        <h1 className="text-3xl font-extrabold text-blue-800 mb-2">כתיבת אותיות</h1>
+        <p className="text-gray-600 mb-8 text-sm">עקוב אחרי הקו ותרגל לכתוב את האותיות בעברית</p>
+
+        <div className="flex flex-col gap-4">
+          <button
+            onClick={() => onStart('guided')}
+            className="bg-blue-500 hover:bg-blue-600 active:scale-95 text-white font-bold py-4 px-6 rounded-2xl text-lg transition-all shadow-md"
+          >
+            🌟 מודרך
+            <p className="text-xs font-normal opacity-80 mt-0.5">עם קו עזר</p>
+          </button>
+          <button
+            onClick={() => onStart('free')}
+            className="bg-purple-500 hover:bg-purple-600 active:scale-95 text-white font-bold py-4 px-6 rounded-2xl text-lg transition-all shadow-md"
+          >
+            🚀 חופשי
+            <p className="text-xs font-normal opacity-80 mt-0.5">ללא קו עזר</p>
+          </button>
+        </div>
+
+        <div className="mt-8 grid grid-cols-6 gap-1 text-xl opacity-50">
+          {'אבגדהוזחטיכלמנסעפצקרשת'.split('').map((c) => (
+            <span key={c}>{c}</span>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/gamesformykids/app/games/letter-trace/letterTraceStore.ts
+++ b/gamesformykids/app/games/letter-trace/letterTraceStore.ts
@@ -1,0 +1,58 @@
+'use client';
+import { create } from 'zustand';
+import { HEBREW_LETTER_PATHS, type HebrewLetterPath } from '@/lib/constants/gameData/hebrewLetterPaths';
+
+export type TraceDifficulty = 'guided' | 'free';
+export type TracePhase = 'menu' | 'tracing' | 'result';
+
+interface LetterTraceState {
+  phase: TracePhase;
+  difficulty: TraceDifficulty;
+  letters: HebrewLetterPath[];
+  currentIndex: number;
+  score: number;
+  total: number;
+}
+
+interface LetterTraceActions {
+  startGame: (difficulty?: TraceDifficulty) => void;
+  nextLetter: (success: boolean) => void;
+  restart: () => void;
+}
+
+export const useLetterTraceStore = create<LetterTraceState & LetterTraceActions>((set, get) => ({
+  phase: 'menu',
+  difficulty: 'guided',
+  letters: [...HEBREW_LETTER_PATHS],
+  currentIndex: 0,
+  score: 0,
+  total: 0,
+
+  startGame: (difficulty = 'guided') =>
+    set({
+      phase: 'tracing',
+      difficulty,
+      letters: [...HEBREW_LETTER_PATHS].sort(() => Math.random() - 0.5),
+      currentIndex: 0,
+      score: 0,
+      total: 0,
+    }),
+
+  nextLetter: (success) => {
+    const { currentIndex, letters, score, total } = get();
+    const next = currentIndex + 1;
+    if (next >= letters.length) {
+      set({ phase: 'result', score: score + (success ? 1 : 0), total: total + 1 });
+    } else {
+      set({ currentIndex: next, score: score + (success ? 1 : 0), total: total + 1 });
+    }
+  },
+
+  restart: () =>
+    set({
+      phase: 'menu',
+      currentIndex: 0,
+      score: 0,
+      total: 0,
+    }),
+}));

--- a/gamesformykids/lib/constants/gameCategories.ts
+++ b/gamesformykids/lib/constants/gameCategories.ts
@@ -30,7 +30,7 @@ export const GAME_CATEGORIES: Record<string, GameCategory> = {
     icon: Book,
     color: "bg-blue-500",
     gradient: "from-blue-400 to-blue-600",
-    gameIds: ["letters","hebrew-letters","hebrew-script","numbers","shapes","colored-shapes","colors","advanced-colors","shapes-3d","phonics","rhyming","nikud","gender","final-letters","alphabet-order","letter-race"],
+    gameIds: ["letters","hebrew-letters","hebrew-script","letter-trace","numbers","shapes","colored-shapes","colors","advanced-colors","shapes-3d","phonics","rhyming","nikud","gender","final-letters","alphabet-order","letter-race"],
   },
   creative: {
     title: "יצירתיות ואומנות",

--- a/gamesformykids/lib/constants/gameData/hebrewLetterPaths.ts
+++ b/gamesformykids/lib/constants/gameData/hebrewLetterPaths.ts
@@ -1,0 +1,173 @@
+// Normalized waypoint coordinates: [x, y] where 0,0 = top-left, 100,100 = bottom-right
+// Each letter may have 1-2 strokes (arrays of waypoints)
+// The first point of the first stroke is the start point shown to the child
+
+export interface HebrewLetterPath {
+  char: string;
+  name: string;         // e.g. 'אָלֶף'
+  sound: string;        // e.g. 'alef'
+  color: string;        // Tailwind background gradient
+  strokes: Array<Array<[number, number]>>;
+}
+
+export const HEBREW_LETTER_PATHS: HebrewLetterPath[] = [
+  {
+    char: 'א', name: 'אָלֶף', sound: 'אָלֶף',
+    color: 'from-red-400 to-red-600',
+    strokes: [
+      [[65, 15], [50, 50], [35, 85]],
+      [[15, 32], [50, 50], [80, 68]],
+    ],
+  },
+  {
+    char: 'ב', name: 'בֵּית', sound: 'בֵּית',
+    color: 'from-orange-400 to-orange-600',
+    strokes: [
+      [[70, 18], [28, 18], [28, 82], [70, 82]],
+    ],
+  },
+  {
+    char: 'ג', name: 'גִּימֶל', sound: 'גִּימֶל',
+    color: 'from-yellow-400 to-yellow-600',
+    strokes: [
+      [[52, 12], [52, 78], [70, 92]],
+    ],
+  },
+  {
+    char: 'ד', name: 'דָּלֶת', sound: 'דָּלֶת',
+    color: 'from-green-400 to-green-600',
+    strokes: [
+      [[28, 22], [70, 22], [70, 85]],
+    ],
+  },
+  {
+    char: 'ה', name: 'הֵא', sound: 'הֵא',
+    color: 'from-teal-400 to-teal-600',
+    strokes: [
+      [[28, 22], [28, 55]],
+      [[70, 22], [28, 22], [70, 22], [70, 85]],
+    ],
+  },
+  {
+    char: 'ו', name: 'וָאו', sound: 'וָאו',
+    color: 'from-cyan-400 to-cyan-600',
+    strokes: [
+      [[50, 12], [50, 88]],
+    ],
+  },
+  {
+    char: 'ז', name: 'זַיִן', sound: 'זַיִן',
+    color: 'from-blue-400 to-blue-600',
+    strokes: [
+      [[28, 16], [70, 16], [55, 88]],
+    ],
+  },
+  {
+    char: 'ח', name: 'חֵת', sound: 'חֵת',
+    color: 'from-indigo-400 to-indigo-600',
+    strokes: [
+      [[22, 85], [22, 18], [78, 18], [78, 85]],
+    ],
+  },
+  {
+    char: 'ט', name: 'טֵת', sound: 'טֵת',
+    color: 'from-violet-400 to-violet-600',
+    strokes: [
+      [[72, 22], [28, 22], [28, 80], [72, 80], [72, 32], [60, 20]],
+    ],
+  },
+  {
+    char: 'י', name: 'יוֹד', sound: 'יוֹד',
+    color: 'from-purple-400 to-purple-600',
+    strokes: [
+      [[50, 20], [52, 42]],
+    ],
+  },
+  {
+    char: 'כ', name: 'כַּף', sound: 'כַּף',
+    color: 'from-pink-400 to-pink-600',
+    strokes: [
+      [[70, 18], [28, 18], [28, 82]],
+    ],
+  },
+  {
+    char: 'ל', name: 'לָמֶד', sound: 'לָמֶד',
+    color: 'from-rose-400 to-rose-600',
+    strokes: [
+      [[50, 82], [50, 28], [35, 10]],
+    ],
+  },
+  {
+    char: 'מ', name: 'מֵם', sound: 'מֵם',
+    color: 'from-red-400 to-red-600',
+    strokes: [
+      [[68, 18], [32, 18], [32, 82], [68, 82], [68, 18]],
+    ],
+  },
+  {
+    char: 'נ', name: 'נוּן', sound: 'נוּן',
+    color: 'from-orange-400 to-orange-600',
+    strokes: [
+      [[50, 18], [50, 72], [65, 85]],
+    ],
+  },
+  {
+    char: 'ס', name: 'סָמֶך', sound: 'סָמֶך',
+    color: 'from-amber-400 to-amber-600',
+    strokes: [
+      [[65, 22], [35, 22], [20, 50], [35, 80], [65, 80], [80, 50], [65, 22]],
+    ],
+  },
+  {
+    char: 'ע', name: 'עַיִן', sound: 'עַיִן',
+    color: 'from-lime-400 to-lime-600',
+    strokes: [
+      [[28, 22], [50, 78], [72, 22]],
+    ],
+  },
+  {
+    char: 'פ', name: 'פֵּא', sound: 'פֵּא',
+    color: 'from-emerald-400 to-emerald-600',
+    strokes: [
+      [[65, 60], [72, 22], [28, 22], [28, 60], [52, 70]],
+    ],
+  },
+  {
+    char: 'צ', name: 'צַדִּי', sound: 'צַדִּי',
+    color: 'from-sky-400 to-sky-600',
+    strokes: [
+      [[28, 22], [50, 58], [72, 22]],
+      [[50, 58], [50, 82], [68, 92]],
+    ],
+  },
+  {
+    char: 'ק', name: 'קוֹף', sound: 'קוֹף',
+    color: 'from-blue-400 to-blue-600',
+    strokes: [
+      [[28, 75], [28, 22], [70, 22], [70, 90]],
+    ],
+  },
+  {
+    char: 'ר', name: 'רֵישׁ', sound: 'רֵישׁ',
+    color: 'from-violet-400 to-violet-600',
+    strokes: [
+      [[28, 22], [70, 22], [70, 85]],
+    ],
+  },
+  {
+    char: 'ש', name: 'שִׁין', sound: 'שִׁין',
+    color: 'from-fuchsia-400 to-fuchsia-600',
+    strokes: [
+      [[25, 14], [50, 32], [50, 85]],
+      [[50, 32], [75, 14]],
+    ],
+  },
+  {
+    char: 'ת', name: 'תָּו', sound: 'תָּו',
+    color: 'from-pink-400 to-pink-600',
+    strokes: [
+      [[28, 85], [28, 22], [70, 22], [70, 85]],
+      [[28, 85], [42, 92]],
+    ],
+  },
+];

--- a/gamesformykids/lib/registry/registryData/batch4.ts
+++ b/gamesformykids/lib/registry/registryData/batch4.ts
@@ -43,6 +43,7 @@ import {
   Shirt,
   Scissors,
   UtensilsCrossed,
+  Pencil,
 } from "lucide-react";
 import type { GameRegistration } from "@/lib/types/games/base";
 
@@ -1122,5 +1123,17 @@ export const gamesRegistryBatch4: GameRegistration[] = [
     available: true,
     order: 212,
     ageMin: 5,
+  },
+  {
+    id: "letter-trace",
+    title: "כתיבת אותיות",
+    description: "עקוב אחרי הקו ותרגל לכתוב את 22 האותיות בעברית — מושלם לגילאי 3-6!",
+    icon: Pencil,
+    emoji: "✏️",
+    color: "bg-blue-500 hover:bg-blue-600",
+    href: "/games/letter-trace",
+    available: true,
+    order: 213,
+    ageMin: 3,
   },
 ];

--- a/gamesformykids/lib/types/core/base.ts
+++ b/gamesformykids/lib/types/core/base.ts
@@ -282,4 +282,6 @@ export type GameType =
   // Cooking game — follow Hebrew recipe steps, tap correct ingredients
   | 'cooking-game'
   // Spot the difference — find 5 differences between two emoji scenes
-  | 'spot-the-difference';
+  | 'spot-the-difference'
+  // Hebrew letter tracing — trace all 22 letters with finger/mouse
+  | 'letter-trace';


### PR DESCRIPTION
## What
Adds a finger/mouse Hebrew letter tracing game targeted at ages 3-6. Children trace all 22 Hebrew block letters following animated waypoints, with real-time path feedback.

## Implementation
- **`lib/constants/gameData/hebrewLetterPaths.ts`** — stroke waypoint data for all 22 Hebrew letters (normalized 0-100 coordinates, 1-2 strokes per letter)
- **`LetterCanvas`** — canvas component with pointer events: records drawn path, captures waypoints in order, draws ghost guide (guided mode) or blank (free mode)
- **`LetterTraceClient`** — main screen with progress bar, letter header, result overlay
- **`LetterTraceMenu`** — start screen with guided/free difficulty picker
- **`letterTraceStore`** — Zustand store managing phase (menu → tracing → result), score, letter order (shuffled)
- Waypoint capture: user must pass within 18px of each waypoint in sequence; 60%+ captured = success
- Completion TTS: speaks the letter name in Hebrew on moving to the next letter

## Why
Closes #1226

## Test plan
- [ ] Visit `/games/letter-trace` — see menu with guided/free buttons
- [ ] Start guided mode — see ghost path + green start arrow on canvas
- [ ] Start free mode — blank canvas, no ghost
- [ ] Trace letter with mouse/finger — waypoints highlight green as captured
- [ ] Complete trace — see "✅ יפה מאוד!" or "💪 נסה שוב!" badge
- [ ] Click "הבאה" — hear TTS of letter name, advance to next letter
- [ ] Complete all 22 letters — see trophy result screen
- [ ] Game appears in "למידה בסיסית" category on home page
- [ ] Works on iOS Safari (touch) and Android Chrome (touch)
- [ ] `tsc --noEmit` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)