### PR TITLE
fix(a11y): resolve 3 arrow-key navigation logic bugs

### DIFF
--- a/gamesformykids/app/games/number-slide/components/NumberSlideBoard.tsx
+++ b/gamesformykids/app/games/number-slide/components/NumberSlideBoard.tsx
@@ -38,6 +38,7 @@ interface Props {
 export default function NumberSlideBoard({ grid, onTouchStart, onTouchEnd }: Props) {
   return (
     <div
+      dir="ltr"
       className="grid grid-cols-4 gap-2 p-3 rounded-2xl bg-gray-300 select-none touch-none"
       style={{ width: 280, height: 280 }}
       onTouchStart={onTouchStart}

--- a/gamesformykids/components/game/quiz/QuizAnswerGrid.tsx
+++ b/gamesformykids/components/game/quiz/QuizAnswerGrid.tsx
@@ -33,6 +33,7 @@ export function QuizAnswerGrid({
     choices.length,
     (idx) => onSelect(choices[idx]!),
     enabled,
+    cols,
   );
 
   const gridClass = cols === 1

--- a/gamesformykids/components/game/universal/navigation/UniversalGameNavigation.tsx
+++ b/gamesformykids/components/game/universal/navigation/UniversalGameNavigation.tsx
@@ -46,7 +46,7 @@ export default function UniversalGameNavigation({
           <Link
             href={navigation.previous.href}
             className="bg-blue-500/90 backdrop-blur-sm hover:bg-blue-600 text-white font-bold py-2 px-3 md:py-3 md:px-4 rounded-xl shadow-lg transition-[transform,colors] duration-200 hover:scale-105 active:scale-95 flex items-center gap-2 text-sm md:text-base border-2 border-blue-400 hover:border-blue-300"
-            title={`${navigation.previous.title} (→)`}
+            title={navigation.previous.title}
             aria-label={`משחק קודם: ${navigation.previous.title}`}
           >
             <ArrowRight className="w-4 h-4 md:w-5 md:h-5" aria-hidden="true" />
@@ -88,7 +88,7 @@ export default function UniversalGameNavigation({
           <Link
             href={navigation.next.href}
             className="bg-green-500/90 backdrop-blur-sm hover:bg-green-600 text-white font-bold py-2 px-3 md:py-3 md:px-4 rounded-xl shadow-lg transition-[transform,colors] duration-200 hover:scale-105 active:scale-95 flex items-center gap-2 text-sm md:text-base border-2 border-green-400 hover:border-green-300"
-            title={`${navigation.next.title} (←)`}
+            title={navigation.next.title}
             aria-label={`משחק הבא: ${navigation.next.title}`}
           >
             <ArrowLeft className="w-4 h-4 md:w-5 md:h-5" aria-hidden="true" />

--- a/gamesformykids/components/shared/GameMainContent.tsx
+++ b/gamesformykids/components/shared/GameMainContent.tsx
@@ -18,6 +18,7 @@ export default function GameMainContent() {
       if (item) game.handleItemClick(item);
     },
     keyboardEnabled,
+    'grid-cols-2 md:grid-cols-4',
   );
 
   return (

--- a/gamesformykids/hooks/shared/useKeyboardAnswerSelect.ts
+++ b/gamesformykids/hooks/shared/useKeyboardAnswerSelect.ts
@@ -1,12 +1,21 @@
 'use client';
 import { useState, useEffect, useRef } from 'react';
+import { parseGridColsClass } from '@/hooks/shared/ui/useGridFillers';
 
 /**
  * Enables keyboard navigation for answer grids:
  * - 1/2/3/4 → immediately select that answer
- * - ArrowRight/Down → move focus right/down
- * - ArrowLeft/Up   → move focus left/up
+ * - ArrowDown/Up → move focus one row down/up (jumps by `gridCols`)
+ * - ArrowLeft/Right → move focus one column over
  * - Enter/Space    → confirm focused answer
+ *
+ * The page is always RTL, so the first item in DOM order renders in the
+ * rightmost column. Visual "right" is therefore the previous DOM index and
+ * visual "left" is the next one — ArrowLeft/Right are mapped accordingly
+ * whenever the grid has more than one column.
+ *
+ * `gridCols` accepts a plain column count, or a Tailwind grid-cols class
+ * string (e.g. "grid-cols-2 md:grid-cols-4") for responsive grids.
  *
  * Only active when `enabled` is true (e.g. question phase, not result/menu).
  */
@@ -14,12 +23,30 @@ export function useKeyboardAnswerSelect(
   count: number,
   onSelect: (idx: number) => void,
   enabled: boolean,
+  gridCols: number | string = 1,
 ) {
   // -1 = no keyboard focus yet; ring only appears after first arrow/number key press
   const [focusedIdx, setFocusedIdx] = useState(-1);
   const focusedRef = useRef(-1);
   const onSelectRef = useRef(onSelect);
   onSelectRef.current = onSelect;
+
+  const breakpoints = typeof gridCols === 'string' ? parseGridColsClass(gridCols) : null;
+  const staticCols = typeof gridCols === 'number' ? gridCols : null;
+  const colsRef = useRef(staticCols ?? breakpoints?.mobile ?? 1);
+
+  useEffect(() => {
+    if (!breakpoints) return;
+    const updateCols = () => {
+      colsRef.current =
+        window.innerWidth >= 1024 ? breakpoints.desktop :
+        window.innerWidth >= 768  ? breakpoints.tablet  :
+        breakpoints.mobile;
+    };
+    updateCols();
+    window.addEventListener('resize', updateCols);
+    return () => window.removeEventListener('resize', updateCols);
+  }, [breakpoints]);
 
   // Reset focus when a new set of choices arrives
   useEffect(() => {
@@ -29,6 +56,16 @@ export function useKeyboardAnswerSelect(
 
   useEffect(() => {
     if (!enabled || count === 0) return;
+
+    const step = (delta: number) => {
+      setFocusedIdx(prev => {
+        const next = prev < 0
+          ? (delta > 0 ? 0 : count - 1)
+          : ((prev + delta) % count + count) % count;
+        focusedRef.current = next;
+        return next;
+      });
+    };
 
     const handleKey = (e: KeyboardEvent) => {
       // Ignore when typing in an input / textarea
@@ -46,25 +83,13 @@ export function useKeyboardAnswerSelect(
         return;
       }
 
-      if (key === 'ArrowRight' || key === 'ArrowDown') {
-        e.preventDefault();
-        setFocusedIdx(prev => {
-          const next = prev < 0 ? 0 : (prev + 1) % count;
-          focusedRef.current = next;
-          return next;
-        });
-        return;
-      }
+      const cols = colsRef.current;
+      const isGrid = cols > 1;
 
-      if (key === 'ArrowLeft' || key === 'ArrowUp') {
-        e.preventDefault();
-        setFocusedIdx(prev => {
-          const next = prev < 0 ? count - 1 : (prev - 1 + count) % count;
-          focusedRef.current = next;
-          return next;
-        });
-        return;
-      }
+      if (key === 'ArrowDown') { e.preventDefault(); step(isGrid ? cols : 1); return; }
+      if (key === 'ArrowUp')   { e.preventDefault(); step(isGrid ? -cols : -1); return; }
+      if (key === 'ArrowLeft')  { e.preventDefault(); step(isGrid ? 1 : -1); return; }
+      if (key === 'ArrowRight') { e.preventDefault(); step(isGrid ? -1 : 1); return; }
 
       if (key === 'Enter' || key === ' ') {
         e.preventDefault();


### PR DESCRIPTION
## Summary
- **NumberSlideBoard**: added `dir="ltr"` — the 4×4 grid was rendered without it and inherited the global `dir="rtl"`, which mirrors CSS Grid column order, causing left/right slides to move the tiles in the opposite screen direction from what was pressed.
- **useKeyboardAnswerSelect** (shared hook used by `QuizAnswerGrid` and `GameMainContent`, i.e. most quiz/card games): now takes a `gridCols` param (number or responsive Tailwind class string). `ArrowUp`/`ArrowDown` now jump a full row instead of behaving identically to `ArrowLeft`/`ArrowRight`, and `ArrowLeft`/`ArrowRight` are mapped to account for the RTL-mirrored column order.
- **UniversalGameNavigation**: removed the misleading `(→)`/`(←)` tooltip hints for prev/next game — those shortcuts were never wired up, and wiring them up would conflict with arrow-key movement controls in games like snake/tetris/maze/pong (pressing the movement key would also switch games).

## Test plan
- [x] `npx tsc --noEmit` — zero errors
- [x] `npm run build` — succeeds
- [ ] Manually verify `/games/number-slide` slides tiles in the correct visual direction with arrow keys
- [ ] Manually verify arrow-key focus navigation moves by row/column correctly in a quiz game (e.g. `/games/riddles`) and a card game (e.g. `/games/animals`)

Closes #1409

🤖 Generated with [Claude Code](https://claude.com/claude-code)