### PR TITLE
docs: sync project markdown files with current codebase state

### DIFF
--- a/.claude/commands/arch-review.md
+++ b/.claude/commands/arch-review.md
@@ -2,7 +2,7 @@
 
 You are a **senior front-end architect** specialising in Next.js 15+/16+ App Router, React 19+, and TypeScript strict-mode.
 
-> **Project context:** This codebase runs Next.js 15.5.x + React 19.1.x. Sections 1–10 cover current best practices. Section 11 covers Next.js 16 readiness (breaking changes, graduating APIs, new primitives).
+> **Project context:** This codebase runs Next.js 16.2.x + React 19.1.x. Sections 1–10 cover current best practices. Section 11 covers Next.js 16 API adoption (the project has already upgraded — this section checks how much of the new surface area is actually in use, and flags any lingering Next.js 15-only patterns).
 
 Your job: scan the GamesForMyKids codebase, identify concrete architectural gaps, and present **prioritised, actionable recommendations** grouped by category.
 
@@ -300,9 +300,9 @@ find gamesformykids -name "index.ts" | xargs grep -l "export \*" 2>/dev/null | h
 
 ---
 
-### 11. Next.js 16+ readiness audit
+### 11. Next.js 16 API adoption audit
 
-**Context:** The project runs Next.js 15.5.x. Next.js 16 is the next major release. Many of its APIs are already shipping as stable or graduating from `unstable_` prefixes. This section checks adoption of those APIs and flags breaking changes to prepare for.
+**Context:** The project runs Next.js 16.2.x already. Many of its APIs graduated from `unstable_` prefixes or changed defaults at the 16 boundary. This section checks how much of that surface area the codebase actually uses, and flags any code still written in the older Next.js 15 style (it will still work, but should be modernized).
 
 ---
 

--- a/.claude/commands/branch-hygiene.md
+++ b/.claude/commands/branch-hygiene.md
@@ -108,7 +108,7 @@ Files changed: <N>
 
 | File | Lines changed | Concern |
 |------|--------------|---------|
-| components/marketing/CategorizedGamesGrid.tsx | +87 / -3 | Unexpected large diff — verify no accidental whitespace reformat |
+| lib/constants/gameCategories.ts | +87 / -3 | Unexpected large diff — verify no accidental whitespace reformat |
 
 ---
 

--- a/.claude/commands/code-ownership-router.md
+++ b/.claude/commands/code-ownership-router.md
@@ -36,7 +36,7 @@ This project has these ownership areas:
 | **Core infrastructure** | `app/games/[gameType]/`, `lib/types/core/base.ts` | Lead developer |
 | **Game data** | `lib/constants/gameData/`, `lib/quiz/data/` | Content creator or any developer |
 | **UI config** | `lib/constants/ui/gameConfigs*.ts` | Any developer |
-| **Registry** | `lib/registry/`, `CategorizedGamesGrid.tsx` | Any developer |
+| **Registry** | `lib/registry/`, `lib/constants/gameCategories.ts` | Any developer |
 | **Shared stores** | `lib/stores/` | Lead developer |
 | **Shared hooks** | `hooks/shared/` | Lead developer |
 | **Shared components** | `components/shared/`, `components/game/shared/` | Lead developer |

--- a/.claude/commands/diff-risk-classifier.md
+++ b/.claude/commands/diff-risk-classifier.md
@@ -31,7 +31,7 @@ Group files by layer:
 |-------|---------|---------------|
 | Game data | `lib/constants/gameData/*.ts` | Low — data-only changes |
 | UI config | `lib/constants/ui/gameConfigs*.ts` | Low |
-| Registry | `lib/registry/`, `CategorizedGamesGrid.tsx` | Medium — affects all pages |
+| Registry | `lib/registry/`, `lib/constants/gameCategories.ts` | Medium — affects all pages |
 | Types | `lib/types/` | High — TypeScript contract changes |
 | Shared stores | `lib/stores/` | High — affects multiple games |
 | Shared hooks | `hooks/shared/` | High — cross-game impact |

--- a/.claude/commands/game-duplicate-checker.md
+++ b/.claude/commands/game-duplicate-checker.md
@@ -50,7 +50,7 @@ ls gamesformykids/lib/quiz/data/
 grep -r "title:\|subTitle:\|challengeTitle:" gamesformykids/lib/constants/ui/ --include="*.ts" -A 1
 
 # Category grid — see which category the existing similar game is in
-grep -n "'<candidate-id>'" gamesformykids/components/marketing/CategorizedGamesGrid.tsx
+grep -n "'<candidate-id>'" gamesformykids/lib/constants/gameCategories.ts
 ```
 
 For each candidate, read its data file to understand what content it covers:

--- a/.claude/commands/game-qa.md
+++ b/.claude/commands/game-qa.md
@@ -46,8 +46,8 @@ grep -o "'[^']*'" gamesformykids/app/games/\[gameType\]/CustomGameRenderer.tsx |
 grep '"id":' gamesformykids/lib/registry/registryData/batch*.ts | grep -o '"[^"]*"' | tr -d '"'
 grep 'available:' gamesformykids/lib/registry/registryData/batch*.ts | head -200
 
-# 1h — Category grid IDs
-grep -o "'[^']*'" gamesformykids/components/marketing/CategorizedGamesGrid.tsx | tr -d "'"
+# 1h — Category grid IDs (gameCategories.ts holds the gameIds arrays; CategorizedGamesGrid.tsx only renders them)
+grep -o "'[^']*'" gamesformykids/lib/constants/gameCategories.ts | tr -d "'"
 
 # 1i — UI config keys (Style A)
 grep -rn "^\s*'[^']*':" gamesformykids/lib/constants/ui/ --include="gameConfigs*.ts" | grep -o "'[^']*':" | tr -d "':'
@@ -78,7 +78,7 @@ For each game, compare against the batch data collected in Phase 1.
 | **R1** GameType union | `lib/types/core/base.ts` | ID present | ❌ TS errors will occur |
 | **R2** SUPPORTED_GAMES | `gamePageConstants.ts` | ID in array | ❌ Route returns 404 |
 | **R3** Registry entry | `batch*.ts` | `id` found with `available: true` and correct `href: "/games/<id>"` | ⚠️ Hidden from home page |
-| **R4** Category grid | `CategorizedGamesGrid.tsx` | ID present | ⚠️ Not browseable from home page |
+| **R4** Category grid | `gameCategories.ts` | ID present in a category's `gameIds` | ⚠️ Not browseable from home page |
 
 ---
 

--- a/.claude/commands/post-merge-smoke.md
+++ b/.claude/commands/post-merge-smoke.md
@@ -83,7 +83,7 @@ grep "'<id>'" gamesformykids/app/games/\[gameType\]/gamePageConstants.ts
 grep '"id": "<id>"' gamesformykids/lib/registry/registryData/batch*.ts
 
 # 4. Category grid
-grep "'<id>'" gamesformykids/components/marketing/CategorizedGamesGrid.tsx
+grep "'<id>'" gamesformykids/lib/constants/gameCategories.ts
 
 # 5. GAME_ITEMS_MAP (Style A only) or quiz registry (Style B/C)
 grep "'<id>'" gamesformykids/lib/constants/gameItemsMap.ts 2>/dev/null || \

--- a/.claude/commands/pre-merge-conflict-predictor.md
+++ b/.claude/commands/pre-merge-conflict-predictor.md
@@ -63,7 +63,7 @@ These files are modified by almost every game-addition PR — they're the most l
 | `app/games/[gameType]/gamePageConstants.ts` | Every game adds to SUPPORTED_GAMES |
 | `lib/constants/gameItemsMap.ts` | Every Style A game adds an entry |
 | `lib/registry/registryData/batch*.ts` | Every game adds a registry entry |
-| `components/marketing/CategorizedGamesGrid.tsx` | Every game adds to a category array |
+| `lib/constants/gameCategories.ts` | Every game adds to a category's `gameIds` array |
 
 ---
 

--- a/.claude/commands/product-manager.md
+++ b/.claude/commands/product-manager.md
@@ -27,7 +27,7 @@ grep -r "GameType" gamesformykids/lib/types/core/base.ts -n
 # All supported games
 cat gamesformykids/app/games/\[gameType\]/gamePageConstants.ts
 # Games appearing on home page
-grep -A 3 "category\|group\|Category" gamesformykids/components/marketing/CategorizedGamesGrid.tsx | head -80
+grep -A 3 "title:\|description:\|gameIds:" gamesformykids/lib/constants/gameCategories.ts | head -80
 ```
 
 ### 1b. Open GitHub issues
