### PR TITLE
arch: championship generateStaticParams + remove print font CDN dependency

### DIFF
--- a/gamesformykids/app/championship/[categoryId]/loading.tsx
+++ b/gamesformykids/app/championship/[categoryId]/loading.tsx
@@ -1,0 +1,14 @@
+import GameSpinnerScreen from '@/components/ui/GameSpinnerScreen';
+
+export default function ChampionshipLoading() {
+  return (
+    <GameSpinnerScreen
+      emoji="🏆"
+      emojiClassName="animate-bounce"
+      dots={['bg-yellow-400', 'bg-orange-400', 'bg-red-400']}
+      label="אליפות נטענת..."
+      labelColor="text-yellow-700"
+      gradientClass="from-yellow-50 via-orange-50 to-red-50"
+    />
+  );
+}

--- a/gamesformykids/app/championship/[categoryId]/page.tsx
+++ b/gamesformykids/app/championship/[categoryId]/page.tsx
@@ -1,7 +1,12 @@
+import { GAME_CATEGORIES } from '@/lib/constants/gameCategories';
 import ChampionshipClient from './ChampionshipClient';
 
 interface Props {
   params: Promise<{ categoryId: string }>;
+}
+
+export function generateStaticParams() {
+  return Object.keys(GAME_CATEGORIES).map((categoryId) => ({ categoryId }));
 }
 
 export default async function ChampionshipPage({ params }: Props) {

--- a/gamesformykids/components/shared/buttons/PrintWorksheetButton.tsx
+++ b/gamesformykids/components/shared/buttons/PrintWorksheetButton.tsx
@@ -29,10 +29,9 @@ function buildWorksheetHtml(items: BaseGameItem[], title: string): string {
   <meta charset="UTF-8">
   <title>דף עבודה — ${safeTitle}</title>
   <style>
-    @import url('https://fonts.googleapis.com/css2?family=Rubik:wght@400;700&display=swap');
     * { box-sizing: border-box; }
     body {
-      font-family: 'Rubik', Arial, sans-serif;
+      font-family: Rubik, 'Segoe UI', Arial, sans-serif;
       direction: rtl;
       margin: 0;
       padding: 20px;


### PR DESCRIPTION
## Summary

Two minor architectural fixes from the arch-review pass.

- **`app/championship/[categoryId]/page.tsx`** — adds `generateStaticParams` so the route shell is pre-built at deploy time (served from CDN) rather than server-rendered per request. The Server Component is a thin pass-through; all content is Zustand-driven client state, making it a perfect static candidate. Adds a `loading.tsx` skeleton for the segment.
- **`components/shared/buttons/PrintWorksheetButton.tsx`** — removes `@import url('https://fonts.googleapis.com/css2?family=Rubik...')` from the `window.open()` print document. This external CDN call blocked offline printing and introduced a network round-trip at print time. Replaced with a system font stack (`Rubik, 'Segoe UI', Arial, sans-serif`) — Rubik renders correctly when the browser already has it cached from the main page.

## Test plan

- [ ] Visit `/championship/<any-category>` — page loads and redirects home if no championship is active (client behavior unchanged)
- [ ] Open any card game → tap "הדפס" → print popup opens and renders correctly without network tab showing a fonts.googleapis.com request
- [ ] `npx tsc --noEmit` — zero errors ✅

Closes #1388