### PR TITLE
fix: migrate middleware to proxy and fix Sentry deprecation

### DIFF
--- a/gamesformykids/next.config.ts
+++ b/gamesformykids/next.config.ts
@@ -128,5 +128,9 @@ export default withSentryConfig(analyzed, {
   // Upload source maps only when SENTRY_AUTH_TOKEN is set (production CI/CD)
   authToken: process.env.SENTRY_AUTH_TOKEN ?? "",
   widenClientFileUpload: true,
-  disableLogger: true,
+  webpack: {
+    treeshake: {
+      removeDebugLogging: true,
+    },
+  },
 });

--- a/gamesformykids/proxy.ts
+++ b/gamesformykids/proxy.ts
@@ -67,7 +67,7 @@ export async function updateSession(request: NextRequest) {
   return supabaseResponse
 }
 
-export async function middleware(request: NextRequest) {
+export async function proxy(request: NextRequest) {
   return await updateSession(request)
 }
 


### PR DESCRIPTION
## Changes

- **middleware.ts → proxy.ts**: Rename per Next.js 16 convention. The \middleware\ file convention is deprecated; \proxy\ better reflects that this runs at the network edge. Export renamed from \middleware()\ to \proxy()\.

- **Sentry config**: Replace deprecated \disableLogger: true\ with \webpack.treeshake.removeDebugLogging: true\ per \@sentry/nextjs\ deprecation warning.

## Result

Both deprecation warnings that appeared on every production build are now gone:
- ~~\The 'middleware' file convention is deprecated\~~
- ~~\disableLogger is deprecated\~~

## Testing

- ✅ \
px tsc --noEmit\ — 0 errors
- ✅ \
px vitest run\ — 282/282 tests pass
- ✅ \
pm run build\ — 0 deprecation warnings