@@ -46,7 +46,7 @@ gh pr list --repo benshabbat/GamesForMyKids --state merged --limit 30 \
 
 ### 1d. Game categories on home page
 
-Read `gamesformykids/components/marketing/CategorizedGamesGrid.tsx` to understand how games are grouped.
+Read `gamesformykids/lib/constants/gameCategories.ts` to understand how games are grouped (it's the data source — `CategorizedGamesGrid.tsx` just renders it).
 
 ---
 

--- a/.claude/commands/release-gate.md
+++ b/.claude/commands/release-gate.md
@@ -77,7 +77,7 @@ GAME_ID="<id>"
 echo "=== GameType ===" && grep "'$GAME_ID'" gamesformykids/lib/types/core/base.ts
 echo "=== SUPPORTED_GAMES ===" && grep "'$GAME_ID'" gamesformykids/app/games/\[gameType\]/gamePageConstants.ts
 echo "=== Registry batch ===" && grep -r "'$GAME_ID'" gamesformykids/lib/registry/registryData/
-echo "=== Category grid ===" && grep "'$GAME_ID'" gamesformykids/components/marketing/CategorizedGamesGrid.tsx
+echo "=== Category grid ===" && grep "'$GAME_ID'" gamesformykids/lib/constants/gameCategories.ts
 ```
 
 Also check style-specific registrations:

--- a/.claude/commands/review-issues.md
+++ b/.claude/commands/review-issues.md
@@ -1,6 +1,6 @@
 # Code Review & Issue Creator
 
-You are a senior code reviewer for the GamesForMyKids project (Next.js 15, React 19, TypeScript, Zustand).
+You are a senior code reviewer for the GamesForMyKids project (Next.js 16, React 19, TypeScript, Zustand).
 Your job: scan the codebase, find concrete improvements, and open a GitHub issue for each one.
 
 ## Repo

--- a/.claude/commands/ux-ui.md
+++ b/.claude/commands/ux-ui.md
@@ -8,7 +8,7 @@ You are a **senior UX/UI designer and front-end engineer** specialising in:
 - Mobile-first responsive design
 - Micro-interactions and game feedback loops
 
-> **Project context:** GamesForMyKids is a Hebrew-language educational games site for young children. It runs Next.js 15+ / React 19 / Tailwind CSS. All UI is in Hebrew (RTL). Games teach vocabulary, math, reading, and more. The primary users are children — clarity, delight, and immediate feedback are paramount.
+> **Project context:** GamesForMyKids is a Hebrew-language educational games site for young children. It runs Next.js 16 / React 19 / Tailwind CSS. All UI is in Hebrew (RTL). Games teach vocabulary, math, reading, and more. The primary users are children — clarity, delight, and immediate feedback are paramount.
 
 Your job: scan the GamesForMyKids codebase, identify concrete UX/UI gaps, and present **prioritised, actionable recommendations**.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,7 +18,7 @@ Before writing any new code, run these checks. The project has rich shared infra
 | A new Zustand store | `createChallengeStore\|makeStore\|makePersistStore` in `lib/stores/` |
 | A new quiz hook | `useGenericQuizGame\|createCategoryIndexQuizHook` in `lib/quiz/` |
 | A new quiz game component | `makeQuizGame\|GenericQuizGame` in `lib/quiz/` |
-| A new "start screen" component | `GenericStartScreen\|UltimateStartScreen` in `components/game/` |
+| A new "start screen" component | `GenericStartScreen` in `components/shared/screens/`, `UltimateStartScreen` in `components/game/universal/ultimate-game/` |
 | A new canvas game loop | `useCanvasLoop\|useCanvasReady` in `hooks/canvas/` |
 | A new score/progress bar | `GameResultCard\|ProgressDisplay\|LivesDisplay` in `components/` |
 | A new celebration/feedback | `GameCompletionCelebration\|CelebrationBox\|feedbackUtils` |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,13 +10,13 @@
 
 ```bash
 cd gamesformykids
-npm run lint        # ESLint
-npm run typecheck   # tsc --noEmit
-npm run test        # Vitest unit tests
+npx tsc --noEmit    # Typecheck (there is no "typecheck" npm script — this is what CI runs)
+npx eslint . --max-warnings=0   # Lint (matches CI; `npm run lint` also works locally)
+npm test -- --run   # Vitest unit tests
 npm run build       # next build (full production build)
 ```
 
-Run all four before opening a PR to catch issues early.
+Run all four before opening a PR to catch issues early — these are exactly the commands the "Typecheck, Lint & Test" CI job runs.
 
 ## Workflow
 

--- a/GAME_CREATION_GUIDE.md
+++ b/GAME_CREATION_GUIDE.md
@@ -14,7 +14,11 @@
 
 כל המשחקים מוגשים ממסלול יחיד: `app/games/[gameType]/page.tsx`
 
-הפלטפורמה תומכת בשלושה סוגי משחקים:
+> **הערה:** מדריך זה מכסה את שני הזרמים העיקריים (כרטיסים ומותאם אישית) בצורה מפורטת ונרטיבית.
+> ל-**חמשת** הסגנונות המלאים (כולל שלוש רמות של משחקי חידון) וטבלת ההחלטה המעודכנת ביותר,
+> ראו `CLAUDE.md` בשורש הפרויקט — הוא מקור האמת הטכני ומתעדכן יחד עם הקוד.
+
+הפלטפורמה תומכת בשלושה זרמי-על של משחקים:
 
 ### 1. משחקי כרטיסים (Card Games)
 - משחקי זיהוי פריטים (צבעים, חיות, פירות וכו')
@@ -44,7 +48,7 @@
 
 ```typescript
 // lib/constants/gameData/myCategory.ts
-import { BaseGameItem } from "@/lib/types/base";
+import { BaseGameItem } from "@/lib/types/core/base";
 
 export const MY_GAME_CONSTANTS: Record<string, BaseGameItem> = {
   ITEM1: {
@@ -101,13 +105,13 @@ export const GAME_ITEMS_MAP = {
 
 ### שלב 2: הוספה לרישום המשחקים
 
-עדכן את `lib/registry/gamesRegistry.ts`:
+עדכן את הקובץ המתאים תחת `lib/registry/registryData/batch<N>.ts` (הרישום מפוצל לכמה קבצי batch — בחר את זה שהכי הגיוני תמטית, או את האחרון אם לא בטוחים):
 
 ```typescript
 // בתחילת הקובץ
 import { YourIcon } from "lucide-react"; // בחר אייקון מתאים
 
-// בתוך GAMES_REGISTRY
+// בתוך מערך הרשומות של קובץ ה-batch
 {
   id: "my-game",
   title: "המשחק שלי",
@@ -122,10 +126,11 @@ import { YourIcon } from "lucide-react"; // בחר אייקון מתאים
 
 ### שלב 3: הוספת הגדרות UI
 
-עדכן את `lib/constants/ui/gameConfigs.ts`:
+עדכן את קובץ הקבוצה המתאים תחת `lib/constants/ui/` (הקובץ מפוצל לפי נושא: `gameConfigs.educational.ts`, `gameConfigs.nature.ts`, `gameConfigs.home-life.ts`, `gameConfigs.activities.ts`, `gameConfigs.advanced.ts`, `gameConfigs.photo-quiz.ts`):
 
 ```typescript
-export const GAME_UI_CONFIGS: Record<GameType, GameUIConfig> = {
+// לדוגמה בתוך gameConfigs.nature.ts
+export const NATURE_GAME_CONFIGS = {
   // ... הגדרות קיימות
   'my-game': {
     title: 'המשחק שלי',
@@ -171,7 +176,7 @@ export const SUPPORTED_GAMES = [
 
 ### שלב 6: הוספה לגריד הקטגוריות
 
-עדכן את `components/marketing/CategorizedGamesGrid.tsx` כדי שהמשחק יופיע בדף הבית תחת הקטגוריה הנכונה.
+עדכן את `lib/constants/gameCategories.ts` — הוסף את מזהה המשחק למערך `gameIds` של הקטגוריה המתאימה, כדי שהמשחק יופיע בדף הבית (הרכיב `components/marketing/CategorizedGamesGrid.tsx` רק מציג את הנתונים מהקובץ הזה, לא צריך לגעת בו).
 
 ## � יצירת משחק מותאם אישית (Custom Game)
 
@@ -180,13 +185,13 @@ export const SUPPORTED_GAMES = [
 
 ### שלב 1: יצירת Zustand store
 
-השתמש ב-`makeStore` / `makePersistStore` מ-`@/lib/stores/storeFactory`:
+בדקו קודם אם `createChallengeStore` (ב-`lib/stores/utils/createChallengeStore.ts`) מתאים למשחק — הוא factory מוכן למשחקי אתגר/ניקוד. אם לא, השתמשו ב-`makeStore` / `makePersistStore` מ-`@/lib/stores/createStore.ts`:
 
 ```typescript
 // app/games/my-game/myGameStore.ts
 'use client';
 
-import { makeStore } from '@/lib/stores/storeFactory';
+import { makeStore } from '@/lib/stores/createStore';
 
 interface MyGameState {
   score: number;
@@ -338,7 +343,7 @@ function MyGameHeader() {
 ## 🔊 הוספת צלילים
 
 ```typescript
-import { useGameAudio } from "@/hooks/shared/ui/useGameAudio";
+import { useGameAudio } from "@/hooks/shared/audio/useGameAudio";
 
 function MyGameComponent() {
   const { playSound, speak } = useGameAudio();
@@ -424,13 +429,13 @@ npm start
 ### משחק כרטיסים
 
 ```
-lib/constants/gameData/myCategory.ts   # נתוני הפריטים
-lib/constants/gameItemsMap.ts          # הוסף ערך
-lib/registry/gamesRegistry.ts         # הוסף רשומה
-lib/types/core/base.ts                # הוסף ל-GameType
-lib/constants/ui/gameConfigs.ts       # הוסף הגדרות UI
-app/games/[gameType]/gamePageConstants.ts  # הוסף ל-SUPPORTED_GAMES
-components/marketing/CategorizedGamesGrid.tsx  # הוסף לקטגוריה
+lib/constants/gameData/myCategory.ts        # נתוני הפריטים
+lib/constants/gameItemsMap.ts               # הוסף ערך
+lib/registry/registryData/batch<N>.ts       # הוסף רשומה
+lib/types/core/base.ts                      # הוסף ל-GameType
+lib/constants/ui/gameConfigs.<group>.ts     # הוסף הגדרות UI (educational/nature/home-life/activities/advanced/photo-quiz)
+app/games/[gameType]/gamePageConstants.ts   # הוסף ל-SUPPORTED_GAMES
+lib/constants/gameCategories.ts             # הוסף למערך gameIds של הקטגוריה
 ```
 
 ### משחק מותאם (Custom)
@@ -447,8 +452,12 @@ app/games/my-game/
 # עדכן גם:
 app/games/[gameType]/CustomGameRenderer.tsx   # הוסף dynamic import
 app/games/[gameType]/gamePageConstants.ts     # הוסף ל-SUPPORTED_GAMES + CUSTOM_GAME_TYPES
-lib/registry/gamesRegistry.ts                # הוסף רשומה
+lib/registry/registryData/batch<N>.ts        # הוסף רשומה
 lib/types/core/base.ts                       # הוסף ל-GameType
 ```
+
+### משחק חידון (Quiz)
+
+משחקי חידון (Style B/C/E) לא מכוסים במדריך זה בפירוט — יש להם שלושה תת-סגנונות (נתונים בלבד / factory מותאם / רכיב עצמאי מורכב) עם קבצי רישום נפרדים תחת `lib/quiz/registry/`. ראו את "Style B/C/E" ב-`CLAUDE.md` לצ'קליסט המלא והעדכני.
 
 בהצלחה ביצירת המשחק החדש! 🎉

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-﻿# Games For My Kids - Kids Educational Games Platform (Ages 2-5)
+# Games For My Kids - Kids Educational Games Platform (Ages 2-5)
 
-[![Next.js](https://img.shields.io/badge/Next.js-15-black?style=flat&logo=next.js)](https://nextjs.org/)
+[![Next.js](https://img.shields.io/badge/Next.js-16-black?style=flat&logo=next.js)](https://nextjs.org/)
 [![TypeScript](https://img.shields.io/badge/TypeScript-5-blue?style=flat&logo=typescript)](https://www.typescriptlang.org/)
 [![Tailwind CSS](https://img.shields.io/badge/Tailwind_CSS-4-06B6D4?style=flat&logo=tailwindcss)](https://tailwindcss.com/)
 [![PWA](https://img.shields.io/badge/PWA-Ready-purple?style=flat)](https://web.dev/progressive-web-apps/)
@@ -8,7 +8,7 @@
 **Developed with love by David-Chen Benshabbat**
 [![LinkedIn](https://img.shields.io/badge/LinkedIn-David--Chen%20Benshabbat-blue?style=flat&logo=linkedin)](https://www.linkedin.com/in/davidchen-benshabbat)
 
-An interactive educational gaming platform for children aged 2-5. Features **131 games** across 15 categories — covering Hebrew letters, math, nature, creativity, holidays, arcade games, board games and more, with full Hebrew audio and a fully responsive mobile-first design.
+An interactive educational gaming platform for children aged 2-5. Features **214 games** across 13 categories — covering Hebrew letters, math, nature, creativity, holidays, arcade games, board games and more, with full Hebrew audio and a fully responsive mobile-first design.
 
 ---
 
@@ -23,52 +23,48 @@ An interactive educational gaming platform for children aged 2-5. Features **131
 
 ---
 
-## Game Categories (131 Games)
+## Game Categories (214 Games)
 
-### Basic Learning
-Hebrew Letters, Letters, Numbers, Colors, Shapes, Colored Shapes, Advanced Colors
+### Basic Learning (20)
+Letters, Hebrew Letters, Hebrew Script, Letter Trace, Numbers, Shapes, Colored Shapes, Colors, Advanced Colors, Shapes 3D, Phonics, Rhyming, Nikud, Gender, Final Letters, Alphabet Order, Letter Race, Nikud Drag, Letter Merge, Word Clicker
 
-### Math & Numbers
-Counting, Math, Arithmetic, Multiplication, Fractions, Emoji Math, Math Race, Number Bubbles, Sequences
+### Creativity & Arts (19)
+Instruments, Puzzles, Drawing, Coloring, Building, Tetris, Magic Fairy Tales, Circus Show, Logic Games, Art & Craft, Superheroes, Fairy Tale Characters, Famous Paintings, Tech Logos, Color Mix, Puppet Story, Melody Maker, Craft Guide, Avatar Maker
 
-### Language & Words
-Spelling, Word Builder, Word Scramble, Opposites, English Words, World Languages, Riddles
+### Nature & Food (16)
+Animals, Fruits, Vegetables, Ocean Life, Garden Plants, Smells & Tastes, Nature Sounds, Dinosaurs, Birds, Bugs & Insects, Dog Breeds, Cat Breeds, Exotic Birds, Butterflies, Nature, Healthy Food
 
-### Nature & Animals
-Animals, Birds, Bugs & Insects, Dinosaurs, Ocean Life, Garden Plants, Nature, Nature Sounds, Exotic Birds, Butterflies, Dog Breeds, Cat Breeds
+### World & Transport (19)
+Transport, Vehicles, Weather, Space, World Food, Advanced Weather, Road Safety, Camping, Flags, Car Brands, World Landmarks, Solar System, Capitals, Continents, Israel, Geography Flags, Geography Capitals, Geography Continents, Israel Map
 
-### Food & Health
-Fruits, Vegetables, Healthy Food, World Food, Cooking Kitchen, Medicine
+### Home & Life (13)
+House Items, Clothing, Professions, Tools, Tzedakah, Kitchen, Family, Body Parts, New Professions, Morning Routine, Dress Up, Cooking Game, Market Game
 
-### World & Geography
-Geography, Capitals, Continents, Israel, Flags, World Landmarks, Transport, World Languages, Solar System
+### Math & Thinking (21)
+Counting, Math, Shopping & Money, Coins Match, Multiplication, Fractions, Sequences, Arithmetic, Ordinals, Number Words, Spatial Concepts, Sorting, Patterns, Skip Counting, Division, Visual Addition, Gematria, Number Slide, Math Stories, Number Merge, Mispar Bonds
 
-### Home & Life
-House Items, Clothing, Professions, Modern Professions, Tools, Family, Kitchen, Body Parts, Human Body, Tzedakah
+### Special Games (9)
+Memory, Bubbles, Emotions, Sports, Circus Show, Soccer Logos, NBA Teams, Sports Quiz, Soccer
 
-### Creativity & Arts
-Instruments, Puzzles, Drawing, Building, Art & Craft, Famous Paintings, Musical Bubbles
+### Health & Safety (7)
+Medicine, Road Safety, Body Parts, Body Movements, Touch Senses, Human Body, Personal Safety
 
-### Science & Thinking
-Science, Recycling, Climate & Planet, Space, Space Adventure, Virtual Reality, Logic Games, True/False
+### Science & Technology (7)
+Recycling, Dinosaurs, Virtual Reality, New Professions, Climate & Planet, Science, Life Cycles
 
-### Health & Emotions
-Emotions, Emotional Social, Body Movements, Touch Senses, Road Safety, Feelings
+### Holidays & Seasons (8)
+Seasons & Holidays, Jewish Holidays, Time & Clock, Tzadikim, Holidays, Days of the Week, Months of the Year, Blessings
 
-### Holidays & Religion
-Jewish Holidays, Holidays, Tzadikim, Seasons & Holidays, Time & Clock
+### Innovative Games (11)
+Sound Imitation, Emotional Social, Advanced Weather, Advanced Colors, Logic Games, Visual Logic, Sound Quiz, Spinner, Team Picker, Dice, Timer
 
-### Trivia & Quizzes
-Trivia, Sports Quiz, Soccer, Soccer Logos, NBA Teams, Car Brands, Tech Logos, Superheroes, Circus Show, Magic Fairy Tales, Fairy Tale Characters, Camping
+### 🕹️ Arcade Games (33)
+Flappy Bird, Snake, Dino Runner, Catch Fruit, Space Defender, Whack-a-Mole, Brick Breaker, Balloon Pop, Pong, Meteor Dodge, Frogger, Stack, Color Tap, Jumper, Simon, Reflex, Taki, Checkers, Chess, Shesh-Besh, Maze, Letter Defender, Snakes & Ladders, Escape Room, Find in Scene, Answer Cannon, Word Fishing, Letter Grow, Letter Slingshot, Syllable Drums, Letter Bubble Shooter, Letter Slicer, Spot the Difference
 
-### Arcade Games
-Flappy Bird, Snake, Dino Runner, Catch Fruit, Space Defender, Whack-a-Mole, Brick Breaker, Balloon Pop, Pong, Meteor Dodge, Frogger, Stack, Color Tap, Jumper, Reflex, Tetris
+### 📚 Educational Games (39)
+True/False, Emoji Math, Math Race, Number Bubbles, Word Scramble, Word Builder, Word Chain, Trivia, Trivia Categories, Clock, Spelling, Opposites, World Languages, Riddles, Riddles Pro, English Words, Singular/Plural, Adjectives, Verbs, Visual Opposites, English Cards, Proverbs, Story Builder, Robot Coder, Hangman, Choose Your Adventure, Picture Dictionary, Word Search, Kids Songs, Kids Encyclopedia, Age Calculator, Jokes Browser, Word Maze, City Builder, Drag & Sort, Word Wheel, Typing Race, Crossword, Hebrew Racer
 
-### Board & Card Games
-Memory, Simon Says, Taki, Checkers, Chess, Shesh-Besh
-
-### Advanced Themes
-Advanced Colors, Advanced Weather, Color Mix, Shapes 3D, Color Tap, Sequences
+*Some games appear in more than one category. `lib/constants/gameCategories.ts` is the source of truth if this list drifts.*
 
 ---
 
@@ -85,7 +81,7 @@ Advanced Colors, Advanced Weather, Color Mix, Shapes 3D, Color Tap, Sequences
 - Large touch-friendly targets
 
 ### Fully Responsive
-- Mobile-first design  works on all screen sizes
+- Mobile-first design — works on all screen sizes
 - Optimized for touch screens
 - Compatible with all modern browsers
 
@@ -99,8 +95,8 @@ Advanced Colors, Advanced Weather, Color Mix, Shapes 3D, Color Tap, Sequences
 ## Quick Start
 
 ### Requirements
-- Node.js 18+
-- npm / yarn / pnpm
+- Node.js 20+ (CI and `.nvmrc` pin Node 22)
+- npm
 
 ### Installation
 
@@ -124,16 +120,19 @@ npm start
 
 ## Technology Stack
 
-- **Next.js 15**  App Router with Server Components and Turbopack
-- **React 19**  Latest stable React with concurrent features
-- **TypeScript**  Strict type safety across the entire codebase
-- **Tailwind CSS 4**  Responsive styling with mobile-first approach
-- **Framer Motion**  Smooth animations and transitions
-- **Zustand**  Lightweight global state management
-- **Web Speech API**  Hebrew text-to-speech narration
-- **Lucide React**  Consistent icon system
-- **Supabase**  Optional auth (app works fully in guest mode without it)
-- **PWA**  Installable as a native app with offline support
+- **Next.js 16** — App Router with Server Components and Turbopack
+- **React 19** — Latest stable React with concurrent features
+- **TypeScript** — Strict type safety across the entire codebase
+- **Tailwind CSS 4** — Responsive styling with mobile-first approach
+- **Framer Motion** — Smooth animations and transitions
+- **Zustand** — Global state management (game stores, UI state, progress)
+- **Web Speech API** — Hebrew text-to-speech narration
+- **Lucide React** — Consistent icon system
+- **Supabase** — Optional auth (app works fully in guest mode without it)
+- **Sentry** — Error monitoring
+- **Vitest + Testing Library** — Unit and component tests
+- **Playwright** — End-to-end tests
+- **PWA** — Installable as a native app with offline support
 
 ---
 
@@ -141,40 +140,49 @@ npm start
 
 ```
 gamesformykids/
- app/
-    games/[gameType]/     # Universal game page (all 131 games route here)
-    layout.tsx
-    page.tsx
- components/
-    game/                 # Game grid, cards, navigation
-    layout/               # Header, Footer, LoadingScreen
-    marketing/            # Featured game, recommendations, category grid
- lib/
-    constants/
-       gameData/         # Game item data (one file per game group)
-       ui/gameConfigs.ts # AutoStartScreen UI config per game
-    registry/gamesRegistry.ts  # Single source of truth for all games
-    types/core/base.ts    # GameType union
- contexts/                 # Auth, game config, game logic contexts
- hooks/                    # Custom React hooks per game
- public/                   # PWA manifest, icons, service worker
+├─ app/
+│  ├─ games/[gameType]/     # Universal game route (all 214 games route here)
+│  │  ├─ page.tsx
+│  │  ├─ gamePageConstants.ts   # SUPPORTED_GAMES / CUSTOM_GAME_TYPES lists
+│  │  └─ CustomGameRenderer.tsx # dispatches fully-custom games (arcade, board, canvas)
+│  ├─ games/<game-name>/    # Per-game folders for custom games (store, hook, components)
+│  ├─ layout.tsx
+│  └─ page.tsx
+├─ components/
+│  ├─ game/                 # Game grid, cards, navigation, quiz screens
+│  ├─ layout/                # Header, Footer, LoadingScreen
+│  └─ marketing/             # Featured game, recommendations, category grid
+├─ lib/
+│  ├─ constants/
+│  │  ├─ gameData/           # Game item data (one file per game group)
+│  │  ├─ gameCategories.ts   # Category → gameIds mapping (home page grid)
+│  │  ├─ gameItemsMap.ts     # GameType → { items, pronunciations }
+│  │  └─ ui/gameConfigs.*.ts # Per-game UI config (title, colors, steps, SEO)
+│  ├─ quiz/                  # Quiz game hooks, data, and registries
+│  │  └─ registry/           # genericQuizGames / customQuizGames / complexQuizGames
+│  ├─ registry/
+│  │  └─ registryData/batch*.ts  # Single source of truth for all games (metadata)
+│  ├─ stores/                # Zustand stores + createStore.ts (makeStore/makePersistStore)
+│  └─ types/core/base.ts     # GameType union
+├─ contexts/                 # Auth, game config, game logic contexts
+├─ hooks/                    # Shared hooks (audio, canvas, progress, search)
+└─ public/                   # PWA manifest, icons, service worker
 ```
 
 ---
 
 ## Adding a New Game
 
-The platform uses a registry-based pattern. To add a game:
+The platform uses a registry-based pattern with five game styles (generic card game, generic quiz, custom quiz, fully custom, complex quiz). See **`CLAUDE.md`** for the full, up-to-date decision tree and step-by-step checklist for each style — it's the canonical reference and is kept current with the codebase. `GAME_CREATION_GUIDE.md` has a narrative walkthrough of the same process.
 
-1. **Add game data**  create or update `lib/constants/gameData/*.ts`
-2. **Export from barrel**  add to `lib/constants/index.ts`
-3. **Register the type**  add to `GameType` union in `lib/types/core/base.ts`
-4. **Add to item map**  add entry in `lib/constants/gameItemsMap.ts`
-5. **Register metadata**  add entry in `lib/registry/gamesRegistry.ts`
-6. **Enable routing**  add to `SUPPORTED_GAMES` in `app/games/[gameType]/page.tsx`
-7. **Add UI config**  add to `lib/constants/ui/gameConfigs.ts`
+At a high level, adding a game touches:
 
-See `GAME_CREATION_GUIDE.md` for a detailed step-by-step guide.
+1. **Game/quiz data** — `lib/constants/gameData/*.ts` or `lib/quiz/data/*.ts`
+2. **Register the type** — add to the `GameType` union in `lib/types/core/base.ts`
+3. **Enable routing** — add to `SUPPORTED_GAMES` (and `CUSTOM_GAME_TYPES` if custom) in `app/games/[gameType]/gamePageConstants.ts`
+4. **Register metadata** — add an entry to `lib/registry/registryData/batch<N>.ts`
+5. **Add to the home page** — add the game id to a category's `gameIds` in `lib/constants/gameCategories.ts`
+6. **UI config** (card games) — add to the relevant `lib/constants/ui/gameConfigs.<group>.ts`
 
 ---
 
@@ -202,11 +210,12 @@ See `GAME_CREATION_GUIDE.md` for a detailed step-by-step guide.
 
 ## Architecture Highlights
 
-- **Registry pattern**  `GamesRegistry` is the single source of truth
-- **Universal game page**  one `[gameType]/page.tsx` handles all 131 game routes
-- **Typed game items**  `GAME_ITEMS_MAP` maps every `GameType` to its data
-- **Guest-mode auth**  app runs fully without Supabase credentials; auth is opt-in
-- **Mobile-first**  all components use Tailwind responsive classes (`md:`, `lg:`)
+- **Registry pattern** — `lib/registry/registryData/batch*.ts` is the single source of truth for game metadata
+- **Universal game page** — one `[gameType]/page.tsx` handles all 214 game routes
+- **Typed game items** — `GAME_ITEMS_MAP` maps every `GameType` to its data
+- **Guest-mode auth** — app runs fully without Supabase credentials; auth is opt-in
+- **Zustand over Context** for custom games — state lives in stores, not props/Context
+- **Mobile-first** — all components use Tailwind responsive classes (`md:`, `lg:`)
 
 ---
 
@@ -215,7 +224,7 @@ See `GAME_CREATION_GUIDE.md` for a detailed step-by-step guide.
 - No user data collection
 - No external tracking
 - Local storage only for session state
-- Safe for children  no external links during gameplay
+- Safe for children — no external links during gameplay
 
 ---
 
@@ -231,7 +240,7 @@ See `GAME_CREATION_GUIDE.md` for a detailed step-by-step guide.
 
 ## License
 
-MIT License  see [LICENSE](LICENSE)
+MIT License. (No `LICENSE` file is currently checked into the repository — add one if you need to make this explicit for downstream users.)
 
 ---
 
@@ -244,11 +253,11 @@ MIT License  see [LICENSE](LICENSE)
 
 **Created with love for children aged 2-5**
 
-*"Because every child deserves quality, fun education  through play!"*
+*"Because every child deserves quality, fun education — through play!"*
 
 ## Project Stats
 
-- **131 Interactive Games**
+- **214 Interactive Games**
 - **Hebrew Audio Support**
 - **Mobile-First Responsive**
 - **TypeScript Strict Mode**

--- a/gamesformykids/README.md
+++ b/gamesformykids/README.md
@@ -7,11 +7,11 @@ An interactive educational games platform for children aged 2-5, featuring full 
 
 ## Overview
 
-160+ educational games across 15 categories — Hebrew letters, math, nature, creativity, holidays, arcade, board games and more. Fully responsive with mobile-first design and Hebrew text-to-speech throughout.
+214 educational games across 13 categories — Hebrew letters, math, nature, creativity, holidays, arcade, board games and more. Fully responsive with mobile-first design and Hebrew text-to-speech throughout.
 
 ## Features
 
-- **160+ Games**  covering all key early-childhood learning areas
+- **214 Games**  covering all key early-childhood learning areas
 - **Daily Featured Game**  smart algorithm recommends a game each day
 - **Age Recommendations**  grouped for ages 2-3, 3-4, and 4-5
 - **Hebrew TTS**  full audio pronunciation via Web Speech API
@@ -21,23 +21,23 @@ An interactive educational games platform for children aged 2-5, featuring full 
 
 ## Game Categories
 
-| Category | Examples |
-|----------|---------|
-| Basic Learning | Hebrew Letters, Numbers, Colors, Shapes, Advanced Colors |
-| Math & Numbers | Counting, Math, Arithmetic, Multiplication, Fractions, Sequences |
-| Language & Words | Spelling, Word Builder, Word Scramble, Opposites, English Words |
-| Nature & Animals | Animals, Birds, Bugs & Insects, Dinosaurs, Ocean Life, Dog Breeds, Cat Breeds |
-| Food & Health | Fruits, Vegetables, Healthy Food, World Food, Medicine |
-| World & Geography | Geography, Capitals, Continents, Israel, Flags, Transport, Solar System |
-| Home & Life | House, Clothing, Professions, Family, Tzedakah |
-| Creativity & Arts | Instruments, Drawing, Building, Art & Craft, Puzzles, Famous Paintings |
-| Science & Thinking | Science, Recycling, Climate, Space, Logic Games, True/False, Trivia |
-| Health & Emotions | Emotions, Emotional Social, Body Movements, Road Safety |
-| Holidays & Religion | Jewish Holidays, Holidays, Tzadikim, Seasons & Holidays |
-| Trivia & Quizzes | Sports Quiz, Soccer, NBA Teams, Car Brands, Superheroes, Magic Fairy Tales |
-| Arcade Games | Flappy Bird, Snake, Dino Runner, Space Defender, Pong, Frogger, Tetris, Reflex |
-| Board & Card Games | Memory, Simon Says, Taki, Checkers, Chess, Shesh-Besh |
-| Advanced Themes | Advanced Colors, Advanced Weather, Color Mix, Shapes 3D, Camping |
+Categories and their game lists live in `lib/constants/gameCategories.ts` (source of truth — a game can belong to more than one category).
+
+| Category | Games | Examples |
+|----------|------:|---------|
+| Basic Learning | 20 | Hebrew Letters, Numbers, Colors, Shapes, Nikud, Phonics |
+| Creativity & Arts | 19 | Instruments, Drawing, Building, Tetris, Famous Paintings |
+| Nature & Food | 16 | Animals, Birds, Ocean Life, Dinosaurs, Dog/Cat Breeds |
+| World & Transport | 19 | Geography, Capitals, Continents, Israel, Flags, Solar System |
+| Home & Life | 13 | House Items, Clothing, Professions, Family, Tzedakah |
+| Math & Thinking | 21 | Counting, Math, Arithmetic, Multiplication, Fractions, Sequences |
+| Special Games | 9 | Memory, Bubbles, Emotions, Sports, Soccer, NBA Teams |
+| Health & Safety | 7 | Medicine, Road Safety, Body Parts, Human Body |
+| Science & Technology | 7 | Recycling, Dinosaurs, Virtual Reality, Climate & Planet |
+| Holidays & Seasons | 8 | Jewish Holidays, Holidays, Tzadikim, Seasons & Holidays |
+| Innovative Games | 11 | Sound Imitation, Visual Logic, Spinner, Team Picker, Dice |
+| Arcade Games | 33 | Flappy Bird, Snake, Dino Runner, Pong, Frogger, Chess, Shesh-Besh |
+| Educational Games | 39 | Trivia, Spelling, Riddles, Word Scramble, Crossword, Clock |
 
 ## Installation
 
@@ -54,7 +54,7 @@ Open [http://localhost:3000](http://localhost:3000)
 
 | Technology | Purpose |
 |------------|---------|
-| **Next.js 15** | App Router, Server Components, Turbopack |
+| **Next.js 16** | App Router, Server Components, Turbopack |
 | **React 19** | Latest stable React with concurrent features |
 | **TypeScript** | Strict type safety |
 | **Tailwind CSS 4** | Responsive styling |
@@ -63,6 +63,8 @@ Open [http://localhost:3000](http://localhost:3000)
 | **Web Speech API** | Hebrew TTS |
 | **Lucide React** | Icon system |
 | **Supabase** | Optional auth (guest mode works without it) |
+| **Sentry** | Error monitoring |
+| **Vitest / Playwright** | Unit + component tests / E2E tests |
 | **PWA / Service Worker** | Offline support |
 
 ## Project Structure
@@ -96,12 +98,13 @@ gamesformykids/
  lib/
     constants/
       gameData/               # Item data per game group
-      ui/gameConfigs.ts       # Per-game UI config
-    registry/gamesRegistry.ts # Single source of truth for game metadata
+      gameCategories.ts       # Category -> gameIds mapping (home page grid)
+      ui/gameConfigs.*.ts     # Per-game UI config, split by group
+    registry/registryData/batch*.ts # Single source of truth for game metadata
     types/core/base.ts        # GameType union
-    stores/                   # Zustand stores (shared/global only)
-    quiz/                     # Quiz hooks + factory functions
-    providers/                # React context providers (GameTypeProvider, etc.)
+    stores/                   # Zustand stores + createStore.ts (makeStore/makePersistStore)
+    quiz/                     # Quiz hooks, data, and registries (generic/custom/complex)
+    providers/                # React context providers (GameTypeProvider, AuthProvider)
  public/                      # manifest.json, sw.js, icons
 ```
 
@@ -112,7 +115,7 @@ All games are served from a single route: `app/games/[gameType]/page.tsx`
 | Game kind | How it renders | Examples |
 |-----------|---------------|----------|
 | **Card games** | `UltimateGamePage` via `GameTypeProvider` + `GameLogicSync` | colors, animals, math |
-| **Quiz games** | `UltimateGamePage` → `QuizGameRouter` | geography, science, spelling |
+| **Quiz games** | `UltimateGamePage` → `QuizGameRouter` (`components/game/quiz/`) | geography, science, spelling |
 | **Custom games** | `CustomGameRenderer` → per-game client component | memory, chess, tetris, drawing |
 
 ## Adding a New Game
@@ -120,12 +123,12 @@ All games are served from a single route: `app/games/[gameType]/page.tsx`
 1. Add item data to `lib/constants/gameData/*.ts`
 2. Export from `lib/constants/gameItemsMap.ts`
 3. Add to `GameType` union in `lib/types/core/base.ts`
-4. Add entry in `lib/registry/gamesRegistry.ts`
+4. Add entry in `lib/registry/registryData/batch<N>.ts`
 5. Add to `SUPPORTED_GAMES` (and `CUSTOM_GAME_TYPES` if custom) in `app/games/[gameType]/gamePageConstants.ts`
-6. Add UI config in `lib/constants/ui/gameConfigs.ts`
-7. Add to category in `components/marketing/CategorizedGamesGrid.tsx`
+6. Add UI config in the relevant `lib/constants/ui/gameConfigs.<group>.ts`
+7. Add the game id to a category's `gameIds` in `lib/constants/gameCategories.ts`
 
-See `../GAME_CREATION_GUIDE.md` for full instructions.
+See `CLAUDE.md` for the full, current step-by-step checklist per game style (it supersedes `GAME_CREATION_GUIDE.md` for anything that conflicts).
 
 ## Auth & Supabase
 
@@ -155,7 +158,7 @@ Chrome 90+, Firefox 88+, Safari 14+, Edge 90+, iOS Safari 14+
 
 ## License
 
-MIT  see [LICENSE](../LICENSE)
+MIT. (No `LICENSE` file is currently checked into the repository — add one if you need to make this explicit for downstream users.)
 
 ## Contact
 

--- a/gamesformykids/app/games/bubbles/components/README.md
+++ b/gamesformykids/app/games/bubbles/components/README.md
@@ -7,9 +7,10 @@
 - **Bubble.tsx** - בועה יחידה עם אנימציה וצלילים
 - **BubbleGame.tsx** - משחק הבועות הראשי
 - **BubbleStartScreen.tsx** - מסך התחלה של המשחק
+- **useBubble.ts** - הוק ללוגיקת בועה בודדת
 
 ## שימוש:
 
 ```tsx
-import { Bubble, BubbleGame } from '@/components/game/bubbles';
+import { Bubble, BubbleGame } from '@/app/games/bubbles/components';
 ```

--- a/gamesformykids/app/games/building/components/README.md
+++ b/gamesformykids/app/games/building/components/README.md
@@ -1,96 +1,54 @@
 # Building Game Components
 
-This directory contains the modular components for the Building Game.
+This directory contains the modular components for the Building Game. State is managed by a **Zustand store** (`useBuildingStore`, composed from slices), not React Context — components read state via store selectors instead of props drilling or a context provider.
 
-## Components
+## Structure
 
-# Building Game Components
+Components are grouped into three subfolders:
 
-This directory contains the modular components for the Building Game. All components use the **BuildingContext** to avoid props drilling.
+```
+components/
+├── canvas/     # BlockRenderer, BlockShape, BuildingCanvas, EmptyCanvasWelcome
+├── controls/   # ActionButtons, ColorPicker, SettingsPanel, ShapeCreator
+└── ui/         # BuildingGameHeader, BuildingGameInstructions, ParticleSystem
+```
 
-## Context-Based Architecture
+### canvas/
+- **BuildingCanvas** - main canvas for building blocks; handles drag and drop, shows `EmptyCanvasWelcome` when empty
+- **BlockRenderer** - renders individual blocks/shapes, handles rotation and dragging (rotation button on hover, double-click to rotate 90°)
+- **BlockShape** - SVG shape primitives (including the heart shape, built from bezier curves with gradient fills)
+- **EmptyCanvasWelcome** - welcome message shown when the canvas is empty
 
-All components access state and functions through `useBuildingContext()` hook, eliminating the need for props drilling.
+### controls/
+- **ColorPicker** - color palette selection, shows the current color
+- **ShapeCreator** - available shapes + tool selection (normal, magic, rainbow)
+- **ActionButtons** - game action buttons (magic shuffle, clear, undo, redo) via the store's history slice
+- **SettingsPanel** - sound/grid/animation toggles, save functionality
 
-## Components
+### ui/
+- **BuildingGameHeader** - game title, score, and achievements
+- **BuildingGameInstructions** - game instructions and help
+- **ParticleSystem** - particle effects for visual feedback
 
-### ColorPicker
-- Displays a color palette for selection
-- Shows the currently selected color
-- **No props needed** - uses BuildingContext
+## State — Zustand store
 
-### ShapeCreator
-- Shows available shapes to create
-- Includes tool selection (normal, magic, rainbow)
-- **No props needed** - uses BuildingContext
+`app/games/building/store/buildingStore.ts` composes the store from slices: `blockSlice`, `blockDragSlice`, `historySlice`, `particleSlice`, `achievementSlice`, `settingsSlice`.
 
-### ActionButtons
-- Contains game action buttons (magic shuffle, clear, undo, redo)
-- Handles history management
-- **No props needed** - uses BuildingContext
+```tsx
+import { useBuildingStore } from '@/app/games/building/store/buildingStore';
 
-### SettingsPanel
-- Game settings toggle buttons
-- Sound, grid, animation controls
-- Save functionality
-- **No props needed** - uses BuildingContext
-
-### BlockRenderer
-- Renders individual blocks/shapes
-- Handles rotation, dragging, and interactions
-- Includes rotation button on hover
-- **Minimal props**: Only receives `block` object
-
-### ParticleSystem
-- Renders particle effects
-- Simple component for visual feedback
-- **No props needed** - uses BuildingContext
-
-### GameHeader
-- Displays game title, score, and achievements
-- **No props needed** - uses BuildingContext
-
-### BuildingCanvas
-- Main canvas for building blocks
-- Handles drag and drop interactions
-- Shows welcome message when empty
-- **No props needed** - uses BuildingContext
-
-### EmptyCanvasWelcome
-- Welcome message shown when canvas is empty
-- **No props needed** - pure presentation component
-
-### GameInstructions
-- Displays game instructions and help
-- **No props needed** - pure presentation component
-
-## Features Added
-
-### Rotation Controls
-- **Rotation Button**: Each block has a rotation button (⟲) that appears on hover
-- **Double Click**: Double-clicking a block rotates it by 90°
-- **Precision Rotation**: The rotation button rotates by 45° increments
-
-### Enhanced Heart Shape ✨
-The heart shape has been completely redesigned with:
-- **SVG-based rendering** for crisp, scalable graphics
-- **Gradient fills** with depth and dimension
-- **Smooth bezier curves** for natural heart shape
-- **Subtle highlights** for 3D appearance
-- **Optimized performance** with unique IDs for each heart
-- **Perfect symmetry** and balanced proportions
-- Proper positioning and scaling
+function MyComponent() {
+  const blocks = useBuildingStore((s) => s.blocks);
+  const createBlock = useBuildingStore((s) => s.createBlock);
+  // ...
+}
+```
 
 ## Usage
 
-Import all components from the index file:
+Import components from the local barrel:
 ```tsx
-import { 
-  ColorPicker, 
-  ShapeCreator, 
-  ActionButtons, 
-  SettingsPanel, 
-  BlockRenderer, 
-  ParticleSystem 
-} from '@/components/game/building';
+import { BuildingCanvas } from '@/app/games/building/components/canvas';
+import { ColorPicker, ActionButtons } from '@/app/games/building/components/controls';
+import { BuildingGameHeader } from '@/app/games/building/components/ui';
 ```

--- a/gamesformykids/app/games/hebrew-letters/components/README.md
+++ b/gamesformykids/app/games/hebrew-letters/components/README.md
@@ -1,70 +1,75 @@
-# Hebrew Letters Context
+# Hebrew Letters Components
 
-קונטקסט ייעודי עבור משחק תרגול האותיות העבריות שמצמצם props drilling ומספק ניהול מצב מרכזי.
+רכיבי משחק תרגול האותיות העבריות. הסטייט חי ב-**Zustand store** (`useHebrewLettersStore`), לא ב-React Context — אין Provider, אין props drilling; רכיבים קוראים ישירות מה-store דרך selectors.
 
-## מה כלול
+## מבנה
 
-### HebrewLettersContext
-קונטקסט ראשי שמכיל:
-- **מצב ציור (Drawing State)**: ניהול כלי הציור במסך הכתיבה
-- **מצב תרגול (Practice State)**: מעקב אחר השלבים והתקדמות
-- **התקדמות אותיות**: מעקב אחר אותיות שהושלמו
-- **הגדרות**: צבעים, עובי קווים, שלבי תרגול
+הרכיבים מפוצלים לארבע תיקיות תחת `components/`:
 
-### useHebrewLetters Hook
-הוק ראשי לגישה לקונטקסט:
-```tsx
-const {
-  currentLetter,
-  setCurrentLetter,
-  drawingState,
-  updateDrawingState,
-  practiceState,
-  updatePracticeState,
-  // ... עוד פונקציות
-} = useHebrewLetters();
+```
+components/
+├── canvas/     # WritingCanvas ומסך הכתיבה
+├── hub/        # דף הבית של המשחק — בחירת אות
+├── practice/   # מסך תרגול אות בודדת (שלבים)
+└── stats/      # מסכי סטטיסטיקה והתקדמות
 ```
 
-### useHebrewLetterPractice Hook
-הוק מותאם אישית לטיפול בלוגיקת תרגול אות ספציפית:
+### canvas/
+- **WritingCanvas** - קנבס הכתיבה הראשי
+- **LetterGuideOverlay** - שכבת הנחיה חזותית מעל האות
+- **CanvasToolbar**, **CanvasColorPicker**, **CanvasStrokeWidthPicker** - בקרות ציור
+- **CanvasDrawArea** - אזור הציור עצמו
+- (פנימי, לא מיוצא מה-barrel: `WritingCanvasContext.tsx`, `useWritingCanvas.ts`, `useLetterGuideOverlay.ts`)
+
+### hub/
+- **HebrewLettersHub** - מסך הבית של המשחק (בחירת אות לתרגול)
+- **HubHeader**, **HubInstructions**, **HubFunFacts** - חלקי הדף הראשי
+- **LettersGrid** - גריד כל האותיות
+- **HebrewLetterProgress** - אינדיקטור התקדמות לאות בודדת:
+  ```tsx
+  <HebrewLetterProgress letter={letterData} showName={true} size="lg" />
+  ```
+
+### practice/
+- **HebrewLetterPractice** - מסך תרגול האות (מנהל את השלבים)
+- **LetterIntroStep**, **LetterTracingStep**, **LetterWritingStep** - שלבי התרגול
+- **LetterFunFacts**, **LetterEncouragement** - משוב וטריוויה
+- (פנימי: `useLetterEncouragement.ts`)
+
+### stats/
+- **HebrewLettersStats** - סטטיסטיקות כלליות של התקדמות במשחק
+- **StatsGrid**, **StatsProgressBar**, **StatsAchievement** - רכיבי תצוגה
+- (קבצים נוספים בתיקייה שלא ב-barrel: `LetterSpecificStats.tsx`, `PracticeHistoryList.tsx`, `StatPanelCard.tsx`)
+
+## State — Zustand store
+
+`app/games/hebrew-letters/store/hebrewLettersStore.ts` מרכיב את ה-store מ-slices: `letterSlice`, `audioSlice`, `drawingSlice`, `practiceSlice`, `statsSlice`.
+
 ```tsx
-const {
-  currentStepInfo,
-  initializeLetter,
-  completeCurrentStep,
-  getCurrentInstructions,
-  // ... עוד פונקציות
-} = useHebrewLetterPractice(letterData);
+import { useHebrewLettersStore } from '@/app/games/hebrew-letters/store/hebrewLettersStore';
+
+function MyComponent() {
+  const currentLetter = useHebrewLettersStore((s) => s.currentLetter);
+  const practiceState = useHebrewLettersStore((s) => s.practiceState);
+  // ...
+}
 ```
 
-## רכיבים
-
-### HebrewLetterProgress
-רכיב להצגת התקדמות אות עם אינדיקטור חזותי:
-```tsx
-<HebrewLetterProgress 
-  letter={letterData} 
-  showName={true} 
-  size="lg" 
-/>
-```
-
-### HebrewLettersStats
-רכיב להצגת סטטיסטיקות כלליות של התקדמות במשחק.
-
-### WritingCanvas
-קנבס לכתיבה שמשתמש בקונטקסט לניהול מצב הציור.
+יש גם `useHebrewLetterPractice` (ב-`app/games/hebrew-letters/hooks/useHebrewLetterPractice.ts`) — הוק ללוגיקת תרגול אות ספציפית שעוטף קריאות ל-store.
 
 ## שימוש
 
-1. **עטיפה בפרובדיר**: עטפו את הרכיבים ב-`HebrewLettersProvider`
-2. **השתמשו בהוקים**: `useHebrewLetters` ו-`useHebrewLetterPractice`
-3. **אין צורך להעביר props**: הרכיבים מקבלים את המידע מהקונטקסט
+```tsx
+import { HebrewLettersHub } from '@/app/games/hebrew-letters/components/hub';
+import { HebrewLetterPractice } from '@/app/games/hebrew-letters/components/practice';
+import { WritingCanvas } from '@/app/games/hebrew-letters/components/canvas';
+import { HebrewLettersStats } from '@/app/games/hebrew-letters/components/stats';
+```
 
 ## יתרונות
 
-- ✅ **אין Props Drilling**: כל הנתונים זמינים דרך הקונטקסט
-- ✅ **ניהול מצב מרכזי**: כל הלוגיקה במקום אחד
-- ✅ **קוד נקי יותר**: רכיבים פשוטים יותר
+- ✅ **אין Props Drilling**: כל הנתונים זמינים דרך ה-store
+- ✅ **ניהול מצב מרכזי**: כל הלוגיקה במקום אחד, מפוצלת ל-slices קריאים
+- ✅ **בחירתיות (selectors)**: רכיבים נרנדרים מחדש רק כשהחלק הרלוונטי ב-state משתנה
 - ✅ **שימוש חוזר**: הוקים ורכיבים ניתנים לשימוש חוזר
 - ✅ **טיפוסים בטוחים**: תמיכה מלאה ב-TypeScript

--- a/gamesformykids/app/games/math/components/README.md
+++ b/gamesformykids/app/games/math/components/README.md
@@ -6,10 +6,9 @@
 
 - **MathNumberCard.tsx** - כרטיס מספר לחישובים
 - **MathStartScreen.tsx** - מסך התחלה של המשחק
-- **StartScreen.tsx** - מסך התחלה נוסף
 
 ## שימוש:
 
 ```tsx
-import { MathNumberCard, MathStartScreen } from '@/components/game/math';
+import { MathNumberCard, MathStartScreen } from '@/app/games/math/components';
 ```

--- a/gamesformykids/app/games/memory/components/README.md
+++ b/gamesformykids/app/games/memory/components/README.md
@@ -7,11 +7,18 @@
 - **MemoryCard.tsx** - קלף זיכרון יחיד
 - **MemoryGameBoard.tsx** - לוח המשחק עם כל הקלפים
 - **MemoryStartScreen.tsx** - מסך התחלה של המשחק
-- **GameHeader.tsx** - כותרת המשחק עם ניקוד וזמן
+- **MemoryGameHeader.tsx** - כותרת המשחק עם ניקוד וזמן
 - **GameWinMessage.tsx** - הודעת ניצחון
+- **GameTimeoutScreen.tsx** - מסך תום זמן
+- **GameControls.tsx** - כפתורי בקרה (השהיה, איפוס וכו')
+- **GameProgressBar.tsx** - פס התקדמות
+- **GameStatsBar.tsx** - שורת סטטיסטיקות
+- **PauseOverlay.tsx** - שכבת השהיה
+- **WinAchievements.tsx** - הישגים במסך ניצחון
+- **WinStatsGrid.tsx** - גריד סטטיסטיקות במסך ניצחון
 
 ## שימוש:
 
 ```tsx
-import { MemoryCard, MemoryGameBoard } from '@/components/game/memory';
+import { MemoryCard, MemoryGameBoard } from '@/app/games/memory/components';
 ```

--- a/gamesformykids/app/games/tetris/components/README.md
+++ b/gamesformykids/app/games/tetris/components/README.md
@@ -7,13 +7,15 @@
 - **TetrisGame.tsx** - משחק הטטריס הראשי
 - **GameBoard.tsx** - לוח המשחק
 - **AnimatedBackground.tsx** - רקע מונפש
-- **LoadingScreen.tsx** - מסך טעינה
 - **NextPieceDisplay.tsx** - תצוגת החלק הבא
 - **TouchControls.tsx** - בקרי מגע למובייל
-- **InfoPanels.tsx** - פאנלי מידע (ניקוד, רמה וכו')
+- **useTouchControls.ts** - הוק ללוגיקת בקרות המגע
+- **InfoPanels.tsx** - פאנלי מידע (`MobileInfoPanel`, `DesktopInfoPanel`)
+
+מסך הטעינה נשאב מהרכיב המשותף `@/components/layout` (`LoadingScreen`), לא מקובץ מקומי.
 
 ## שימוש:
 
 ```tsx
-import { TetrisGame, GameBoard } from '@/components/game/tetris';
+import { TetrisGame, GameBoard } from '@/app/games/tetris/components';
 ```


### PR DESCRIPTION
## Summary
- Both `README.md` files, `CLAUDE.md`, `CONTRIBUTING.md`, and `GAME_CREATION_GUIDE.md` had drifted from the code: stale game counts (131/160+ → **214**) and categories (15 → **13**, rebuilt from `lib/constants/gameCategories.ts`), Next.js 15 → 16, Node 18+ → 20+, a non-existent `npm run typecheck` script, and dead paths (`lib/types/base`, `lib/stores/storeFactory`, single-file `gamesRegistry.ts`/`gameConfigs.ts`).
- `building` and `hebrew-letters` component READMEs described a React Context architecture that was migrated to Zustand stores, with a folder layout that no longer matches reality — rewritten to reflect the current `store/` + subfolder structure.
- Several `.claude/commands/*.md` checks grepped `CategorizedGamesGrid.tsx` for game IDs — that data now lives in `lib/constants/gameCategories.ts`, so those checks silently matched nothing. Fixed in `game-qa`, `game-duplicate-checker`, `post-merge-smoke`, `product-manager`, `release-gate`, plus reference tables in `code-ownership-router`, `diff-risk-classifier`, `pre-merge-conflict-predictor`, `branch-hygiene`.
- `arch-review.md`, `review-issues.md`, `ux-ui.md` claimed the project runs Next.js 15.5.x — corrected to 16.2.x (left alone all the "Next.js 15 introduced async params" style historical/technical statements, which remain true regardless of current version).

All facts (game/category counts, file paths, exported names) were re-verified against the live codebase, not just cross-referenced between docs.

Closes #1421

## Test plan
- [x] Game count (214) and category count (13) cross-checked against `SUPPORTED_GAMES` in `gamePageConstants.ts` and `gameCategories.ts` directly
- [x] Every path/import mentioned in edited docs verified to exist via grep/ls against the actual source tree
- [x] `CONTRIBUTING.md` commands checked against `.github/workflows/ci.yml` for exact parity
- Docs-only change — no code paths affected, no `npm run build`/`tsc` needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)