### PR TITLE
fix(qa): resolve category-grid drift and orphan UI configs

### DIFF
--- a/gamesformykids/lib/constants/gameCategories.ts
+++ b/gamesformykids/lib/constants/gameCategories.ts
@@ -38,7 +38,7 @@ export const GAME_CATEGORIES: Record<string, GameCategory> = {
     icon: Palette,
     color: "bg-purple-500",
     gradient: "from-purple-400 to-purple-600",
-    gameIds: ["instruments","puzzles","drawing","building","tetris","magic-fairy-tales","circus-show","logic-games","art-craft","superheroes","fairy-tale-chars","famous-paintings","tech-logos","color-mix","puppet-story","melody-maker","craft-guide","avatar-maker"],
+    gameIds: ["instruments","puzzles","drawing","coloring","building","tetris","magic-fairy-tales","circus-show","logic-games","art-craft","superheroes","fairy-tale-chars","famous-paintings","tech-logos","color-mix","puppet-story","melody-maker","craft-guide","avatar-maker"],
   },
   nature: {
     title: "טבע ואוכל",
@@ -94,7 +94,7 @@ export const GAME_CATEGORIES: Record<string, GameCategory> = {
     icon: Microscope,
     color: "bg-cyan-500",
     gradient: "from-cyan-400 to-cyan-600",
-    gameIds: ["recycling","dinosaurs","space-adventure","virtual-reality","new-professions","climate-planet","science","life-cycles"],
+    gameIds: ["recycling","dinosaurs","virtual-reality","new-professions","climate-planet","science","life-cycles"],
   },
   holidays: {
     title: "חגים ועונות",

--- a/gamesformykids/lib/constants/ui/activitiesConfigData/fantasy.ts
+++ b/gamesformykids/lib/constants/ui/activitiesConfigData/fantasy.ts
@@ -34,39 +34,6 @@ export const fantasyConfigs: Partial<Record<string, GameUIConfig>> = {
     },
   },
 
-  "space-adventure": {
-    title: "🚀 משחק הרפתקאות בחלל 🌌",
-    subTitle: "טוס אל הכוכבים וגלה את החלל!",
-    itemsTitle: "עצמי החלל שנלמד:",
-    itemsDescription: "לחץ על עצם כדי לשמוע עליו!",
-    steps: [
-      { icon: "👀", title: "1. תראה", description: "איזה עצם חלל אני מציג" },
-      { icon: "🎤", title: "2. תשמע", description: "את השם שלו" },
-      { icon: "👆", title: "3. תלחץ", description: "על העצם הנכון" },
-    ],
-    colors: {
-      background: "linear-gradient(135deg, #0c0c0c 0%, #1a1a2e 25%, #16213e 50%, #0f3460 75%, #533483 100%)",
-      header: "text-white",
-      subHeader: "text-blue-100",
-      itemsDescription: "text-blue-100",
-      button: { from: "indigo", to: "purple" },
-      stepsBg: "bg-indigo-100 bg-opacity-90",
-    },
-    grid: {
-      className: "flex flex-wrap justify-center gap-4",
-    },
-    challengeTitle: "איזה עצם חלל שמעת?",
-    challengeIcon: "🚀🌌⭐🪐",
-    challengeDescription: "בחר את העצם הנכון!",
-    itemLabel: "עצם חלל",
-    tip: "💡 טיפ: תשמע את השם!",
-    tipDescription: "לחץ על הסמל למעלה כדי לשמוע שוב, או על עצמי החלל למטה לשמוע את השמות",
-    metadata: {
-      keywords: "חלל, כוכבי לכת, חללית, גלקסיה, חקר חלל, גיל 5-10, אסטרונומיה לילדים",
-      description: "טוסו לחלל וגלו כוכבי לכת וכוכבים! חללית, גלקסיה ועוד — לגיל 5-10.",
-    },
-  },
-
   "superheroes": {
     title: "🦸 משחק גיבורי על ⚡",
     subTitle: "למד על כוחות סופר!",

--- a/gamesformykids/lib/constants/ui/activitiesConfigData/sportsTech.ts
+++ b/gamesformykids/lib/constants/ui/activitiesConfigData/sportsTech.ts
@@ -34,39 +34,6 @@ export const sportsTechConfigs: Partial<Record<string, GameUIConfig>> = {
     },
   },
 
-  "cooking-kitchen": {
-    title: "👨‍🍳 משחק בישול במטבח 🍳",
-    subTitle: "למד על כלי מטבח ובישול!",
-    itemsTitle: "כלי המטבח שנלמד:",
-    itemsDescription: "לחץ על כלי כדי לשמוע את השם שלו!",
-    steps: [
-      { icon: "👀", title: "1. תראה", description: "איזה כלי מטבח אני מציג" },
-      { icon: "🎤", title: "2. תשמע", description: "את השם שלו" },
-      { icon: "👆", title: "3. תלחץ", description: "על הכלי הנכון" },
-    ],
-    colors: {
-      background: "linear-gradient(135deg, #ff6b6b 0%, #feca57 25%, #48dbfb 50%, #ff9ff3 75%, #54a0ff 100%)",
-      header: "text-white",
-      subHeader: "text-orange-100",
-      itemsDescription: "text-orange-100",
-      button: { from: "orange", to: "red" },
-      stepsBg: "bg-orange-100 bg-opacity-90",
-    },
-    grid: {
-      className: "flex flex-wrap justify-center gap-4",
-    },
-    challengeTitle: "איזה כלי מטבח שמעת?",
-    challengeIcon: "👨‍🍳🍳🍲🥄",
-    challengeDescription: "בחר את הכלי הנכון!",
-    itemLabel: "כלי מטבח",
-    tip: "💡 טיפ: תשמע את השם!",
-    tipDescription: "לחץ על הסמל למעלה כדי לשמוע שוב, או על כלי המטבח למטה לשמוע את השמות",
-    metadata: {
-      keywords: "מטבח, כלי בישול, סיר, מחבת, מאפה, בישול, גיל 4-8, מטבח לילדים",
-      description: "למדו על כלי מטבח ובישול בעברית! מחבת, סיר, מזלג ועוד — חינוך בבית המטבח לגיל 4-8.",
-    },
-  },
-
   "circus-show": {
     title: "🎪 משחק מופע קרקס 🤡",
     subTitle: "הכנס לעולם הקרקס המרתק!",

--- a/gamesformykids/lib/constants/ui/educationalConfigData/socialEmotional.ts
+++ b/gamesformykids/lib/constants/ui/educationalConfigData/socialEmotional.ts
@@ -62,37 +62,4 @@ export const socialEmotionalConfigs: Partial<Record<string, GameUIConfig>> = {
       description: "הרכיבו פאזלים צבעוניים ומהנים! פיתוח ריכוז, חשיבה מרחבית וסבלנות לגיל 3-8.",
     },
   },
-
-  feelings: {
-    title: "😊 משחק רגשות 😢",
-    subTitle: "למד להכיר ולזהות רגשות!",
-    itemsTitle: "הרגשות שנלמד:",
-    itemsDescription: "לחץ על רגש כדי לשמוע את השם שלו!",
-    steps: [
-      { icon: "👀", title: "1. תראה", description: "איזה רגש אני מציג" },
-      { icon: "🎤", title: "2. תשמע", description: "את שם הרגש" },
-      { icon: "👆", title: "3. תלחץ", description: "על הרגש הנכון" },
-    ],
-    colors: {
-      background: "linear-gradient(135deg, #ffecd2 0%, #fcb69f 25%, #ff9a9e 50%, #fecfef 75%, #fecfef 100%)",
-      header: "text-white",
-      subHeader: "text-pink-100",
-      itemsDescription: "text-pink-100",
-      button: { from: "pink", to: "rose" },
-      stepsBg: "bg-pink-100 bg-opacity-90",
-    },
-    grid: {
-      className: "flex flex-wrap justify-center gap-4",
-    },
-    challengeTitle: "איזה רגש ראית?",
-    challengeIcon: "😊😢😡😴",
-    challengeDescription: "בחר את הרגש הנכון!",
-    itemLabel: "רגש",
-    tip: "💡 טיפ: תראה את הרגש!",
-    tipDescription: "לחץ על הסמל למעלה כדי לראות שוב, או על הרגשות למטה לשמוע את השמות",
-    metadata: {
-      keywords: "רגשות, זיהוי רגשות, אינטליגנציה רגשית, גיל 3-7, פנים, הבעות פנים, חינוך רגשי",
-      description: "למדו לזהות ולקרוא שמות לרגשות! שמחה, עצב, כעס, פחד — חינוך רגשי חיוני לגיל 3-7.",
-    },
-  },
 };


### PR DESCRIPTION
## Summary
Full game-registration QA sweep across all 214 games (GameType union, SUPPORTED_GAMES, registry batches, category grid, UI configs). Found and fixed:

- `coloring` was registered and available but missing from every `gameIds` list in `gameCategories.ts` — not discoverable from the home page grid. Added to the `creative` category.
- `space-adventure` was a ghost ID in the `science` category's `gameIds`, with a full UI config block, but no `GameType`, `SUPPORTED_GAMES`, or registry entry backing it. Removed from the category grid and deleted its dead UI config block.
- `cooking-kitchen` and `feelings` were orphan UI config blocks with no matching game anywhere in the system. Deleted.

## Test plan
- [x] `npx tsc --noEmit` — 0 errors
- [x] Cross-referenced GameType union / SUPPORTED_GAMES / registry / category grid / UI configs — all sets now match exactly, zero orphans, zero ghost IDs

Closes #1407

🤖 Generated with [Claude Code](https://claude.com/claude-code)