### PR TITLE
feat(dashboard): weekly insight card — category strength/weakness

### DIFF
--- a/gamesformykids/app/dashboard/DashboardClient.tsx
+++ b/gamesformykids/app/dashboard/DashboardClient.tsx
@@ -4,6 +4,7 @@ import { useAuth } from '@/hooks/shared/auth/useAuth';
 import Link from 'next/link';
 import { DashboardHeader } from './components/DashboardHeader';
 import { ActivitySummaryCard } from './components/ActivitySummaryCard';
+import { WeeklyInsightCard } from './components/WeeklyInsightCard';
 import { MostPlayedCard } from './components/MostPlayedCard';
 import { ScoreSummaryCard } from './components/ScoreSummaryCard';
 import { RecentAchievementsCard } from './components/RecentAchievementsCard';
@@ -48,6 +49,7 @@ export default function DashboardClient() {
         <div className="space-y-6">
           <ActivitySummaryCard />
           <div className="grid md:grid-cols-2 gap-6">
+            <WeeklyInsightCard />
             <MostPlayedCard />
             <ScoreSummaryCard />
             <ScoreHistoryCard />

--- a/gamesformykids/app/dashboard/components/WeeklyInsightCard.tsx
+++ b/gamesformykids/app/dashboard/components/WeeklyInsightCard.tsx
@@ -1,0 +1,55 @@
+'use client';
+
+import Link from 'next/link';
+import { useWeeklyInsight } from '@/hooks/shared/progress/useWeeklyInsight';
+import { getGameLabel } from './gameLabels';
+
+export function WeeklyInsightCard() {
+  const insight = useWeeklyInsight();
+
+  if (!insight) {
+    return (
+      <div className="bg-gradient-to-br from-indigo-100 to-blue-100 rounded-2xl shadow-md p-6 col-span-2">
+        <h2 className="text-lg font-bold text-gray-800 mb-2">🗓️ השבוע שהיה</h2>
+        <p className="text-gray-500 text-sm">שחקו השבוע כדי לראות תובנות לפי נושא!</p>
+      </div>
+    );
+  }
+
+  const { strongest, weakest, recommendedGameId, gamesPlayedThisWeek } = insight;
+  const sameCategory = strongest.categoryKey === weakest.categoryKey;
+  const { name: recommendedName, emoji: recommendedEmoji } = getGameLabel(recommendedGameId);
+
+  return (
+    <div className="bg-gradient-to-br from-indigo-100 to-blue-100 rounded-2xl shadow-md p-6 col-span-2">
+      <h2 className="text-lg font-bold text-gray-800 mb-1">🗓️ השבוע שהיה</h2>
+      <p className="text-xs text-gray-500 mb-4">{gamesPlayedThisWeek} משחקים השבוע</p>
+
+      {sameCategory ? (
+        <div className="bg-white/70 rounded-xl p-4">
+          <p className="font-semibold text-gray-800">🎯 {strongest.title}</p>
+          <p className="text-sm text-gray-600 mt-1">דיוק ממוצע: {strongest.accuracy}%</p>
+        </div>
+      ) : (
+        <div className="grid sm:grid-cols-2 gap-3">
+          <div className="bg-white/70 rounded-xl p-4">
+            <p className="font-semibold text-gray-800">🏆 החזקה השבוע</p>
+            <p className="text-sm text-gray-600 mt-1">{strongest.title} — {strongest.accuracy}% דיוק</p>
+          </div>
+          <div className="bg-white/70 rounded-xl p-4">
+            <p className="font-semibold text-gray-800">💪 כדאי לתרגל</p>
+            <p className="text-sm text-gray-600 mt-1">{weakest.title} — {weakest.accuracy}% דיוק</p>
+          </div>
+        </div>
+      )}
+
+      <Link
+        href={`/games/${recommendedGameId}`}
+        className="mt-4 flex items-center justify-between bg-white hover:bg-indigo-50 transition-colors rounded-xl p-3"
+      >
+        <span className="text-sm font-medium text-gray-700">{recommendedEmoji} תרגלו: {recommendedName}</span>
+        <span className="text-indigo-600 font-bold">←</span>
+      </Link>
+    </div>
+  );
+}

--- a/gamesformykids/hooks/shared/progress/useWeeklyInsight.ts
+++ b/gamesformykids/hooks/shared/progress/useWeeklyInsight.ts
@@ -1,0 +1,66 @@
+'use client';
+import { useMemo } from 'react';
+import { useProgressTrackingStore } from '@/lib/stores/progressTrackingStore';
+import { GAME_CATEGORIES } from '@/lib/constants/gameCategories';
+
+const SEVEN_DAYS_MS = 7 * 24 * 60 * 60 * 1000;
+
+export interface CategoryAccuracy {
+  categoryKey: string;
+  title: string;
+  accuracy: number;
+  sessionCount: number;
+}
+
+export interface WeeklyInsight {
+  categories: CategoryAccuracy[];
+  strongest: CategoryAccuracy;
+  weakest: CategoryAccuracy;
+  recommendedGameId: string;
+  gamesPlayedThisWeek: number;
+}
+
+function findCategoryKey(gameType: string): string | undefined {
+  return Object.entries(GAME_CATEGORIES).find(([, cat]) => cat.gameIds.includes(gameType))?.[0];
+}
+
+/** Aggregates this week's sessions into per-category accuracy, surfacing the strongest and weakest categories. */
+export function useWeeklyInsight(): WeeklyInsight | null {
+  const allSessions = useProgressTrackingStore((s) => s.allSessions);
+
+  return useMemo(() => {
+    const now = Date.now();
+    // session.accuracy is not reliably populated on save — derive from correct/total answers instead.
+    const weekSessions = allSessions.filter(
+      (s) => now - new Date(s.startTime).getTime() < SEVEN_DAYS_MS && s.totalAnswers > 0,
+    );
+    if (weekSessions.length === 0) return null;
+
+    const byCategory: Record<string, { correct: number; total: number; sessionCount: number }> = {};
+    for (const session of weekSessions) {
+      const categoryKey = findCategoryKey(session.gameType as string);
+      if (!categoryKey) continue;
+      const entry = byCategory[categoryKey] ?? { correct: 0, total: 0, sessionCount: 0 };
+      entry.correct += session.correctAnswers;
+      entry.total += session.totalAnswers;
+      entry.sessionCount += 1;
+      byCategory[categoryKey] = entry;
+    }
+
+    const categories: CategoryAccuracy[] = Object.entries(byCategory).map(
+      ([categoryKey, { correct, total, sessionCount }]) => ({
+        categoryKey,
+        title: GAME_CATEGORIES[categoryKey]!.title,
+        accuracy: total > 0 ? Math.round((correct / total) * 100) : 0,
+        sessionCount,
+      }),
+    );
+    if (categories.length === 0) return null;
+
+    const strongest = categories.reduce((best, c) => (c.accuracy > best.accuracy ? c : best), categories[0]!);
+    const weakest = categories.reduce((worst, c) => (c.accuracy < worst.accuracy ? c : worst), categories[0]!);
+    const recommendedGameId = GAME_CATEGORIES[weakest.categoryKey]!.gameIds[0]!;
+
+    return { categories, strongest, weakest, recommendedGameId, gamesPlayedThisWeek: weekSessions.length };
+  }, [allSessions]);
+}


### PR DESCRIPTION
## Summary
- New `useWeeklyInsight` hook (`hooks/shared/progress/`) aggregates the last 7 days of `useProgressTrackingStore` sessions into per-category accuracy using `GAME_CATEGORIES`, and surfaces the strongest/weakest category plus a recommended game to practice.
- New `WeeklyInsightCard.tsx` in `app/dashboard/components/`, added to `DashboardClient.tsx`'s card grid.
- Found and worked around a pre-existing bug: `GameSession.accuracy` is never actually updated after session start (stays 0) — see `useSessionStats.ts` `endSession`, which computes accuracy locally but never writes it back onto the saved session. Accuracy here is derived directly from `correctAnswers`/`totalAnswers` instead of trusting the stored field. Did not fix the underlying bug since it's out of scope for this issue.

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npx eslint` on changed files passes
- [x] `npm test -- --run` passes (340/340)
- [x] `npm run build` passes
- [ ] Manually play a few games across categories and confirm the card shows sensible strongest/weakest breakdown at `/dashboard`

Closes #1429