### PR TITLE
feat(accessibility): dyslexia-friendly reading mode toggle

### DIFF
--- a/gamesformykids/app/globals.css
+++ b/gamesformykids/app/globals.css
@@ -464,3 +464,14 @@ body {
   transition-duration: 0.01ms !important;
   scroll-behavior: auto !important;
 }
+
+/* ═══════════════════════════════════════════════════════
+   Dyslexia-friendly reading mode
+   Wider letter/line spacing + a plainer font for easier reading.
+   Activated by [data-dyslexia-mode] on <html>
+   ═══════════════════════════════════════════════════════ */
+[data-dyslexia-mode="true"] {
+  letter-spacing: 0.04em;
+  line-height: 1.7;
+  font-family: Verdana, Tahoma, Arial, sans-serif;
+}

--- a/gamesformykids/app/settings/SettingsClient.tsx
+++ b/gamesformykids/app/settings/SettingsClient.tsx
@@ -8,6 +8,7 @@ import { AudioSection } from '@/components/settings/AudioSection';
 import { AppearanceSection } from '@/components/settings/AppearanceSection';
 import { AccountSection } from '@/components/settings/AccountSection';
 import { ColorblindSection } from '@/components/settings/ColorblindSection';
+import { DyslexiaSection } from '@/components/settings/DyslexiaSection';
 import { AvatarSection } from '@/components/settings/AvatarSection';
 import { ScreenTimeSection } from '@/components/settings/ScreenTimeSection';
 import { AgeFilterSection } from '@/components/settings/AgeFilterSection';
@@ -77,6 +78,7 @@ export default function SettingsClient() {
             disabled={saving}
           />
           <ColorblindSection />
+          <DyslexiaSection />
           <SoundThemeSection />
           <AvatarSection />
           <AgeFilterSection />

--- a/gamesformykids/components/settings/DyslexiaSection.tsx
+++ b/gamesformykids/components/settings/DyslexiaSection.tsx
@@ -1,0 +1,54 @@
+'use client';
+import { useState, useEffect } from 'react';
+import { SectionContainer } from './SectionContainer';
+
+const DYSLEXIA_KEY = 'gfk_dyslexia_mode';
+
+function Toggle({ enabled, onToggle, label }: { enabled: boolean; onToggle: () => void; label: string }) {
+  return (
+    <button
+      onClick={onToggle}
+      role="switch"
+      aria-checked={enabled}
+      aria-label={label}
+      className={`relative w-12 h-6 rounded-full transition-colors ${enabled ? 'bg-blue-500' : 'bg-gray-300'}`}
+    >
+      <span
+        className={`absolute top-0.5 w-5 h-5 bg-white rounded-full shadow transition-transform ${enabled ? 'translate-x-6' : 'translate-x-0.5'}`}
+      />
+    </button>
+  );
+}
+
+export function DyslexiaSection() {
+  const [dyslexiaMode, setDyslexiaMode] = useState(false);
+
+  useEffect(() => {
+    try {
+      const dm = localStorage.getItem(DYSLEXIA_KEY) === 'true';
+      setDyslexiaMode(dm);
+      document.documentElement.dataset.dyslexiaMode = dm ? 'true' : '';
+    } catch {}
+  }, []);
+
+  const toggleDyslexiaMode = () => {
+    const next = !dyslexiaMode;
+    setDyslexiaMode(next);
+    try {
+      if (next) { localStorage.setItem(DYSLEXIA_KEY, 'true'); document.documentElement.dataset.dyslexiaMode = 'true'; }
+      else { localStorage.removeItem(DYSLEXIA_KEY); document.documentElement.dataset.dyslexiaMode = ''; }
+    } catch {}
+  };
+
+  return (
+    <SectionContainer title="קריאה נגישה" emoji="📖">
+      <div className="flex items-center justify-between p-3 bg-white rounded-xl border border-gray-200">
+        <div>
+          <p className="font-medium text-gray-800">מצב קריאה לדיסלקציה 🔤</p>
+          <p className="text-sm text-gray-500">מגדיל מרווח בין אותיות ושורות ומקל על קריאת טקסט במשחקים</p>
+        </div>
+        <Toggle enabled={dyslexiaMode} onToggle={toggleDyslexiaMode} label="הפעל מצב קריאה לדיסלקציה" />
+      </div>
+    </SectionContainer>
+  );
+}


### PR DESCRIPTION
## Summary
- Adds `DyslexiaSection.tsx` to Settings, following the same `useState` + `localStorage` + `document.documentElement.dataset` pattern as the existing `ColorblindSection.tsx`.
- New `[data-dyslexia-mode="true"]` CSS rule in `globals.css` widens letter-spacing/line-height and swaps to a plainer font, inherited globally from `<html>`.

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npx eslint` on changed files passes
- [x] `npm run build` passes
- [ ] Manually toggle the setting at `/settings` and confirm text spacing changes across a text-heavy game (e.g. riddles)

Closes #1431