### PR TITLE
Fix raw setTimeout anti-pattern in find-in-scene and market-game stores

### DIFF
--- a/gamesformykids/app/games/find-in-scene/findInSceneStore.ts
+++ b/gamesformykids/app/games/find-in-scene/findInSceneStore.ts
@@ -18,6 +18,7 @@ interface State {
 interface Actions {
   startRound: (sceneId: string, promptIdx?: number) => void;
   tapObject: (objectId: string) => 'correct' | 'wrong' | 'already';
+  clearWrong: (objectId: string) => void;
   tick: () => void;
   resetGame: () => void;
 }
@@ -70,11 +71,12 @@ export const useFindInSceneStore = create<State & Actions>((set, get) => ({
       return 'correct';
     } else {
       set({ wrongId: objectId });
-      setTimeout(() => {
-        if (get().wrongId === objectId) set({ wrongId: null });
-      }, 600);
       return 'wrong';
     }
+  },
+
+  clearWrong: (objectId) => {
+    if (get().wrongId === objectId) set({ wrongId: null });
   },
 
   tick: () => {

--- a/gamesformykids/app/games/find-in-scene/useFindInScene.ts
+++ b/gamesformykids/app/games/find-in-scene/useFindInScene.ts
@@ -13,7 +13,7 @@ export function useFindInScene() {
   const wrongId   = useFindInSceneStore(s => s.wrongId);
   const timeLeft  = useFindInSceneStore(s => s.timeLeft);
   const score     = useFindInSceneStore(s => s.score);
-  const { startRound, tapObject, tick, resetGame } = useFindInSceneStore();
+  const { startRound, tapObject, clearWrong, tick, resetGame } = useFindInSceneStore();
 
   // Countdown timer
   useEffect(() => {
@@ -21,6 +21,13 @@ export function useFindInScene() {
     const interval = setInterval(() => tick(), 1000);
     return () => clearInterval(interval);
   }, [phase, tick]);
+
+  // Clear the "wrong tap" shake flag after a short delay
+  useEffect(() => {
+    if (!wrongId) return;
+    const timeout = setTimeout(() => clearWrong(wrongId), 600);
+    return () => clearTimeout(timeout);
+  }, [wrongId, clearWrong]);
 
   // Announce prompt when round starts
   useEffect(() => {

--- a/gamesformykids/app/games/market-game/MarketClient.tsx
+++ b/gamesformykids/app/games/market-game/MarketClient.tsx
@@ -28,11 +28,18 @@ function numberWord(n: number): string {
 
 export default function MarketClient() {
   const {
-    phase, customer, cart, score, customersServed, totalCustomers, feedback, difficulty,
-    startGame, addToCart, removeFromCart, confirmSale, tickTimer, restart,
+    phase, customer, cart, score, customersServed, totalCustomers, feedback, difficulty, confirming,
+    startGame, addToCart, removeFromCart, confirmSale, advanceCustomer, tickTimer, restart,
   } = useMarketStore();
 
   const timerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  // Advance to the next customer a beat after showing sale feedback
+  useEffect(() => {
+    if (!confirming) return;
+    const timeout = setTimeout(() => advanceCustomer(), 1200);
+    return () => clearTimeout(timeout);
+  }, [confirming, advanceCustomer]);
 
   useEffect(() => {
     if (phase === 'playing' && customer) {

--- a/gamesformykids/app/games/market-game/marketStore.ts
+++ b/gamesformykids/app/games/market-game/marketStore.ts
@@ -140,7 +140,7 @@ export const useMarketStore = create<MarketState & MarketActions>((set, get) => 
   },
 
   confirmSale: () => {
-    const { customer, cart, score, customersServed, difficulty, totalCustomers, nextCustomerId, confirming } = get();
+    const { customer, cart, score, confirming } = get();
     if (!customer || confirming) return;
 
     const cartCount = cart[customer.order.item.id] ?? 0;

--- a/gamesformykids/app/games/market-game/marketStore.ts
+++ b/gamesformykids/app/games/market-game/marketStore.ts
@@ -89,6 +89,7 @@ interface MarketActions {
   addToCart: (itemId: string) => void;
   removeFromCart: (itemId: string) => void;
   confirmSale: () => void;
+  advanceCustomer: () => void;
   tickTimer: () => void;
   endGame: () => void;
   restart: () => void;
@@ -146,23 +147,26 @@ export const useMarketStore = create<MarketState & MarketActions>((set, get) => 
     const correct = cartCount === customer.order.count;
 
     set({ feedback: correct ? 'correct' : 'wrong', score: correct ? score + 1 : score, confirming: true });
+  },
 
-    setTimeout(() => {
-      const served = customersServed + 1;
-      if (served >= totalCustomers) {
-        set({ phase: 'result', customersServed: served, feedback: 'none', confirming: false });
-        return;
-      }
-      const next = buildCustomer(difficulty, nextCustomerId);
-      set({
-        customer: next,
-        cart: {},
-        feedback: 'none',
-        customersServed: served,
-        nextCustomerId: nextCustomerId + 1,
-        confirming: false,
-      });
-    }, 1200);
+  advanceCustomer: () => {
+    const { customersServed, difficulty, totalCustomers, nextCustomerId, confirming } = get();
+    if (!confirming) return;
+
+    const served = customersServed + 1;
+    if (served >= totalCustomers) {
+      set({ phase: 'result', customersServed: served, feedback: 'none', confirming: false });
+      return;
+    }
+    const next = buildCustomer(difficulty, nextCustomerId);
+    set({
+      customer: next,
+      cart: {},
+      feedback: 'none',
+      customersServed: served,
+      nextCustomerId: nextCustomerId + 1,
+      confirming: false,
+    });
   },
 
   tickTimer: () => {


### PR DESCRIPTION
## Summary
- A full game-QA sweep of all 214 games (registration + file existence checks + `tsc --noEmit`) found only two non-critical issues: `find-in-scene` and `market-game` both call `setTimeout` directly inside their Zustand store actions instead of owning the timer in the consuming React component.
- Raw timers in a store bypass React's cleanup lifecycle — if the game resets or unmounts mid-delay, a stale `set()` can still fire afterward.
- Moved both delays into `useEffect` in the respective client component/hook, with `clearTimeout` cleanup, matching the pattern already used for the countdown timers in these same games.

## Changes
- `find-in-scene`: added a `clearWrong` store action; the 600ms "wrong tap" shake-clear now lives in `useFindInScene.ts`.
- `market-game`: split `confirmSale` into `confirmSale` (sets feedback) + `advanceCustomer` (moves to next customer); the 1200ms delay now lives in `MarketClient.tsx`.

## Test plan
- [x] `npx tsc --noEmit` — 0 errors
- [x] `npm run build` — succeeds, all 214 `/games/[gameType]` routes compile including `find-in-scene` and `market-game`
- [ ] Manual click-through of both games in browser (not done in this session — logic is otherwise unchanged, only timer ownership moved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)