### PR TITLE
feat(accessibility): high-contrast mode toggle

### DIFF
--- a/gamesformykids/app/globals.css
+++ b/gamesformykids/app/globals.css
@@ -464,3 +464,24 @@ body {
   transition-duration: 0.01ms !important;
   scroll-behavior: auto !important;
 }
+
+/* ═══════════════════════════════════════════════════════
+   High-contrast mode — for low-vision users
+   Activated by [data-high-contrast] on <html>
+   ═══════════════════════════════════════════════════════ */
+[data-high-contrast="true"] body {
+  background: #ffffff !important;
+  color: #000000 !important;
+}
+
+[data-high-contrast="true"] button,
+[data-high-contrast="true"] a,
+[data-high-contrast="true"] [role="button"] {
+  outline: 2px solid #000000 !important;
+  outline-offset: 2px;
+}
+
+[data-high-contrast="true"] [class*="bg-gradient-to-"],
+[data-high-contrast="true"] [style*="linear-gradient"] {
+  filter: contrast(1.3) saturate(1.2);
+}

--- a/gamesformykids/components/settings/ColorblindSection.tsx
+++ b/gamesformykids/components/settings/ColorblindSection.tsx
@@ -4,6 +4,7 @@ import { SectionContainer } from './SectionContainer';
 
 const CB_KEY = 'gfk_colorblind';
 const RM_KEY = 'gfk_reduced_motion';
+const HC_KEY = 'gfk_high_contrast';
 
 function Toggle({ enabled, onToggle, label }: { enabled: boolean; onToggle: () => void; label: string }) {
   return (
@@ -24,6 +25,7 @@ function Toggle({ enabled, onToggle, label }: { enabled: boolean; onToggle: () =
 export function ColorblindSection() {
   const [colorblind, setColorblind] = useState(false);
   const [reducedMotion, setReducedMotion] = useState(false);
+  const [highContrast, setHighContrast] = useState(false);
 
   useEffect(() => {
     try {
@@ -35,6 +37,10 @@ export function ColorblindSection() {
       const rm = localStorage.getItem(RM_KEY) === 'true' || osReducedMotion;
       setReducedMotion(rm);
       document.documentElement.dataset.reducedMotion = rm ? 'true' : '';
+
+      const hc = localStorage.getItem(HC_KEY) === 'true';
+      setHighContrast(hc);
+      document.documentElement.dataset.highContrast = hc ? 'true' : '';
     } catch {}
   }, []);
 
@@ -56,6 +62,15 @@ export function ColorblindSection() {
     } catch {}
   };
 
+  const toggleHighContrast = () => {
+    const next = !highContrast;
+    setHighContrast(next);
+    try {
+      if (next) { localStorage.setItem(HC_KEY, 'true'); document.documentElement.dataset.highContrast = 'true'; }
+      else { localStorage.removeItem(HC_KEY); document.documentElement.dataset.highContrast = ''; }
+    } catch {}
+  };
+
   return (
     <SectionContainer title="נגישות" emoji="♿">
       <div className="space-y-3">
@@ -72,6 +87,13 @@ export function ColorblindSection() {
             <p className="text-sm text-gray-500">מבטל אנימציות ומעברים (מומלץ לרגישות חושית ו-ADHD)</p>
           </div>
           <Toggle enabled={reducedMotion} onToggle={toggleReducedMotion} label="הפחת תנועה" />
+        </div>
+        <div className="flex items-center justify-between p-3 bg-white rounded-xl border border-gray-200">
+          <div>
+            <p className="font-medium text-gray-800">ניגודיות גבוהה ⬛⬜</p>
+            <p className="text-sm text-gray-500">מגביר ניגודיות רקע/טקסט ומדגיש מסגרות סביב כפתורים וכרטיסים</p>
+          </div>
+          <Toggle enabled={highContrast} onToggle={toggleHighContrast} label="הפעל ניגודיות גבוהה" />
         </div>
       </div>
     </SectionContainer>


### PR DESCRIPTION
## Summary
- Extends the existing `ColorblindSection.tsx` accessibility panel with a third toggle for high-contrast mode, targeting low-vision users (distinct from the existing colorblind-palette toggle).
- New `[data-high-contrast="true"]` CSS rules: pure black/white body, bold outlines on interactive elements, boosted gradient contrast.

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npx eslint` on changed files passes
- [x] `npm run build` passes
- [ ] Manually toggle the setting at `/settings` and confirm contrast changes across a game screen

Closes #1432