### PR TITLE
refactor(dead-code): resolve duplicate exports and rename conflicting types

### DIFF
--- a/gamesformykids/app/HomePageClient.tsx
+++ b/gamesformykids/app/HomePageClient.tsx
@@ -20,7 +20,7 @@ import JokeOfTheDay from "@/components/marketing/JokeOfTheDay";
 import FactOfTheDay from "@/components/marketing/FactOfTheDay";
 import RiddleOfTheDay from "@/components/marketing/RiddleOfTheDay";
 import CategoryJumpBar from "@/components/marketing/CategoryJumpBar";
-import ContentTypeTabBar, { type ContentType } from "@/components/marketing/ContentTypeTabBar";
+import ContentTypeTabBar, { type TabContentType } from "@/components/marketing/ContentTypeTabBar";
 import ContentTypeGrid from "@/components/marketing/ContentTypeGrid";
 import HolidayLane from "@/components/marketing/HolidayLane";
 import ChildProfileSwitcher from "@/components/marketing/ChildProfileSwitcher";
@@ -30,7 +30,7 @@ const SESSION_KEY = 'home-content-tab';
 
 export default function HomePageClient() {
   const { isLoading, shouldShowLoader, handleLoadingComplete } = useHomePage();
-  const [activeTab, setActiveTab] = useState<ContentType>('games');
+  const [activeTab, setActiveTab] = useState<TabContentType>('games');
 
   useEffect(() => {
     const saved = sessionStorage.getItem(SESSION_KEY);
@@ -39,7 +39,7 @@ export default function HomePageClient() {
     }
   }, []);
 
-  function handleTabChange(tab: ContentType) {
+  function handleTabChange(tab: TabContentType) {
     setActiveTab(tab);
     sessionStorage.setItem(SESSION_KEY, tab);
   }

--- a/gamesformykids/app/games/jokes-browser/JokesBrowserClient.tsx
+++ b/gamesformykids/app/games/jokes-browser/JokesBrowserClient.tsx
@@ -1,6 +1,6 @@
 'use client';
 import { useJokesBrowser } from './useJokesBrowser';
-import { CATEGORY_LABELS, CATEGORY_COLORS, type JokeCategory } from '@/lib/constants/jokes';
+import { JOKE_CATEGORY_LABELS, JOKE_CATEGORY_COLORS, type JokeCategory } from '@/lib/constants/jokes';
 
 const CATEGORIES: JokeCategory[] = ['animals', 'school', 'food'];
 
@@ -22,8 +22,8 @@ export default function JokesBrowserClient() {
           <div className="space-y-3">
             {CATEGORIES.map((cat) => (
               <button key={cat} onClick={() => selectCategory(cat)}
-                className={`w-full bg-linear-to-br ${CATEGORY_COLORS[cat]} text-white font-bold py-4 rounded-2xl shadow-lg text-xl active:scale-95 transition-transform`}>
-                {CATEGORY_LABELS[cat]}
+                className={`w-full bg-linear-to-br ${JOKE_CATEGORY_COLORS[cat]} text-white font-bold py-4 rounded-2xl shadow-lg text-xl active:scale-95 transition-transform`}>
+                {JOKE_CATEGORY_LABELS[cat]}
               </button>
             ))}
           </div>

--- a/gamesformykids/app/games/word-maze/WordMazeClient.tsx
+++ b/gamesformykids/app/games/word-maze/WordMazeClient.tsx
@@ -1,9 +1,9 @@
 'use client';
 import { useWordMaze } from './useWordMaze';
 import WordMazeCanvas from './components/WordMazeCanvas';
-import type { DifficultyLevel } from '@/lib/constants/wordMazeWords';
+import type { MazeDifficulty } from '@/lib/constants/wordMazeWords';
 
-const LEVEL_LABELS: Record<DifficultyLevel, string> = {
+const LEVEL_LABELS: Record<MazeDifficulty, string> = {
   easy: 'קל (3 אותיות)',
   medium: 'בינוני (4 אותיות)',
   hard: 'קשה (5 אותיות)',
@@ -28,7 +28,7 @@ export default function WordMazeClient() {
           <h1 className="text-3xl font-extrabold text-amber-800">מבוך מילים</h1>
           <p className="text-gray-600">נווט במבוך ואסוף אותיות בסדר הנכון כדי לאיית מילה!</p>
           <div className="space-y-3">
-            {(['easy', 'medium', 'hard'] as DifficultyLevel[]).map((lvl) => (
+            {(['easy', 'medium', 'hard'] as MazeDifficulty[]).map((lvl) => (
               <button key={lvl} onClick={() => startGame(lvl)}
                 className="w-full bg-linear-to-br from-amber-400 to-orange-500 text-white font-bold py-3 rounded-2xl shadow-lg active:scale-95 transition-transform">
                 {LEVEL_LABELS[lvl]}

--- a/gamesformykids/app/games/word-maze/useWordMaze.ts
+++ b/gamesformykids/app/games/word-maze/useWordMaze.ts
@@ -1,6 +1,6 @@
 'use client';
 import { useState, useCallback, useRef, useEffect } from 'react';
-import { MAZE_WORDS, type DifficultyLevel } from '@/lib/constants/wordMazeWords';
+import { MAZE_WORDS, type MazeDifficulty } from '@/lib/constants/wordMazeWords';
 import { speakHebrew } from '@/lib/utils/speech/enhancedSpeechUtils';
 
 export const GRID_SIZE = 13;
@@ -78,7 +78,7 @@ export function useWordMaze() {
   const [targetWord, setTargetWord] = useState('');
   const [nextLetterIndex, setNextLetterIndex] = useState(0);
   const [score, setScore] = useState(0);
-  const [level, setLevel] = useState<DifficultyLevel>('easy');
+  const [level, setLevel] = useState<MazeDifficulty>('easy');
   const [wordsCompleted, setWordsCompleted] = useState(0);
   const [bouncing, setBouncing] = useState(false);
 
@@ -89,7 +89,7 @@ export function useWordMaze() {
   const targetWordRef = useRef('');
   const phaseRef = useRef<Phase>('menu');
 
-  const startGame = useCallback((lvl?: DifficultyLevel) => {
+  const startGame = useCallback((lvl?: MazeDifficulty) => {
     const actualLevel = lvl ?? level;
     const wordList = MAZE_WORDS[actualLevel];
     const word = wordList[Math.floor(Math.random() * wordList.length)] ?? wordList[0] ?? '';
@@ -167,7 +167,7 @@ export function useWordMaze() {
   }, [movePlayer]);
 
   const nextLevel = useCallback(() => {
-    const nextLvl: DifficultyLevel = level === 'easy' ? 'medium' : level === 'medium' ? 'hard' : 'easy';
+    const nextLvl: MazeDifficulty = level === 'easy' ? 'medium' : level === 'medium' ? 'hard' : 'easy';
     setLevel(nextLvl);
     startGame(nextLvl);
   }, [level, startGame]);

--- a/gamesformykids/components/game/quiz/screens/HumanBodyMenuScreen.tsx
+++ b/gamesformykids/components/game/quiz/screens/HumanBodyMenuScreen.tsx
@@ -1,6 +1,6 @@
 'use client';
 import type { BodyCategory } from '@/lib/quiz/data/body';
-import { BODY_CATEGORIES, CATEGORY_GRADIENT_COLORS, CATEGORY_LABELS } from '@/lib/quiz/data/body';
+import { BODY_CATEGORIES, CATEGORY_GRADIENT_COLORS, BODY_CATEGORY_LABELS } from '@/lib/quiz/data/body';
 import QuizCategoryMenuScreen from '@/components/game/quiz/QuizCategoryMenuScreen';
 
 interface Props {
@@ -18,7 +18,7 @@ export default function HumanBodyMenuScreen({ onStart }: Props) {
       description="גלה את הפלאות של גוף האדם!"
       categories={BODY_CATEGORIES}
       categoryClassName={cat => `py-3 px-4 rounded-xl font-bold text-white shadow-md active:scale-95 transition-transform bg-gradient-to-r ${CATEGORY_GRADIENT_COLORS[cat] ?? 'from-gray-400 to-gray-600'} ${cat === 'הכל' ? 'col-span-2' : ''}`}
-      categoryLabel={cat => CATEGORY_LABELS[cat]}
+      categoryLabel={cat => BODY_CATEGORY_LABELS[cat]}
       gridCols={2}
       onStart={onStart}
     />

--- a/gamesformykids/components/game/quiz/screens/IsraelMenuScreen.tsx
+++ b/gamesformykids/components/game/quiz/screens/IsraelMenuScreen.tsx
@@ -1,6 +1,6 @@
 'use client';
 import type { IsraelCategory } from '@/lib/quiz/data/israel';
-import { CATEGORIES, CATEGORY_COLORS } from '@/lib/quiz/data/israel';
+import { ISRAEL_CATEGORIES, ISRAEL_CATEGORY_COLORS } from '@/lib/quiz/data/israel';
 import QuizCategoryMenuScreen from '@/components/game/quiz/QuizCategoryMenuScreen';
 
 interface Props {
@@ -15,8 +15,8 @@ export default function IsraelMenuScreen({ onStart }: Props) {
       emoji="🇮🇱"
       title="ישראל שלי"
       description="בחר קטגוריה ובחן את הידע שלך!"
-      categories={CATEGORIES}
-      categoryClassName={cat => `py-3 px-2 rounded-xl font-bold text-sm transition-opacity shadow hover:opacity-90 ${CATEGORY_COLORS[cat] ?? 'bg-gray-400 text-white'}`}
+      categories={ISRAEL_CATEGORIES}
+      categoryClassName={cat => `py-3 px-2 rounded-xl font-bold text-sm transition-opacity shadow hover:opacity-90 ${ISRAEL_CATEGORY_COLORS[cat] ?? 'bg-gray-400 text-white'}`}
       onStart={onStart}
     />
   );

--- a/gamesformykids/components/game/quiz/screens/NatureMenuScreen.tsx
+++ b/gamesformykids/components/game/quiz/screens/NatureMenuScreen.tsx
@@ -1,6 +1,6 @@
 'use client';
 import type { NatureCategory } from '@/lib/quiz/data/nature';
-import { CATEGORIES, CATEGORY_COLORS } from '@/lib/quiz/data/nature';
+import { NATURE_CATEGORIES, NATURE_CATEGORY_COLORS } from '@/lib/quiz/data/nature';
 import QuizCategoryMenuScreen from '@/components/game/quiz/QuizCategoryMenuScreen';
 
 interface Props {
@@ -15,8 +15,8 @@ export default function NatureMenuScreen({ onStart }: Props) {
       emoji="🌱"
       title="עולם הטבע"
       description="בחר קטגוריה ולמד על הטבע!"
-      categories={CATEGORIES}
-      categoryClassName={cat => `py-3 rounded-xl font-bold text-sm transition-opacity shadow hover:opacity-90 ${CATEGORY_COLORS[cat] ?? 'bg-gray-400 text-white'}`}
+      categories={NATURE_CATEGORIES}
+      categoryClassName={cat => `py-3 rounded-xl font-bold text-sm transition-opacity shadow hover:opacity-90 ${NATURE_CATEGORY_COLORS[cat] ?? 'bg-gray-400 text-white'}`}
       onStart={onStart}
     />
   );

--- a/gamesformykids/components/game/quiz/screens/TriviaCategoriesQuestion.tsx
+++ b/gamesformykids/components/game/quiz/screens/TriviaCategoriesQuestion.tsx
@@ -1,6 +1,6 @@
 'use client';
 import { QuizQuestionShell } from '@/components/game/quiz';
-import { CATEGORY_EMOJIS, DIFFICULTY_EMOJIS, type TriviaCatQuestion, type TriviaCatDifficulty } from '@/lib/quiz/data/trivia-categories';
+import { TRIVIA_CAT_CATEGORY_EMOJIS, DIFFICULTY_EMOJIS, type TriviaCatQuestion, type TriviaCatDifficulty } from '@/lib/quiz/data/trivia-categories';
 
 interface Props {
   current: TriviaCatQuestion;
@@ -25,7 +25,7 @@ export default function TriviaCategoriesQuestion({ current, choices, correctLabe
     >
       <div className="flex items-center justify-between mb-2">
         <span className="text-sm font-bold text-amber-700">
-          {CATEGORY_EMOJIS[current.category]} {current.category}
+          {TRIVIA_CAT_CATEGORY_EMOJIS[current.category]} {current.category}
         </span>
         <div className="flex items-center gap-2">
           <span className="text-xs text-amber-600">{DIFFICULTY_EMOJIS[difficulty]}</span>

--- a/gamesformykids/components/game/quiz/screens/TriviaCategoryPicker.tsx
+++ b/gamesformykids/components/game/quiz/screens/TriviaCategoryPicker.tsx
@@ -3,7 +3,7 @@ import { useState } from 'react';
 import {
   TRIVIA_CAT_CATEGORIES,
   TRIVIA_CAT_DIFFICULTIES,
-  CATEGORY_EMOJIS,
+  TRIVIA_CAT_CATEGORY_EMOJIS,
   DIFFICULTY_EMOJIS,
   DIFFICULTY_COLORS,
   type TriviaCatCategory,
@@ -31,7 +31,7 @@ export default function TriviaCategoryPicker({ onStart }: Props) {
                 onClick={() => setSelectedCategory(cat)}
                 className="flex flex-col items-center gap-2 p-4 rounded-2xl border-2 border-amber-200 hover:border-amber-400 hover:bg-amber-50 transition-[border-color,background-color,transform] active:scale-95 bg-white"
               >
-                <span className="text-3xl">{CATEGORY_EMOJIS[cat]}</span>
+                <span className="text-3xl">{TRIVIA_CAT_CATEGORY_EMOJIS[cat]}</span>
                 <span className="font-bold text-gray-700">{cat}</span>
               </button>
             ))}
@@ -50,7 +50,7 @@ export default function TriviaCategoryPicker({ onStart }: Props) {
         >
           ← חזרה לנושאים
         </button>
-        <div className="text-5xl mb-3">{CATEGORY_EMOJIS[selectedCategory]}</div>
+        <div className="text-5xl mb-3">{TRIVIA_CAT_CATEGORY_EMOJIS[selectedCategory]}</div>
         <h2 className="text-2xl font-bold text-amber-800 mb-2">{selectedCategory}</h2>
         <p className="text-amber-600 mb-6">בחר רמת קושי:</p>
         <div className="flex flex-col gap-3">

--- a/gamesformykids/components/game/quiz/screens/TriviaMenuScreen.tsx
+++ b/gamesformykids/components/game/quiz/screens/TriviaMenuScreen.tsx
@@ -1,7 +1,7 @@
 'use client';
 import QuizTopicMenuScreen from '@/components/game/quiz/QuizTopicMenuScreen';
 import type { TriviaCategory } from '@/lib/quiz/data/trivia';
-import { CATEGORIES, CATEGORY_EMOJIS } from '@/lib/quiz/data/trivia';
+import { TRIVIA_CATEGORIES, TRIVIA_CATEGORY_EMOJIS } from '@/lib/quiz/data/trivia';
 
 interface Props {
   onStart: (category: TriviaCategory | 'all') => void;
@@ -16,8 +16,8 @@ export default function TriviaMenuScreen({ onStart }: Props) {
       emoji="🎯"
       title="ידע כללי"
       description="בחר נושא או שחק הכל!"
-      topics={CATEGORIES}
-      topicEmoji={cat => CATEGORY_EMOJIS[cat]}
+      topics={TRIVIA_CATEGORIES}
+      topicEmoji={cat => TRIVIA_CATEGORY_EMOJIS[cat]}
       topicClassName="bg-white border-2 border-amber-200 hover:border-amber-400 hover:bg-amber-50 text-gray-700"
       allLabel="🎯 שאלות מכל הנושאים!"
       allButtonClassName="from-amber-500 to-yellow-500"

--- a/gamesformykids/components/game/quiz/screens/TriviaQuestion.tsx
+++ b/gamesformykids/components/game/quiz/screens/TriviaQuestion.tsx
@@ -1,6 +1,6 @@
 'use client';
 import { QuizQuestionShell } from '@/components/game/quiz';
-import { CATEGORY_EMOJIS, type TriviaQuestion as Q } from '@/lib/quiz/data/trivia';
+import { TRIVIA_CATEGORY_EMOJIS, type TriviaQuestion as Q } from '@/lib/quiz/data/trivia';
 
 interface Props {
   current: Q;
@@ -21,7 +21,7 @@ export default function TriviaQuestion({ current, choices, correctLabel, onSelec
       funFact={current.funFact}
       correctMsg="🌟 מעולה!"
     >
-      <span className="text-sm font-bold text-amber-700">{CATEGORY_EMOJIS[current.category]} {current.category}</span>
+      <span className="text-sm font-bold text-amber-700">{TRIVIA_CATEGORY_EMOJIS[current.category]} {current.category}</span>
       <p className="text-xl font-bold text-gray-800 mt-2">{current.question}</p>
     </QuizQuestionShell>
   );

--- a/gamesformykids/components/marketing/ContentTypeGrid.tsx
+++ b/gamesformykids/components/marketing/ContentTypeGrid.tsx
@@ -2,9 +2,9 @@
 import { useMemo, useState, useEffect } from 'react';
 import GameCard from '@/components/game/GameCard';
 import { GamesRegistry } from '@/lib/registry/gamesRegistry';
-import type { ContentType } from './ContentTypeTabBar';
+import type { TabContentType } from './ContentTypeTabBar';
 
-const CONTENT_IDS: Record<Exclude<ContentType, 'games'>, string[]> = {
+const CONTENT_IDS: Record<Exclude<TabContentType, 'games'>, string[]> = {
   creative: [
     'drawing', 'coloring', 'color-mix', 'art-craft', 'building', 'puzzles',
     'melody-maker', 'craft-guide', 'avatar-maker', 'tetris', 'puppet-story',
@@ -21,17 +21,17 @@ const CONTENT_IDS: Record<Exclude<ContentType, 'games'>, string[]> = {
   ],
 };
 
-const TAB_TITLES: Record<Exclude<ContentType, 'games'>, { title: string; subtitle: string }> = {
+const TAB_TITLES: Record<Exclude<TabContentType, 'games'>, { title: string; subtitle: string }> = {
   creative: { title: '🎨 יצירה ואומנות', subtitle: 'ציור, יצירה, מוזיקה ועוד' },
   riddles:  { title: '🤣 חידות וטריוויה', subtitle: 'חידות, ניחושים ושאלות' },
   tools:    { title: '🎲 כלים חינוכיים', subtitle: 'כלים שימושיים לכיתה ולבית' },
 };
 
 interface Props {
-  contentType: Exclude<ContentType, 'games'>;
+  contentType: Exclude<TabContentType, 'games'>;
 }
 
-export default function ContentTypeGrid({ contentType }: Props) {
+export default function TabContentTypeGrid({ contentType }: Props) {
   const [hydrated, setHydrated] = useState(false);
   useEffect(() => { setHydrated(true); }, []);
 

--- a/gamesformykids/components/marketing/ContentTypeTabBar.tsx
+++ b/gamesformykids/components/marketing/ContentTypeTabBar.tsx
@@ -1,8 +1,8 @@
 'use client';
 
-export type ContentType = 'games' | 'creative' | 'riddles' | 'tools';
+export type TabContentType = 'games' | 'creative' | 'riddles' | 'tools';
 
-const TABS: { id: ContentType; label: string; emoji: string; color: string }[] = [
+const TABS: { id: TabContentType; label: string; emoji: string; color: string }[] = [
   { id: 'games',    label: 'משחקים', emoji: '🎮', color: 'from-blue-500 to-indigo-600' },
   { id: 'creative', label: 'יצירה',  emoji: '🎨', color: 'from-pink-500 to-purple-600' },
   { id: 'riddles',  label: 'חידות',  emoji: '🤣', color: 'from-yellow-500 to-orange-500' },
@@ -10,11 +10,11 @@ const TABS: { id: ContentType; label: string; emoji: string; color: string }[] =
 ];
 
 interface Props {
-  active: ContentType;
-  onChange: (tab: ContentType) => void;
+  active: TabContentType;
+  onChange: (tab: TabContentType) => void;
 }
 
-export default function ContentTypeTabBar({ active, onChange }: Props) {
+export default function TabContentTypeTabBar({ active, onChange }: Props) {
   return (
     <div className="max-w-6xl mx-auto px-4 py-4" dir="rtl">
       <div className="flex gap-2 overflow-x-auto pb-1 scrollbar-none">

--- a/gamesformykids/lib/constants/gameData/basicData/shapes.ts
+++ b/gamesformykids/lib/constants/gameData/basicData/shapes.ts
@@ -18,7 +18,7 @@ export const SHAPE_GAME_CONSTANTS = DEFAULT_GAME_CONFIG;
 
 // ─── Colored shapes ────────────────────────────────────────────────────────
 
-export interface ColoredShapeItem extends BaseGameItem {
+export interface ColoredShapeGameItem extends BaseGameItem {
   readonly shape: string;
   readonly colorName?: string;
   readonly svgPath?: string;
@@ -27,7 +27,7 @@ export interface ColoredShapeItem extends BaseGameItem {
   readonly tailwindClass?: string;
 }
 
-export const COLORED_SHAPES_CONSTANTS: Record<string, ColoredShapeItem> = {
+export const COLORED_SHAPES_CONSTANTS: Record<string, ColoredShapeGameItem> = {
   RED_CIRCLE: { name: "red_circle", hebrew: "עיגול אדום", english: "Red Circle", emoji: "🔴", color: "bg-gradient-to-br from-red-400 to-red-600", sound: [440, 550, 660], shape: "circle", shapeHebrew: "עיגול", svg: "circle", value: "#ef4444", tailwindClass: "bg-red-500" },
   BLUE_CIRCLE: { name: "blue_circle", hebrew: "עיגול כחול", english: "Blue Circle", emoji: "🔵", color: "bg-gradient-to-br from-blue-400 to-blue-600", sound: [523, 659, 784], shape: "circle", shapeHebrew: "עיגול", svg: "circle", value: "#3b82f6", tailwindClass: "bg-blue-500" },
   GREEN_CIRCLE: { name: "green_circle", hebrew: "עיגול ירוק", english: "Green Circle", emoji: "🟢", color: "bg-gradient-to-br from-green-400 to-green-600", sound: [349, 440, 523], shape: "circle", shapeHebrew: "עיגול", svg: "circle", value: "#10b981", tailwindClass: "bg-green-500" },

--- a/gamesformykids/lib/constants/jokes.ts
+++ b/gamesformykids/lib/constants/jokes.ts
@@ -98,13 +98,13 @@ export const JOKES: Joke[] = [
   { id: 80, category: 'school',  emoji: '🔦', setup: 'למה הפנס הביא מטריה לבית ספר?',      punchline: 'כי שמע שיהיה מבחן ב׳אור׳! ☔' },
 ];
 
-export const CATEGORY_LABELS: Record<JokeCategory, string> = {
+export const JOKE_CATEGORY_LABELS: Record<JokeCategory, string> = {
   animals: '🐾 בעלי חיים',
   school:  '📚 בית ספר',
   food:    '🍕 אוכל',
 };
 
-export const CATEGORY_COLORS: Record<JokeCategory, string> = {
+export const JOKE_CATEGORY_COLORS: Record<JokeCategory, string> = {
   animals: 'from-green-400 to-emerald-500',
   school:  'from-blue-400 to-indigo-500',
   food:    'from-orange-400 to-amber-500',

--- a/gamesformykids/lib/constants/wordMazeWords.ts
+++ b/gamesformykids/lib/constants/wordMazeWords.ts
@@ -4,4 +4,4 @@ export const MAZE_WORDS = {
   hard:   ['ספריה', 'שמחה', 'ילדים', 'חיוך', 'כובע', 'שוקו', 'כלבים'],
 } as const;
 
-export type DifficultyLevel = keyof typeof MAZE_WORDS;
+export type MazeDifficulty = keyof typeof MAZE_WORDS;

--- a/gamesformykids/lib/quiz/data/body.ts
+++ b/gamesformykids/lib/quiz/data/body.ts
@@ -39,7 +39,7 @@ export const CATEGORY_GRADIENT_COLORS: Partial<Record<BodyCategory, string>> = {
   'איברים פנימיים': 'from-red-400 to-red-600',
 };
 
-export const CATEGORY_LABELS: Record<BodyCategory, string> = {
+export const BODY_CATEGORY_LABELS: Record<BodyCategory, string> = {
   'הכל':            '🦴 הכל',
   'ראש':            '🧠 ראש',
   'גוף':            '💪 גוף',

--- a/gamesformykids/lib/quiz/data/english-words.ts
+++ b/gamesformykids/lib/quiz/data/english-words.ts
@@ -31,5 +31,5 @@ export const ENGLISH_WORDS: EnglishWord[] = [
   { id: 20, category: 'מספרים',  emoji: '⭐', hebrew: 'כוכב',     english: 'star',     wrongOptions: ['moon', 'sun', 'sky'] },
 ];
 
-export const CATEGORIES = ['הכל', 'חיות', 'אוכל', 'גוף', 'בית', 'צבעים', 'מספרים'] as const;
-export type EnglishCategory = typeof CATEGORIES[number];
+export const ENGLISH_CATEGORIES = ['הכל', 'חיות', 'אוכל', 'גוף', 'בית', 'צבעים', 'מספרים'] as const;
+export type EnglishCategory = typeof ENGLISH_CATEGORIES[number];

--- a/gamesformykids/lib/quiz/data/israel.ts
+++ b/gamesformykids/lib/quiz/data/israel.ts
@@ -27,10 +27,10 @@ export const ISRAEL_QUESTIONS: IsraelQuestion[] = [
   { id: 15, category: 'היסטוריה',  emoji: '🕍', question: 'מי כתב את "מדינת היהודים"?',                               answers: ['חיים ויצמן', 'דוד בן גוריון', 'תאודור הרצל', 'זאב ז\'בוטינסקי'], correctIndex: 2, funFact: 'הרצל כתב את הספר ב-1896 בוינה' },
 ];
 
-export const CATEGORIES = ['הכל', 'גאוגרפיה', 'היסטוריה', 'תרבות', 'טבע', 'ערים'] as const;
-export type IsraelCategory = typeof CATEGORIES[number];
+export const ISRAEL_CATEGORIES = ['הכל', 'גאוגרפיה', 'היסטוריה', 'תרבות', 'טבע', 'ערים'] as const;
+export type IsraelCategory = typeof ISRAEL_CATEGORIES[number];
 
-export const CATEGORY_COLORS: Record<IsraelCategory, string> = {
+export const ISRAEL_CATEGORY_COLORS: Record<IsraelCategory, string> = {
   'הכל':      'bg-blue-600 text-white',
   'גאוגרפיה': 'bg-teal-500 text-white',
   'היסטוריה': 'bg-amber-500 text-white',

--- a/gamesformykids/lib/quiz/data/nature.ts
+++ b/gamesformykids/lib/quiz/data/nature.ts
@@ -27,10 +27,10 @@ export const NATURE_QUESTIONS: NatureQuestion[] = [
   { id: 15, category: 'צמחים',    emoji: '🌺', question: 'מה פונקציית העלים של הצמח?',                       answers: ['הגנה', 'פוטוסינתזה', 'נשיאת מזון', 'רבייה'],  correctIndex: 1, funFact: 'פוטוסינתזה היא התהליך שבו צמחים מייצרים אוכל מאור שמש!' },
 ];
 
-export const CATEGORIES = ['הכל', 'בעלי חיים', 'צמחים', 'מזג אוויר', 'חלל', 'מים'] as const;
-export type NatureCategory = (typeof CATEGORIES)[number];
+export const NATURE_CATEGORIES = ['הכל', 'בעלי חיים', 'צמחים', 'מזג אוויר', 'חלל', 'מים'] as const;
+export type NatureCategory = (typeof NATURE_CATEGORIES)[number];
 
-export const CATEGORY_COLORS: Record<NatureCategory, string> = {
+export const NATURE_CATEGORY_COLORS: Record<NatureCategory, string> = {
   'הכל':       'bg-green-600 text-white',
   'בעלי חיים': 'bg-amber-500 text-white',
   'צמחים':     'bg-emerald-500 text-white',

--- a/gamesformykids/lib/quiz/data/opposites.ts
+++ b/gamesformykids/lib/quiz/data/opposites.ts
@@ -30,4 +30,4 @@ export const OPPOSITE_WORDS: OppositeWord[] = [
   { id: 20, word: 'נקי',    opposite: 'מלוכלך', emoji: '🧼🗑️', wrongOptions: ['ריחני', 'ישן', 'רטוב'] },
 ];
 
-export const CATEGORIES = ['הכל', 'גדלים', 'מצבורג', 'תחושות', 'מיקום'] as const;
+export const OPPOSITES_CATEGORIES = ['הכל', 'גדלים', 'מצבורג', 'תחושות', 'מיקום'] as const;

--- a/gamesformykids/lib/quiz/data/trivia-categories.ts
+++ b/gamesformykids/lib/quiz/data/trivia-categories.ts
@@ -130,7 +130,7 @@ export const TRIVIA_CAT_QUESTIONS: TriviaCatQuestion[] = [
 export const TRIVIA_CAT_CATEGORIES: TriviaCatCategory[] = ['טבע', 'מדע', 'ישראל', 'בעלי חיים', 'חגים', 'ספורט'];
 export const TRIVIA_CAT_DIFFICULTIES: TriviaCatDifficulty[] = ['קל', 'בינוני', 'קשה'];
 
-export const CATEGORY_EMOJIS: Record<TriviaCatCategory, string> = {
+export const TRIVIA_CAT_CATEGORY_EMOJIS: Record<TriviaCatCategory, string> = {
   'טבע': '🌿',
   'מדע': '🔬',
   'ישראל': '🇮🇱',

--- a/gamesformykids/lib/quiz/data/trivia.ts
+++ b/gamesformykids/lib/quiz/data/trivia.ts
@@ -40,7 +40,7 @@ export const TRIVIA_QUESTIONS: TriviaQuestion[] = [
   { id: 'g4', category: 'גוף האדם', question: 'כמה שיניים יש לאדם בוגר?', answers: ['20', '28-32', '40', '16'], correctIndex: 1, funFact: 'שיניות חלב הן 20, שיניות קבועות הן 32 (כולל בינה)!' },
 ];
 
-export const CATEGORIES: TriviaCategory[] = ['טבע', 'מדע', 'היסטוריה', 'חלל', 'בעלי חיים', 'גוף האדם'];
-export const CATEGORY_EMOJIS: Record<TriviaCategory, string> = {
+export const TRIVIA_CATEGORIES: TriviaCategory[] = ['טבע', 'מדע', 'היסטוריה', 'חלל', 'בעלי חיים', 'גוף האדם'];
+export const TRIVIA_CATEGORY_EMOJIS: Record<TriviaCategory, string> = {
   'טבע': '🌿', 'מדע': '🔬', 'היסטוריה': '📜', 'חלל': '🚀', 'בעלי חיים': '🐘', 'גוף האדם': '🫀'
 };

--- a/gamesformykids/lib/quiz/registry/customQuizGames.tsx
+++ b/gamesformykids/lib/quiz/registry/customQuizGames.tsx
@@ -29,9 +29,9 @@ import { useLifeCyclesGame } from '@/lib/quiz/useLifeCyclesGame';
 // Category data constants needed synchronously in render props
 import type { TriviaCatCategory, TriviaCatDifficulty } from '@/lib/quiz/data/trivia-categories';
 import type { NatureCategory } from '@/lib/quiz/data/nature';
-import { CATEGORY_COLORS as NATURE_COLORS } from '@/lib/quiz/data/nature';
+import { NATURE_CATEGORY_COLORS as NATURE_COLORS } from '@/lib/quiz/data/nature';
 import type { IsraelCategory } from '@/lib/quiz/data/israel';
-import { CATEGORY_COLORS as ISRAEL_COLORS } from '@/lib/quiz/data/israel';
+import { ISRAEL_CATEGORY_COLORS as ISRAEL_COLORS } from '@/lib/quiz/data/israel';
 
 import QuizGameSkeleton from '@/components/ui/QuizGameSkeleton';
 

--- a/gamesformykids/lib/quiz/useIsraelGame.ts
+++ b/gamesformykids/lib/quiz/useIsraelGame.ts
@@ -1,13 +1,13 @@
 'use client';
 import { createCategoryIndexQuizHook } from '@/lib/quiz/createCategoryIndexQuizHook';
-import { ISRAEL_QUESTIONS, CATEGORIES } from '@/lib/quiz/data/israel';
+import { ISRAEL_QUESTIONS, ISRAEL_CATEGORIES } from '@/lib/quiz/data/israel';
 import { QUESTIONS_PER_GAME } from '@/lib/quiz/constants';
 
 export const useIsraelGame = createCategoryIndexQuizHook({
   questions: ISRAEL_QUESTIONS,
   gameType: 'israel',
   questionsPerGame: QUESTIONS_PER_GAME,
-  categories: CATEGORIES,
+  categories: ISRAEL_CATEGORIES,
   allCategory: 'הכל' as const,
   getCategoryOf: q => q.category,
 });

--- a/gamesformykids/lib/quiz/useNatureGame.ts
+++ b/gamesformykids/lib/quiz/useNatureGame.ts
@@ -1,13 +1,13 @@
 'use client';
 import { createCategoryIndexQuizHook } from '@/lib/quiz/createCategoryIndexQuizHook';
-import { NATURE_QUESTIONS, CATEGORIES } from '@/lib/quiz/data/nature';
+import { NATURE_QUESTIONS, NATURE_CATEGORIES } from '@/lib/quiz/data/nature';
 import { QUESTIONS_PER_GAME } from '@/lib/quiz/constants';
 
 export const useNatureGame = createCategoryIndexQuizHook({
   questions: NATURE_QUESTIONS,
   gameType: 'nature',
   questionsPerGame: QUESTIONS_PER_GAME,
-  categories: CATEGORIES,
+  categories: NATURE_CATEGORIES,
   allCategory: 'הכל' as const,
   getCategoryOf: q => q.category,
 });

--- a/gamesformykids/lib/quiz/useTriviaGame.ts
+++ b/gamesformykids/lib/quiz/useTriviaGame.ts
@@ -1,13 +1,13 @@
 'use client';
 import { createCategoryIndexQuizHook } from '@/lib/quiz/createCategoryIndexQuizHook';
-import { TRIVIA_QUESTIONS, CATEGORIES } from '@/lib/quiz/data/trivia';
+import { TRIVIA_QUESTIONS, TRIVIA_CATEGORIES } from '@/lib/quiz/data/trivia';
 import { QUESTIONS_PER_GAME } from '@/lib/quiz/constants';
 
 export const useTriviaGame = createCategoryIndexQuizHook({
   questions: TRIVIA_QUESTIONS,
   gameType: 'trivia',
   questionsPerGame: QUESTIONS_PER_GAME,
-  categories: ['all', ...CATEGORIES] as const,
+  categories: ['all', ...TRIVIA_CATEGORIES] as const,
   allCategory: 'all' as const,
   getCategoryOf: q => q.category,
 });

--- a/gamesformykids/lib/stores/index.ts
+++ b/gamesformykids/lib/stores/index.ts
@@ -24,7 +24,6 @@ export type { Notification, NotificationType } from './uiStore';
 
 // Game Type
 export { useGameTypeStore } from './gameTypeStore';
-export type { GameTypeState } from './gameTypeStore';
 
 // Game Progress
 export { useGameProgressStore } from './gameProgressStore';

--- a/gamesformykids/lib/types/ui/index.ts
+++ b/gamesformykids/lib/types/ui/index.ts
@@ -7,5 +7,3 @@
 // ===== טיפוסי UI מרכזיים =====
 export * from './core';        // ButtonProps, ModalProps, וכו'
 
-// ===== תאימות לאחור =====
-// export * from './legacy';   // רק במידת הצורך


### PR DESCRIPTION
## Summary

Dead-code hunter scan found 7 categories of issues. This PR resolves all of them:

- **`ColoredShapeItem` type conflict** — two incompatible interfaces with the same name in `basicData/shapes.ts` (extends `BaseGameItem`, uses `svgPath`) vs `lib/types/components/cards.ts` (standalone, uses `svg`). Renamed the shapes.ts one to `ColoredShapeGameItem`.
- **`ContentType` type conflict** — two definitions with different string literal sets (`'game'|'tool'|'creative'|'riddle'` vs `'games'|'tools'|'creative'|'riddles'`). The tab-bar-local one is renamed to `TabContentType`.
- **`DifficultyLevel` name collision** — local shadow in `wordMazeWords.ts` (`keyof typeof MAZE_WORDS`) conflicting with the canonical `lib/types/games/base.ts` version. Renamed to `MazeDifficulty`.
- **Unused `GameTypeState` re-export** from `lib/stores/index.ts` — nothing imports it from there. Removed.
- **Dead comment** — `// export * from './legacy'` in `lib/types/ui/index.ts` (file doesn't exist). Deleted.
- **Duplicate per-file quiz constants** — `CATEGORIES`, `CATEGORY_COLORS`, `CATEGORY_EMOJIS`, `CATEGORY_LABELS` each defined in multiple quiz data files. Prefixed with domain names (`ISRAEL_CATEGORIES`, `NATURE_CATEGORY_COLORS`, `TRIVIA_CATEGORY_EMOJIS`, `BODY_CATEGORY_LABELS`, etc.) and updated all 13 consumer files.

## Test plan

- [x] `npx tsc --noEmit` — zero errors
- [ ] Spot-check Israel quiz, Nature quiz, Trivia game, Word Maze, Jokes Browser, Human Body quiz in browser
- [ ] Verify homepage tab bar still switches between games/creative/riddles/tools

Closes #1386

🤖 Generated with [Claude Code](https://claude.ai/claude-code)