### PR TITLE
fix(stores): resolve 9 Zustand anti-patterns — round-2 store health audit

### DIFF
--- a/gamesformykids/app/games/hebrew-racer/components/HebrewRacerScreen.tsx
+++ b/gamesformykids/app/games/hebrew-racer/components/HebrewRacerScreen.tsx
@@ -13,8 +13,8 @@ function shuffle<T>(arr: T[]): T[] {
 export default function HebrewRacerScreen() {
   const {
     phase, lives, checkpoint, score,
-    currentQuestion,
-    triggerQuestion, answerQuestion, resumeRacing,
+    currentQuestion, speakText,
+    triggerQuestion, answerQuestion, resumeRacing, clearSpeakText,
   } = useHebrewRacerStore();
 
   const [choices, setChoices] = useState<string[]>([]);
@@ -40,6 +40,13 @@ export default function HebrewRacerScreen() {
     return () => clearTimeout(t);
   }, [phase, resumeRacing]);
 
+  // Speak TTS text triggered by store actions
+  useEffect(() => {
+    if (!speakText) return;
+    void speakHebrew(speakText);
+    clearSpeakText();
+  }, [speakText, clearSpeakText]);
+
   const replayAudio = useCallback(() => {
     if (currentQuestion) void speakHebrew(currentQuestion.question);
   }, [currentQuestion]);
@@ -52,7 +59,7 @@ export default function HebrewRacerScreen() {
   const progressPct = Math.round((checkpoint / TOTAL_CHECKPOINTS) * 100);
 
   return (
-    <div className="min-h-screen flex flex-col bg-gradient-to-b from-sky-400 to-sky-200 select-none" dir="rtl">
+    <div className="min-h-screen flex flex-col bg-linear-to-b from-sky-400 to-sky-200 select-none" dir="rtl">
       {/* HUD */}
       <div className="flex justify-between items-center px-4 py-2 bg-sky-600 bg-opacity-60">
         <div className="flex gap-1">

--- a/gamesformykids/app/games/hebrew-racer/hebrewRacerStore.ts
+++ b/gamesformykids/app/games/hebrew-racer/hebrewRacerStore.ts
@@ -1,6 +1,5 @@
 'use client';
 import { create } from 'zustand';
-import { speakHebrew } from '@/lib/utils/speech/speaker';
 import { RACER_QUESTIONS, TOTAL_CHECKPOINTS, type RacerQuestion } from './hebrewRacerData';
 
 const MAX_LIVES = 3;
@@ -16,6 +15,7 @@ interface HebrewRacerState {
   currentQuestion: RacerQuestion | null;
   usedQuestionIds: number[];
   feedback: 'correct' | 'wrong' | null;
+  speakText: string | null;
 }
 
 interface HebrewRacerActions {
@@ -24,6 +24,7 @@ interface HebrewRacerActions {
   answerQuestion: (choice: string) => void;
   resumeRacing: () => void;
   reset: () => void;
+  clearSpeakText: () => void;
 }
 
 function pickQuestion(usedIds: number[]): RacerQuestion {
@@ -41,6 +42,7 @@ export const useHebrewRacerStore = create<HebrewRacerState & HebrewRacerActions>
   currentQuestion: null,
   usedQuestionIds: [],
   feedback: null,
+  speakText: null,
 
   startGame: () => set({
     phase: 'racing',
@@ -51,16 +53,17 @@ export const useHebrewRacerStore = create<HebrewRacerState & HebrewRacerActions>
     currentQuestion: null,
     usedQuestionIds: [],
     feedback: null,
+    speakText: null,
   }),
 
   triggerQuestion: () => {
     const { usedQuestionIds } = get();
     const q = pickQuestion(usedQuestionIds);
-    void speakHebrew(q.question);
     set({
       phase: 'question',
       currentQuestion: q,
       usedQuestionIds: [...usedQuestionIds, q.id],
+      speakText: q.question,
     });
   },
 
@@ -75,8 +78,6 @@ export const useHebrewRacerStore = create<HebrewRacerState & HebrewRacerActions>
     const won = newCheckpoint >= TOTAL_CHECKPOINTS;
     const lost = newLives <= 0;
 
-    void speakHebrew(isCorrect ? 'כל הכבוד!' : 'אוי, לא נכון');
-
     const newPhase: Phase = (won || lost) ? 'result' : (isCorrect ? 'jumping' : 'crashing');
 
     set({
@@ -86,6 +87,7 @@ export const useHebrewRacerStore = create<HebrewRacerState & HebrewRacerActions>
       score: newScore,
       won,
       feedback: isCorrect ? 'correct' : 'wrong',
+      speakText: isCorrect ? 'כל הכבוד!' : 'אוי, לא נכון',
     });
   },
 
@@ -107,5 +109,8 @@ export const useHebrewRacerStore = create<HebrewRacerState & HebrewRacerActions>
     currentQuestion: null,
     usedQuestionIds: [],
     feedback: null,
+    speakText: null,
   }),
+
+  clearSpeakText: () => set({ speakText: null }),
 }));

