### PR TITLE
Fix UI/UX bugs: hydration mismatch, low-contrast nav pill, reduced-motion SSR

### DIFF
--- a/gamesformykids/components/game/shared/MascotCharacter.tsx
+++ b/gamesformykids/components/game/shared/MascotCharacter.tsx
@@ -44,6 +44,7 @@ const BUBBLE_MESSAGES: Record<MascotState, string | null> = {
 export default function MascotCharacter() {
   const [mascotState, setMascotState] = useState<MascotState>('idle');
   const [showBubble, setShowBubble] = useState(false);
+  const [reducedMotion, setReducedMotion] = useState(false);
   const prevCelebration = useRef(false);
   const prevWrong = useRef(0);
   const resetTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -75,10 +76,13 @@ export default function MascotCharacter() {
     };
   }, []);
 
-  const reducedMotion =
-    typeof window !== 'undefined'
-      ? window.matchMedia('(prefers-reduced-motion: reduce)').matches
-      : false;
+  useEffect(() => {
+    const mql = window.matchMedia('(prefers-reduced-motion: reduce)');
+    setReducedMotion(mql.matches);
+    const onChange = () => setReducedMotion(mql.matches);
+    mql.addEventListener('change', onChange);
+    return () => mql.removeEventListener('change', onChange);
+  }, []);
 
   const animation = reducedMotion
     ? mascotState === 'idle'

--- a/gamesformykids/components/game/universal/navigation/UniversalGameNavigation.tsx
+++ b/gamesformykids/components/game/universal/navigation/UniversalGameNavigation.tsx
@@ -74,7 +74,7 @@ export default function UniversalGameNavigation({
 
         {currentGame && (
           <div
-            className="bg-black/20 backdrop-blur-sm text-white px-3 py-1 md:px-4 md:py-2 rounded-xl text-sm md:text-base font-medium"
+            className="bg-gray-900/90 backdrop-blur-sm text-white px-3 py-1 md:px-4 md:py-2 rounded-xl text-sm md:text-base font-medium"
             aria-current="page"
           >
             {currentGame.title}

--- a/gamesformykids/components/marketing/SurpriseMeButton.tsx
+++ b/gamesformykids/components/marketing/SurpriseMeButton.tsx
@@ -28,10 +28,7 @@ export default function SurpriseMeButton() {
       <button
         onClick={handleClick}
         disabled={spinning}
-        className="flex items-center gap-3 px-8 py-4 rounded-2xl font-bold text-xl text-white shadow-xl
-          bg-linear-to-r from-fuchsia-500 to-orange-400
-          hover:from-fuchsia-600 hover:to-orange-500
-          active:scale-95 transition-[transform,opacity,background] duration-200 disabled:opacity-80"
+        className="flex items-center gap-3 px-8 py-4 rounded-2xl font-bold text-xl text-white shadow-xl bg-linear-to-r from-fuchsia-500 to-orange-400 hover:from-fuchsia-600 hover:to-orange-500 active:scale-95 transition-[transform,opacity,background] duration-200 disabled:opacity-80"
         aria-label="משחק אקראי"
       >
         <span


### PR DESCRIPTION
## Summary
Fixes three issues found during a UI/UX review of the home page and game pages:

- **`SurpriseMeButton.tsx`** — the `className` was a multi-line plain string whose embedded newlines/indentation collapsed inconsistently between server and client render, throwing a React hydration-mismatch warning on every homepage load. Collapsed it to a single line.
- **`UniversalGameNavigation.tsx`** — the current-game pill used `bg-black/20`, which renders as near-invisible light gray on light/pastel game backgrounds (confirmed visually on the colors and balloon-pop game pages). Switched to a solid dark background for reliable contrast.
- **`MascotCharacter.tsx`** — `prefers-reduced-motion` was read via `window.matchMedia(...).matches` directly during render (an SSR/client branch), which can mismatch at hydration for users with the OS setting enabled and never updates if the setting changes mid-session. Moved detection into a `useEffect` with `matchMedia` + a `change` listener, backed by state.

## Test plan
- [x] `npx tsc --noEmit` — zero errors
- [x] Ran the dev server, loaded the home page with Playwright — zero console errors (previously threw a hydration-mismatch warning)
- [x] Visually verified the current-game pill on `/games/colors` now renders with solid background and legible white text

🤖 Generated with [Claude Code](https://claude.com/claude-code)