### PR TITLE
fix(ux): RTL, accessibility, mobile & consistency fixes from UX review

### DIFF
--- a/gamesformykids/app/games/word-clicker/components/WordClickerScreen.tsx
+++ b/gamesformykids/app/games/word-clicker/components/WordClickerScreen.tsx
@@ -28,12 +28,12 @@ export default function WordClickerScreen() {
         {/* Target word */}
         <div className="bg-white rounded-2xl p-5 shadow-md mb-4 text-center">
           <p className="text-xs text-gray-400 mb-1">בנה את המילה:</p>
-          <p className="text-5xl font-black text-pink-700 tracking-widest" dir="rtl">{word}</p>
+          <p className="text-5xl font-black text-pink-700" dir="rtl">{word}</p>
 
           {/* Progress bar */}
           <div className="mt-3 h-3 bg-pink-100 rounded-full overflow-hidden">
             <div
-              className="h-full bg-pink-500 rounded-full transition-all duration-300"
+              className="h-full bg-pink-500 rounded-full transition-[width] duration-300"
               style={{ width: `${progress}%` }}
             />
           </div>
@@ -43,7 +43,7 @@ export default function WordClickerScreen() {
             {word.split('').map((letter, i) => (
               <span
                 key={i}
-                className={`text-2xl font-bold w-8 h-8 flex items-center justify-center rounded-lg transition-all ${
+                className={`text-2xl font-bold w-8 h-8 flex items-center justify-center rounded-lg transition-[background-color,color,border-color] ${
                   i < currentLetterIndex
                     ? 'bg-pink-500 text-white'
                     : i === currentLetterIndex
@@ -60,9 +60,9 @@ export default function WordClickerScreen() {
         {/* Feedback banner */}
         {feedback && (
           <div className={`text-center font-black text-xl mb-3 py-2 rounded-xl ${
-            feedback === 'correct' ? 'bg-green-100 text-green-700' : 'bg-red-100 text-red-600'
+            feedback === 'correct' ? 'bg-green-100 text-green-700' : 'bg-amber-50 text-amber-700'
           }`}>
-            {feedback === 'correct' ? '✅ נכון!' : '❌ נסה שוב'}
+            {feedback === 'correct' ? '✅ נכון!' : '💙 נסה שוב!'}
           </div>
         )}
 

--- a/gamesformykids/components/game/CategoryCard.tsx
+++ b/gamesformykids/components/game/CategoryCard.tsx
@@ -16,7 +16,7 @@ export default function CategoryCard({
       type="button"
       onClick={onClick}
       aria-label={`${category.title} — ${gamesCount} משחקים${playedCount > 0 ? `, שיחקת ${playedCount}` : ''}`}
-      className={`w-full relative p-3 md:p-4 lg:p-6 rounded-2xl md:rounded-3xl shadow-lg md:shadow-xl transition-[transform,box-shadow] duration-300 hover:scale-105 cursor-pointer hover:shadow-2xl bg-gradient-to-br ${category.gradient}`}
+      className={`w-full relative p-3 md:p-4 lg:p-6 rounded-2xl md:rounded-3xl shadow-lg md:shadow-xl transition-[transform,box-shadow] duration-300 hover:scale-105 cursor-pointer hover:shadow-2xl bg-linear-to-br ${category.gradient}`}
     >
       <div className="text-center text-white">
         <div className="mb-2 md:mb-4 flex justify-center">
@@ -35,15 +35,11 @@ export default function CategoryCard({
         </div>
         {playedCount > 0 && (
           <div className="mt-2 md:mt-3">
-            <div className="flex items-center justify-between px-1 mb-1">
-              <span className="text-white/80 text-xs">{playedCount}/{gamesCount}</span>
-              <span className="text-white/80 text-xs">{progressPct}%</span>
-            </div>
             <div className="h-1.5 bg-black/25 rounded-full overflow-hidden">
               <div
-                className="h-full bg-white/70 rounded-full transition-all"
+                className="h-full bg-white/70 rounded-full transition-[width]"
                 style={{ width: `${progressPct}%` }}
-                aria-hidden
+                aria-label={`${progressPct}% הושלם`}
               />
             </div>
           </div>

--- a/gamesformykids/components/game/GameCard.tsx
+++ b/gamesformykids/components/game/GameCard.tsx
@@ -47,6 +47,9 @@ export default function GameCard({ game, animationDelay }: GameCardProps) {
               <h3 className="text-base md:text-lg lg:text-xl font-bold mb-1 md:mb-2 drop-shadow-sm leading-tight">
                 {game.title}
               </h3>
+              <p className="text-xs opacity-80 drop-shadow-sm line-clamp-1 sm:hidden">
+                {game.description}
+              </p>
               <p className="text-sm md:text-base opacity-90 drop-shadow-sm hidden sm:block">
                 {game.description}
               </p>

--- a/gamesformykids/components/game/QRButton.tsx
+++ b/gamesformykids/components/game/QRButton.tsx
@@ -49,7 +49,7 @@ export default function QRButton({ gameType }: Props) {
     <>
       <button
         onClick={() => setOpen(true)}
-        className="fixed bottom-4 left-4 z-40 bg-white/90 backdrop-blur-sm rounded-full p-2.5 shadow-lg border border-gray-200 hover:bg-indigo-50 hover:border-indigo-300 transition-all"
+        className="fixed bottom-4 inset-s-4 z-40 bg-white/90 backdrop-blur-sm rounded-full p-2.5 shadow-lg border border-gray-200 hover:bg-indigo-50 hover:border-indigo-300 transition-[background-color,border-color]"
         aria-label="הצג קוד QR"
         title="קוד QR לשיתוף"
       >

--- a/gamesformykids/components/game/quiz/QuizResultScreen.tsx
+++ b/gamesformykids/components/game/quiz/QuizResultScreen.tsx
@@ -50,9 +50,18 @@ export function QuizResultScreen({ onRestart, theme, title = 'כל הכבוד!',
         </p>
         <div className={`text-5xl font-black ${t.text} mb-1`}>{score}</div>
         <p className="text-gray-400 text-base mb-6">נקודות</p>
+        {nextGame && (
+          <Link
+            href={nextGame.href}
+            className={`w-full py-3 rounded-2xl ${t.button} text-white font-bold text-lg flex items-center justify-center gap-2 hover:opacity-90 active:scale-95 transition-[transform,opacity]`}
+          >
+            <span>{nextGame.emoji} {nextGame.title}</span>
+            <span aria-hidden>←</span>
+          </Link>
+        )}
         <button
           onClick={onRestart}
-          className={`w-full py-3 rounded-2xl ${t.button} text-white font-bold text-lg transition-opacity`}
+          className="mt-3 w-full py-3 rounded-2xl border-2 border-gray-200 text-gray-600 font-bold text-lg hover:bg-gray-50 active:scale-95 transition-[transform,background-color]"
         >
           שחק שוב
         </button>
@@ -64,15 +73,13 @@ export function QuizResultScreen({ onRestart, theme, title = 'כל הכבוד!',
             🖨️ הדפס תעודה
           </button>
         )}
-        {nextGame && (
-          <Link
-            href={nextGame.href}
-            className="mt-3 flex items-center justify-center gap-2 w-full py-2.5 rounded-2xl border-2 border-indigo-100 text-indigo-600 font-semibold text-sm hover:bg-indigo-50 active:scale-95 transition-[transform,colors]"
-          >
-            <span>המשחק הבא: {nextGame.emoji} {nextGame.title}</span>
-            <span aria-hidden>←</span>
-          </Link>
-        )}
+        <Link
+          href="/"
+          className="mt-3 flex items-center justify-center gap-1.5 w-full py-2 text-gray-400 text-sm hover:text-gray-600 transition-colors"
+        >
+          <span aria-hidden>🏠</span>
+          <span>חזור לדף הבית</span>
+        </Link>
         <div className="mt-4 pt-3 border-t border-gray-100">
           {rating ? (
             <p className="text-sm text-gray-400">

--- a/gamesformykids/components/game/quiz/screens/RiddleProQuestion.tsx
+++ b/gamesformykids/components/game/quiz/screens/RiddleProQuestion.tsx
@@ -60,10 +60,10 @@ export default function RiddleProQuestion({
 
       {/* Feedback */}
       {waiting && (
-        <div className={`text-center text-xl font-bold mb-3 ${lastCorrect ? 'text-green-600' : 'text-red-500'}`}>
+        <div className={`rounded-2xl p-3 mb-3 text-center text-xl font-bold ${lastCorrect ? 'bg-green-50 text-green-700' : 'bg-amber-50 text-amber-700'}`}>
           {lastCorrect
             ? `✅ נכון! +${lastPoints} ${lastPoints === 3 ? '🌟🌟🌟' : lastPoints === 2 ? '🌟🌟' : '🌟'}`
-            : `❌ לא נכון — ${current.answer}`}
+            : `💙 כמעט! הנכון: ${current.answer}`}
         </div>
       )}
 

--- a/gamesformykids/components/game/quiz/screens/StoryBuilderQuestion.tsx
+++ b/gamesformykids/components/game/quiz/screens/StoryBuilderQuestion.tsx
@@ -27,7 +27,7 @@ export default function StoryBuilderQuestion({ story, currentBlank, currentBlank
         </div>
 
         {/* Story preview with blanks */}
-        <div className="bg-amber-50 rounded-2xl p-4 w-full text-base leading-loose text-right" dir="rtl">
+        <div className="bg-amber-50 rounded-2xl p-4 w-full text-base leading-loose text-start" dir="rtl">
           {story.segments.map((seg, i) => (
             <span key={i}>
               <span>{seg}</span>

--- a/gamesformykids/components/game/quiz/screens/StoryBuilderResult.tsx
+++ b/gamesformykids/components/game/quiz/screens/StoryBuilderResult.tsx
@@ -14,14 +14,14 @@ export default function StoryBuilderResult({ story, completedStory, onRestart }:
   };
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-yellow-100 to-pink-100 flex items-center justify-center p-4">
+    <div className="min-h-screen bg-linear-to-br from-yellow-100 to-pink-100 flex items-center justify-center p-4">
       <div className="bg-white rounded-3xl shadow-2xl max-w-lg w-full p-6 flex flex-col items-center gap-5 text-center">
         <div className="text-5xl">🎉</div>
         <h2 className="text-2xl font-black text-gray-800" dir="rtl">
           {story.emoji} {story.title}
         </h2>
 
-        <div className="bg-yellow-50 border-2 border-yellow-200 rounded-2xl p-5 w-full text-lg leading-relaxed font-medium text-gray-800 text-right" dir="rtl">
+        <div className="bg-yellow-50 border-2 border-yellow-200 rounded-2xl p-5 w-full text-lg leading-relaxed font-medium text-gray-800 text-start" dir="rtl">
           {completedStory}
         </div>
 

--- a/gamesformykids/components/game/quiz/screens/TriviaCategoryPicker.tsx
+++ b/gamesformykids/components/game/quiz/screens/TriviaCategoryPicker.tsx
@@ -29,7 +29,7 @@ export default function TriviaCategoryPicker({ onStart }: Props) {
               <button
                 key={cat}
                 onClick={() => setSelectedCategory(cat)}
-                className="flex flex-col items-center gap-2 p-4 rounded-2xl border-2 border-amber-200 hover:border-amber-400 hover:bg-amber-50 transition-all active:scale-95 bg-white"
+                className="flex flex-col items-center gap-2 p-4 rounded-2xl border-2 border-amber-200 hover:border-amber-400 hover:bg-amber-50 transition-[border-color,background-color,transform] active:scale-95 bg-white"
               >
                 <span className="text-3xl">{CATEGORY_EMOJIS[cat]}</span>
                 <span className="font-bold text-gray-700">{cat}</span>
@@ -58,7 +58,7 @@ export default function TriviaCategoryPicker({ onStart }: Props) {
             <button
               key={diff}
               onClick={() => onStart(selectedCategory, diff)}
-              className={`bg-gradient-to-r ${DIFFICULTY_COLORS[diff]} text-white font-bold py-4 px-6 rounded-2xl text-lg flex items-center justify-between hover:opacity-90 active:scale-95 transition-all shadow-md`}
+              className={`bg-gradient-to-r ${DIFFICULTY_COLORS[diff]} text-white font-bold py-4 px-6 rounded-2xl text-lg flex items-center justify-between hover:opacity-90 active:scale-95 transition-[opacity,transform] shadow-md`}
             >
               <span>{DIFFICULTY_EMOJIS[diff]}</span>
               <span>{diff}</span>

--- a/gamesformykids/components/game/shared/GameMenuCard.tsx
+++ b/gamesformykids/components/game/shared/GameMenuCard.tsx
@@ -1,5 +1,6 @@
 'use client';
 import { ReactNode } from 'react';
+import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { useKeyboardControls } from '@/hooks/shared/game-controls/useKeyboardControls';
 
@@ -78,6 +79,13 @@ export default function GameMenuCard({
             {secondaryAction.label}
           </button>
         )}
+        <Link
+          href="/"
+          className="mt-4 flex items-center justify-center gap-1.5 w-full py-2 text-gray-400 dark:text-gray-500 text-sm hover:text-gray-600 dark:hover:text-gray-300 transition-colors"
+        >
+          <span aria-hidden>🏠</span>
+          <span>חזור לדף הבית</span>
+        </Link>
       </div>
     </div>
   );

--- a/gamesformykids/components/marketing/ChildProfileSwitcher.tsx
+++ b/gamesformykids/components/marketing/ChildProfileSwitcher.tsx
@@ -42,10 +42,10 @@ function AddProfileModal({ onAdd, onClose }: { onAdd: (name: string, emoji: stri
             value={name}
             onChange={(e) => setName(e.target.value)}
             maxLength={20}
-            className="w-full border border-gray-300 dark:border-gray-600 rounded-xl px-4 py-2 mb-4 text-right bg-white dark:bg-gray-700 text-gray-800 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-purple-400"
+            className="w-full border border-gray-300 dark:border-gray-600 rounded-xl px-4 py-2 mb-4 text-start bg-white dark:bg-gray-700 text-gray-800 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-purple-400"
           />
           <p className="text-sm text-gray-500 dark:text-gray-400 mb-2">בחר אייקון</p>
-          <div className="grid grid-cols-6 gap-2 mb-5">
+          <div className="grid grid-cols-4 sm:grid-cols-6 gap-2 mb-5">
             {AVATAR_LIST.map((av) => (
               <button
                 key={av}
@@ -99,7 +99,7 @@ function ProfileBubble({ profile, isActive, isManaging, onClick, onDelete }: Pro
     <div className="relative flex flex-col items-center gap-1 shrink-0">
       <button
         onClick={onClick}
-        className={`w-12 h-12 rounded-full text-2xl flex items-center justify-center transition-all active:scale-90 ${
+        className={`w-12 h-12 rounded-full text-2xl flex items-center justify-center transition-[transform,box-shadow,ring-color] active:scale-90 ${
           isActive
             ? 'ring-4 ring-purple-500 ring-offset-2 ring-offset-white dark:ring-offset-gray-900 scale-110 shadow-md'
             : 'ring-2 ring-gray-200 dark:ring-gray-600 hover:ring-purple-300'
@@ -155,7 +155,7 @@ export default function ChildProfileSwitcher() {
           {profiles.length > 0 && (
             <button
               onClick={() => setIsManaging((m) => !m)}
-              className="mr-auto text-xs text-purple-500 dark:text-purple-400 hover:text-purple-700 dark:hover:text-purple-300 transition-colors"
+              className="me-auto text-xs text-purple-500 dark:text-purple-400 hover:text-purple-700 dark:hover:text-purple-300 transition-colors"
             >
               {isManaging ? 'סיים עריכה' : '✏️ ערוך'}
             </button>
@@ -183,7 +183,7 @@ export default function ChildProfileSwitcher() {
             <div className="flex flex-col items-center gap-1 shrink-0">
               <button
                 onClick={() => setShowAdd(true)}
-                className="w-12 h-12 rounded-full text-2xl flex items-center justify-center ring-2 ring-dashed ring-gray-300 dark:ring-gray-600 hover:ring-purple-400 bg-gray-50 dark:bg-gray-800 transition-all active:scale-90 text-gray-400 dark:text-gray-500"
+                className="w-12 h-12 rounded-full text-2xl flex items-center justify-center ring-2 ring-dashed ring-gray-300 dark:ring-gray-600 hover:ring-purple-400 bg-gray-50 dark:bg-gray-800 transition-[transform,ring-color] active:scale-90 text-gray-400 dark:text-gray-500"
                 aria-label="הוסף פרופיל"
               >
                 +

--- a/gamesformykids/components/marketing/ContentTypeTabBar.tsx
+++ b/gamesformykids/components/marketing/ContentTypeTabBar.tsx
@@ -26,7 +26,7 @@ export default function ContentTypeTabBar({ active, onChange }: Props) {
               onClick={() => onChange(tab.id)}
               className={`
                 flex items-center gap-2 px-5 py-2.5 rounded-2xl text-sm font-bold
-                whitespace-nowrap transition-all duration-200 flex-shrink-0
+                whitespace-nowrap transition-[background-color,box-shadow,transform,color] duration-200 shrink-0
                 ${isActive
                   ? `bg-gradient-to-l ${tab.color} text-white shadow-lg scale-105`
                   : 'bg-white/70 dark:bg-gray-800/70 text-gray-600 dark:text-gray-300 hover:bg-white dark:hover:bg-gray-700 shadow-sm hover:shadow-md'

--- a/gamesformykids/components/marketing/HolidayLane.tsx
+++ b/gamesformykids/components/marketing/HolidayLane.tsx
@@ -45,7 +45,7 @@ export default function HolidayLane() {
             <Link
               key={game.id}
               href={game.href}
-              className="flex-shrink-0 flex flex-col items-center bg-white/90 hover:bg-white rounded-xl p-3 gap-1 shadow-sm hover:shadow-md transition-all duration-150 active:scale-95"
+              className="flex-shrink-0 flex flex-col items-center bg-white/90 hover:bg-white rounded-xl p-3 gap-1 shadow-sm hover:shadow-md transition-[background-color,box-shadow,transform] duration-150 active:scale-95"
               style={{ minWidth: '88px', maxWidth: '96px' }}
             >
               <span className="text-2xl">{game.emoji}</span>

--- a/gamesformykids/components/settings/AgeFilterSection.tsx
+++ b/gamesformykids/components/settings/AgeFilterSection.tsx
@@ -28,7 +28,7 @@ export function AgeFilterSection() {
               onClick={() => setAgeRange(value)}
               title={desc}
               className={`
-                px-4 py-2 rounded-xl text-sm font-semibold border-2 transition-all
+                px-4 py-2 rounded-xl text-sm font-semibold border-2 transition-[background-color,border-color,color,box-shadow]
                 ${ageRange === value
                   ? 'bg-purple-500 border-purple-600 text-white shadow-md'
                   : 'bg-white border-gray-200 text-gray-700 hover:border-purple-300'}

--- a/gamesformykids/components/settings/ScreenTimeSection.tsx
+++ b/gamesformykids/components/settings/ScreenTimeSection.tsx
@@ -28,7 +28,7 @@ export function ScreenTimeSection() {
               type="button"
               onClick={() => setTimeLimit(value)}
               className={`
-                px-4 py-2 rounded-xl text-sm font-semibold border-2 transition-all
+                px-4 py-2 rounded-xl text-sm font-semibold border-2 transition-[background-color,border-color,color,box-shadow]
                 ${timeLimitMinutes === value
                   ? 'bg-purple-500 border-purple-600 text-white shadow-md'
                   : 'bg-white border-gray-200 text-gray-700 hover:border-purple-300'}

--- a/gamesformykids/components/settings/SoundThemeSection.tsx
+++ b/gamesformykids/components/settings/SoundThemeSection.tsx
@@ -38,7 +38,7 @@ export function SoundThemeSection() {
               type="button"
               onClick={() => handleSelect(value)}
               className={`
-                flex items-center gap-2 px-3 py-3 rounded-xl border-2 text-right transition-all
+                flex items-center gap-2 px-3 py-3 rounded-xl border-2 text-start transition-[background-color,border-color,color,box-shadow]
                 ${theme === value
                   ? 'bg-purple-500 border-purple-600 text-white shadow-md'
                   : 'bg-white border-gray-200 text-gray-700 hover:border-purple-300'}

--- a/gamesformykids/components/shared/EmojiAvatarPicker.tsx
+++ b/gamesformykids/components/shared/EmojiAvatarPicker.tsx
@@ -27,7 +27,7 @@ export default function EmojiAvatarPicker({ current, onSelect, onClose }: Props)
               type="button"
               onClick={() => { onSelect(e); onClose(); }}
               className={`
-                text-3xl p-2 rounded-2xl transition-all duration-150 active:scale-90
+                text-3xl p-2 rounded-2xl transition-[transform,background-color] duration-150 active:scale-90
                 ${current === e
                   ? 'bg-purple-100 ring-2 ring-purple-500 scale-110'
                   : 'hover:bg-gray-100'}

--- a/gamesformykids/components/shared/screens/AutoStartScreen.tsx
+++ b/gamesformykids/components/shared/screens/AutoStartScreen.tsx
@@ -68,7 +68,7 @@ export default function AutoStartScreen() {
         <div className="flex justify-center gap-3 mt-3 flex-wrap">
           <button
             onClick={() => setStudyMode(v => !v)}
-            className={`flex items-center gap-2 px-4 py-2 rounded-xl text-sm font-semibold transition-all border-2 ${
+            className={`flex items-center gap-2 px-4 py-2 rounded-xl text-sm font-semibold transition-[background-color,border-color,box-shadow,color] border-2 ${
               studyMode
                 ? 'bg-amber-400 border-amber-500 text-amber-900 shadow-md'
                 : 'bg-white/30 border-white/50 text-white hover:bg-white/40'
@@ -79,7 +79,7 @@ export default function AutoStartScreen() {
           </button>
           <button
             onClick={toggleSpeed}
-            className={`flex items-center gap-2 px-4 py-2 rounded-xl text-sm font-semibold transition-all border-2 ${
+            className={`flex items-center gap-2 px-4 py-2 rounded-xl text-sm font-semibold transition-[background-color,border-color,box-shadow,color] border-2 ${
               speedEnabled
                 ? 'bg-yellow-400 border-yellow-500 text-yellow-900 shadow-md'
                 : 'bg-white/30 border-white/50 text-white hover:bg-white/40'

--- a/gamesformykids/lib/quiz/configs/math.tsx
+++ b/gamesformykids/lib/quiz/configs/math.tsx
@@ -61,7 +61,7 @@ export const visualAdditionConfig = defineConfig({
   renderQuestion: (q) => (
     <><div className="text-4xl mb-3">{q.emoji}</div>
       <p className="text-gray-600 text-sm mb-2">{'כמה סה"כ?'}</p>
-      <p className="text-3xl font-black text-green-700 tracking-widest">{q.question}</p></>
+      <p className="text-3xl font-black text-green-700">{q.question}</p></>
   ),
 });
 
@@ -139,7 +139,7 @@ export const misparBondsConfig = defineConfig({
     <div className="w-full flex flex-col items-center gap-2">
       <div className="text-5xl">{q.emoji}</div>
       <p className="text-gray-600 text-sm mb-1" dir="rtl">מה המספר החסר?</p>
-      <p className="text-3xl font-black text-green-700 tracking-widest" dir="ltr">{q.question}</p>
+      <p className="text-3xl font-black text-green-700" dir="ltr">{q.question}</p>
     </div>
   ),
 });


### PR DESCRIPTION
## Summary

Batch of UX/UI fixes from a full `/ux-ui` review. 19 files, 0 new components — all are targeted corrections to existing code.

- 🔴 **3 critical** — Hebrew letter-spacing, punitive wrong-answer style, mobile tap targets
- 🟡 **12 important** — home navigation, game descriptions on mobile, RTL logical properties, transition-all cleanup

## Changes

### 🔴 Critical
- Remove `tracking-widest` from Hebrew word display in `word-clicker` and math quiz questions — letter-spacing disconnects Hebrew glyphs visually
- Replace `❌ לא נכון` (red, punitive) in `RiddleProQuestion` with `💙 כמעט!` (amber, friendly) — consistent with every other game's wrong-answer pattern
- Fix `grid-cols-6` → `grid-cols-4 sm:grid-cols-6` in `ChildProfileSwitcher` — emoji tap targets were ~40px on 360px phones (WCAG requires 44px)

### 🟡 Important
- `GameCard` — add `text-xs line-clamp-1` description on mobile (`sm:hidden`); descriptions were fully hidden, children couldn't tell games apart
- `QuizResultScreen` — add 🏠 "חזור לדף הבית" link; promote "next game" to the primary (top) button; "play again" is now secondary
- `GameMenuCard` — add 🏠 "חזור לדף הבית" link (previously only Escape key)
- `QRButton` — fix `left-4` → `inset-s-4` so button appears at the RTL-correct (start) corner
- `ChildProfileSwitcher` — fix `mr-auto` → `me-auto`, `text-right` → `text-start`, `transition-all` → specific properties on both profile bubbles
- `StoryBuilderQuestion`, `StoryBuilderResult`, `SoundThemeSection` — `text-right` → `text-start`
- `CategoryCard` — remove unreadable `text-xs text-white/80` numeric progress labels; keep the bar visual only
- `transition-all` → specific property lists (`transition-[background-color,border-color,…]`) in 11 instances across `ContentTypeTabBar`, `HolidayLane`, `AgeFilterSection`, `ScreenTimeSection`, `SoundThemeSection`, `EmojiAvatarPicker`, `AutoStartScreen`, `TriviaCategoryPicker` — prevents layout-triggering transitions on low-end Android devices
- Canonical Tailwind: `bg-gradient-to-br` → `bg-linear-to-br`, `flex-shrink-0` → `shrink-0`

## Test plan
- [ ] word-clicker: Hebrew word renders without gaps between letters
- [ ] riddles-pro: wrong answer shows amber 💙 message, not red ❌
- [ ] ChildProfileSwitcher (mobile): emoji picker has 4-column grid on narrow screens
- [ ] Any game card on mobile: short description visible below title
- [ ] Any quiz result screen: "next game" is the top button; 🏠 home link present at bottom
- [ ] Any `GameMenuCard` (e.g. riddles-pro menu): 🏠 home link present
- [ ] QR button: appears at start (right) corner on RTL pages
- [ ] Category cards with progress: only the bar shows, no tiny `3/8` text

Closes #1376

🤖 Generated with [Claude Code](https://claude.com/claude-code)