### PR TITLE
feat(game): מיזוג אותיות / letter-merge — Suika mechanic with Hebrew alef-bet

### DIFF
--- a/gamesformykids/app/games/[gameType]/CustomGameRenderer.tsx
+++ b/gamesformykids/app/games/[gameType]/CustomGameRenderer.tsx
@@ -91,6 +91,7 @@ const GAME_CLIENTS: Record<string, ComponentType> = {
   'number-merge':          dynamic(() => import('../number-merge/NumberMergeClient'),                   { ssr: false }),
   'word-clicker':          dynamic(() => import('../word-clicker/WordClickerClient'),                   { ssr: false }),
   'nikud-drag':            dynamic(() => import('../nikud-drag/NikudDragClient'),                       { ssr: false }),
+  'letter-merge':          dynamic(() => import('../letter-merge/LetterMergeClient'),                   { ssr: false }),
 };
 
 interface Props { gameType: string; }

--- a/gamesformykids/app/games/letter-merge/LetterMergeClient.tsx
+++ b/gamesformykids/app/games/letter-merge/LetterMergeClient.tsx
@@ -1,0 +1,58 @@
+'use client';
+import { useLetterMergeStore } from './letterMergeStore';
+import LetterMergeScreen from './components/LetterMergeScreen';
+
+function LetterMergeMenu({ onStart }: { onStart: () => void }) {
+  return (
+    <div className="min-h-screen flex flex-col items-center justify-center bg-linear-to-br from-blue-100 to-purple-100 p-6" dir="rtl">
+      <div className="text-8xl mb-6">🔤</div>
+      <h1 className="text-4xl font-black text-blue-800 mb-3 text-center">מיזוג אותיות</h1>
+      <p className="text-blue-600 text-lg mb-2 text-center">שחרר אותיות — שתי אותיות זהות מתמזגות לאות הבאה!</p>
+      <div className="bg-white rounded-2xl p-5 shadow-md mb-8 max-w-xs w-full">
+        <div className="flex flex-col gap-3">
+          <div className="flex items-center gap-3">
+            <span className="text-2xl">👆</span>
+            <span className="text-gray-700">לחץ עמודה כדי להוריד אות</span>
+          </div>
+          <div className="flex items-center gap-3">
+            <span className="text-2xl">🔤</span>
+            <span className="text-gray-700">שתי זהות מתמזגות: א+א→ב</span>
+          </div>
+          <div className="flex items-center gap-3">
+            <span className="text-2xl">🏆</span>
+            <span className="text-gray-700">הגע לתָּו כדי לנצח!</span>
+          </div>
+        </div>
+      </div>
+      <button
+        onClick={onStart}
+        className="bg-blue-500 hover:bg-blue-600 active:scale-95 text-white font-black text-xl px-10 py-4 rounded-2xl shadow-lg transition-all"
+      >
+        התחל! 🔤
+      </button>
+    </div>
+  );
+}
+
+function LetterMergeResult({ score, won, onRestart }: { score: number; won: boolean; onRestart: () => void }) {
+  return (
+    <div className="min-h-screen flex flex-col items-center justify-center bg-linear-to-br from-blue-100 to-purple-100 p-6" dir="rtl">
+      <div className="text-7xl mb-4">{won ? '🏆' : '😅'}</div>
+      <h2 className="text-3xl font-black text-blue-800 mb-2">{won ? 'ניצחת! הגעת לתָּו!' : 'המשחק נגמר'}</h2>
+      <p className="text-blue-600 text-xl font-bold mb-6">ניקוד: {score}</p>
+      <button
+        onClick={onRestart}
+        className="bg-blue-500 hover:bg-blue-600 active:scale-95 text-white font-black text-xl px-10 py-4 rounded-2xl shadow-lg transition-all"
+      >
+        שחק שוב! 🔄
+      </button>
+    </div>
+  );
+}
+
+export default function LetterMergeClient() {
+  const { phase, score, won, startGame, reset } = useLetterMergeStore();
+  if (phase === 'idle')   return <LetterMergeMenu onStart={startGame} />;
+  if (phase === 'result') return <LetterMergeResult score={score} won={won} onRestart={reset} />;
+  return <LetterMergeScreen />;
+}

