### PR TITLE
feat(discovery): guided learning paths — curated game sequences

### DIFF
--- a/gamesformykids/app/learning-paths/LearningPathsPageClient.tsx
+++ b/gamesformykids/app/learning-paths/LearningPathsPageClient.tsx
@@ -1,0 +1,50 @@
+'use client';
+
+import Link from 'next/link';
+import { LEARNING_PATHS, type LearningPath } from '@/lib/constants/learningPaths';
+import { useLearningPathProgress } from '@/hooks/shared/progress/useLearningPathProgress';
+
+function LearningPathCard({ path }: { path: LearningPath }) {
+  const { completedCount, totalCount } = useLearningPathProgress(path);
+  const percent = Math.round((completedCount / totalCount) * 100);
+
+  return (
+    <Link
+      href={`/learning-paths/${path.id}`}
+      className="block bg-white rounded-2xl shadow-md hover:shadow-lg transition-shadow p-6"
+    >
+      <div className="text-4xl mb-2">{path.emoji}</div>
+      <h2 className="text-lg font-bold text-gray-800 mb-1">{path.title}</h2>
+      <p className="text-sm text-gray-500 mb-4">{path.description}</p>
+      <div className="w-full bg-gray-100 rounded-full h-2 mb-1">
+        <div
+          className="bg-indigo-500 h-2 rounded-full transition-all"
+          style={{ width: `${percent}%` }}
+        />
+      </div>
+      <p className="text-xs text-gray-400">{completedCount}/{totalCount} הושלמו</p>
+    </Link>
+  );
+}
+
+export default function LearningPathsPageClient() {
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-indigo-50 via-blue-50 to-purple-50 p-4">
+      <div className="max-w-4xl mx-auto">
+        <div className="text-center mb-8">
+          <Link href="/" className="inline-flex items-center text-indigo-600 hover:text-indigo-800 mb-4">
+            → חזור לדף הבית
+          </Link>
+          <h1 className="text-3xl font-bold text-indigo-800 mb-2">🗺️ מסלולי למידה</h1>
+          <p className="text-gray-600">רצף משחקים מומלץ סביב נושא — שלב אחרי שלב</p>
+        </div>
+
+        <div className="grid sm:grid-cols-2 gap-4">
+          {LEARNING_PATHS.map((path) => (
+            <LearningPathCard key={path.id} path={path} />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/gamesformykids/app/learning-paths/[pathId]/LearningPathDetailClient.tsx
+++ b/gamesformykids/app/learning-paths/[pathId]/LearningPathDetailClient.tsx
@@ -1,0 +1,85 @@
+'use client';
+
+import { useMemo } from 'react';
+import Link from 'next/link';
+import { getLearningPath } from '@/lib/constants/learningPaths';
+import { useLearningPathProgress } from '@/hooks/shared/progress/useLearningPathProgress';
+import { GamesRegistry } from '@/lib/registry/gamesRegistry';
+
+interface Props {
+  pathId: string;
+}
+
+export default function LearningPathDetailClient({ pathId }: Props) {
+  const path = getLearningPath(pathId);
+  const gameLabelById = useMemo(() => {
+    const map = new Map<string, { title: string; emoji: string }>();
+    for (const g of GamesRegistry.getAllGameRegistrations()) {
+      map.set(g.id, { title: g.title, emoji: g.emoji });
+    }
+    return map;
+  }, []);
+
+  const { completedGameIds, completedCount, totalCount, nextGameId } = useLearningPathProgress(path);
+
+  // path existence is already validated server-side (notFound() in page.tsx)
+  if (!path) return null;
+
+  const isPathComplete = completedCount === totalCount;
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-indigo-50 via-blue-50 to-purple-50 p-4">
+      <div className="max-w-2xl mx-auto">
+        <div className="text-center mb-8">
+          <Link href="/learning-paths" className="inline-flex items-center text-indigo-600 hover:text-indigo-800 mb-4">
+            → כל המסלולים
+          </Link>
+          <div className="text-5xl mb-2">{path.emoji}</div>
+          <h1 className="text-3xl font-bold text-indigo-800 mb-2">{path.title}</h1>
+          <p className="text-gray-600">{path.description}</p>
+        </div>
+
+        {isPathComplete ? (
+          <div className="bg-green-50 border border-green-200 rounded-2xl p-6 text-center mb-6">
+            <p className="text-4xl mb-2">🎉</p>
+            <p className="font-bold text-green-800">סיימתם את כל המסלול!</p>
+          </div>
+        ) : (
+          nextGameId && (
+            <Link
+              href={`/games/${nextGameId}`}
+              className="block bg-indigo-600 hover:bg-indigo-700 text-white font-bold text-center py-3 px-6 rounded-xl transition-colors mb-6"
+            >
+              ▶️ המשחק הבא: {gameLabelById.get(nextGameId)?.title ?? nextGameId}
+            </Link>
+          )
+        )}
+
+        <p className="text-sm text-gray-500 text-center mb-4">{completedCount}/{totalCount} הושלמו</p>
+
+        <ol className="space-y-3">
+          {path.gameIds.map((gameId, index) => {
+            const isDone = completedGameIds.has(gameId);
+            const label = gameLabelById.get(gameId);
+            return (
+              <li key={gameId}>
+                <Link
+                  href={`/games/${gameId}`}
+                  className={`flex items-center gap-3 rounded-xl border p-4 transition-colors ${
+                    isDone
+                      ? 'bg-green-50 border-green-200'
+                      : 'bg-white border-gray-200 hover:border-indigo-200'
+                  }`}
+                >
+                  <span className="text-2xl w-8 text-center">{isDone ? '✅' : index + 1}</span>
+                  <span className="text-2xl">{label?.emoji ?? '🎮'}</span>
+                  <span className="font-medium text-gray-800">{label?.title ?? gameId}</span>
+                </Link>
+              </li>
+            );
+          })}
+        </ol>
+      </div>
+    </div>
+  );
+}

--- a/gamesformykids/app/learning-paths/[pathId]/page.tsx
+++ b/gamesformykids/app/learning-paths/[pathId]/page.tsx
@@ -1,0 +1,29 @@
+import type { Metadata } from 'next';
+import { notFound } from 'next/navigation';
+import { LEARNING_PATHS, getLearningPath } from '@/lib/constants/learningPaths';
+import LearningPathDetailClient from './LearningPathDetailClient';
+
+interface Props {
+  params: Promise<{ pathId: string }>;
+}
+
+export function generateStaticParams() {
+  return LEARNING_PATHS.map((path) => ({ pathId: path.id }));
+}
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { pathId } = await params;
+  const path = getLearningPath(pathId);
+  if (!path) return {};
+  return {
+    title: `${path.title} | מסלולי למידה | GamesForMyKids`,
+    description: path.description,
+  };
+}
+
+export default async function LearningPathDetailPage({ params }: Props) {
+  const { pathId } = await params;
+  const path = getLearningPath(pathId);
+  if (!path) notFound();
+  return <LearningPathDetailClient pathId={pathId} />;
+}

--- a/gamesformykids/app/learning-paths/page.tsx
+++ b/gamesformykids/app/learning-paths/page.tsx
@@ -1,0 +1,12 @@
+import type { Metadata } from 'next';
+import LearningPathsPageClient from './LearningPathsPageClient';
+
+export const metadata: Metadata = {
+  title: 'מסלולי למידה | GamesForMyKids',
+  description: 'רצפי משחקים מומלצים סביב נושא — אותיות, מספרים, טבע וזמן',
+  keywords: 'מסלולי למידה, תוכנית לימודים, משחקים לילדים, למידה מודרכת',
+};
+
+export default function LearningPathsPage() {
+  return <LearningPathsPageClient />;
+}

--- a/gamesformykids/components/layout/Footer.tsx
+++ b/gamesformykids/components/layout/Footer.tsx
@@ -49,10 +49,11 @@ function Footer() {
 
           {/* Section links */}
           <div className="flex flex-wrap justify-center gap-3 md:gap-5 text-sm mt-5 md:mt-6">
-            <Link href="/tools"    className="text-teal-600 hover:text-teal-800 font-medium transition-colors">🎲 כלי כיתה</Link>
-            <Link href="/creative" className="text-purple-600 hover:text-purple-800 font-medium transition-colors">🎨 יצירה</Link>
-            <Link href="/riddles"  className="text-orange-600 hover:text-orange-800 font-medium transition-colors">🤣 חידות</Link>
-            <Link href="/"         className="text-blue-600 hover:text-blue-800 font-medium transition-colors">🎮 משחקים</Link>
+            <Link href="/tools"          className="text-teal-600 hover:text-teal-800 font-medium transition-colors">🎲 כלי כיתה</Link>
+            <Link href="/creative"       className="text-purple-600 hover:text-purple-800 font-medium transition-colors">🎨 יצירה</Link>
+            <Link href="/riddles"        className="text-orange-600 hover:text-orange-800 font-medium transition-colors">🤣 חידות</Link>
+            <Link href="/learning-paths" className="text-indigo-600 hover:text-indigo-800 font-medium transition-colors">🗺️ מסלולי למידה</Link>
+            <Link href="/"               className="text-blue-600 hover:text-blue-800 font-medium transition-colors">🎮 משחקים</Link>
           </div>
           
           {/* Developer credit */}

--- a/gamesformykids/hooks/shared/progress/useLearningPathProgress.ts
+++ b/gamesformykids/hooks/shared/progress/useLearningPathProgress.ts
@@ -1,0 +1,37 @@
+'use client';
+import { useMemo } from 'react';
+import { useProgressTrackingStore } from '@/lib/stores/progressTrackingStore';
+import type { LearningPath } from '@/lib/constants/learningPaths';
+
+const MASTERY_THRESHOLD = 0.7;
+
+export interface LearningPathProgress {
+  completedGameIds: Set<string>;
+  completedCount: number;
+  totalCount: number;
+  /** First not-yet-mastered gameId in path order, or null once the whole path is complete. */
+  nextGameId: string | null;
+}
+
+/** A game counts as mastered for a path once any session hit >=70% accuracy — same bar as the daily-challenge badge. */
+export function useLearningPathProgress(path: LearningPath | undefined): LearningPathProgress {
+  const allSessions = useProgressTrackingStore((s) => s.allSessions);
+
+  return useMemo(() => {
+    if (!path) return { completedGameIds: new Set<string>(), completedCount: 0, totalCount: 0, nextGameId: null };
+    const completedGameIds = new Set<string>();
+    for (const gameId of path.gameIds) {
+      const mastered = allSessions.some(
+        (s) => s.gameType === gameId && s.totalAnswers > 0 && s.correctAnswers / s.totalAnswers >= MASTERY_THRESHOLD,
+      );
+      if (mastered) completedGameIds.add(gameId);
+    }
+    const nextGameId = path.gameIds.find((id) => !completedGameIds.has(id)) ?? null;
+    return {
+      completedGameIds,
+      completedCount: completedGameIds.size,
+      totalCount: path.gameIds.length,
+      nextGameId,
+    };
+  }, [allSessions, path]);
+}

--- a/gamesformykids/lib/constants/learningPaths.ts
+++ b/gamesformykids/lib/constants/learningPaths.ts
@@ -1,0 +1,51 @@
+import type { GameType } from '@/lib/types/core/base';
+
+export interface LearningPath {
+  id: string;
+  title: string;
+  emoji: string;
+  description: string;
+  gameIds: GameType[];
+}
+
+export const LEARNING_PATHS: LearningPath[] = [
+  {
+    id: 'letters-week',
+    title: 'שבוע האותיות',
+    emoji: '🔤',
+    description: 'מסע מודרך להכרת האותיות העבריות — מזיהוי ועד קריאה',
+    gameIds: ['letters', 'hebrew-letters', 'letter-trace', 'alphabet-order', 'final-letters'],
+  },
+  {
+    id: 'numbers-week',
+    title: 'שבוע המספרים',
+    emoji: '🔢',
+    description: 'מספירה בסיסית ועד תרגילי חשבון ראשונים',
+    gameIds: ['numbers', 'counting', 'math', 'arithmetic', 'sequences'],
+  },
+  {
+    id: 'nature-week',
+    title: 'שבוע הטבע',
+    emoji: '🌿',
+    description: 'הכירו בעלי חיים, פירות וירקות ויצורי הים',
+    gameIds: ['animals', 'fruits', 'vegetables', 'ocean-life', 'dinosaurs'],
+  },
+  {
+    id: 'time-week',
+    title: 'שבוע הזמן',
+    emoji: '🗓️',
+    description: 'שעון, ימות השבוע, חודשי השנה ועונות',
+    gameIds: ['time-clock', 'days-of-week', 'months-of-year', 'seasons-holidays'],
+  },
+  {
+    id: 'colors-shapes-week',
+    title: 'שבוע הצבעים והצורות',
+    emoji: '🎨',
+    description: 'זיהוי צבעים, צורות דו-ממדיות ותלת-ממדיות',
+    gameIds: ['colors', 'shapes', 'colored-shapes', 'advanced-colors', 'shapes-3d'],
+  },
+];
+
+export function getLearningPath(pathId: string): LearningPath | undefined {
+  return LEARNING_PATHS.find((p) => p.id === pathId);
+}


### PR DESCRIPTION
## Summary
- New `lib/constants/learningPaths.ts` — 5 curated `LearningPath` sequences (letters, numbers, nature, time, colors/shapes), built entirely from `GameType` ids verified against `SUPPORTED_GAMES`.
- New `/learning-paths` (list) and `/learning-paths/[pathId]` (detail, with `generateStaticParams`) routes, following the `app/championship/[categoryId]` pattern for the dynamic route.
- New `useLearningPathProgress` hook (`hooks/shared/progress/`) computes per-path completion.
- Footer link (`components/layout/Footer.tsx`) for home-page discoverability, alongside the existing `/tools`, `/creative`, `/riddles` links.

## Design deviation from the issue
The issue suggested using `useGameProgress` (Supabase-backed) for completion tracking. `useGameProgress` returns nothing until a user is logged in (`if (!user) return`), which would make progress tracking non-functional in guest mode — a core supported mode per the README ("app runs fully without Supabase credentials"). Instead, completion is derived from `useProgressTrackingStore.allSessions` (localStorage, already used by `ScoreHistoryCard`/`useCategoryProgress` without auth), marking a game "mastered" once any session hits ≥70% accuracy — the same bar the daily-challenge badge uses.

Also worth flagging: while building this I found `GameSession.accuracy` is never actually populated when a session is saved (`useSessionStats.ts` `endSession` computes accuracy but doesn't write it back before calling `addSession`). This PR doesn't touch that — it derives accuracy from `correctAnswers`/`totalAnswers` directly instead of trusting the stored field.

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npx eslint` on changed files passes (including `react-hooks/rules-of-hooks`)
- [x] `npm test -- --run` passes (340/340)
- [x] `npm run build` passes — confirmed all 5 paths pre-render as static params (`letters-week`, `numbers-week`, `nature-week`, `time-week`, `colors-shapes-week`)
- [ ] Manually browse `/learning-paths`, open a path, play a game to ≥70%, confirm it's marked complete and "next game" advances

Closes #1430