### PR TITLE
fix(css): load tailwind.config.js via @config in Tailwind v4

### DIFF
--- a/gamesformykids/app/globals.css
+++ b/gamesformykids/app/globals.css
@@ -1,4 +1,5 @@
 @import "tailwindcss";
+@config "../tailwind.config.js";
 
 /* Critical CSS for LCP optimization */
 .font-bold {

--- a/gamesformykids/tailwind.config.js
+++ b/gamesformykids/tailwind.config.js
@@ -4,6 +4,8 @@ module.exports = {
     "./app/**/*.{js,ts,jsx,tsx}",
     "./pages/**/*.{js,ts,jsx,tsx}",
     "./components/**/*.{js,ts,jsx,tsx}",
+    "./lib/**/*.{js,ts,jsx,tsx}",
+    "./hooks/**/*.{js,ts,jsx,tsx}",
   ],
   theme: {
     extend: {


### PR DESCRIPTION
## Summary
- The project runs Tailwind v4, which no longer auto-detects a JS config file — `tailwind.config.js` was completely inert (no `@config` directive anywhere in the CSS).
- Confirmed real breakage: `components/ui/NotificationToast.tsx` uses `animate-slide-in-up`, which was silently rendering with no animation since the keyframe only existed in the unloaded config.
- Added `@config "../tailwind.config.js";` to `app/globals.css`, and expanded `content` in `tailwind.config.js` to include `./lib/**` and `./hooks/**` first — needed because once `@config` is wired up, the JS config's `content` list replaces v4's automatic whole-project content detection, and `lib/quiz/configs/{knowledge,language,math,social}.tsx` contain real Tailwind classNames that would otherwise stop being scanned.

## Verification
- `npx tsc --noEmit` — clean
- `npm run build` — succeeds
- Inspected compiled CSS output directly: confirmed `.animate-slide-in-up{animation:.2s ease-out slide-in-up}` and the `@keyframes slide-in-up` block are now present, and the custom `375px`/`480px` breakpoints are emitted — proving the config is now actually loaded (previously absent from build output).

## Test plan
- [x] `tsc --noEmit` passes
- [x] `next build` passes
- [x] Compiled CSS contains `animate-slide-in-up` keyframes/class
- [ ] Manually verify the toast slide-in animation visually in a running dev server

Closes #1413