### PR TITLE
feat(game): number-merge drop & merge mechanic for ages 5-9 (closes #1182)

### DIFF
--- a/gamesformykids/app/games/[gameType]/CustomGameRenderer.tsx
+++ b/gamesformykids/app/games/[gameType]/CustomGameRenderer.tsx
@@ -88,6 +88,7 @@ const GAME_CLIENTS: Record<string, ComponentType> = {
   'letter-trace':          dynamic(() => import('../letter-trace/LetterTraceClient'),                  { ssr: false }),
   'market-game':           dynamic(() => import('../market-game/MarketClient'),                         { ssr: false }),
   'crossword':             dynamic(() => import('../crossword/CrosswordClient'),                        { ssr: false }),
+  'number-merge':          dynamic(() => import('../number-merge/NumberMergeClient'),                   { ssr: false }),
 };
 
 interface Props { gameType: string; }

--- a/gamesformykids/app/games/[gameType]/gamePageConstants.ts
+++ b/gamesformykids/app/games/[gameType]/gamePageConstants.ts
@@ -110,6 +110,7 @@ export const SUPPORTED_GAMES = [
   'spot-the-difference',
   'market-game',
   'crossword',
+  'number-merge',
 ] as const;
 
 export type SupportedGameType = typeof SUPPORTED_GAMES[number];
@@ -124,7 +125,7 @@ export const CUSTOM_GAME_TYPES = new Set([
   'word-builder', 'word-scramble', 'maze', 'letter-defender', 'puppet-story', 'number-slide', 'snakes-ladders',
 
 
-  'escape-room', 'robot-coder', 'find-in-scene', 'hangman', 'choose-adventure', 'picture-dictionary', 'word-search', 'israel-map', 'kids-songs', 'melody-maker', 'kids-encyclopedia', 'age-calculator', 'craft-guide', 'jokes-browser', 'word-maze', 'avatar-maker', 'sound-quiz', 'spinner', 'team-picker', 'dice', 'timer', 'letter-race', 'drag-sort', 'answer-cannon', 'typing-race', 'word-fishing', 'letter-grow', 'letter-slingshot', 'syllable-drums', 'dress-up', 'letter-bubble-shooter', 'letter-slicer', 'cooking-game', 'spot-the-difference', 'letter-trace', 'market-game', 'crossword',
+  'escape-room', 'robot-coder', 'find-in-scene', 'hangman', 'choose-adventure', 'picture-dictionary', 'word-search', 'israel-map', 'kids-songs', 'melody-maker', 'kids-encyclopedia', 'age-calculator', 'craft-guide', 'jokes-browser', 'word-maze', 'avatar-maker', 'sound-quiz', 'spinner', 'team-picker', 'dice', 'timer', 'letter-race', 'drag-sort', 'answer-cannon', 'typing-race', 'word-fishing', 'letter-grow', 'letter-slingshot', 'syllable-drums', 'dress-up', 'letter-bubble-shooter', 'letter-slicer', 'cooking-game', 'spot-the-difference', 'letter-trace', 'market-game', 'crossword', 'number-merge',
   
   
 ]);

--- a/gamesformykids/app/games/number-merge/NumberMergeClient.tsx
+++ b/gamesformykids/app/games/number-merge/NumberMergeClient.tsx
@@ -1,0 +1,141 @@
+'use client';
+import dynamic from 'next/dynamic';
+import { useNumberMergeStore, type Difficulty } from './numberMergeStore';
+
+const MergeCanvas = dynamic(() => import('./components/MergeCanvas'), { ssr: false });
+
+const DIFFICULTY_LABELS: Record<Difficulty, { label: string; desc: string; emoji: string; color: string }> = {
+  easy:   { label: 'קל',    desc: 'הגע ל-200',  emoji: '⭐',  color: 'bg-green-400 hover:bg-green-500' },
+  medium: { label: 'בינוני', desc: 'הגע ל-500',  emoji: '⭐⭐', color: 'bg-yellow-400 hover:bg-yellow-500' },
+  hard:   { label: 'קשה',   desc: 'הגע ל-1000', emoji: '⭐⭐⭐', color: 'bg-red-400 hover:bg-red-500' },
+};
+
+export default function NumberMergeClient() {
+  const { phase, score, targetScore, highScore, difficulty, gameOver, mergeFlash, startGame, restart, clearMergeFlash } = useNumberMergeStore();
+
+  if (mergeFlash) {
+    setTimeout(clearMergeFlash, 800);
+  }
+
+  if (phase === 'menu') {
+    return (
+      <div className="min-h-screen bg-gradient-to-br from-orange-100 to-yellow-200 flex flex-col items-center justify-center p-4 gap-6" dir="rtl">
+        <div className="text-center">
+          <div className="text-6xl mb-2">🔢</div>
+          <h1 className="text-4xl font-bold text-orange-800">מיזוג מספרים</h1>
+          <p className="text-orange-600 mt-1">שחרר מספרים ומזג זוגות!</p>
+        </div>
+
+        <div className="bg-white rounded-2xl p-5 shadow-lg w-full max-w-xs text-center">
+          <p className="text-gray-600 mb-1 text-sm">שיא אישי</p>
+          <p className="text-3xl font-bold text-orange-500">{highScore}</p>
+        </div>
+
+        <div className="bg-white rounded-2xl p-5 shadow-lg w-full max-w-xs">
+          <p className="text-gray-700 font-bold mb-3 text-center">בחר רמת קושי</p>
+          <div className="flex flex-col gap-3">
+            {(Object.keys(DIFFICULTY_LABELS) as Difficulty[]).map(d => {
+              const { label, desc, emoji, color } = DIFFICULTY_LABELS[d];
+              return (
+                <button
+                  key={d}
+                  onClick={() => startGame(d)}
+                  className={`${color} text-white rounded-xl py-3 px-4 font-bold text-lg transition-all flex items-center justify-between`}
+                >
+                  <span>{emoji} {label}</span>
+                  <span className="text-sm opacity-80">{desc}</span>
+                </button>
+              );
+            })}
+          </div>
+        </div>
+
+        <div className="bg-white bg-opacity-70 rounded-xl p-4 w-full max-w-xs text-sm text-gray-600 text-center">
+          <p>🖱️ הזז את העכבר ולחץ כדי לשחרר מספר</p>
+          <p>🔢 שני מספרים זהים שנוגעים — מתמזגים!</p>
+        </div>
+      </div>
+    );
+  }
+
+  if (phase === 'result') {
+    return (
+      <div className="min-h-screen bg-gradient-to-br from-orange-100 to-yellow-200 flex flex-col items-center justify-center p-4 gap-6" dir="rtl">
+        <div className="text-6xl">{gameOver ? '💥' : '🎉'}</div>
+        <h2 className="text-3xl font-bold text-orange-800">
+          {gameOver ? 'המשחק נגמר!' : 'כל הכבוד!'}
+        </h2>
+
+        <div className="bg-white rounded-2xl p-6 shadow-xl text-center w-full max-w-xs">
+          <p className="text-gray-500 text-sm">הניקוד שלך</p>
+          <p className="text-5xl font-bold text-orange-500 my-2">{score}</p>
+          <p className="text-gray-500 text-sm">שיא: {highScore}</p>
+          {!gameOver && (
+            <p className="text-green-600 font-bold mt-2">🎯 הגעת ל-{targetScore}!</p>
+          )}
+        </div>
+
+        <div className="flex flex-col gap-3 w-full max-w-xs">
+          <button
+            onClick={() => startGame(difficulty)}
+            className="bg-orange-400 hover:bg-orange-500 text-white rounded-xl py-3 font-bold text-lg transition-all"
+          >
+            🔄 שחק שוב
+          </button>
+          <button
+            onClick={restart}
+            className="bg-gray-200 hover:bg-gray-300 text-gray-700 rounded-xl py-3 font-bold text-lg transition-all"
+          >
+            🏠 תפריט ראשי
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  // Playing
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-orange-100 to-yellow-200 flex flex-col items-center p-3 gap-3" dir="rtl">
+      {/* Header */}
+      <div className="w-full max-w-xs flex items-center justify-between">
+        <div className="bg-white rounded-xl px-4 py-2 shadow text-center min-w-[90px]">
+          <p className="text-xs text-gray-500">ניקוד</p>
+          <p className="text-xl font-bold text-orange-500">{score}</p>
+        </div>
+
+        <div className="text-center">
+          <p className="text-2xl font-bold text-orange-800">🔢 מיזוג</p>
+        </div>
+
+        <div className="bg-white rounded-xl px-4 py-2 shadow text-center min-w-[90px]">
+          <p className="text-xs text-gray-500">יעד</p>
+          <p className="text-xl font-bold text-orange-700">{targetScore}</p>
+        </div>
+      </div>
+
+      {/* Progress bar */}
+      <div className="w-full max-w-xs bg-white bg-opacity-60 rounded-full h-3 overflow-hidden">
+        <div
+          className="h-full bg-gradient-to-r from-orange-400 to-yellow-400 rounded-full transition-all duration-300"
+          style={{ width: `${Math.min(100, (score / targetScore) * 100)}%` }}
+        />
+      </div>
+
+      {/* Merge flash overlay */}
+      {mergeFlash && (
+        <div
+          key={mergeFlash.id}
+          className="fixed pointer-events-none z-50 text-2xl font-bold text-orange-600 animate-bounce"
+          style={{ top: '40%', left: '50%', transform: 'translateX(-50%)' }}
+        >
+          +{mergeFlash.value * 10} ✨
+        </div>
+      )}
+
+      {/* Canvas */}
+      <MergeCanvas />
+
+      <p className="text-orange-700 text-sm opacity-70">לחץ על הלוח כדי לשחרר מספר</p>
+    </div>
+  );
+}

--- a/gamesformykids/app/games/number-merge/components/MergeCanvas.tsx
+++ b/gamesformykids/app/games/number-merge/components/MergeCanvas.tsx
@@ -49,7 +49,7 @@ function resolveCollision(balls: Ball[]): { balls: Ball[]; merges: { x: number; 
       if (!a || !b || toRemove.has(a.id) || toRemove.has(b.id)) continue;
       if (a.value !== b.value) continue;
 
-      const { dist, minDist, dx, dy } = circlePair(a, b);
+      const { dist, minDist } = circlePair(a, b);
       if (dist >= minDist) continue;
 
       // Same value touching → merge
@@ -112,7 +112,7 @@ function stepPhysics(balls: Ball[]): { balls: Ball[]; merges: { x: number; y: nu
       const a = balls[i];
       const b = balls[j];
       if (!a || !b) continue;
-      const { dist, minDist, dx, dy, overlap } = circlePair(a, b);
+      const { dist, dx, dy, overlap } = circlePair(a, b);
       if (overlap <= 0 || dist === 0) continue;
       if (a.value === b.value) continue; // will be merged separately
 

--- a/gamesformykids/app/games/number-merge/components/MergeCanvas.tsx
+++ b/gamesformykids/app/games/number-merge/components/MergeCanvas.tsx
@@ -1,0 +1,294 @@
+'use client';
+import { useRef, useEffect, useCallback } from 'react';
+import { useNumberMergeStore, Ball, RADIUS_FOR_VALUE } from '../numberMergeStore';
+import { speakHebrew } from '@/lib/utils/speech/speaker';
+
+const CANVAS_W = 320;
+const CANVAS_H = 480;
+const FLOOR_Y = CANVAS_H - 20;
+const WALL_LEFT = 10;
+const WALL_RIGHT = CANVAS_W - 10;
+const GRAVITY = 0.4;
+const DAMPING = 0.55;
+const FRICTION = 0.85;
+
+const NUMBER_COLORS: Record<number, string> = {
+  1:  '#FF6B6B',
+  2:  '#FF8E53',
+  3:  '#FFCA28',
+  4:  '#66BB6A',
+  5:  '#26C6DA',
+  6:  '#42A5F5',
+  7:  '#7E57C2',
+  8:  '#EC407A',
+  9:  '#8D6E63',
+  10: '#455A64',
+};
+
+const HEBREW_NUMBERS: Record<number, string> = {
+  1:'אחד',2:'שניים',3:'שלוש',4:'ארבע',5:'חמש',
+  6:'שש',7:'שבע',8:'שמונה',9:'תשע',10:'עשר',
+};
+
+function circlePair(a: Ball, b: Ball) {
+  const dx = b.x - a.x;
+  const dy = b.y - a.y;
+  const dist = Math.sqrt(dx * dx + dy * dy);
+  const minDist = a.radius + b.radius;
+  return { dx, dy, dist, minDist, overlap: minDist - dist };
+}
+
+function resolveCollision(balls: Ball[]): { balls: Ball[]; merges: { x: number; y: number; value: number }[] } {
+  const merges: { x: number; y: number; value: number }[] = [];
+  const toRemove = new Set<number>();
+
+  for (let i = 0; i < balls.length; i++) {
+    for (let j = i + 1; j < balls.length; j++) {
+      const a = balls[i];
+      const b = balls[j];
+      if (!a || !b || toRemove.has(a.id) || toRemove.has(b.id)) continue;
+      if (a.value !== b.value) continue;
+
+      const { dist, minDist, dx, dy } = circlePair(a, b);
+      if (dist >= minDist) continue;
+
+      // Same value touching → merge
+      toRemove.add(a.id);
+      toRemove.add(b.id);
+      const newVal = Math.min(a.value + b.value, 10);
+      const nx = (a.x + b.x) / 2;
+      const ny = (a.y + b.y) / 2;
+      const merged: Ball = {
+        id: Date.now() + Math.random(),
+        x: nx,
+        y: ny,
+        vx: (a.vx + b.vx) * 0.5,
+        vy: (a.vy + b.vy) * 0.5,
+        value: newVal,
+        radius: RADIUS_FOR_VALUE(newVal),
+        merging: false,
+        merged: false,
+      };
+      balls.push(merged);
+      merges.push({ x: nx, y: ny, value: newVal });
+      // skip inner j loop since a is gone
+      break;
+    }
+  }
+
+  return {
+    balls: balls.filter(b => !toRemove.has(b.id)),
+    merges,
+  };
+}
+
+function stepPhysics(balls: Ball[]): { balls: Ball[]; merges: { x: number; y: number; value: number }[] } {
+  // Apply gravity + velocity
+  for (const b of balls) {
+    b.vy += GRAVITY;
+    b.x += b.vx;
+    b.y += b.vy;
+
+    // Floor
+    if (b.y + b.radius >= FLOOR_Y) {
+      b.y = FLOOR_Y - b.radius;
+      b.vy *= -DAMPING;
+      b.vx *= FRICTION;
+    }
+    // Walls
+    if (b.x - b.radius <= WALL_LEFT) {
+      b.x = WALL_LEFT + b.radius;
+      b.vx *= -DAMPING;
+    }
+    if (b.x + b.radius >= WALL_RIGHT) {
+      b.x = WALL_RIGHT - b.radius;
+      b.vx *= -DAMPING;
+    }
+  }
+
+  // Ball-ball separation (push apart first, then merge)
+  for (let i = 0; i < balls.length; i++) {
+    for (let j = i + 1; j < balls.length; j++) {
+      const a = balls[i];
+      const b = balls[j];
+      if (!a || !b) continue;
+      const { dist, minDist, dx, dy, overlap } = circlePair(a, b);
+      if (overlap <= 0 || dist === 0) continue;
+      if (a.value === b.value) continue; // will be merged separately
+
+      const nx = dx / dist;
+      const ny = dy / dist;
+      const push = overlap / 2;
+      a.x -= nx * push;
+      a.y -= ny * push;
+      b.x += nx * push;
+      b.y += ny * push;
+
+      // Elastic-ish bounce
+      const dvx = b.vx - a.vx;
+      const dvy = b.vy - a.vy;
+      const dot = dvx * nx + dvy * ny;
+      if (dot < 0) {
+        const impulse = dot * 0.5;
+        a.vx += impulse * nx;
+        a.vy += impulse * ny;
+        b.vx -= impulse * nx;
+        b.vy -= impulse * ny;
+      }
+    }
+  }
+
+  return resolveCollision(balls);
+}
+
+function drawBall(ctx: CanvasRenderingContext2D, ball: Ball) {
+  const color = NUMBER_COLORS[ball.value] ?? '#999';
+  ctx.beginPath();
+  ctx.arc(ball.x, ball.y, ball.radius, 0, Math.PI * 2);
+  ctx.fillStyle = color;
+  ctx.fill();
+  ctx.strokeStyle = 'rgba(0,0,0,0.2)';
+  ctx.lineWidth = 2;
+  ctx.stroke();
+
+  ctx.fillStyle = '#fff';
+  ctx.font = `bold ${Math.max(10, ball.radius * 0.85)}px Arial`;
+  ctx.textAlign = 'center';
+  ctx.textBaseline = 'middle';
+  ctx.fillText(String(ball.value), ball.x, ball.y);
+}
+
+function drawWalls(ctx: CanvasRenderingContext2D) {
+  ctx.fillStyle = '#d1a96a';
+  ctx.fillRect(0, FLOOR_Y, CANVAS_W, CANVAS_H - FLOOR_Y);
+  ctx.fillRect(0, 0, WALL_LEFT, CANVAS_H);
+  ctx.fillRect(WALL_RIGHT, 0, CANVAS_W - WALL_RIGHT, CANVAS_H);
+}
+
+export default function MergeCanvas() {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const ballsRef = useRef<Ball[]>([]);
+  const animRef = useRef<number>(0);
+  const dropCooldownRef = useRef(false);
+
+  const { balls, dropX, nextValue, phase, addScore, setBalls, triggerMergeFlash, endGame } = useNumberMergeStore();
+
+  // Sync store balls → ref on external changes (drop)
+  useEffect(() => {
+    ballsRef.current = balls.map(b => ({ ...b }));
+  }, [balls]);
+
+  const announceEquation = useCallback((a: number, b: number, result: number) => {
+    const heA = HEBREW_NUMBERS[a] ?? String(a);
+    const heB = HEBREW_NUMBERS[b] ?? String(b);
+    const heR = HEBREW_NUMBERS[result] ?? String(result);
+    speakHebrew(`${heA} ועוד ${heB} שווה ${heR}!`);
+  }, []);
+
+  useEffect(() => {
+    if (phase !== 'playing') return;
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+
+    let frameCount = 0;
+
+    function loop() {
+      if (!ctx) return;
+      // Physics step
+      const { balls: newBalls, merges } = stepPhysics(ballsRef.current);
+      ballsRef.current = newBalls;
+      frameCount++;
+
+      // Handle merges
+      for (const m of merges) {
+        const half = Math.floor(m.value / 2);
+        const score = m.value * 10;
+        addScore(score);
+        announceEquation(half, half, m.value);
+        triggerMergeFlash(m.x, m.y, m.value);
+      }
+
+      // Check overflow (ball reaches top)
+      const overflow = newBalls.some(b => b.y - b.radius <= 10 && Math.abs(b.vy) < 0.5);
+      if (overflow) {
+        endGame();
+        return;
+      }
+
+      // Sync store periodically (every 10 frames) to avoid re-render storm
+      if (frameCount % 10 === 0) {
+        setBalls(newBalls.map(b => ({ ...b })));
+      }
+
+      // Draw
+      ctx.clearRect(0, 0, CANVAS_W, CANVAS_H);
+      // Background
+      ctx.fillStyle = '#FFF8E1';
+      ctx.fillRect(0, 0, CANVAS_W, CANVAS_H);
+      drawWalls(ctx);
+
+      // Drop indicator line
+      ctx.setLineDash([4, 4]);
+      ctx.strokeStyle = 'rgba(0,0,0,0.15)';
+      ctx.lineWidth = 1;
+      ctx.beginPath();
+      ctx.moveTo(dropX, 0);
+      ctx.lineTo(dropX, FLOOR_Y);
+      ctx.stroke();
+      ctx.setLineDash([]);
+
+      // Preview ball at top
+      const previewR = RADIUS_FOR_VALUE(nextValue);
+      const previewColor = NUMBER_COLORS[nextValue] ?? '#999';
+      ctx.globalAlpha = 0.5;
+      ctx.beginPath();
+      ctx.arc(dropX, previewR + 2, previewR, 0, Math.PI * 2);
+      ctx.fillStyle = previewColor;
+      ctx.fill();
+      ctx.fillStyle = '#fff';
+      ctx.font = `bold ${Math.max(10, previewR * 0.85)}px Arial`;
+      ctx.textAlign = 'center';
+      ctx.textBaseline = 'middle';
+      ctx.fillText(String(nextValue), dropX, previewR + 2);
+      ctx.globalAlpha = 1;
+
+      for (const b of newBalls) drawBall(ctx, b);
+
+      animRef.current = requestAnimationFrame(loop);
+    }
+
+    animRef.current = requestAnimationFrame(loop);
+    return () => cancelAnimationFrame(animRef.current);
+  }, [phase, dropX, nextValue, addScore, setBalls, triggerMergeFlash, endGame, announceEquation]);
+
+  const handlePointerMove = useCallback((e: React.PointerEvent<HTMLCanvasElement>) => {
+    const rect = canvasRef.current?.getBoundingClientRect();
+    if (!rect) return;
+    const scaleX = CANVAS_W / rect.width;
+    const rawX = (e.clientX - rect.left) * scaleX;
+    const clampedX = Math.max(WALL_LEFT + 20, Math.min(WALL_RIGHT - 20, rawX));
+    useNumberMergeStore.getState().setDropX(clampedX);
+  }, []);
+
+  const handleDrop = useCallback(() => {
+    if (dropCooldownRef.current) return;
+    dropCooldownRef.current = true;
+    useNumberMergeStore.getState().dropBall();
+    setTimeout(() => { dropCooldownRef.current = false; }, 600);
+  }, []);
+
+  return (
+    <canvas
+      ref={canvasRef}
+      width={CANVAS_W}
+      height={CANVAS_H}
+      className="w-full max-w-xs rounded-2xl shadow-2xl cursor-crosshair touch-none"
+      style={{ imageRendering: 'pixelated' }}
+      onPointerMove={handlePointerMove}
+      onClick={handleDrop}
+      onPointerDown={handleDrop}
+    />
+  );
+}

--- a/gamesformykids/app/games/number-merge/numberMergeStore.ts
+++ b/gamesformykids/app/games/number-merge/numberMergeStore.ts
@@ -1,0 +1,137 @@
+'use client';
+import { create } from 'zustand';
+
+export type Phase = 'menu' | 'playing' | 'result';
+export type Difficulty = 'easy' | 'medium' | 'hard';
+
+export interface Ball {
+  id: number;
+  x: number;
+  y: number;
+  vx: number;
+  vy: number;
+  value: number; // 1-10
+  radius: number;
+  merging: boolean;
+  merged: boolean;
+}
+
+export interface NumberMergeState {
+  phase: Phase;
+  difficulty: Difficulty;
+  balls: Ball[];
+  nextId: number;
+  dropX: number;        // current drop cursor X position
+  nextValue: number;    // next ball value to drop (preview)
+  score: number;
+  highScore: number;
+  targetScore: number;  // goal based on difficulty
+  gameOver: boolean;
+  mergeFlash: { x: number; y: number; value: number; id: number } | null;
+}
+
+export interface NumberMergeActions {
+  startGame: (difficulty: Difficulty) => void;
+  dropBall: () => void;
+  setDropX: (x: number) => void;
+  setBalls: (balls: Ball[]) => void;
+  addScore: (points: number) => void;
+  triggerMergeFlash: (x: number, y: number, value: number) => void;
+  clearMergeFlash: () => void;
+  endGame: () => void;
+  restart: () => void;
+}
+
+const RADIUS_FOR_VALUE = (v: number) => 12 + v * 4;
+
+const TARGET_SCORES: Record<Difficulty, number> = {
+  easy: 200,
+  medium: 500,
+  hard: 1000,
+};
+
+let _nextFlashId = 0;
+
+export const useNumberMergeStore = create<NumberMergeState & NumberMergeActions>((set, get) => ({
+  phase: 'menu',
+  difficulty: 'easy',
+  balls: [],
+  nextId: 1,
+  dropX: 160,
+  nextValue: 1,
+  score: 0,
+  highScore: 0,
+  targetScore: TARGET_SCORES.easy,
+  gameOver: false,
+  mergeFlash: null,
+
+  startGame: (difficulty) => {
+    set({
+      phase: 'playing',
+      difficulty,
+      balls: [],
+      nextId: 1,
+      dropX: 160,
+      nextValue: randomValue(),
+      score: 0,
+      targetScore: TARGET_SCORES[difficulty],
+      gameOver: false,
+      mergeFlash: null,
+    });
+  },
+
+  dropBall: () => {
+    const { dropX, nextValue, nextId, balls } = get();
+    const radius = RADIUS_FOR_VALUE(nextValue);
+    const newBall: Ball = {
+      id: nextId,
+      x: dropX,
+      y: radius + 2,
+      vx: 0,
+      vy: 0,
+      value: nextValue,
+      radius,
+      merging: false,
+      merged: false,
+    };
+    set({
+      balls: [...balls, newBall],
+      nextId: nextId + 1,
+      nextValue: randomValue(),
+    });
+  },
+
+  setDropX: (x) => set({ dropX: x }),
+
+  setBalls: (balls) => set({ balls }),
+
+  addScore: (points) => {
+    const { score, targetScore, highScore } = get();
+    const newScore = score + points;
+    set({
+      score: newScore,
+      highScore: Math.max(highScore, newScore),
+      phase: newScore >= targetScore ? 'result' : 'playing',
+    });
+  },
+
+  triggerMergeFlash: (x, y, value) => {
+    set({ mergeFlash: { x, y, value, id: ++_nextFlashId } });
+  },
+
+  clearMergeFlash: () => set({ mergeFlash: null }),
+
+  endGame: () => {
+    const { score, highScore } = get();
+    set({ phase: 'result', gameOver: true, highScore: Math.max(score, highScore) });
+  },
+
+  restart: () => set({ phase: 'menu', balls: [], score: 0, gameOver: false }),
+}));
+
+function randomValue(): number {
+  // Drop values 1-5 to keep game manageable
+  return Math.ceil(Math.random() * 5);
+}
+
+export { RADIUS_FOR_VALUE };

--- a/gamesformykids/lib/constants/gameCategories.ts
+++ b/gamesformykids/lib/constants/gameCategories.ts
@@ -70,7 +70,7 @@ export const GAME_CATEGORIES: Record<string, GameCategory> = {
     icon: Calculator,
     color: "bg-indigo-500",
     gradient: "from-indigo-400 to-indigo-600",
-    gameIds: ["counting","math","shopping-money","coins-match","multiplication","fractions","sequences","arithmetic","ordinals","number-words","spatial-concepts","sorting","patterns","skip-counting","division","visual-addition","gematria","number-slide","math-stories"],
+    gameIds: ["counting","math","shopping-money","coins-match","multiplication","fractions","sequences","arithmetic","ordinals","number-words","spatial-concepts","sorting","patterns","skip-counting","division","visual-addition","gematria","number-slide","math-stories","number-merge"],
   },
   games: {
     title: "משחקים מיוחדים",

--- a/gamesformykids/lib/registry/registryData/batch4.ts
+++ b/gamesformykids/lib/registry/registryData/batch4.ts
@@ -1160,4 +1160,16 @@ export const gamesRegistryBatch4: GameRegistration[] = [
     order: 216,
     ageMin: 6,
   },
+  {
+    id: "number-merge",
+    title: "מיזוג מספרים",
+    description: "שחרר מספרים לקערה ומזג זוגות זהים — תרגול חיבור מהנה!",
+    icon: Hash,
+    emoji: "🔢",
+    color: "bg-yellow-500 hover:bg-yellow-600",
+    href: "/games/number-merge",
+    available: true,
+    order: 217,
+    ageMin: 5,
+  },
 ];

--- a/gamesformykids/lib/types/core/base.ts
+++ b/gamesformykids/lib/types/core/base.ts
@@ -288,4 +288,6 @@ export type GameType =
   // Market game — serve customers, count items, calculate change
   | 'market-game'
   // Hebrew crossword — fill in crossword answers from picture/audio clues
-  | 'crossword';
+  | 'crossword'
+  // Number merge — drop numbers into bowl, merge matching pairs
+  | 'number-merge';


### PR DESCRIPTION
## What
Implements a Suika/Waterfall-style drop-and-merge game with Hebrew educational skin.

- Custom 2D canvas physics engine: gravity, floor/wall bounce, elastic circle-circle collision
- Same-value numbers that touch merge into their sum (1+1→2, 2+2→4, up to 10)
- TTS announces each merge equation in Hebrew: *"שלוש ועוד שלוש שווה שש!"*
- 3 difficulty levels: easy (reach 200pts), medium (500pts), hard (1000pts)
- Drop cursor with ghost-preview ball; 600ms cooldown prevents spam drops
- Score flash overlay with animated "+N ✨" popup on each merge
- Game-over when a settled ball reaches the top of the bowl

## Why
Closes #1182

## Test plan
- [ ] Drop balls and verify physics (gravity, floor bounce, wall bounce)
- [ ] Verify two balls of the same value merge on contact and announce equation in Hebrew TTS
- [ ] Verify score increments by `value × 10` per merge
- [ ] Verify all 3 difficulty targets trigger win screen
- [ ] Verify game-over triggers when bowl overflows
- [ ] Test on mobile (touch events via `onPointerMove` + `onPointerDown`)
- [ ] Verify game appears in math category on home page
- [ ] `npx tsc --noEmit` passes ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)