### PR TITLE
Dedupe page templates and formatTime duplication

### DIFF
--- a/gamesformykids/app/creative/CreativePageClient.tsx
+++ b/gamesformykids/app/creative/CreativePageClient.tsx
@@ -1,28 +1,18 @@
 'use client';
 
-import Header from '@/components/layout/Header';
-import Footer from '@/components/layout/Footer';
-import ContentTypeGrid from '@/components/marketing/ContentTypeGrid';
-import Link from 'next/link';
+import ContentTypePage from '@/components/marketing/ContentTypePage';
 
 export default function CreativePageClient() {
   return (
-    <div className="min-h-screen bg-linear-to-br from-pink-50 via-purple-50 to-rose-50 dark:from-gray-900 dark:via-gray-800 dark:to-gray-900">
-      <Header />
-      <div className="max-w-6xl mx-auto px-4 pt-6 pb-2" dir="rtl">
-        <div className="text-center mb-6">
-          <div className="text-5xl mb-3">🎨</div>
-          <h1 className="text-3xl md:text-4xl font-bold text-purple-800 dark:text-purple-200 mb-2">יצירה ואומנות</h1>
-          <p className="text-purple-600 dark:text-purple-400 text-base md:text-lg mb-4">
-            ציור, צביעה, מוזיקה ויצירה חופשית לכל גיל
-          </p>
-          <Link href="/" className="text-sm text-purple-500 hover:text-purple-700 underline underline-offset-2 transition-colors">
-            ← חזרה לדף הבית
-          </Link>
-        </div>
-      </div>
-      <ContentTypeGrid contentType="creative" />
-      <Footer />
-    </div>
+    <ContentTypePage
+      contentType="creative"
+      gradientClass="from-pink-50 via-purple-50 to-rose-50"
+      emoji="🎨"
+      title="יצירה ואומנות"
+      titleColorClass="text-purple-800 dark:text-purple-200"
+      description="ציור, צביעה, מוזיקה ויצירה חופשית לכל גיל"
+      descriptionColorClass="text-purple-600 dark:text-purple-400"
+      linkColorClass="text-purple-500 hover:text-purple-700"
+    />
   );
 }

--- a/gamesformykids/app/games/drawing/hooks/useDrawingGame.ts
+++ b/gamesformykids/app/games/drawing/hooks/useDrawingGame.ts
@@ -9,6 +9,7 @@
 
 import { useState, useCallback, useEffect } from 'react';
 import { useDrawingStore } from '../store/drawingStore';
+import { formatGameTime } from '@/lib/utils/game/gameUtils';
 
 export interface GameSettings {
   difficulty: 'easy' | 'medium' | 'hard';
@@ -90,13 +91,6 @@ export const useDrawingGame = () => {
     }
   };
 
-  // פורמט זמן למציג
-  const formatTime = (seconds: number) => {
-    const minutes = Math.floor(seconds / 60);
-    const remainingSeconds = seconds % 60;
-    return `${minutes}:${remainingSeconds.toString().padStart(2, '0')}`;
-  };
-
   // נושאי ציור זמינים
   const availableThemes = [
     { id: 'free-draw', name: 'ציור חופשי', description: 'צייר מה שתרצה!' },
@@ -134,7 +128,7 @@ export const useDrawingGame = () => {
     difficultySettings,
     
     // Utilities
-    formatTime,
+    formatTime: formatGameTime,
     handleGameEnd
   };
 };

--- a/gamesformykids/app/games/memory/stores/memoryPureHelpers.ts
+++ b/gamesformykids/app/games/memory/stores/memoryPureHelpers.ts
@@ -3,12 +3,9 @@
  * Extracted from useMemoryStore.ts where they lived as store actions
  * despite having no access to Zustand state.
  */
+import { formatGameTime } from '@/lib/utils/game/gameUtils';
 
