### PR TITLE
fix(css): homepage bg-opacity, scrollbar-hide, transition-colors, gradient v4 canonicals

### DIFF
--- a/gamesformykids/app/HomePageSkeleton.tsx
+++ b/gamesformykids/app/HomePageSkeleton.tsx
@@ -1,6 +1,6 @@
 export default function HomePageSkeleton() {
   return (
-    <div className="min-h-screen bg-gradient-to-br from-blue-100 via-purple-100 to-pink-100 dark:from-gray-900 dark:via-gray-800 dark:to-gray-900 animate-pulse">
+    <div className="min-h-screen bg-linear-to-br from-blue-100 via-purple-100 to-pink-100 dark:from-gray-900 dark:via-gray-800 dark:to-gray-900 motion-safe:animate-pulse">
       {/* Header skeleton */}
       <div className="text-center py-6 md:py-8 lg:py-12">
         <div className="h-10 md:h-14 lg:h-16 bg-purple-200 dark:bg-purple-900 rounded-2xl mx-auto mb-4 max-w-xs" />

--- a/gamesformykids/components/game/CategoryGamesView.tsx
+++ b/gamesformykids/components/game/CategoryGamesView.tsx
@@ -64,7 +64,7 @@ export default function CategoryGamesView() {
           onClick={backToCategories}
           className="mb-3 md:mb-4 px-4 py-2 bg-gray-200 hover:bg-gray-300 text-gray-700 rounded-full font-medium transition-colors text-sm md:text-base"
         >
-          חזור לקטגוריות ←
+          חזור לקטגוריות →
         </button>
         <h2 className="text-2xl md:text-3xl font-bold text-gray-800 mb-1 md:mb-2">
           {category.title}

--- a/gamesformykids/components/game/CategoryNavigation.tsx
+++ b/gamesformykids/components/game/CategoryNavigation.tsx
@@ -5,7 +5,7 @@ import { useHomePageStore } from "@/lib/stores";
 import { useFavoritesStore } from "@/lib/stores";
 import { GamesRegistry } from "@/lib/registry/gamesRegistry";
 
-const TAB_BASE = "px-4 py-2 md:px-6 md:py-3 rounded-full font-bold text-sm md:text-base transition-[transform,colors] duration-300 hover:scale-105";
+const TAB_BASE = "px-4 py-2 md:px-6 md:py-3 rounded-full font-bold text-sm md:text-base transition duration-300 hover:scale-105";
 const TAB_ACTIVE = "bg-purple-600 text-white shadow-lg";
 const TAB_INACTIVE = "bg-white dark:bg-gray-700 text-purple-600 dark:text-purple-300 hover:bg-purple-50 dark:hover:bg-gray-600 shadow-md";
 const FAV_ACTIVE = "bg-yellow-400 text-white shadow-lg";

--- a/gamesformykids/components/game/GameCard.tsx
+++ b/gamesformykids/components/game/GameCard.tsx
@@ -105,7 +105,7 @@ export default function GameCard({ game, animationDelay }: GameCardProps) {
         aria-label={`${game.title} — בקרוב`}
         aria-disabled="true"
       >
-        <div className="absolute inset-0 bg-gray-400 bg-opacity-50 rounded-2xl md:rounded-3xl flex items-center justify-center" aria-hidden="true">
+        <div className="absolute inset-0 bg-gray-400/50 rounded-2xl md:rounded-3xl flex items-center justify-center" aria-hidden="true">
           <span className="text-white text-sm md:text-base lg:text-xl font-bold">בקרוב!</span>
         </div>
         <div className="text-center text-white">

--- a/gamesformykids/components/marketing/CategoryJumpBar.tsx
+++ b/gamesformykids/components/marketing/CategoryJumpBar.tsx
@@ -21,7 +21,7 @@ export default function CategoryJumpBar() {
       dir="rtl"
       className="sticky top-16 z-30 bg-white/80 dark:bg-gray-900/80 backdrop-blur-sm border-b border-gray-200 dark:border-gray-700 shadow-sm"
     >
-      <div className="overflow-x-auto scrollbar-hide">
+      <div className="overflow-x-auto scrollbar-none">
         <div className="flex gap-1 px-3 py-2 min-w-max">
           {Object.entries(GAME_CATEGORIES).map(([key, category]) => {
             const Icon = category.icon;
@@ -32,10 +32,10 @@ export default function CategoryJumpBar() {
                 aria-label={category.title}
                 className="flex flex-col items-center gap-0.5 px-3 py-1.5 rounded-xl hover:bg-purple-50 dark:hover:bg-gray-700 transition-colors group shrink-0"
               >
-                <div className={`w-8 h-8 rounded-lg bg-gradient-to-br ${category.gradient} flex items-center justify-center shadow-sm group-hover:scale-110 transition-transform`}>
+                <div className={`w-8 h-8 rounded-lg bg-linear-to-br ${category.gradient} flex items-center justify-center shadow-sm group-hover:scale-110 transition-transform`}>
                   <Icon className="w-4 h-4 text-white" />
                 </div>
-                <span className="text-xs text-gray-600 dark:text-gray-300 font-medium leading-tight max-w-[60px] text-center line-clamp-1">
+                <span className="text-xs text-gray-600 dark:text-gray-300 font-medium leading-tight max-w-15 text-center line-clamp-1">
                   {category.title.replace('📚 ', '').replace('🕹️ ', '')}
                 </span>
               </button>

--- a/gamesformykids/components/marketing/ContentTypeGrid.tsx
+++ b/gamesformykids/components/marketing/ContentTypeGrid.tsx
@@ -48,10 +48,10 @@ export default function ContentTypeGrid({ contentType }: Props) {
   if (!hydrated) {
     return (
       <div className="max-w-6xl mx-auto px-4 pb-8">
-        <div className="h-10 w-64 bg-gray-200 animate-pulse rounded-xl mx-auto mb-6" />
+        <div className="h-10 w-64 bg-gray-200 motion-safe:animate-pulse rounded-xl mx-auto mb-6" />
         <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-3 md:gap-4">
           {Array.from({ length: 8 }).map((_, i) => (
-            <div key={i} className="h-32 bg-gray-200 animate-pulse rounded-2xl" />
+            <div key={i} className="h-32 bg-gray-200 motion-safe:animate-pulse rounded-2xl" />
           ))}
         </div>
       </div>

--- a/gamesformykids/components/marketing/ContentTypeTabBar.tsx
+++ b/gamesformykids/components/marketing/ContentTypeTabBar.tsx
@@ -17,7 +17,7 @@ interface Props {
 export default function ContentTypeTabBar({ active, onChange }: Props) {
   return (
     <div className="max-w-6xl mx-auto px-4 py-4" dir="rtl">
-      <div className="flex gap-2 overflow-x-auto pb-1 scrollbar-hide">
+      <div className="flex gap-2 overflow-x-auto pb-1 scrollbar-none">
         {TABS.map((tab) => {
           const isActive = active === tab.id;
           return (
@@ -28,7 +28,7 @@ export default function ContentTypeTabBar({ active, onChange }: Props) {
                 flex items-center gap-2 px-5 py-2.5 rounded-2xl text-sm font-bold
                 whitespace-nowrap transition-[background-color,box-shadow,transform,color] duration-200 shrink-0
                 ${isActive
-                  ? `bg-gradient-to-l ${tab.color} text-white shadow-lg scale-105`
+                  ? `bg-linear-to-l ${tab.color} text-white shadow-lg scale-105`
                   : 'bg-white/70 dark:bg-gray-800/70 text-gray-600 dark:text-gray-300 hover:bg-white dark:hover:bg-gray-700 shadow-sm hover:shadow-md'
                 }
               `}

--- a/gamesformykids/components/marketing/HolidayLane.tsx
+++ b/gamesformykids/components/marketing/HolidayLane.tsx
@@ -22,7 +22,7 @@ export default function HolidayLane() {
 
   return (
     <div className="max-w-6xl mx-auto px-4 py-4" dir="rtl">
-      <div className={`rounded-2xl bg-gradient-to-l ${holiday.color} p-4 shadow-lg`}>
+      <div className={`rounded-2xl bg-linear-to-l ${holiday.color} p-4 shadow-lg`}>
         {/* Header */}
         <div className="flex items-center justify-between mb-3">
           <div className="flex items-center gap-2">
@@ -40,13 +40,12 @@ export default function HolidayLane() {
         </div>
 
         {/* Horizontal scroll lane */}
-        <div className="flex gap-3 overflow-x-auto pb-1 scrollbar-hide">
+        <div className="flex gap-3 overflow-x-auto pb-1 scrollbar-none">
           {games.map((game) => (
             <Link
               key={game.id}
               href={game.href}
-              className="flex-shrink-0 flex flex-col items-center bg-white/90 hover:bg-white rounded-xl p-3 gap-1 shadow-sm hover:shadow-md transition-[background-color,box-shadow,transform] duration-150 active:scale-95"
-              style={{ minWidth: '88px', maxWidth: '96px' }}
+              className="flex-shrink-0 flex flex-col items-center bg-white/90 hover:bg-white rounded-xl p-3 gap-1 shadow-sm hover:shadow-md transition-[background-color,box-shadow,transform] duration-150 active:scale-95 min-w-22 max-w-24"
             >
               <span className="text-2xl">{game.emoji}</span>
               <span className="text-xs font-bold text-gray-700 text-center leading-tight line-clamp-2">


### PR DESCRIPTION
## Summary

- **🔴 Broken overlay:** `bg-opacity-50` removed in Tailwind v4 — "בקרוב" (coming soon) cards had their overlay at 100% opacity, hiding game titles. Fixed to `bg-gray-400/50`
- **🔴 Broken tab transitions:** `transition-[transform,colors]` used an invalid CSS property `colors` (not a real CSS transition target) — nav tab background color changes were not animating. Fixed to `transition`
- **🟠 Visible scrollbars:** `scrollbar-hide` is not defined in Tailwind v4 or globals.css — the CategoryJumpBar, ContentTypeTabBar, and HolidayLane horizontal scroll lanes were showing native scrollbars. Fixed to `scrollbar-none` (Tailwind v4 built-in)
- **🟠 Gradient canonicals:** 4 components still used `bg-gradient-to-*` (v3 syntax) — migrated to `bg-linear-to-*` to match the rest of the codebase (same migration done in PR #1381 for game files)
- **🟡 RTL arrow:** back button showed `←` in Hebrew context — changed to `→` (back = rightward in RTL flow)
- **🟡 Motion safety:** `animate-pulse` skeleton loaders prefixed with `motion-safe:`
- **🟡 Canonical classes:** `max-w-[60px]` → `max-w-15`, `style={{ minWidth/maxWidth }}` → Tailwind classes

## Test plan

- [ ] Navigate to homepage — verify "בקרוב" game cards show the blurred overlay (not opaque)
- [ ] Click between קטגוריות / כל המשחקים / מועדפים nav tabs — verify smooth background color transition
- [ ] On mobile: CategoryJumpBar, ContentTypeTabBar, HolidayLane — no scrollbar visible while scrolling horizontally
- [ ] "חזור לקטגוריות" button points `→` (rightward)
- [ ] `npx tsc --noEmit` — zero errors ✅

Closes #1384

🤖 Generated with [Claude Code](https://claude.com/claude-code)