--- a/gamesformykids/app/games/israel-map/mapStore.ts
+++ b/gamesformykids/app/games/israel-map/mapStore.ts
@@ -74,6 +74,7 @@ export const useMapStore = create<State & Actions>((set, get) => ({
   resetGame: () =>
     set({
       phase: 'menu',
+      level: 1,
       queue: [],
       current: null,
       foundIds: [],

--- a/gamesformykids/app/games/letter-merge/components/LetterMergeScreen.tsx
+++ b/gamesformykids/app/games/letter-merge/components/LetterMergeScreen.tsx
@@ -1,4 +1,6 @@
 'use client';
+import { useEffect } from 'react';
+import { speakHebrew } from '@/lib/utils/speech/speaker';
 import { useLetterMergeStore, ALEF_BET } from '../letterMergeStore';
 
 const LETTER_COLORS: Record<number, string> = {
@@ -32,7 +34,13 @@ function letterColor(letter: string): string {
 }
 
 export default function LetterMergeScreen() {
-  const { columns, nextLetterVal, score, dropLetter } = useLetterMergeStore();
+  const { columns, nextLetterVal, score, speakText, dropLetter, clearSpeakText } = useLetterMergeStore();
+
+  useEffect(() => {
+    if (!speakText) return;
+    void speakHebrew(speakText);
+    clearSpeakText();
+  }, [speakText, clearSpeakText]);
 
   return (
     <div className="min-h-screen flex flex-col items-center bg-linear-to-br from-blue-100 to-purple-100 p-3" dir="rtl">

--- a/gamesformykids/app/games/letter-merge/letterMergeStore.ts
+++ b/gamesformykids/app/games/letter-merge/letterMergeStore.ts
@@ -1,6 +1,5 @@
 'use client';
 import { create } from 'zustand';
-import { speakHebrew } from '@/lib/utils/speech/speaker';
 
 export const ALEF_BET = ['א','ב','ג','ד','ה','ו','ז','ח','ט','י','כ','ל','מ','נ','ס','ע','פ','צ','ק','ר','ש','ת'];
 const LETTER_NAMES: Record<string, string> = {
@@ -42,11 +41,13 @@ interface LetterMergeState {
   maxLetterReached: string;
   won: boolean;
   lastMerged: string | null;
+  speakText: string | null;
 }
 interface LetterMergeActions {
   startGame: () => void;
   dropLetter: (colIndex: number) => void;
   reset: () => void;
+  clearSpeakText: () => void;
 }
 
 export const useLetterMergeStore = create<LetterMergeState & LetterMergeActions>((set, get) => ({
@@ -57,6 +58,7 @@ export const useLetterMergeStore = create<LetterMergeState & LetterMergeActions>
   maxLetterReached: 'א',
   won: false,
   lastMerged: null,
+  speakText: null,
 
   startGame: () => set({
     phase: 'playing',
@@ -66,6 +68,7 @@ export const useLetterMergeStore = create<LetterMergeState & LetterMergeActions>
     maxLetterReached: 'א',
     won: false,
     lastMerged: null,
+    speakText: null,
   }),
 
   dropLetter: (colIndex: number) => {
@@ -93,7 +96,6 @@ export const useLetterMergeStore = create<LetterMergeState & LetterMergeActions>
           totalScore += (mergedIdx + 1) * 10;
           if (mergedIdx > ALEF_BET.indexOf(newMax)) newMax = merged;
           if (merged === 'ת') { won = true; merging = false; }
-          void speakHebrew(LETTER_NAMES[merged] ?? merged);
         }
       }
     }
@@ -107,6 +109,7 @@ export const useLetterMergeStore = create<LetterMergeState & LetterMergeActions>
       score: totalScore,
       maxLetterReached: newMax,
       lastMerged: lastMergedLetter,
+      speakText: lastMergedLetter ? (LETTER_NAMES[lastMergedLetter] ?? lastMergedLetter) : null,
       ...(won || gameOver ? { phase: 'result', won } : {}),
     });
   },
@@ -119,5 +122,8 @@ export const useLetterMergeStore = create<LetterMergeState & LetterMergeActions>
     maxLetterReached: 'א',
     won: false,
     lastMerged: null,
+    speakText: null,
   }),
+
+  clearSpeakText: () => set({ speakText: null }),
 }));

--- a/gamesformykids/app/games/letter-trace/letterTraceStore.ts
+++ b/gamesformykids/app/games/letter-trace/letterTraceStore.ts
@@ -51,6 +51,8 @@ export const useLetterTraceStore = create<LetterTraceState & LetterTraceActions>
   restart: () =>
     set({
       phase: 'menu',
+      difficulty: 'guided',
+      letters: [...HEBREW_LETTER_PATHS],
       currentIndex: 0,
       score: 0,
       total: 0,

--- a/gamesformykids/app/games/number-merge/numberMergeStore.ts
+++ b/gamesformykids/app/games/number-merge/numberMergeStore.ts
@@ -126,7 +126,7 @@ export const useNumberMergeStore = create<NumberMergeState & NumberMergeActions>
     set({ phase: 'result', gameOver: true, highScore: Math.max(score, highScore) });
   },
 
-  restart: () => set({ phase: 'menu', balls: [], score: 0, gameOver: false }),
+  restart: () => set({ phase: 'menu', difficulty: 'easy', balls: [], nextId: 1, dropX: 160, nextValue: 1, score: 0, targetScore: TARGET_SCORES.easy, gameOver: false, mergeFlash: null }),
 }));
 
 function randomValue(): number {

--- a/gamesformykids/app/games/picture-dictionary/PictureDictionaryClient.tsx
+++ b/gamesformykids/app/games/picture-dictionary/PictureDictionaryClient.tsx
@@ -1,5 +1,4 @@
 'use client';
-import { useEffect } from 'react';
 import { usePictureDictionaryStore } from './pictureDictionaryStore';
 import type { BrowseMode } from './pictureDictionaryStore';
 import DictionaryBrowse from './components/DictionaryBrowse';
@@ -48,12 +47,8 @@ function CollectionTab() {
 }
 
 export default function PictureDictionaryClient() {
-  const { browseMode, setBrowseMode, expandedItem, searchQuery, setSearchQuery, initCollection } =
+  const { browseMode, setBrowseMode, expandedItem, searchQuery, setSearchQuery } =
     usePictureDictionaryStore();
-
-  useEffect(() => {
-    initCollection();
-  }, [initCollection]);
 
   return (
     <div

--- a/gamesformykids/app/games/picture-dictionary/pictureDictionaryStore.ts
+++ b/gamesformykids/app/games/picture-dictionary/pictureDictionaryStore.ts
@@ -1,5 +1,5 @@
 'use client';
-import { create } from 'zustand';
+import { makePersistStore } from '@/lib/stores/createStore';
 import { GAME_ITEMS_MAP } from '@/lib/constants/gameItemsMap';
 import type { BaseGameItem } from '@/lib/types/core/base';
 
@@ -78,26 +78,6 @@ export function buildDictionary(): DictionaryItem[] {
   return items;
 }
 
-const COLLECTION_KEY = 'picture-dictionary-collection';
-
-function loadCollection(): DictionaryItem[] {
-  if (typeof window === 'undefined') return [];
-  try {
-    const raw = localStorage.getItem(COLLECTION_KEY);
-    return raw ? (JSON.parse(raw) as DictionaryItem[]) : [];
-  } catch {
-    return [];
-  }
-}
-
-function saveCollection(items: DictionaryItem[]): void {
-  try {
-    localStorage.setItem(COLLECTION_KEY, JSON.stringify(items));
-  } catch {
-    // ignore storage errors
-  }
-}
-
 export type BrowseMode = 'letter' | 'category' | 'search' | 'collection';
 
 interface State {
@@ -117,35 +97,34 @@ interface Actions {
   expandItem: (item: DictionaryItem) => void;
   closeExpanded: () => void;
   toggleCollection: (item: DictionaryItem) => void;
-  initCollection: () => void;
 }
 
-export const usePictureDictionaryStore = create<State & Actions>((set, get) => ({
-  browseMode: 'letter',
-  selectedLetter: 'א',
-  selectedCategory: null,
-  searchQuery: '',
-  expandedItem: null,
-  collection: [],
+export const usePictureDictionaryStore = makePersistStore<State & Actions>(
+  'PictureDictionaryStore',
+  'picture-dictionary-collection',
+  (set, get) => ({
+    browseMode: 'letter',
+    selectedLetter: 'א',
+    selectedCategory: null,
+    searchQuery: '',
+    expandedItem: null,
+    collection: [],
 
-  setBrowseMode: (mode) => set({ browseMode: mode, expandedItem: null }),
-  selectLetter: (letter) => set({ selectedLetter: letter }),
-  selectCategory: (category) => set({ selectedCategory: category }),
-  setSearchQuery: (q) => set({ searchQuery: q }),
-  expandItem: (item) => set({ expandedItem: item }),
-  closeExpanded: () => set({ expandedItem: null }),
+    setBrowseMode: (mode) => set({ browseMode: mode, expandedItem: null }),
+    selectLetter: (letter) => set({ selectedLetter: letter }),
+    selectCategory: (category) => set({ selectedCategory: category }),
+    setSearchQuery: (q) => set({ searchQuery: q }),
+    expandItem: (item) => set({ expandedItem: item }),
+    closeExpanded: () => set({ expandedItem: null }),
 
-  toggleCollection: (item) => {
-    const { collection } = get();
-    const exists = collection.some((c) => c.hebrew === item.hebrew);
-    const next = exists
-      ? collection.filter((c) => c.hebrew !== item.hebrew)
-      : collection.length < 50 ? [...collection, item] : collection;
-    saveCollection(next);
-    set({ collection: next });
-  },
-
-  initCollection: () => {
-    set({ collection: loadCollection() });
-  },
-}));
+    toggleCollection: (item) => {
+      const { collection } = get();
+      const exists = collection.some((c) => c.hebrew === item.hebrew);
+      const next = exists
+        ? collection.filter((c) => c.hebrew !== item.hebrew)
+        : collection.length < 50 ? [...collection, item] : collection;
+      set({ collection: next });
+    },
+  }),
+  { partialize: (s) => ({ collection: s.collection }) },
+);

--- a/gamesformykids/app/games/sound-quiz/soundQuizStore.ts
+++ b/gamesformykids/app/games/sound-quiz/soundQuizStore.ts
@@ -42,5 +42,5 @@ export const useSoundQuizStore = create<SoundQuizState>((set) => ({
   })),
   nextQuestion: (clip, choices) => set({ current: clip, choices, choicesRevealed: false, lastCorrect: null }),
   endGame: () => set({ phase: 'result' }),
-  reset: () => set({ phase: 'menu', current: null, choices: [], score: 0, total: 0, lastCorrect: null }),
+  reset: () => set({ phase: 'menu', category: 'all', current: null, choices: [], choicesRevealed: false, score: 0, total: 0, lastCorrect: null }),
 }));

--- a/gamesformykids/app/games/spinner/spinnerStore.ts
+++ b/gamesformykids/app/games/spinner/spinnerStore.ts
@@ -1,5 +1,5 @@
 'use client';
-import { create } from 'zustand';
+import { makePersistStore } from '@/lib/stores/createStore';
 
 export type SegmentPreset = 'letters' | 'numbers' | 'colors' | 'animals';
 
@@ -17,8 +17,6 @@ export const PRESET_LABELS: Record<SegmentPreset, string> = {
   animals: '🐾 חיות',
 };
 
-const STORAGE_KEY = 'spinner-segments';
-
 interface SpinnerState {
   segments: string[];
   result: string | null;
@@ -35,37 +33,30 @@ interface SpinnerActions {
   toggleEditing: () => void;
 }
 
-export const useSpinnerStore = create<SpinnerState & SpinnerActions>((set, get) => ({
-  segments: PRESETS.letters,
-  result: null,
-  isEditing: false,
+export const useSpinnerStore = makePersistStore<SpinnerState & SpinnerActions>(
+  'SpinnerStore',
+  'spinner-segments',
+  (set, get) => ({
+    segments: PRESETS.letters,
+    result: null,
+    isEditing: false,
 
-  setSegments: (segments) => {
-    if (typeof window !== 'undefined') {
-      localStorage.setItem(STORAGE_KEY, JSON.stringify(segments));
-    }
-    set({ segments });
-  },
-  addSegment: (text) => {
-    const segments = [...get().segments, text.trim()].filter(Boolean);
-    if (typeof window !== 'undefined') localStorage.setItem(STORAGE_KEY, JSON.stringify(segments));
-    set({ segments });
-  },
-  removeSegment: (index) => {
-    const segments = get().segments.filter((_, i) => i !== index);
-    if (typeof window !== 'undefined') localStorage.setItem(STORAGE_KEY, JSON.stringify(segments));
-    set({ segments });
-  },
-  editSegment: (index, text) => {
-    const segments = get().segments.map((s, i) => (i === index ? text : s));
-    if (typeof window !== 'undefined') localStorage.setItem(STORAGE_KEY, JSON.stringify(segments));
-    set({ segments });
-  },
-  applyPreset: (preset) => {
-    const segments = PRESETS[preset];
-    if (typeof window !== 'undefined') localStorage.setItem(STORAGE_KEY, JSON.stringify(segments));
-    set({ segments, result: null });
-  },
-  setResult: (result) => set({ result }),
-  toggleEditing: () => set((s) => ({ isEditing: !s.isEditing })),
-}));
+    setSegments: (segments) => set({ segments }, false, 'spinner/setSegments'),
+    addSegment: (text) => {
+      const segments = [...get().segments, text.trim()].filter(Boolean);
+      set({ segments }, false, 'spinner/addSegment');
+    },
+    removeSegment: (index) => {
+      const segments = get().segments.filter((_, i) => i !== index);
+      set({ segments }, false, 'spinner/removeSegment');
+    },
+    editSegment: (index, text) => {
+      const segments = get().segments.map((s, i) => (i === index ? text : s));
+      set({ segments }, false, 'spinner/editSegment');
+    },
+    applyPreset: (preset) => set({ segments: PRESETS[preset], result: null }, false, 'spinner/applyPreset'),
+    setResult: (result) => set({ result }, false, 'spinner/setResult'),
+    toggleEditing: () => set((s) => ({ isEditing: !s.isEditing }), false, 'spinner/toggleEditing'),
+  }),
+  { partialize: (s) => ({ segments: s.segments }) },
+);

--- a/gamesformykids/app/games/word-search/wordSearchStore.ts
+++ b/gamesformykids/app/games/word-search/wordSearchStore.ts
@@ -128,6 +128,6 @@ export const useWordSearchStore = create<State & Actions>((set, get) => ({
   },
 
   resetGame: () => {
-    set({ phase: 'menu', found: new Set(), score: 0 });
+    set({ phase: 'menu', theme: WORD_SETS[0]!, grid: [], placed: [], found: new Set(), score: 0 });
   },
 }));


### PR DESCRIPTION
## Summary

- **`soundQuizStore`** — `reset()` left `category` and `choicesRevealed` stale in menu phase; now fully resets to initial values
- **`spinnerStore`** — replaced 5 inline `localStorage.setItem()` calls in actions with `makePersistStore` + `partialize`
- **`pictureDictionaryStore`** — replaced manual `loadCollection`/`saveCollection`/`initCollection` with `makePersistStore`; removed `initCollection` from component
- **`hebrewRacerStore`** — removed `speakHebrew()` calls from `triggerQuestion` and `answerQuestion`; added `speakText` signal field + `clearSpeakText()` action
- **`HebrewRacerScreen`** — added `useEffect` watching `speakText` to call `speakHebrew` with lifecycle cleanup; fixed `bg-gradient-to-b` → `bg-linear-to-b`
- **`letterMergeStore`** — same signal pattern: removed `speakHebrew()` from `dropLetter`, added `speakText` signal
- **`LetterMergeScreen`** — added `useEffect` for `speakText`
- **`mapStore`** — `resetGame()` now resets `level: 1`
- **`wordSearchStore`** — `resetGame()` now resets `theme`, `grid`, `placed`
- **`letterTraceStore`** — `restart()` now resets `difficulty` and `letters`
- **`numberMergeStore`** — `restart()` now resets all fields to initial values

## Test plan

- [ ] `tsc --noEmit` — zero errors ✅
- [ ] `npm run build` — zero errors ✅
- [ ] `/games/spinner` — segments persist across reload; preset changes work
- [ ] `/games/picture-dictionary` — collection persists across reload; `initCollection` no longer called
- [ ] `/games/hebrew-racer` — TTS fires on question appearance and on answer feedback
- [ ] `/games/letter-merge` — TTS fires when letters merge
- [ ] `/games/sound-quiz` — after playing and resetting, category selector shows 'all'
- [ ] `/games/israel-map` — after reset, level selector defaults to 1
- [ ] `/games/word-search` — after reset, grid is cleared
- [ ] `/games/letter-trace` — after restart, difficulty resets to 'guided'
- [ ] `/games/number-merge` — after restart, returns to clean menu state

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #1405