### PR TITLE
feat(ux+engagement): WhatsApp share, difficulty picker, Canvas share card

### DIFF
--- a/gamesformykids/components/game/quiz/QuizResultScreen.tsx
+++ b/gamesformykids/components/game/quiz/QuizResultScreen.tsx
@@ -8,6 +8,8 @@ import { GameCompletionCelebration } from '@/components/game/shared/GameCompleti
 import { useGameRating } from '@/hooks/shared/social/useGameRating';
 import { printCertificate } from '@/lib/utils/game/printCertificate';
 import { getNextGameInCategory } from '@/lib/utils/game/getNextGameInCategory';
+import WhatsAppShareButton from '@/components/shared/buttons/WhatsAppShareButton';
+import ShareCardButton from '@/components/shared/buttons/ShareCardButton';
 
 interface Props {
   onRestart: () => void;
@@ -65,6 +67,13 @@ export function QuizResultScreen({ onRestart, theme, title = 'כל הכבוד!',
         >
           שחק שוב
         </button>
+        <WhatsAppShareButton text={`${emoji} השגתי ${score} נקודות (${pct}%)! בואו לשחק גם אתם 🎮`} />
+        <ShareCardButton
+          gameEmoji={emoji}
+          gameTitle={title}
+          score={score}
+          pct={pct}
+        />
         {showCertificate && (
           <button
             onClick={() => printCertificate({ emoji, title, scorePercent: pct })}

--- a/gamesformykids/components/game/shared/GameResultCard.tsx
+++ b/gamesformykids/components/game/shared/GameResultCard.tsx
@@ -7,6 +7,7 @@ import { useGameRating } from '@/hooks/shared/social/useGameRating';
 import { printCertificate } from '@/lib/utils/game/printCertificate';
 import { getNextGameInCategory } from '@/lib/utils/game/getNextGameInCategory';
 import WhatsAppShareButton from '@/components/shared/buttons/WhatsAppShareButton';
+import ShareCardButton from '@/components/shared/buttons/ShareCardButton';
 import { useCategoryCompletion } from '@/hooks/shared/progress/useCategoryCompletion';
 import { getActiveHoliday } from '@/lib/constants/holidayLanes';
 import { useAudioSettingsStore } from '@/lib/stores/audioSettingsStore';
@@ -139,6 +140,14 @@ export default function GameResultCard({
             </button>
             <WhatsAppShareButton text={shareText} />
           </>
+        )}
+        {gameType && score !== undefined && (
+          <ShareCardButton
+            gameEmoji={emoji}
+            gameTitle={title}
+            score={score}
+            pct={scorePercent}
+          />
         )}
         {showCertificate && (
           <button

--- a/gamesformykids/components/shared/buttons/ShareCardButton.tsx
+++ b/gamesformykids/components/shared/buttons/ShareCardButton.tsx
@@ -1,0 +1,35 @@
+'use client';
+import { useState } from 'react';
+import { useShareCard } from '@/hooks/shared/social/useShareCard';
+
+interface Props {
+  gameEmoji: string;
+  gameTitle: string;
+  score: number;
+  masteryStars?: number | undefined;
+  pct?: number | undefined;
+}
+
+export default function ShareCardButton({ gameEmoji, gameTitle, score, masteryStars, pct }: Props) {
+  const { shareCard } = useShareCard();
+  const [busy, setBusy] = useState(false);
+
+  async function handleClick() {
+    if (busy) return;
+    setBusy(true);
+    await shareCard({ gameEmoji, gameTitle, score, masteryStars, pct });
+    setBusy(false);
+  }
+
+  return (
+    <button
+      onClick={handleClick}
+      disabled={busy}
+      className="mt-3 w-full py-2.5 rounded-2xl bg-[#25D366] text-white font-semibold text-sm hover:bg-[#1ebe5d] active:scale-95 transition-[transform,background-color] flex items-center justify-center gap-2 disabled:opacity-60"
+      aria-label="שתף כרטיס תוצאה"
+    >
+      <span>🖼️</span>
+      <span>{busy ? 'מכין כרטיס...' : 'שתף כרטיס תוצאה'}</span>
+    </button>
+  );
+}

--- a/gamesformykids/components/shared/screens/AutoStartScreen.tsx
+++ b/gamesformykids/components/shared/screens/AutoStartScreen.tsx
@@ -10,6 +10,7 @@ import RealPhotoToggleButton from '../buttons/RealPhotoToggleButton';
 import PrintWorksheetButton from '../buttons/PrintWorksheetButton';
 import { REAL_PHOTO_CARD_MAP } from '../GameCardMap';
 import { useSpeedBurstStore } from '@/lib/stores/speedBurstStore';
+import { DifficultyPicker } from '@/components/game/shared/DifficultyPicker';
 
 export default function AutoStartScreen() {
   const { config, speakItemName, gameType, items, startGame, lastMistakeItems, startMistakeReview } = useUniversalGame();
@@ -65,7 +66,9 @@ export default function AutoStartScreen() {
       }}
       customOnStart={studyMode ? handleStartWithStudy : undefined}
       extraControls={
-        <div className="flex justify-center gap-3 mt-3 flex-wrap">
+        <div className="flex flex-col items-center gap-3 mt-3">
+          <DifficultyPicker />
+          <div className="flex justify-center gap-3 flex-wrap">
           <button
             onClick={() => setStudyMode(v => !v)}
             className={`flex items-center gap-2 px-4 py-2 rounded-xl text-sm font-semibold transition-[background-color,border-color,box-shadow,color] border-2 ${
@@ -99,6 +102,7 @@ export default function AutoStartScreen() {
               🔁 תרגל טעויות ({lastMistakeItems.length})
             </button>
           )}
+          </div>
         </div>
       }
     />

--- a/gamesformykids/hooks/shared/social/useShareCard.ts
+++ b/gamesformykids/hooks/shared/social/useShareCard.ts
@@ -1,0 +1,114 @@
+'use client';
+import { useCallback } from 'react';
+
+interface ShareCardOptions {
+  gameEmoji: string;
+  gameTitle: string;
+  score: number;
+  masteryStars?: number | undefined;
+  pct?: number | undefined;
+}
+
+export function useShareCard() {
+  const generateCard = useCallback((opts: ShareCardOptions): Promise<Blob | null> => {
+    return new Promise((resolve) => {
+      if (typeof document === 'undefined') { resolve(null); return; }
+
+      const W = 600, H = 340;
+      const canvas = document.createElement('canvas');
+      canvas.width = W;
+      canvas.height = H;
+      const ctx = canvas.getContext('2d');
+      if (!ctx) { resolve(null); return; }
+
+      // Background gradient (RTL purple-to-pink)
+      const grad = ctx.createLinearGradient(W, 0, 0, H);
+      grad.addColorStop(0, '#667eea');
+      grad.addColorStop(1, '#f093fb');
+      ctx.fillStyle = grad;
+      ctx.roundRect(0, 0, W, H, 24);
+      ctx.fill();
+
+      // White inner card
+      ctx.fillStyle = 'rgba(255,255,255,0.15)';
+      ctx.roundRect(20, 20, W - 40, H - 40, 16);
+      ctx.fill();
+
+      // Emoji (large, center-top)
+      ctx.font = '80px serif';
+      ctx.textAlign = 'center';
+      ctx.textBaseline = 'top';
+      ctx.fillText(opts.gameEmoji, W / 2, 40);
+
+      // Game title
+      ctx.font = 'bold 28px "Rubik", sans-serif';
+      ctx.fillStyle = '#ffffff';
+      ctx.direction = 'rtl';
+      ctx.textBaseline = 'top';
+      ctx.fillText(opts.gameTitle, W / 2, 140);
+
+      // Score line
+      ctx.font = 'bold 48px "Rubik", sans-serif';
+      ctx.fillStyle = '#ffe066';
+      ctx.fillText(String(opts.score), W / 2, 180);
+
+      // "נקודות" label
+      ctx.font = '20px "Rubik", sans-serif';
+      ctx.fillStyle = 'rgba(255,255,255,0.85)';
+      ctx.fillText('נקודות', W / 2, 236);
+
+      // Mastery stars
+      if (opts.masteryStars && opts.masteryStars > 0) {
+        ctx.font = '30px serif';
+        ctx.fillText('⭐'.repeat(opts.masteryStars), W / 2, 268);
+      }
+
+      // Site watermark
+      ctx.font = '14px "Rubik", sans-serif';
+      ctx.fillStyle = 'rgba(255,255,255,0.6)';
+      ctx.fillText('gamesformykids.com', W / 2, H - 30);
+
+      canvas.toBlob((blob) => resolve(blob), 'image/png');
+    });
+  }, []);
+
+  const shareCard = useCallback(async (opts: ShareCardOptions) => {
+    const blob = await generateCard(opts);
+    if (!blob) return;
+
+    const siteUrl = typeof window !== 'undefined'
+      ? `${window.location.origin}${window.location.pathname}?utm_source=whatsapp&utm_medium=share_card&utm_campaign=game_result`
+      : '';
+    const shareText = `${opts.gameEmoji} השגתי ${opts.score} נקודות ב${opts.gameTitle}! 🎮\n${siteUrl}`;
+
+    // Try Web Share API with file
+    if (typeof navigator !== 'undefined' && navigator.canShare) {
+      const file = new File([blob], 'result.png', { type: 'image/png' });
+      if (navigator.canShare({ files: [file] })) {
+        try {
+          await navigator.share({ files: [file], text: shareText });
+          return;
+        } catch {
+          // cancelled — fall through
+        }
+      }
+    }
+
+    // Fallback: WhatsApp with text link
+    const waUrl = `https://wa.me/?text=${encodeURIComponent(shareText)}`;
+    window.open(waUrl, '_blank', 'noopener,noreferrer');
+  }, [generateCard]);
+
+  const downloadCard = useCallback(async (opts: ShareCardOptions) => {
+    const blob = await generateCard(opts);
+    if (!blob) return;
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = `${opts.gameTitle}-result.png`;
+    a.click();
+    URL.revokeObjectURL(url);
+  }, [generateCard]);
+
+  return { shareCard, downloadCard };
+}


### PR DESCRIPTION
## Summary
- **#1391** — הוסף `WhatsAppShareButton` + `ShareCardButton` למסך תוצאות החידון (`QuizResultScreen`)
- **#1397** — הוסף `DifficultyPicker` (קל/בינוני/קשה) ל-`AutoStartScreen` של משחקי הכרטיסיות — מחובר ישר ל-`useGenericGame` שכבר קורא `gameDifficultyStore`
- **#1401** — Hook חדש `useShareCard` שמייצר PNG ב-Canvas API ומשתף ב-Web Share API (עם fallback לוואטסאפ), ו-`ShareCardButton` component

## Changed files
- `components/game/quiz/QuizResultScreen.tsx` — WhatsApp + Share Card buttons
- `components/game/shared/GameResultCard.tsx` — Share Card button (כשיש `gameType` + `score`)
- `components/shared/screens/AutoStartScreen.tsx` — DifficultyPicker
- `hooks/shared/social/useShareCard.ts` — Canvas card generation + share logic
- `components/shared/buttons/ShareCardButton.tsx` — UI button with loading state

## Test plan
- [ ] פתח משחק חידון כלשהו → השלם → בדוק כפתור "שתף בוואצאפ" + "שתף כרטיס תוצאה"
- [ ] פתח משחק כרטיסיות (כגון animals) → בדוק שמסך הפתיחה מציג בורר ⭐/⭐⭐/⭐⭐⭐
- [ ] שנה קושי ל"קל" → בדוק שיש 3 אפשרויות במשחק (במקום 4)
- [ ] לחץ "שתף כרטיס תוצאה" → אמור לפתוח Web Share API (מובייל) או וואטסאפ (desktop)
- [ ] `npx tsc --noEmit` passes ✅
- [ ] Works on mobile (iOS Safari + Android Chrome)
- [ ] RTL / Hebrew text renders correctly

Closes #1391
Closes #1397
Closes #1401

🤖 Generated with [Claude Code](https://claude.com/claude-code)