### PR TITLE
fix(css): font override, RTL margins, redundant inline styles, Tailwind v4 canonicals

### DIFF
--- a/gamesformykids/app/games/answer-cannon/CannonClient.tsx
+++ b/gamesformykids/app/games/answer-cannon/CannonClient.tsx
@@ -13,7 +13,7 @@ export default function CannonClient() {
 
   if (phase === 'menu') {
     return (
-      <div className="min-h-screen flex flex-col items-center justify-center bg-gradient-to-b from-blue-900 to-blue-700 p-6 text-white">
+      <div className="min-h-screen flex flex-col items-center justify-center bg-linear-to-b from-blue-900 to-blue-700 p-6 text-white">
         <div className="text-7xl mb-4">🎯</div>
         <h1 className="text-4xl font-bold mb-2">תותחן תשובות</h1>
         <p className="text-xl mb-2 text-blue-200">כוון את התותח — ירה על התשובה הנכונה!</p>
@@ -40,7 +40,7 @@ export default function CannonClient() {
     const pct = Math.round((score / Math.min(total, 20)) * 100);
     const medal = pct >= 80 ? '🥇' : pct >= 60 ? '🥈' : '🥉';
     return (
-      <div className="min-h-screen flex flex-col items-center justify-center bg-gradient-to-b from-blue-900 to-blue-700 p-6 text-white">
+      <div className="min-h-screen flex flex-col items-center justify-center bg-linear-to-b from-blue-900 to-blue-700 p-6 text-white">
         <div className="text-6xl mb-4">{medal}</div>
         <h1 className="text-3xl font-bold mb-2">כל הכבוד!</h1>
         <p className="text-xl mb-6 text-blue-200">פגעת ב־{score} מטרות!</p>
@@ -86,7 +86,6 @@ export default function CannonClient() {
       <canvas
         ref={canvasRef}
         className="flex-1 w-full touch-none cursor-crosshair"
-        style={{ touchAction: 'none' }}
         onPointerDown={handlePointerDown}
         onPointerMove={handlePointerMove}
         onPointerUp={handlePointerUp}

--- a/gamesformykids/app/games/cooking-game/CookingClient.tsx
+++ b/gamesformykids/app/games/cooking-game/CookingClient.tsx
@@ -12,7 +12,7 @@ export default function CookingClient() {
 
   if (phase === 'menu') {
     return (
-      <div className="min-h-screen bg-gradient-to-br from-orange-50 via-yellow-50 to-red-50 flex flex-col items-center justify-center p-4">
+      <div className="min-h-screen bg-linear-to-br from-orange-50 via-yellow-50 to-red-50 flex flex-col items-center justify-center p-4">
         <div className="text-center mb-8">
           <div className="text-7xl mb-4">👨‍🍳</div>
           <h1 className="text-4xl font-bold text-orange-800 mb-2">המטבח של ילדים</h1>
@@ -33,7 +33,7 @@ export default function CookingClient() {
         </div>
         <button
           onClick={startGame}
-          className="bg-gradient-to-r from-orange-400 to-red-400 text-white font-bold text-xl px-10 py-4 rounded-2xl shadow-lg hover:scale-105 active:scale-95 transition-all"
+          className="bg-linear-to-r from-orange-400 to-red-400 text-white font-bold text-xl px-10 py-4 rounded-2xl shadow-lg hover:scale-105 active:scale-95 transition-all"
         >
           בואו נבשל! 👨‍🍳
         </button>
@@ -43,7 +43,7 @@ export default function CookingClient() {
 
   if (phase === 'recipe-done') {
     return (
-      <div className="min-h-screen bg-gradient-to-br from-yellow-50 to-orange-100 flex flex-col items-center justify-center p-4">
+      <div className="min-h-screen bg-linear-to-br from-yellow-50 to-orange-100 flex flex-col items-center justify-center p-4">
         <div className="bg-white rounded-3xl p-8 text-center max-w-sm w-full shadow-xl">
           <div className="text-7xl mb-4">{recipe?.emoji}</div>
           <h2 className="text-2xl font-bold text-orange-800 mb-1">המנה מוכנה!</h2>
@@ -80,7 +80,7 @@ export default function CookingClient() {
   const progress = recipe ? `${stepIdx + 1}/${recipe.steps.length}` : '';
 
   return (
-    <div className={`min-h-screen flex flex-col bg-gradient-to-br from-orange-50 to-yellow-50 transition-all ${wrongFlash ? 'bg-red-100' : ''}`}>
+    <div className={`min-h-screen flex flex-col bg-linear-to-br from-orange-50 to-yellow-50 transition-all ${wrongFlash ? 'bg-red-100' : ''}`}>
       <div className="flex items-center justify-between p-3 bg-white shadow-sm">
         <div className="flex items-center gap-2">
           <span className="text-2xl">{recipe?.emoji}</span>

--- a/gamesformykids/app/games/dress-up/DressUpClient.tsx
+++ b/gamesformykids/app/games/dress-up/DressUpClient.tsx
@@ -11,8 +11,8 @@ export default function DressUpClient() {
 
   if (phase === 'menu') {
     return (
-      <div className="min-h-screen bg-gradient-to-br from-pink-100 via-purple-50 to-purple-200 flex flex-col items-center justify-center p-6 text-center">
-        <div className="text-8xl mb-4 animate-bounce">👗</div>
+      <div className="min-h-screen bg-linear-to-br from-pink-100 via-purple-50 to-purple-200 flex flex-col items-center justify-center p-6 text-center">
+        <div className="text-8xl mb-4 motion-safe:animate-bounce">👗</div>
         <h1 className="text-4xl font-bold text-purple-800 mb-3">לבוש את הדמות</h1>
         <p className="text-xl text-purple-600 mb-2">הקשב לשם הבגד ובחר את הנכון!</p>
         <div className="flex gap-4 text-lg text-purple-500 mb-8 flex-wrap justify-center">
@@ -35,7 +35,7 @@ export default function DressUpClient() {
     const medal = pct === 100 ? '🥇' : pct >= 75 ? '🥈' : pct >= 50 ? '🥉' : '⭐';
     const msg = pct === 100 ? 'מושלם! לבשת הכל נכון!' : pct >= 75 ? 'כל הכבוד!' : pct >= 50 ? 'יפה מאוד!' : 'נסה שוב!';
     return (
-      <div className="min-h-screen bg-gradient-to-br from-pink-100 via-purple-50 to-purple-200 flex flex-col items-center justify-center p-6 text-center">
+      <div className="min-h-screen bg-linear-to-br from-pink-100 via-purple-50 to-purple-200 flex flex-col items-center justify-center p-6 text-center">
         <div className="text-8xl mb-4">{medal}</div>
         <h2 className="text-4xl font-bold text-purple-800 mb-2">{msg}</h2>
         <p className="text-2xl text-purple-600 mb-6">{score} מתוך {QUESTIONS_PER_GAME} נכון</p>
@@ -65,7 +65,7 @@ export default function DressUpClient() {
 
   // Playing phase
   return (
-    <div className="min-h-screen bg-gradient-to-br from-pink-100 via-purple-50 to-purple-200 flex flex-col items-center p-4" dir="rtl">
+    <div className="min-h-screen bg-linear-to-br from-pink-100 via-purple-50 to-purple-200 flex flex-col items-center p-4" dir="rtl">
       <div className="w-full max-w-md flex justify-between items-center mb-4 pt-2">
         <span className="bg-white rounded-full px-4 py-1 text-purple-700 font-bold text-lg shadow">
           {qIdx + 1} / {QUESTIONS_PER_GAME}
@@ -81,8 +81,8 @@ export default function DressUpClient() {
           <div className="flex flex-col gap-2 items-center">
             {ZONE_ORDER.map(zone => (
               <div key={zone} className="flex items-center gap-2">
-                <span className="text-xs text-gray-400 w-12 text-left">{ZONE_LABEL[zone]}</span>
-                <div className={`w-14 h-12 flex items-center justify-center rounded-xl border-2 transition-all ${
+                <span className="text-xs text-gray-400 w-12 text-start">{ZONE_LABEL[zone]}</span>
+                <div className={`w-14 h-12 flex items-center justify-center rounded-xl border-2 transition-colors ${
                   dressed[zone]
                     ? 'border-purple-300 bg-purple-50'
                     : 'border-dashed border-gray-200 bg-gray-50'
@@ -113,7 +113,7 @@ export default function DressUpClient() {
           <span>{current?.prompt}</span>
         </button>
         {feedback === 'correct' && (
-          <p className="text-green-600 font-bold mt-2 text-lg animate-bounce">✅ כן! {current?.hebrew}!</p>
+          <p className="text-green-600 font-bold mt-2 text-lg motion-safe:animate-bounce">✅ כן! {current?.hebrew}!</p>
         )}
         {feedback === 'wrong' && (
           <p className="text-red-500 font-bold mt-2">❌ לא נכון, נסה שוב!</p>
@@ -126,7 +126,7 @@ export default function DressUpClient() {
             key={item.name}
             onClick={() => selectAnswer(item)}
             disabled={feedback === 'correct'}
-            className={`bg-white rounded-2xl shadow-md p-4 flex flex-col items-center gap-2 border-2 transition-all active:scale-95 ${
+            className={`bg-white rounded-2xl shadow-md p-4 flex flex-col items-center gap-2 border-2 transition active:scale-95 ${
               feedback === 'correct' && item.name === current?.name
                 ? 'border-green-500 bg-green-50 scale-105'
                 : feedback === 'wrong' && item.name === current?.name

--- a/gamesformykids/app/games/letter-bubble-shooter/BubbleShooterClient.tsx
+++ b/gamesformykids/app/games/letter-bubble-shooter/BubbleShooterClient.tsx
@@ -9,8 +9,8 @@ export default function BubbleShooterClient() {
 
   if (phase === 'menu') {
     return (
-      <div className="min-h-screen bg-gradient-to-br from-slate-900 to-indigo-950 flex flex-col items-center justify-center p-6 text-center">
-        <div className="text-7xl mb-4 animate-bounce">🫧</div>
+      <div className="min-h-screen bg-linear-to-br from-slate-900 to-indigo-950 flex flex-col items-center justify-center p-6 text-center">
+        <div className="text-7xl mb-4 motion-safe:animate-bounce">🫧</div>
         <h1 className="text-4xl font-bold text-white mb-3">ירי אותיות</h1>
         <p className="text-xl text-indigo-300 mb-2">ירה בועות אל עמודות של 3 אותיות זהות!</p>
         <div className="flex gap-6 mb-8 flex-wrap justify-center">
@@ -31,7 +31,7 @@ export default function BubbleShooterClient() {
 
   if (phase === 'result') {
     return (
-      <div className="min-h-screen bg-gradient-to-br from-slate-900 to-indigo-950 flex flex-col items-center justify-center p-6 text-center">
+      <div className="min-h-screen bg-linear-to-br from-slate-900 to-indigo-950 flex flex-col items-center justify-center p-6 text-center">
         <div className="text-7xl mb-4">{won ? '🥇' : '💥'}</div>
         <h2 className="text-4xl font-bold text-white mb-2">{won ? 'ניצחת!' : 'ניסיון טוב!'}</h2>
         <p className="text-2xl text-indigo-300 mb-8">ניקוד: {score}</p>
@@ -50,8 +50,7 @@ export default function BubbleShooterClient() {
         <span className="text-white font-bold text-lg">⭐ {score}</span>
         <span className="text-indigo-300 text-sm">הזז אצבע לכיוון וגע כדי לירות</span>
       </div>
-      <div className="relative w-full max-w-md flex-1"
-        style={{ minHeight: 520 }}
+      <div className="relative w-full max-w-md flex-1 min-h-[520px]"
         onPointerMove={handlePointer}
         onClick={handleTap}
       >

--- a/gamesformykids/app/games/letter-grow/LetterGrowClient.tsx
+++ b/gamesformykids/app/games/letter-grow/LetterGrowClient.tsx
@@ -9,7 +9,7 @@ export default function LetterGrowClient() {
 
   if (phase === 'menu') {
     return (
-      <div className="min-h-screen flex flex-col items-center justify-center bg-gradient-to-b from-indigo-950 to-purple-900 p-6 text-white" dir="rtl">
+      <div className="min-h-screen flex flex-col items-center justify-center bg-linear-to-b from-indigo-950 to-purple-900 p-6 text-white" dir="rtl">
         <div className="text-7xl mb-4">🌱</div>
         <h1 className="text-4xl font-bold mb-2">לצמוח למילה</h1>
         <p className="text-xl mb-2 text-purple-200">תפוס אותיות ותגדל למילה!</p>
@@ -33,8 +33,8 @@ export default function LetterGrowClient() {
 
   if (phase === 'evolving' && evolveInfo) {
     return (
-      <div className="min-h-screen flex flex-col items-center justify-center bg-gradient-to-b from-indigo-950 to-purple-900 p-6 text-white" dir="rtl">
-        <div className="animate-bounce text-8xl mb-6">{evolveInfo.emoji}</div>
+      <div className="min-h-screen flex flex-col items-center justify-center bg-linear-to-b from-indigo-950 to-purple-900 p-6 text-white" dir="rtl">
+        <div className="motion-safe:animate-bounce text-8xl mb-6">{evolveInfo.emoji}</div>
         <div className="text-6xl font-bold mb-2 text-yellow-300">{evolveInfo.letter}</div>
         <div className="text-4xl mb-2">→</div>
         <div className="text-5xl font-bold text-green-300 mb-4">{evolveInfo.word}!</div>
@@ -52,7 +52,7 @@ export default function LetterGrowClient() {
     const pct = Math.round((score / ROUNDS_PER_GAME) * 100);
     const medal = pct >= 80 ? '🥇' : pct >= 60 ? '🥈' : '🥉';
     return (
-      <div className="min-h-screen flex flex-col items-center justify-center bg-gradient-to-b from-indigo-950 to-purple-900 p-6 text-white" dir="rtl">
+      <div className="min-h-screen flex flex-col items-center justify-center bg-linear-to-b from-indigo-950 to-purple-900 p-6 text-white" dir="rtl">
         <div className="text-6xl mb-4">{medal}</div>
         <h1 className="text-3xl font-bold mb-2">כל הכבוד!</h1>
         <p className="text-xl mb-6 text-purple-200">גידלת {score} מתוך {ROUNDS_PER_GAME} מילים!</p>

--- a/gamesformykids/app/games/letter-slicer/LetterSlicerClient.tsx
+++ b/gamesformykids/app/games/letter-slicer/LetterSlicerClient.tsx
@@ -9,7 +9,7 @@ export default function LetterSlicerClient() {
 
   if (phase === 'menu') {
     return (
-      <div className="min-h-screen flex flex-col items-center justify-center bg-gradient-to-br from-slate-900 via-indigo-950 to-slate-900 p-4">
+      <div className="min-h-screen flex flex-col items-center justify-center bg-linear-to-br from-slate-900 via-indigo-950 to-slate-900 p-4">
         <div className="text-center mb-8">
           <div className="text-7xl mb-4">✂️</div>
           <h1 className="text-4xl font-bold text-white mb-2">חותך מילים</h1>
@@ -35,7 +35,7 @@ export default function LetterSlicerClient() {
         </div>
         <button
           onClick={() => startGame(diff)}
-          className="bg-gradient-to-r from-indigo-500 to-purple-500 text-white font-bold text-xl px-10 py-4 rounded-2xl shadow-lg hover:scale-105 active:scale-95 transition-all"
+          className="bg-linear-to-r from-indigo-500 to-purple-500 text-white font-bold text-xl px-10 py-4 rounded-2xl shadow-lg hover:scale-105 active:scale-95 transition-all"
         >
           התחל! ✂️
         </button>
@@ -46,7 +46,7 @@ export default function LetterSlicerClient() {
   if (phase === 'result') {
     const stars = score >= 100 ? 3 : score >= 50 ? 2 : 1;
     return (
-      <div className="min-h-screen flex flex-col items-center justify-center bg-gradient-to-br from-slate-900 via-indigo-950 to-slate-900 p-4">
+      <div className="min-h-screen flex flex-col items-center justify-center bg-linear-to-br from-slate-900 via-indigo-950 to-slate-900 p-4">
         <div className="bg-white/10 backdrop-blur rounded-3xl p-8 text-center max-w-sm w-full">
           <div className="text-6xl mb-4">{stars === 3 ? '🏆' : stars === 2 ? '🥈' : '🥉'}</div>
           <h2 className="text-3xl font-bold text-white mb-2">כל הכבוד!</h2>

--- a/gamesformykids/app/games/letter-slingshot/SlingshotClient.tsx
+++ b/gamesformykids/app/games/letter-slingshot/SlingshotClient.tsx
@@ -9,7 +9,7 @@ export default function SlingshotClient() {
 
   if (phase === 'menu') {
     return (
-      <div className="min-h-screen flex flex-col items-center justify-center bg-gradient-to-b from-blue-200 to-blue-400 p-6 text-white" dir="rtl">
+      <div className="min-h-screen flex flex-col items-center justify-center bg-linear-to-b from-blue-200 to-blue-400 p-6 text-white" dir="rtl">
         <div className="text-7xl mb-4">🎯</div>
         <h1 className="text-4xl font-bold mb-2 text-blue-900">קלע אותיות</h1>
         <p className="text-xl mb-2 text-blue-800">קלע לקופסה עם המילה הנכונה!</p>
@@ -35,7 +35,7 @@ export default function SlingshotClient() {
     const pct = Math.round((score / (LEVELS_PER_GAME * 10)) * 100);
     const medal = pct >= 80 ? '🥇' : pct >= 50 ? '🥈' : '🥉';
     return (
-      <div className="min-h-screen flex flex-col items-center justify-center bg-gradient-to-b from-blue-200 to-blue-400 p-6 text-white" dir="rtl">
+      <div className="min-h-screen flex flex-col items-center justify-center bg-linear-to-b from-blue-200 to-blue-400 p-6 text-white" dir="rtl">
         <div className="text-6xl mb-4">{medal}</div>
         <h1 className="text-3xl font-bold mb-2 text-blue-900">כל הכבוד, קלעי!</h1>
         <p className="text-xl mb-6 text-blue-800">ניקוד: {score} מתוך {LEVELS_PER_GAME * 10}</p>
@@ -82,7 +82,7 @@ export default function SlingshotClient() {
       <canvas
         ref={canvasRef}
         className="flex-1 w-full touch-none"
-        style={{ touchAction: 'none', cursor: phase === 'aiming' ? 'crosshair' : 'default' }}
+        style={{ cursor: phase === 'aiming' ? 'crosshair' : 'default' }}
         onPointerDown={handlePointerDown}
         onPointerMove={handlePointerMove}
         onPointerUp={handlePointerUp}

--- a/gamesformykids/app/games/spot-the-difference/SpotClient.tsx
+++ b/gamesformykids/app/games/spot-the-difference/SpotClient.tsx
@@ -9,7 +9,7 @@ export default function SpotClient() {
 
   if (phase === 'menu') {
     return (
-      <div className="min-h-screen bg-gradient-to-br from-purple-50 to-pink-100 flex flex-col items-center justify-center p-4">
+      <div className="min-h-screen bg-linear-to-br from-purple-50 to-pink-100 flex flex-col items-center justify-center p-4">
         <div className="text-center mb-8">
           <div className="text-7xl mb-4">🔍</div>
           <h1 className="text-4xl font-bold text-purple-900 mb-2">מצא את ההבדל</h1>
@@ -31,7 +31,7 @@ export default function SpotClient() {
         </div>
         <button
           onClick={startGame}
-          className="bg-gradient-to-r from-purple-500 to-pink-500 text-white font-bold text-xl px-10 py-4 rounded-2xl shadow-lg hover:scale-105 active:scale-95 transition-all"
+          className="bg-linear-to-r from-purple-500 to-pink-500 text-white font-bold text-xl px-10 py-4 rounded-2xl shadow-lg hover:scale-105 active:scale-95 transition-all"
         >
           התחל! 🔍
         </button>
@@ -42,7 +42,7 @@ export default function SpotClient() {
   if (phase === 'result') {
     const stars = found.size >= 5 ? 3 : found.size >= 3 ? 2 : 1;
     return (
-      <div className="min-h-screen bg-gradient-to-br from-purple-50 to-pink-100 flex flex-col items-center justify-center p-4">
+      <div className="min-h-screen bg-linear-to-br from-purple-50 to-pink-100 flex flex-col items-center justify-center p-4">
         <div className="bg-white rounded-3xl p-8 text-center max-w-sm w-full shadow-xl">
           <div className="text-5xl mb-3">{found.size >= 5 ? '🏆' : found.size >= 3 ? '🥈' : '🥉'}</div>
           <h2 className="text-2xl font-bold text-purple-900 mb-1">
@@ -87,7 +87,7 @@ export default function SpotClient() {
 
   const renderPanel = (items: string[], panel: 'A' | 'B') => (
     <div
-      className={`bg-white/80 rounded-2xl p-2 shadow-md flex-1 transition-all ${shakePanel ? 'animate-pulse' : ''}`}
+      className={`bg-white/80 rounded-2xl p-2 shadow-md flex-1 transition-colors ${shakePanel ? 'motion-safe:animate-pulse' : ''}`}
     >
       <p className="text-center text-xs text-gray-500 mb-1 font-bold">תמונה {panel === 'A' ? 'א' : 'ב'}</p>
       <div
@@ -118,7 +118,7 @@ export default function SpotClient() {
   );
 
   return (
-    <div className={`min-h-screen flex flex-col bg-gradient-to-br ${scene.bg} p-3`}>
+    <div className={`min-h-screen flex flex-col bg-linear-to-br ${scene.bg} p-3`}>
       <div className="flex items-center justify-between mb-2">
         <div className="flex items-center gap-2">
           <span className="text-2xl">{scene.emoji}</span>
@@ -138,7 +138,7 @@ export default function SpotClient() {
             {found.has(d.index) ? '✓' : i + 1}
           </div>
         ))}
-        <span className="text-sm text-purple-700 mr-1">{found.size}/5</span>
+        <span className="text-sm text-purple-700 me-1">{found.size}/5</span>
       </div>
 
       <div className="flex flex-col sm:flex-row gap-2 flex-1">

--- a/gamesformykids/app/games/syllable-drums/DrumsClient.tsx
+++ b/gamesformykids/app/games/syllable-drums/DrumsClient.tsx
@@ -9,7 +9,7 @@ export default function DrumsClient() {
 
   if (phase === 'menu') {
     return (
-      <div className="min-h-screen flex flex-col items-center justify-center bg-gradient-to-b from-slate-900 to-indigo-900 p-6 text-white" dir="rtl">
+      <div className="min-h-screen flex flex-col items-center justify-center bg-linear-to-b from-slate-900 to-indigo-900 p-6 text-white" dir="rtl">
         <div className="text-7xl mb-4">🥁</div>
         <h1 className="text-4xl font-bold mb-2">תופים עבריים</h1>
         <p className="text-xl mb-2 text-indigo-200">הקש בזמן הנכון לכל אות!</p>
@@ -40,7 +40,7 @@ export default function DrumsClient() {
     const pct = Math.round((score / Math.max(1, WORDS_PER_GAME * 3.5 * 30)) * 100);
     const medal = pct >= 80 ? '🥇' : pct >= 50 ? '🥈' : '🥉';
     return (
-      <div className="min-h-screen flex flex-col items-center justify-center bg-gradient-to-b from-slate-900 to-indigo-900 p-6 text-white" dir="rtl">
+      <div className="min-h-screen flex flex-col items-center justify-center bg-linear-to-b from-slate-900 to-indigo-900 p-6 text-white" dir="rtl">
         <div className="text-6xl mb-4">{medal}</div>
         <h1 className="text-3xl font-bold mb-2">כל הכבוד, מתופף!</h1>
         <p className="text-xl mb-6 text-indigo-200">ניקוד סופי: {score} נקודות</p>
@@ -97,7 +97,6 @@ export default function DrumsClient() {
       <canvas
         ref={canvasRef}
         className="flex-1 w-full touch-none cursor-pointer"
-        style={{ touchAction: 'none' }}
         onPointerDown={handleTap}
       />
       <div className="text-center py-2 text-sm text-indigo-400 bg-slate-900">

--- a/gamesformykids/app/games/team-picker/TeamPickerClient.tsx
+++ b/gamesformykids/app/games/team-picker/TeamPickerClient.tsx
@@ -70,7 +70,7 @@ export default function TeamPickerClient() {
           <button
             onClick={divide}
             disabled={!namesInput.trim()}
-            className="w-full py-3 bg-gradient-to-l from-teal-500 to-cyan-500 text-white font-extrabold rounded-2xl text-lg shadow-lg hover:shadow-xl disabled:opacity-40 transition-all active:scale-95"
+            className="w-full py-3 bg-linear-to-l from-teal-500 to-cyan-500 text-white font-extrabold rounded-2xl text-lg shadow-lg hover:shadow-xl disabled:opacity-40 transition-all active:scale-95"
           >
             🎲 חלק לקבוצות!
           </button>
@@ -87,7 +87,7 @@ export default function TeamPickerClient() {
                 <h3 className={`${color.text} font-extrabold text-lg mb-3 flex items-center gap-2`}>
                   <span>{color.emoji}</span>
                   <span>קבוצה {i + 1}</span>
-                  <span className={`${color.badge} text-white text-xs px-2 py-0.5 rounded-full mr-auto`}>
+                  <span className={`${color.badge} text-white text-xs px-2 py-0.5 rounded-full me-auto`}>
                     {team.length} חברים
                   </span>
                 </h3>
@@ -108,7 +108,7 @@ export default function TeamPickerClient() {
           <div className="flex gap-3 mt-2">
             <button
               onClick={reshuffle}
-              className="flex-1 py-3 bg-gradient-to-l from-purple-500 to-pink-500 text-white font-extrabold rounded-2xl shadow-lg hover:shadow-xl transition-all active:scale-95"
+              className="flex-1 py-3 bg-linear-to-l from-purple-500 to-pink-500 text-white font-extrabold rounded-2xl shadow-lg hover:shadow-xl transition-all active:scale-95"
             >
               🔀 ערבב שוב
             </button>

--- a/gamesformykids/app/games/word-fishing/WordFishingClient.tsx
+++ b/gamesformykids/app/games/word-fishing/WordFishingClient.tsx
@@ -10,7 +10,7 @@ export default function WordFishingClient() {
 
   if (phase === 'menu') {
     return (
-      <div className="min-h-screen flex flex-col items-center justify-center bg-gradient-to-b from-blue-900 to-blue-700 p-6 text-white">
+      <div className="min-h-screen flex flex-col items-center justify-center bg-linear-to-b from-blue-900 to-blue-700 p-6 text-white">
         <div className="text-7xl mb-4">🎣</div>
         <h1 className="text-4xl font-bold mb-2">דיג מילים</h1>
         <p className="text-xl mb-2 text-blue-200">תפוס את הדג הנכון לפי השאלה!</p>
@@ -36,7 +36,7 @@ export default function WordFishingClient() {
     const pct = Math.round((score / totalWaves) * 100);
     const medal = pct >= 80 ? '🥇' : pct >= 60 ? '🥈' : '🥉';
     return (
-      <div className="min-h-screen flex flex-col items-center justify-center bg-gradient-to-b from-blue-900 to-blue-700 p-6 text-white">
+      <div className="min-h-screen flex flex-col items-center justify-center bg-linear-to-b from-blue-900 to-blue-700 p-6 text-white">
         <div className="text-6xl mb-4">{medal}</div>
         <h1 className="text-3xl font-bold mb-2">כל הכבוד, דַּיָּג!</h1>
         <p className="text-xl mb-6 text-blue-200">תפסת {score} מתוך {totalWaves} דגים!</p>
@@ -80,7 +80,6 @@ export default function WordFishingClient() {
       <canvas
         ref={canvasRef}
         className="flex-1 w-full touch-none cursor-pointer"
-        style={{ touchAction: 'none' }}
         onPointerDown={handlePointerDown}
       />
     </div>

--- a/gamesformykids/app/globals.css
+++ b/gamesformykids/app/globals.css
@@ -41,15 +41,12 @@
   transform: rotate(180deg);
 }
 
-body {
-  font-family: var(--font-rubik), sans-serif;
-}
-
 @media (prefers-reduced-motion: reduce) {
   *, *::before, *::after {
     animation-duration: 0.01ms !important;
     animation-iteration-count: 1 !important;
     transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
   }
 }
 
@@ -190,7 +187,7 @@ body {
 body {
   background: var(--background);
   color: var(--foreground);
-  font-family: Arial, Helvetica, sans-serif;
+  font-family: var(--font-rubik), sans-serif;
 }
 @keyframes bounce-in {
   0% { 
@@ -456,16 +453,6 @@ body {
 }
 
 /* Reduced-motion mode — OS media query baseline */
-@media (prefers-reduced-motion: reduce) {
-  *,
-  *::before,
-  *::after {
-    animation-duration: 0.01ms !important;
-    animation-iteration-count: 1 !important;
-    transition-duration: 0.01ms !important;
-    scroll-behavior: auto !important;
-  }
-}
 
 /* Reduced-motion mode — manual override via data attribute */
 [data-reduced-motion="true"] *,

--- a/gamesformykids/components/game/shared/SpeedBurstTimer.tsx
+++ b/gamesformykids/components/game/shared/SpeedBurstTimer.tsx
@@ -21,7 +21,7 @@ export default function SpeedBurstTimer({ gameType }: Props) {
                 style={{ width: `${pct}%` }}
               />
             </div>
-            <span className={`tabular-nums w-6 text-center ${timeLeft <= 10 ? 'text-red-400 animate-pulse' : ''}`}>
+            <span className={`tabular-nums w-6 text-center ${timeLeft <= 10 ? 'text-red-400 motion-safe:animate-pulse' : ''}`}>
               {timeLeft}
             </span>
           </div>


### PR DESCRIPTION
## Summary

- **🔴 Critical:** `globals.css` had a duplicate `body {}` block where the second set `font-family: Arial`, silently overriding `var(--font-rubik)` — breaking the Hebrew Rubik font across the whole app
- **🟠 RTL/inline cleanup:** redundant `touchAction` inline styles on canvases that already carry `touch-none`, `mr-auto`/`mr-1` → logical `me-auto`/`me-1`, `text-left` → `text-start`, `minHeight: 520` → `min-h-[520px]`
- **🟡 Quality:** `animate-bounce`/`animate-pulse` → `motion-safe:` prefixed (5 instances), `transition-all` → specific `transition`/`transition-colors`, duplicate `prefers-reduced-motion` block consolidated
- **Tailwind v4:** `bg-gradient-to-*` → `bg-linear-to-*` across all 13 changed files (IDE was surfacing these as canonical-class warnings)

## Test plan

- [ ] Verify Hebrew text renders in Rubik font (was Arial due to body override)
- [ ] Spot-check RTL layout on DressUpClient zone labels and TeamPicker badge positioning
- [ ] Canvas games (Cannon, Slingshot, Drums, WordFishing) — touch still works (touch-none class carries the property)
- [ ] BubbleShooter play area height intact at `min-h-[520px]`
- [ ] Run `npx tsc --noEmit` — zero errors ✅ (verified before PR)

Closes #1380

🤖 Generated with [Claude Code](https://claude.com/claude-code)