### PR TITLE
feat(engagement): sibling leaderboard on dashboard (closes #1044)

### DIFF
--- a/gamesformykids/app/dashboard/DashboardClient.tsx
+++ b/gamesformykids/app/dashboard/DashboardClient.tsx
@@ -9,6 +9,7 @@ import { ScoreSummaryCard } from './components/ScoreSummaryCard';
 import { RecentAchievementsCard } from './components/RecentAchievementsCard';
 import { RecommendedGameCard } from './components/RecommendedGameCard';
 import { ScoreHistoryCard } from './components/ScoreHistoryCard';
+import { SiblingLeaderboardCard } from './components/SiblingLeaderboardCard';
 
 export default function DashboardClient() {
   const { user, loading: authLoading } = useAuth();
@@ -52,6 +53,7 @@ export default function DashboardClient() {
             <ScoreHistoryCard />
             <RecentAchievementsCard />
             <RecommendedGameCard />
+            <SiblingLeaderboardCard />
           </div>
         </div>
       </div>

--- a/gamesformykids/app/dashboard/components/SiblingLeaderboardCard.tsx
+++ b/gamesformykids/app/dashboard/components/SiblingLeaderboardCard.tsx
@@ -1,0 +1,144 @@
+'use client';
+import { useState } from 'react';
+import { useFamilyLeaderboard } from '@/hooks/shared/user/useFamilyLeaderboard';
+import { getGameLabel } from './gameLabels';
+
+export function SiblingLeaderboardCard() {
+  const { familyGroupId, members, leaderboard, loading, error, create, join, leave } = useFamilyLeaderboard();
+  const [joinInput, setJoinInput] = useState('');
+  const [showJoinForm, setShowJoinForm] = useState(false);
+
+  const siblings = members.filter(m => {
+    // At runtime we compare against the auth user's id — the hook already filters
+    // siblingProgress by user_id !== user.id, so any member with progress is a sibling
+    return true;
+  });
+
+  if (loading) {
+    return (
+      <div className="bg-white rounded-2xl shadow-md p-6 animate-pulse" dir="rtl">
+        <div className="h-4 bg-gray-200 rounded w-2/3 mb-4" />
+        <div className="space-y-3">
+          {[1, 2, 3].map(i => <div key={i} className="h-8 bg-gray-100 rounded" />)}
+        </div>
+      </div>
+    );
+  }
+
+  // No family group yet
+  if (!familyGroupId) {
+    return (
+      <div className="bg-white rounded-2xl shadow-md p-6 col-span-2" dir="rtl">
+        <h2 className="text-lg font-bold text-gray-800 mb-1">🏆 תחרות משפחתית</h2>
+        <p className="text-gray-500 text-sm mb-4">השווה ניקוד עם אח/אחות — צור קבוצה משפחתית כדי להתחיל!</p>
+
+        {error && <p className="text-red-500 text-sm mb-3">{error}</p>}
+
+        <div className="flex flex-col gap-3">
+          <button
+            onClick={create}
+            className="bg-purple-600 hover:bg-purple-700 text-white font-bold py-2 px-4 rounded-xl text-sm transition-colors"
+          >
+            ✨ צור קבוצה חדשה
+          </button>
+
+          {showJoinForm ? (
+            <div className="flex gap-2">
+              <input
+                value={joinInput}
+                onChange={e => setJoinInput(e.target.value)}
+                placeholder="הכנס קוד קבוצה..."
+                className="flex-1 border border-gray-300 rounded-xl px-3 py-2 text-sm text-right"
+                dir="ltr"
+              />
+              <button
+                onClick={() => { if (joinInput.trim()) join(joinInput); }}
+                className="bg-blue-500 hover:bg-blue-600 text-white font-bold py-2 px-3 rounded-xl text-sm"
+              >
+                הצטרף
+              </button>
+              <button
+                onClick={() => setShowJoinForm(false)}
+                className="bg-gray-200 hover:bg-gray-300 text-gray-600 py-2 px-3 rounded-xl text-sm"
+              >
+                ✕
+              </button>
+            </div>
+          ) : (
+            <button
+              onClick={() => setShowJoinForm(true)}
+              className="bg-gray-100 hover:bg-gray-200 text-gray-700 font-bold py-2 px-4 rounded-xl text-sm transition-colors"
+            >
+              🔗 הצטרף לקבוצה קיימת
+            </button>
+          )}
+        </div>
+      </div>
+    );
+  }
+
+  // Has family group — show group code and leaderboard
+  return (
+    <div className="bg-white rounded-2xl shadow-md p-6 col-span-2" dir="rtl">
+      <div className="flex items-center justify-between mb-4">
+        <h2 className="text-lg font-bold text-gray-800">🏆 תחרות משפחתית</h2>
+        <button
+          onClick={leave}
+          className="text-xs text-gray-400 hover:text-red-500 transition-colors"
+        >
+          עזוב קבוצה
+        </button>
+      </div>
+
+      {/* Group code to share */}
+      <div className="bg-purple-50 rounded-xl p-3 mb-4 text-center">
+        <p className="text-xs text-purple-600 mb-1">קוד הקבוצה שלך — שתף עם אח/אחות:</p>
+        <code className="text-purple-800 font-mono text-sm break-all select-all">{familyGroupId}</code>
+      </div>
+
+      {error && <p className="text-red-500 text-sm mb-3">{error}</p>}
+
+      {leaderboard.length === 0 ? (
+        <div className="text-center py-6 text-gray-400 text-sm">
+          <p>עדיין אין משחקים משותפים.</p>
+          <p className="mt-1">ברגע שגם הצד השני ישחק, הטבלה תתמלא!</p>
+          {siblings.length <= 1 && (
+            <p className="mt-3 text-xs text-purple-500">
+              ממתין לחבר/ת קבוצה… ({siblings.length} חבר/ים כרגע)
+            </p>
+          )}
+        </div>
+      ) : (
+        <>
+          {/* Legend */}
+          <div className="flex justify-end gap-4 mb-2 text-xs text-gray-500">
+            <span>אני</span>
+            <span>אח/אחות</span>
+          </div>
+
+          {/* Table */}
+          <ul className="space-y-2">
+            {leaderboard.map(row => {
+              const { name, emoji } = getGameLabel(row.gameType);
+              return (
+                <li key={row.gameType} className="flex items-center gap-2 bg-gray-50 rounded-xl px-3 py-2">
+                  <span className="text-base">{emoji}</span>
+                  <span className="flex-1 text-sm text-gray-700 truncate">{name}</span>
+                  <span className={`text-sm font-bold w-12 text-center ${row.winner === 'me' ? 'text-purple-600' : 'text-gray-500'}`}>
+                    {row.myBest}
+                    {row.winner === 'me' && ' 🏆'}
+                  </span>
+                  <span className={`text-sm font-bold w-12 text-center ${row.winner === 'sibling' ? 'text-blue-600' : 'text-gray-500'}`}>
+                    {row.siblingBest}
+                    {row.winner === 'sibling' && ' 🏆'}
+                  </span>
+                  {row.winner === 'tie' && <span className="text-xs text-yellow-500">🤝</span>}
+                </li>
+              );
+            })}
+          </ul>
+        </>
+      )}
+    </div>
+  );
+}

--- a/gamesformykids/app/dashboard/components/SiblingLeaderboardCard.tsx
+++ b/gamesformykids/app/dashboard/components/SiblingLeaderboardCard.tsx
@@ -8,12 +8,6 @@ export function SiblingLeaderboardCard() {
   const [joinInput, setJoinInput] = useState('');
   const [showJoinForm, setShowJoinForm] = useState(false);
 
-  const siblings = members.filter(m => {
-    // At runtime we compare against the auth user's id — the hook already filters
-    // siblingProgress by user_id !== user.id, so any member with progress is a sibling
-    return true;
-  });
-
   if (loading) {
     return (
       <div className="bg-white rounded-2xl shadow-md p-6 animate-pulse" dir="rtl">
@@ -102,9 +96,9 @@ export function SiblingLeaderboardCard() {
         <div className="text-center py-6 text-gray-400 text-sm">
           <p>עדיין אין משחקים משותפים.</p>
           <p className="mt-1">ברגע שגם הצד השני ישחק, הטבלה תתמלא!</p>
-          {siblings.length <= 1 && (
+          {members.length <= 1 && (
             <p className="mt-3 text-xs text-purple-500">
-              ממתין לחבר/ת קבוצה… ({siblings.length} חבר/ים כרגע)
+              ממתין לחבר/ת קבוצה… ({members.length} חבר/ים כרגע)
             </p>
           )}
         </div>

--- a/gamesformykids/hooks/shared/user/useFamilyLeaderboard.ts
+++ b/gamesformykids/hooks/shared/user/useFamilyLeaderboard.ts
@@ -1,0 +1,134 @@
+'use client';
+import { useState, useEffect, useCallback } from 'react';
+import { useAuth } from '@/hooks/shared/auth/useAuth';
+import { useUserProfile } from './useUserProfile';
+import {
+  fetchFamilyMembers,
+  fetchFamilyProgress,
+  joinFamilyGroup,
+  createFamilyGroup,
+  leaveFamilyGroup,
+  type FamilyMemberProfile,
+} from '@/lib/supabase/familyGroup';
+import type { GameProgress } from '@/hooks/shared/progress/useGameProgress';
+
+export interface LeaderboardRow {
+  gameType: string;
+  myBest: number;
+  siblingBest: number;
+  winner: 'me' | 'sibling' | 'tie';
+}
+
+export interface FamilyLeaderboardState {
+  members: FamilyMemberProfile[];
+  myProgress: GameProgress[];
+  siblingProgress: GameProgress[];
+  leaderboard: LeaderboardRow[];
+  loading: boolean;
+  error: string | null;
+  familyGroupId: string | null;
+}
+
+export function useFamilyLeaderboard() {
+  const { user } = useAuth();
+  const { profile, updateProfile } = useUserProfile();
+  const [state, setState] = useState<FamilyLeaderboardState>({
+    members: [],
+    myProgress: [],
+    siblingProgress: [],
+    leaderboard: [],
+    loading: false,
+    error: null,
+    familyGroupId: null,
+  });
+
+  const load = useCallback(async () => {
+    if (!user || !profile?.family_group_id) {
+      setState(s => ({ ...s, familyGroupId: profile?.family_group_id ?? null, loading: false }));
+      return;
+    }
+
+    setState(s => ({ ...s, loading: true, error: null, familyGroupId: profile.family_group_id }));
+    try {
+      const members = await fetchFamilyMembers(profile.family_group_id!);
+      const allProgress = await fetchFamilyProgress(members.map(m => m.id));
+
+      const mine = allProgress.filter(p => p.user_id === user.id);
+      const siblings = allProgress.filter(p => p.user_id !== user.id);
+
+      // Build leaderboard: only games where BOTH me and a sibling have played
+      const myMap = Object.fromEntries(mine.map(p => [p.game_type, p.best_score]));
+      const sibMap: Record<string, number> = {};
+      for (const p of siblings) {
+        sibMap[p.game_type] = Math.max(sibMap[p.game_type] ?? 0, p.best_score);
+      }
+
+      const shared = Object.keys(myMap).filter(gt => gt in sibMap && (myMap[gt]! > 0 || (sibMap[gt] ?? 0) > 0));
+      const rows: LeaderboardRow[] = shared
+        .map(gt => {
+          const me = myMap[gt] ?? 0;
+          const sib = sibMap[gt] ?? 0;
+          return {
+            gameType: gt,
+            myBest: me,
+            siblingBest: sib,
+            winner: (me > sib ? 'me' : sib > me ? 'sibling' : 'tie') as 'me' | 'sibling' | 'tie',
+          };
+        })
+        .sort((a, b) => Math.max(b.myBest, b.siblingBest) - Math.max(a.myBest, a.siblingBest))
+        .slice(0, 10);
+
+      setState(s => ({
+        ...s,
+        members,
+        myProgress: mine,
+        siblingProgress: siblings,
+        leaderboard: rows,
+        loading: false,
+        familyGroupId: profile.family_group_id,
+      }));
+    } catch (err) {
+      setState(s => ({ ...s, loading: false, error: err instanceof Error ? err.message : 'שגיאה בטעינה' }));
+    }
+  }, [user, profile]);
+
+  useEffect(() => { load(); }, [load]);
+
+  async function handleCreate() {
+    if (!user) return;
+    setState(s => ({ ...s, loading: true, error: null }));
+    try {
+      const groupId = await createFamilyGroup(user.id);
+      await updateProfile({ family_group_id: groupId });
+      await load();
+    } catch (err) {
+      setState(s => ({ ...s, loading: false, error: err instanceof Error ? err.message : 'שגיאה ביצירת הקבוצה' }));
+    }
+  }
+
+  async function handleJoin(groupId: string) {
+    if (!user) return;
+    setState(s => ({ ...s, loading: true, error: null }));
+    try {
+      await joinFamilyGroup(user.id, groupId.trim());
+      await updateProfile({ family_group_id: groupId.trim() });
+      await load();
+    } catch (err) {
+      setState(s => ({ ...s, loading: false, error: err instanceof Error ? err.message : 'שגיאה בהצטרפות לקבוצה' }));
+    }
+  }
+
+  async function handleLeave() {
+    if (!user) return;
+    setState(s => ({ ...s, loading: true, error: null }));
+    try {
+      await leaveFamilyGroup(user.id);
+      await updateProfile({ family_group_id: null });
+      setState({ members: [], myProgress: [], siblingProgress: [], leaderboard: [], loading: false, error: null, familyGroupId: null });
+    } catch (err) {
+      setState(s => ({ ...s, loading: false, error: err instanceof Error ? err.message : 'שגיאה ביציאה מהקבוצה' }));
+    }
+  }
+
+  return { ...state, create: handleCreate, join: handleJoin, leave: handleLeave, refresh: load };
+}

--- a/gamesformykids/hooks/shared/user/useUserProfile.ts
+++ b/gamesformykids/hooks/shared/user/useUserProfile.ts
@@ -30,6 +30,7 @@ export interface UserProfile {
   full_name: string | null
   avatar_url: string | null
   gender: 'male' | 'female' | null
+  family_group_id: string | null
   created_at: string
   updated_at: string
 }

--- a/gamesformykids/lib/supabase/familyGroup.ts
+++ b/gamesformykids/lib/supabase/familyGroup.ts
@@ -1,0 +1,71 @@
+/**
+ * ===============================================
+ * Supabase Service — Family Group / Sibling Leaderboard
+ * ===============================================
+ */
+
+import { supabase } from './client';
+import type { GameProgress } from '@/hooks/shared/progress/useGameProgress';
+
+export interface FamilyMemberProfile {
+  id: string;
+  full_name: string | null;
+  avatar_url: string | null;
+  family_group_id: string;
+}
+
+/** Fetch all profiles that share the same family_group_id. */
+export async function fetchFamilyMembers(familyGroupId: string): Promise<FamilyMemberProfile[]> {
+  const { data, error } = await supabase
+    .from('profiles')
+    .select('id, full_name, avatar_url, family_group_id')
+    .eq('family_group_id', familyGroupId);
+
+  if (error) throw error;
+  return (data ?? []) as FamilyMemberProfile[];
+}
+
+/** Fetch game_progress rows for a list of user IDs (family members). */
+export async function fetchFamilyProgress(userIds: string[]): Promise<GameProgress[]> {
+  if (userIds.length === 0) return [];
+  const { data, error } = await supabase
+    .from('game_progress')
+    .select('*')
+    .in('user_id', userIds);
+
+  if (error) throw error;
+  return (data ?? []) as GameProgress[];
+}
+
+/** Set a user's family_group_id (join an existing group). */
+export async function joinFamilyGroup(userId: string, familyGroupId: string): Promise<void> {
+  const { error } = await supabase
+    .from('profiles')
+    .update({ family_group_id: familyGroupId, updated_at: new Date().toISOString() })
+    .eq('id', userId);
+
+  if (error) throw error;
+}
+
+/** Create a new family group by assigning a fresh UUID to the current user and returning it. */
+export async function createFamilyGroup(userId: string): Promise<string> {
+  // Generate UUID in-JS so we can return it without a separate DB call
+  const groupId = crypto.randomUUID();
+  const { error } = await supabase
+    .from('profiles')
+    .update({ family_group_id: groupId, updated_at: new Date().toISOString() })
+    .eq('id', userId);
+
+  if (error) throw error;
+  return groupId;
+}
+
+/** Remove the current user from their family group. */
+export async function leaveFamilyGroup(userId: string): Promise<void> {
+  const { error } = await supabase
+    .from('profiles')
+    .update({ family_group_id: null, updated_at: new Date().toISOString() })
+    .eq('id', userId);
+
+  if (error) throw error;
+}

--- a/gamesformykids/supabase/migrations/003_add_family_group.sql
+++ b/gamesformykids/supabase/migrations/003_add_family_group.sql
@@ -1,0 +1,37 @@
+-- Add family_group_id to profiles for sibling leaderboard feature
+ALTER TABLE public.profiles
+  ADD COLUMN IF NOT EXISTS family_group_id UUID DEFAULT NULL;
+
+-- Index for fast family group lookups
+CREATE INDEX IF NOT EXISTS idx_profiles_family_group_id
+  ON public.profiles (family_group_id)
+  WHERE family_group_id IS NOT NULL;
+
+-- Allow family members to view each other's profiles
+CREATE POLICY "Family members can view each other's profiles"
+  ON public.profiles
+  FOR SELECT
+  USING (
+    family_group_id IS NOT NULL
+    AND family_group_id = (
+      SELECT p2.family_group_id
+      FROM public.profiles p2
+      WHERE p2.id = auth.uid()
+      LIMIT 1
+    )
+  );
+
+-- Allow family members to view each other's game progress
+CREATE POLICY "Family members can view each other's game progress"
+  ON public.game_progress
+  FOR SELECT
+  USING (
+    EXISTS (
+      SELECT 1
+      FROM public.profiles me
+      JOIN public.profiles them ON them.id = game_progress.user_id
+      WHERE me.id = auth.uid()
+        AND me.family_group_id IS NOT NULL
+        AND me.family_group_id = them.family_group_id
+    )
+  );


### PR DESCRIPTION
## What
Adds a family leaderboard to the dashboard where two linked accounts can compare their best scores side by side.

**Supabase changes:**
- Migration `003_add_family_group.sql`: adds `family_group_id UUID` to `profiles`; adds RLS policies so family members can read each other's `profiles` and `game_progress`

**New files:**
- `lib/supabase/familyGroup.ts` — service: `createFamilyGroup`, `joinFamilyGroup`, `leaveFamilyGroup`, `fetchFamilyMembers`, `fetchFamilyProgress`
- `hooks/shared/user/useFamilyLeaderboard.ts` — hook that builds top-10 head-to-head rows from shared game progress
- `app/dashboard/components/SiblingLeaderboardCard.tsx` — card with create/join/leave flow and comparison table

**Modified files:**
- `hooks/shared/user/useUserProfile.ts` — adds `family_group_id: string | null` to `UserProfile`
- `app/dashboard/DashboardClient.tsx` — renders `<SiblingLeaderboardCard />`

## Why
Closes #1044

## Test plan
- [ ] Without family group: card shows "create group" / "join group" buttons
- [ ] "Create new group" generates a UUID and stores it; group code appears on screen
- [ ] Second user joins by pasting the UUID; after refresh both see each other's scores
- [ ] Leaderboard shows games where **both** siblings have played, sorted by highest score
- [ ] Winner row shows 🏆 emoji; tie shows 🤝
- [ ] "Leave group" resets the card to the empty state
- [ ] Card is RTL and responsive
- [ ] `npx tsc --noEmit` passes ✅

> **Note:** The Supabase migration must be applied to the production database before this PR goes live. SQL file is at `supabase/migrations/003_add_family_group.sql`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)