### PR TITLE
feat(gamification): show locked badges with unlock hint on profile

### DIFF
--- a/gamesformykids/app/profile/components/AchievementsList.tsx
+++ b/gamesformykids/app/profile/components/AchievementsList.tsx
@@ -1,4 +1,6 @@
+import { useAuth } from '@/hooks/shared/auth/useAuth';
 import { useAchievements } from '@/hooks';
+import { ACHIEVEMENT_DEFS, getLocalAchievementTypes } from '@/lib/utils/engagement/checkAchievements';
 
 function formatEarnedAt(iso: string): string {
   return new Date(iso).toLocaleDateString('he-IL', {
@@ -9,34 +11,46 @@ function formatEarnedAt(iso: string): string {
 }
 
 export function AchievementsList() {
+  const { user } = useAuth();
   const { achievements } = useAchievements();
+
+  const earnedAt = new Map(achievements.map((a) => [a.achievement_type, a.earned_at]));
+  const earnedTypes = user
+    ? new Set(achievements.map((a) => a.achievement_type))
+    : getLocalAchievementTypes();
+
   return (
     <div className="bg-white rounded-2xl shadow-lg p-6">
-      <h3 className="text-xl font-bold text-gray-800 mb-4">הישגים</h3>
-      {achievements.length > 0 ? (
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
-          {achievements.slice(0, 6).map((achievement) => (
+      <h3 className="text-xl font-bold text-gray-800 mb-4">
+        הישגים ({earnedTypes.size}/{ACHIEVEMENT_DEFS.length})
+      </h3>
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+        {ACHIEVEMENT_DEFS.map((def) => {
+          const unlocked = earnedTypes.has(def.type);
+          const date = earnedAt.get(def.type);
+          return (
             <div
-              key={achievement.id}
-              className="flex items-start gap-3 p-4 bg-linear-to-br from-yellow-50 to-amber-50 rounded-xl border border-amber-200 hover:border-amber-300 transition-colors"
+              key={def.type}
+              className={`flex items-start gap-3 p-4 rounded-xl border transition-colors ${
+                unlocked
+                  ? 'bg-linear-to-br from-yellow-50 to-amber-50 border-amber-200 hover:border-amber-300'
+                  : 'bg-gray-50 border-gray-200 grayscale opacity-70'
+              }`}
             >
-              <div className="text-3xl shrink-0">{achievement.icon ?? '🏅'}</div>
+              <div className="text-3xl shrink-0">{unlocked ? def.icon : '🔒'}</div>
               <div className="min-w-0">
-                <h4 className="font-semibold text-gray-800">{achievement.achievement_name}</h4>
-                {achievement.description && (
-                  <p className="text-sm text-gray-600 mt-0.5">{achievement.description}</p>
+                <h4 className="font-semibold text-gray-800">{def.name}</h4>
+                <p className="text-sm text-gray-600 mt-0.5">
+                  {unlocked ? def.description : def.hint}
+                </p>
+                {unlocked && date && (
+                  <p className="text-xs text-amber-500 mt-1">{formatEarnedAt(date)}</p>
                 )}
-                <p className="text-xs text-amber-500 mt-1">{formatEarnedAt(achievement.earned_at)}</p>
               </div>
             </div>
-          ))}
-        </div>
-      ) : (
-        <div className="text-center py-12">
-          <div className="text-5xl mb-3">🏅</div>
-          <p className="text-gray-500">עדיין אין הישגים. שחק כדי לזכות בהישגים!</p>
-        </div>
-      )}
+          );
+        })}
+      </div>
     </div>
   );
 }

--- a/gamesformykids/lib/utils/engagement/checkAchievements.ts
+++ b/gamesformykids/lib/utils/engagement/checkAchievements.ts
@@ -7,6 +7,8 @@ export interface AchievementDef {
   description: string;
   /** gameType stored on the Supabase row (empty string for cross-game achievements) */
   gameType: string;
+  /** Shown instead of `description` while the badge is still locked. */
+  hint: string;
 }
 
 const LOCAL_KEY = 'gfk_achievements_local';
@@ -58,6 +60,7 @@ const SPECS: AchievementSpec[] = [
     name: 'משחקן ראשון',
     icon: '🎮',
     description: 'סיימת את המשחק הראשון שלך!',
+    hint: 'סיים משחק אחד',
     gameType: '',
     check: (sessions) => sessions.length >= 1,
   },
@@ -66,6 +69,7 @@ const SPECS: AchievementSpec[] = [
     name: 'עשרה משחקים',
     icon: '🔟',
     description: 'שיחקת ב-10 משחקים שונים!',
+    hint: 'שחק ב-10 משחקים שונים',
     gameType: '',
     check: (sessions) => uniqueGameTypes(sessions).size >= 10,
   },
@@ -74,6 +78,7 @@ const SPECS: AchievementSpec[] = [
     name: 'מושלם!',
     icon: '🎯',
     description: 'דיוק מושלם — כל התשובות נכונות!',
+    hint: 'ענה נכון על כל השאלות בסבב (לפחות 5)',
     gameType: '',
     check: (_sessions, newSession) =>
       newSession.totalAnswers >= 5 &&
@@ -84,6 +89,7 @@ const SPECS: AchievementSpec[] = [
     name: 'מומחה חיות',
     icon: '🦁',
     description: 'שיחקת במשחק החיות 3 פעמים!',
+    hint: 'שחק במשחק החיות 3 פעמים',
     gameType: 'animals',
     check: (sessions) =>
       sessions.filter((s) => String(s.gameType) === 'animals').length >= 3,
@@ -93,6 +99,7 @@ const SPECS: AchievementSpec[] = [
     name: 'מחשבון',
     icon: '➕',
     description: 'השגת דיוק מעל 80% במתמטיקה!',
+    hint: 'השג דיוק מעל 80% במשחק המתמטיקה',
     gameType: 'math',
     check: (_sessions, newSession) =>
       String(newSession.gameType) === 'math' &&
@@ -104,6 +111,7 @@ const SPECS: AchievementSpec[] = [
     name: 'כוכב',
     icon: '⭐',
     description: 'השלמת 10 סשנים של משחק!',
+    hint: 'השלם 10 סבבי משחק',
     gameType: '',
     check: (sessions) => sessions.length >= 10,
   },
@@ -112,6 +120,7 @@ const SPECS: AchievementSpec[] = [
     name: 'גיאוגרף',
     icon: '🌍',
     description: 'שיחקת ב-3 משחקי גאוגרפיה!',
+    hint: 'שחק ב-3 משחקי גאוגרפיה שונים',
     gameType: '',
     check: (sessions) => {
       const geoGames = ['flags', 'capitals', 'continents', 'israel'];
@@ -124,6 +133,7 @@ const SPECS: AchievementSpec[] = [
     name: 'אלוף הספירה',
     icon: '🏆',
     description: 'דיוק מושלם בספירה!',
+    hint: 'ענה נכון על כל השאלות במשחק הספירה (לפחות 5)',
     gameType: 'counting',
     check: (_sessions, newSession) =>
       String(newSession.gameType) === 'counting' &&
@@ -135,6 +145,7 @@ const SPECS: AchievementSpec[] = [
     name: 'קורא',
     icon: '📚',
     description: 'שיחקת במשחקי שפה!',
+    hint: 'שחק ב-2 ממשחקי השפה (אותיות, פונטיקה, חריזה)',
     gameType: '',
     check: (sessions) => {
       const langGames = ['letters', 'phonics', 'rhyming'];
@@ -147,10 +158,16 @@ const SPECS: AchievementSpec[] = [
     name: 'בוער!',
     icon: '🔥',
     description: '5 ימים של משחק ברציפות!',
+    hint: 'שחק 5 ימים ברציפות',
     gameType: '',
     check: () => getStreakCount() >= 5,
   },
 ];
+
+/** Metadata for every possible badge (locked + unlocked), for rendering a full badges screen. */
+export const ACHIEVEMENT_DEFS: AchievementDef[] = SPECS.map(
+  ({ type, name, icon, description, gameType, hint }) => ({ type, name, icon, description, gameType, hint }),
+);
 
 /**
  * Returns the list of newly unlocked achievements given the full session history
@@ -171,6 +188,7 @@ export function checkAchievements(
         icon: spec.icon,
         description: spec.description,
         gameType: spec.gameType,
+        hint: spec.hint,
       });
     }
   }


### PR DESCRIPTION
## Summary
- `AchievementsList` on `/profile` now renders **all 10 badges** (not just earned ones) — unlocked badges keep their full description + earned date, locked ones render greyed out with a 🔒 icon and a hint describing how to unlock them.
- Added a `hint` field to every entry in `checkAchievements.ts` and exported `ACHIEVEMENT_DEFS` (metadata for all badges, no check functions) so the UI can render the full catalogue independent of what's been earned.
- Header now shows progress as `הישגים (X/10)`.

Closes #1399

## Context
Investigated the full engagement-features backlog (#1390–#1400): 8 of the 9 open issues turned out to already be shipped in the codebase (mastery stars, streak badge, daily challenge, recently-played row, PWA install banner, surprise-me button, replay-audio button, and the study-first learn-mode carousel) — those were closed with links to the implementing code. #1399 (badges) was the only one with a real gap: the achievement-checking engine, toasts, and earned-badges list already existed, but there was no way to see *locked* badges or what unlocks them.

Note: `/profile` (and `/dashboard`) currently require login, so this screen is only reachable for authenticated users — guest-mode users still only get the toast notification when they earn a badge. That's a pre-existing limitation, not introduced by this PR; flagged separately for a possible follow-up issue.

## Test plan
- [x] `npx tsc --noEmit` — zero errors
- [x] `npm run build` — zero errors, 486 pages generated
- [x] Verified `/profile` and `/` return 200 on local dev server
- [ ] Manually sign in and check the profile page renders 10 badges (locked grey / unlocked color) — recommend a quick look before merge since the auth-gated screen wasn't visually verified live

🤖 Generated with [Claude Code](https://claude.com/claude-code)