--- a/gamesformykids/app/games/letter-merge/components/LetterMergeScreen.tsx
+++ b/gamesformykids/app/games/letter-merge/components/LetterMergeScreen.tsx
@@ -1,0 +1,92 @@
+'use client';
+import { useLetterMergeStore, ALEF_BET } from '../letterMergeStore';
+
+const LETTER_COLORS: Record<number, string> = {
+  0: 'bg-blue-200 text-blue-800',
+  1: 'bg-green-200 text-green-800',
+  2: 'bg-yellow-200 text-yellow-800',
+  3: 'bg-orange-200 text-orange-800',
+  4: 'bg-red-200 text-red-800',
+  5: 'bg-pink-200 text-pink-800',
+  6: 'bg-purple-200 text-purple-800',
+  7: 'bg-indigo-200 text-indigo-800',
+  8: 'bg-teal-200 text-teal-800',
+  9: 'bg-cyan-200 text-cyan-800',
+  10: 'bg-lime-200 text-lime-800',
+  11: 'bg-amber-200 text-amber-800',
+  12: 'bg-rose-200 text-rose-800',
+  13: 'bg-fuchsia-200 text-fuchsia-800',
+  14: 'bg-violet-200 text-violet-800',
+  15: 'bg-sky-200 text-sky-800',
+  16: 'bg-emerald-200 text-emerald-800',
+  17: 'bg-red-300 text-red-900',
+  18: 'bg-orange-300 text-orange-900',
+  19: 'bg-yellow-300 text-yellow-900',
+  20: 'bg-green-300 text-green-900',
+  21: 'bg-gradient-to-br from-yellow-300 to-orange-400 text-orange-900 font-black shadow-md',
+};
+
+function letterColor(letter: string): string {
+  const idx = ALEF_BET.indexOf(letter);
+  return LETTER_COLORS[idx] ?? 'bg-gray-200 text-gray-800';
+}
+
+export default function LetterMergeScreen() {
+  const { columns, nextLetterVal, score, dropLetter } = useLetterMergeStore();
+
+  return (
+    <div className="min-h-screen flex flex-col items-center bg-linear-to-br from-blue-100 to-purple-100 p-3" dir="rtl">
+      {/* Header */}
+      <div className="flex justify-between w-full max-w-sm mb-3 px-1">
+        <span className="text-blue-700 font-black text-lg">⭐ {score}</span>
+        <span className="text-blue-500 text-sm font-bold">מזג אותיות — הגע לתָּו!</span>
+      </div>
+
+      {/* Next letter preview */}
+      <div className="mb-3 flex flex-col items-center">
+        <p className="text-xs text-blue-400 mb-1">הבאה:</p>
+        <div className={`w-12 h-12 flex items-center justify-center rounded-xl text-2xl font-black ${letterColor(nextLetterVal)}`}>
+          {nextLetterVal}
+        </div>
+      </div>
+
+      {/* Game board */}
+      <div className="bg-white rounded-2xl p-3 shadow-lg w-full max-w-sm">
+        <div className="flex gap-2 justify-center">
+          {columns.map((col, colIdx) => (
+            <button
+              key={colIdx}
+              onClick={() => dropLetter(colIdx)}
+              className="flex flex-col-reverse gap-1 items-center w-14 min-h-48 bg-blue-50 rounded-xl p-1 hover:bg-blue-100 active:scale-95 transition-all"
+            >
+              {col.map((letter, rowIdx) => (
+                <div
+                  key={rowIdx}
+                  className={`w-10 h-10 flex items-center justify-center rounded-lg text-xl font-black transition-all ${letterColor(letter)}`}
+                >
+                  {letter}
+                </div>
+              ))}
+              {col.length === 0 && (
+                <span className="text-blue-200 text-2xl mt-auto">↓</span>
+              )}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {/* Alef-bet progress */}
+      <div className="mt-3 flex flex-wrap gap-1 justify-center max-w-sm">
+        {ALEF_BET.map((l, i) => (
+          <span key={l} className={`text-xs w-6 h-6 flex items-center justify-center rounded ${
+            columns.flat().includes(l)
+              ? letterColor(l)
+              : 'bg-gray-100 text-gray-300'
+          }`}>
+            {l}
+          </span>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/gamesformykids/app/games/letter-merge/letterMergeStore.ts
+++ b/gamesformykids/app/games/letter-merge/letterMergeStore.ts
@@ -1,0 +1,124 @@
+'use client';
+import { create } from 'zustand';
+import { speakHebrew } from '@/lib/utils/speech/speaker';
+
+export const ALEF_BET = ['א','ב','ג','ד','ה','ו','ז','ח','ט','י','כ','ל','מ','נ','ס','ע','פ','צ','ק','ר','ש','ת'];
+const LETTER_NAMES: Record<string, string> = {
+  'א':'אָלֶף','ב':'בֵּית','ג':'גִּימֶל','ד':'דָּלֶת','ה':'הֵא','ו':'וָו','ז':'זַיִן','ח':'חֵית',
+  'ט':'טֵית','י':'יוֹד','כ':'כַּף','ל':'לָמֶד','מ':'מֵם','נ':'נוּן','ס':'סָמֶך','ע':'עַיִן',
+  'פ':'פֵּא','צ':'צָדִי','ק':'קוֹף','ר':'רֵישׁ','ש':'שִׁין','ת':'תָּו',
+};
+const MAX_COLS = 5;
+const MAX_HEIGHT = 7;
+
+function nextLetter(letter: string): string | null {
+  const idx = ALEF_BET.indexOf(letter);
+  if (idx === -1 || idx === ALEF_BET.length - 1) return null;
+  return ALEF_BET[idx + 1] ?? null;
+}
+
+function randomStartLetter(): string {
+  const poolSize = Math.min(4, ALEF_BET.length);
+  return ALEF_BET[Math.floor(Math.random() * poolSize)] ?? 'א';
+}
+
+function mergeColumn(col: string[]): { col: string[]; merged: boolean; mergedLetter: string | null } {
+  if (col.length < 2) return { col, merged: false, mergedLetter: null };
+  const top = col[col.length - 1];
+  const second = col[col.length - 2];
+  if (top && second && top === second) {
+    const next = nextLetter(top);
+    const newCol = [...col.slice(0, col.length - 2)];
+    if (next) newCol.push(next);
+    return { col: newCol, merged: true, mergedLetter: next };
+  }
+  return { col, merged: false, mergedLetter: null };
+}
+
+interface LetterMergeState {
+  phase: 'idle' | 'playing' | 'result';
+  columns: string[][];
+  nextLetterVal: string;
+  score: number;
+  maxLetterReached: string;
+  won: boolean;
+  lastMerged: string | null;
+}
+interface LetterMergeActions {
+  startGame: () => void;
+  dropLetter: (colIndex: number) => void;
+  reset: () => void;
+}
+
+export const useLetterMergeStore = create<LetterMergeState & LetterMergeActions>((set, get) => ({
+  phase: 'idle',
+  columns: [[], [], [], [], []],
+  nextLetterVal: randomStartLetter(),
+  score: 0,
+  maxLetterReached: 'א',
+  won: false,
+  lastMerged: null,
+
+  startGame: () => set({
+    phase: 'playing',
+    columns: [[], [], [], [], []],
+    nextLetterVal: randomStartLetter(),
+    score: 0,
+    maxLetterReached: 'א',
+    won: false,
+    lastMerged: null,
+  }),
+
+  dropLetter: (colIndex: number) => {
+    const { columns, nextLetterVal, score, maxLetterReached } = get();
+    const col = columns[colIndex];
+    if (!col || col.length >= MAX_HEIGHT) return;
+
+    let newColumns = columns.map((c, i) => i === colIndex ? [...c, nextLetterVal] : [...c]);
+    let totalScore = score;
+    let newMax = maxLetterReached;
+    let lastMergedLetter: string | null = null;
+    let won = false;
+
+    // Cascade merge in the dropped column
+    let merging = true;
+    while (merging) {
+      const result = mergeColumn(newColumns[colIndex] ?? []);
+      merging = result.merged;
+      if (merging) {
+        newColumns = newColumns.map((c, i) => i === colIndex ? result.col : c);
+        const merged = result.mergedLetter;
+        if (merged) {
+          lastMergedLetter = merged;
+          const mergedIdx = ALEF_BET.indexOf(merged);
+          totalScore += (mergedIdx + 1) * 10;
+          if (mergedIdx > ALEF_BET.indexOf(newMax)) newMax = merged;
+          if (merged === 'ת') { won = true; merging = false; }
+          void speakHebrew(LETTER_NAMES[merged] ?? merged);
+        }
+      }
+    }
+
+    // Check game over: any column exceeds MAX_HEIGHT
+    const gameOver = !won && newColumns.some(c => c.length >= MAX_HEIGHT);
+
+    set({
+      columns: newColumns,
+      nextLetterVal: randomStartLetter(),
+      score: totalScore,
+      maxLetterReached: newMax,
+      lastMerged: lastMergedLetter,
+      ...(won || gameOver ? { phase: 'result', won } : {}),
+    });
+  },
+
+  reset: () => set({
+    phase: 'idle',
+    columns: [[], [], [], [], []],
+    nextLetterVal: randomStartLetter(),
+    score: 0,
+    maxLetterReached: 'א',
+    won: false,
+    lastMerged: null,
+  }),
+}));


### PR DESCRIPTION
## Summary
- Adapts CoolMathGames Suika Watermelon mechanic into Hebrew alef-bet learning (Style D)
- Drop letters into 5 columns; identical adjacent letters merge into the next letter
- Cascade merge detection; TTS speaks each merged letter name via speakHebrew
- Win condition: reach תָּו; lose: any column overflows MAX_HEIGHT (7)
- Score: (letter index + 1) × 10 per merge

## How to test
1. `npm run dev`
2. Open http://localhost:3000/games/letter-merge
3. Tap columns to drop letters; verify merges cascade correctly
4. Verify TTS speaks letter name on each merge

Closes #1366

🤖 Generated with [Claude Code](https://claude.com/claude-code)