-export function formatTime(seconds: number): string {
-  const mins = Math.floor(seconds / 60);
-  const secs = seconds % 60;
-  return `${mins}:${secs.toString().padStart(2, '0')}`;
-}
+export const formatTime = formatGameTime;
 
 export function getTimeColor(timeLeft: number): string {
   if (timeLeft <= 10) return 'text-red-500';

--- a/gamesformykids/app/games/puzzles/utils/puzzleScoring.ts
+++ b/gamesformykids/app/games/puzzles/utils/puzzleScoring.ts
@@ -1,4 +1,5 @@
 import type { PuzzlePiece } from './puzzleTypes';
+import { formatGameTime } from '@/lib/utils/game/gameUtils';
 
 export const isPieceInCorrectPosition = (
   piece: PuzzlePiece,
@@ -15,11 +16,7 @@ export const calculateCompletionPercentage = (
   return Math.round((completedPieces / totalPieces) * 100);
 };
 
-export const formatTime = (seconds: number): string => {
-  const mins = Math.floor(seconds / 60);
-  const secs = seconds % 60;
-  return `${mins}:${secs.toString().padStart(2, '0')}`;
-};
+export const formatTime = formatGameTime;
 
 export const calculateFinalScore = (
   baseScore: number,

--- a/gamesformykids/app/riddles/RiddlesPageClient.tsx
+++ b/gamesformykids/app/riddles/RiddlesPageClient.tsx
@@ -1,28 +1,18 @@
 'use client';
 
-import Header from '@/components/layout/Header';
-import Footer from '@/components/layout/Footer';
-import ContentTypeGrid from '@/components/marketing/ContentTypeGrid';
-import Link from 'next/link';
+import ContentTypePage from '@/components/marketing/ContentTypePage';
 
 export default function RiddlesPageClient() {
   return (
-    <div className="min-h-screen bg-linear-to-br from-yellow-50 via-orange-50 to-amber-50 dark:from-gray-900 dark:via-gray-800 dark:to-gray-900">
-      <Header />
-      <div className="max-w-6xl mx-auto px-4 pt-6 pb-2" dir="rtl">
-        <div className="text-center mb-6">
-          <div className="text-5xl mb-3">🤣</div>
-          <h1 className="text-3xl md:text-4xl font-bold text-orange-800 dark:text-orange-200 mb-2">חידות ובדיחות</h1>
-          <p className="text-orange-600 dark:text-orange-400 text-base md:text-lg mb-4">
-            חידות, טריוויה ובדיחות לאתגר את המוח
-          </p>
-          <Link href="/" className="text-sm text-orange-500 hover:text-orange-700 underline underline-offset-2 transition-colors">
-            ← חזרה לדף הבית
-          </Link>
-        </div>
-      </div>
-      <ContentTypeGrid contentType="riddles" />
-      <Footer />
-    </div>
+    <ContentTypePage
+      contentType="riddles"
+      gradientClass="from-yellow-50 via-orange-50 to-amber-50"
+      emoji="🤣"
+      title="חידות ובדיחות"
+      titleColorClass="text-orange-800 dark:text-orange-200"
+      description="חידות, טריוויה ובדיחות לאתגר את המוח"
+      descriptionColorClass="text-orange-600 dark:text-orange-400"
+      linkColorClass="text-orange-500 hover:text-orange-700"
+    />
   );
 }

--- a/gamesformykids/app/tools/ToolsPageClient.tsx
+++ b/gamesformykids/app/tools/ToolsPageClient.tsx
@@ -1,28 +1,18 @@
 'use client';
 
-import Header from '@/components/layout/Header';
-import Footer from '@/components/layout/Footer';
-import ContentTypeGrid from '@/components/marketing/ContentTypeGrid';
-import Link from 'next/link';
+import ContentTypePage from '@/components/marketing/ContentTypePage';
 
 export default function ToolsPageClient() {
   return (
-    <div className="min-h-screen bg-linear-to-br from-teal-50 via-green-50 to-cyan-50 dark:from-gray-900 dark:via-gray-800 dark:to-gray-900">
-      <Header />
-      <div className="max-w-6xl mx-auto px-4 pt-6 pb-2" dir="rtl">
-        <div className="text-center mb-6">
-          <div className="text-5xl mb-3">🎲</div>
-          <h1 className="text-3xl md:text-4xl font-bold text-teal-800 dark:text-teal-200 mb-2">כלי כיתה</h1>
-          <p className="text-teal-600 dark:text-teal-400 text-base md:text-lg mb-4">
-            כלים שימושיים למורים, להורים ולילדים
-          </p>
-          <Link href="/" className="text-sm text-teal-500 hover:text-teal-700 underline underline-offset-2 transition-colors">
-            ← חזרה לדף הבית
-          </Link>
-        </div>
-      </div>
-      <ContentTypeGrid contentType="tools" />
-      <Footer />
-    </div>
+    <ContentTypePage
+      contentType="tools"
+      gradientClass="from-teal-50 via-green-50 to-cyan-50"
+      emoji="🎲"
+      title="כלי כיתה"
+      titleColorClass="text-teal-800 dark:text-teal-200"
+      description="כלים שימושיים למורים, להורים ולילדים"
+      descriptionColorClass="text-teal-600 dark:text-teal-400"
+      linkColorClass="text-teal-500 hover:text-teal-700"
+    />
   );
 }

--- a/gamesformykids/components/marketing/ContentTypePage.tsx
+++ b/gamesformykids/components/marketing/ContentTypePage.tsx
@@ -1,0 +1,46 @@
+'use client';
+
+import Header from '@/components/layout/Header';
+import Footer from '@/components/layout/Footer';
+import ContentTypeGrid from '@/components/marketing/ContentTypeGrid';
+import Link from 'next/link';
+import type { TabContentType } from '@/components/marketing/ContentTypeTabBar';
+
+/** תבנית משותפת לדפי נחיתה של סוג תוכן (יצירה, חידות, כלים וכו') */
+export default function ContentTypePage({
+  contentType,
+  gradientClass,
+  emoji,
+  title,
+  titleColorClass,
+  description,
+  descriptionColorClass,
+  linkColorClass,
+}: {
+  contentType: Exclude<TabContentType, 'games'>;
+  gradientClass: string;
+  emoji: string;
+  title: string;
+  titleColorClass: string;
+  description: string;
+  descriptionColorClass: string;
+  linkColorClass: string;
+}) {
+  return (
+    <div className={`min-h-screen bg-linear-to-br ${gradientClass} dark:from-gray-900 dark:via-gray-800 dark:to-gray-900`}>
+      <Header />
+      <div className="max-w-6xl mx-auto px-4 pt-6 pb-2" dir="rtl">
+        <div className="text-center mb-6">
+          <div className="text-5xl mb-3">{emoji}</div>
+          <h1 className={`text-3xl md:text-4xl font-bold ${titleColorClass} mb-2`}>{title}</h1>
+          <p className={`${descriptionColorClass} text-base md:text-lg mb-4`}>{description}</p>
+          <Link href="/" className={`text-sm ${linkColorClass} underline underline-offset-2 transition-colors`}>
+            ← חזרה לדף הבית
+          </Link>
+        </div>
+      </div>
+      <ContentTypeGrid contentType={contentType} />
+      <Footer />
+    </div>
+  );
+}

--- a/gamesformykids/lib/utils/game/gameUtils.ts
+++ b/gamesformykids/lib/utils/game/gameUtils.ts
@@ -19,6 +19,15 @@ export function delay(ms: number): Promise<void> {
 }
 
 /**
+ * מפרמט שניות לתצוגת שעון "M:SS" (בלי אפס מוביל בדקות)
+ */
+export function formatGameTime(seconds: number): string {
+  const mins = Math.floor(seconds / 60);
+  const secs = seconds % 60;
+  return `${mins}:${secs.toString().padStart(2, '0')}`;
+}
+
+/**
  * מספר שלם אקראי בטווח [min, max] (כולל קצוות)
  */
 export function randInt(min: number, max: number): number {


### PR DESCRIPTION
## Summary
Ran the `find-duplicate-js` CLI (AST-similarity based, complements jscpd's exact-token matching) across `app/` and manually triaged the ~386 reported pairs. Most were false positives (trivial one-line functions with coincidentally similar shape, or intentional shared-factory usage like `TimedMathGame`/`GameSpinnerScreen`). Two real findings, fixed here:

- **Page-template duplication**: `CreativePageClient`, `RiddlesPageClient`, and `ToolsPageClient` were byte-for-byte identical layouts (`Header` → hero section → `ContentTypeGrid` → `Footer`), differing only in gradient color, emoji, title, description, and the `contentType` prop. Extracted a shared `components/marketing/ContentTypePage.tsx` that all three now call with just their content.
- **formatTime duplicated 3x**: `memoryPureHelpers.ts`, `puzzleScoring.ts`, and `useDrawingGame.ts` each reimplemented an identical `M:SS` time formatter. Added `formatGameTime` to `lib/utils/game/gameUtils.ts` and had all three delegate to it (kept their original export names so no call sites changed). Left `app/games/timer/useTimer.ts`'s `formatTime` alone — it zero-pads minutes (`05:03` vs `5:03`), a genuine behavioral difference, not a duplicate.

Investigated and deliberately left alone: `BalloonHUD`/`WhackHUD` (already share the real duplicated piece, `TimerProgressBar`; the rest differs — hearts vs. combo badge), and all five route `loading.tsx` skeletons (decorative Suspense fallbacks with only superficial "rounded card + animate-pulse" resemblance; forcing one shared component would need more props than the four-line savings justify).

No behavior changes intended — pure dedup/refactor.

## Test plan
- [x] `npx tsc --noEmit` — zero errors
- [x] `npx eslint` on all touched files — zero errors/warnings
- [ ] Manually spin up `npm run dev` and check `/creative`, `/riddles`, `/tools` render with correct colors/copy, and that memory/puzzles/drawing games still show the right elapsed time

🤖 Generated with [Claude Code](https://claude.com/claude-code)