### PR TITLE
feat(shesh-besh): animate piece movement

### DIFF
--- a/gamesformykids/app/games/shesh-besh/components/Bar.tsx
+++ b/gamesformykids/app/games/shesh-besh/components/Bar.tsx
@@ -3,6 +3,8 @@ interface BarProps {
   compBar: number;
   isSelected: boolean;
   onClickPlayer: () => void;
+  playerRef?: (el: HTMLButtonElement | null) => void;
+  computerRef?: (el: HTMLDivElement | null) => void;
 }
 
 const disc = (isPlayer: boolean) =>
@@ -10,7 +12,7 @@ const disc = (isPlayer: boolean) =>
     ? 'bg-gradient-to-br from-rose-300 via-rose-500 to-rose-800 border-rose-200/60'
     : 'bg-gradient-to-br from-white via-slate-100 to-slate-400 border-white/70';
 
-export function Bar({ playerBar, compBar, isSelected, onClickPlayer }: BarProps) {
+export function Bar({ playerBar, compBar, isSelected, onClickPlayer, playerRef, computerRef }: BarProps) {
   return (
     <div
       className="flex flex-col items-center justify-between w-10 border-x-2 border-amber-900/60 relative"
@@ -23,7 +25,7 @@ export function Bar({ playerBar, compBar, isSelected, onClickPlayer }: BarProps)
       />
 
       {/* Computer bar pieces (top) */}
-      <div className="relative z-10 flex flex-col items-center gap-[3px] pt-2 flex-1 justify-start">
+      <div ref={computerRef} className="relative z-10 flex flex-col items-center gap-[3px] pt-2 flex-1 justify-start">
         {Array.from({ length: Math.min(compBar, 5) }).map((_, i) => (
           <div key={i} className={['w-[26px] h-[15px] rounded-full border-2 shadow-[0_2px_5px_rgba(0,0,0,.7)]', disc(false)].join(' ')} />
         ))}
@@ -39,6 +41,7 @@ export function Bar({ playerBar, compBar, isSelected, onClickPlayer }: BarProps)
 
       {/* Player bar pieces (bottom) — clickable */}
       <button
+        ref={playerRef}
         onClick={onClickPlayer}
         aria-label="bar player"
         className={[

--- a/gamesformykids/app/games/shesh-besh/components/BoardPoint.tsx
+++ b/gamesformykids/app/games/shesh-besh/components/BoardPoint.tsx
@@ -8,14 +8,16 @@ interface BoardPointProps {
   isSelected: boolean;
   isTarget: boolean;
   onClick: () => void;
+  registerRef?: (el: HTMLButtonElement | null) => void;
 }
 
-export function BoardPoint({ idx, pt, isTop, isSelected, isTarget, onClick }: BoardPointProps) {
+export function BoardPoint({ idx, pt, isTop, isSelected, isTarget, onClick, registerRef }: BoardPointProps) {
   // Alternating deep crimson / warm parchment — classic backgammon palette
   const fillColor = idx % 2 === 0 ? '#7f1d1d' : '#e8d0a0';
 
   return (
     <button
+      ref={registerRef}
       onClick={onClick}
       tabIndex={0}
       aria-label={`point ${idx}`}

--- a/gamesformykids/app/games/shesh-besh/components/BorneOff.tsx
+++ b/gamesformykids/app/games/shesh-besh/components/BorneOff.tsx
@@ -3,11 +3,13 @@ interface BorneOffProps {
   compCount: number;
   onBearOff: () => void;
   isBearOffTarget: boolean;
+  playerRef?: (el: HTMLButtonElement | null) => void;
+  computerRef?: (el: HTMLDivElement | null) => void;
 }
 
 const TOTAL = 15;
 
-export function BorneOff({ playerCount, compCount, onBearOff, isBearOffTarget }: BorneOffProps) {
+export function BorneOff({ playerCount, compCount, onBearOff, isBearOffTarget, playerRef, computerRef }: BorneOffProps) {
   return (
     <div
       className="flex flex-col items-center justify-between border-l-2 border-amber-900/60 px-1.5 py-3 w-16 h-full gap-2 relative"
@@ -20,7 +22,7 @@ export function BorneOff({ playerCount, compCount, onBearOff, isBearOffTarget }:
       />
 
       {/* Computer borne off */}
-      <div className="relative z-10 flex flex-col items-center gap-1.5 w-full">
+      <div ref={computerRef} className="relative z-10 flex flex-col items-center gap-1.5 w-full">
         <span className="text-[8px] text-gray-400 font-bold">מחשב</span>
         <div className="flex flex-wrap gap-[3px] justify-center w-full">
           {Array.from({ length: TOTAL }).map((_, i) => (
@@ -41,6 +43,7 @@ export function BorneOff({ playerCount, compCount, onBearOff, isBearOffTarget }:
 
       {/* Player borne off — clickable bear-off target */}
       <button
+        ref={playerRef}
         onClick={onBearOff}
         aria-label="bear off"
         className={[

--- a/gamesformykids/app/games/shesh-besh/components/GameBoard.tsx
+++ b/gamesformykids/app/games/shesh-besh/components/GameBoard.tsx
@@ -1,14 +1,74 @@
+import { useLayoutEffect, useRef, useState } from 'react';
+import { motion } from 'framer-motion';
 import { useGameBoard } from '../hooks';
 import { BoardPoint } from './BoardPoint';
 import { Bar } from './Bar';
 import { BorneOff } from './BorneOff';
+import { PIECE_MOVE_MS } from '../sheshBeshAnimation';
+import type { Side } from '../types';
 
 const TOP_POINTS = [13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24];
 const BOT_POINTS = [12, 11, 10,  9,  8,  7,  6,  5,  4,  3,  2,  1];
 
+const PIECE_W = 28;
+const PIECE_H = 17;
+
+type Flight = { x1: number; y1: number; x2: number; y2: number; side: Side; key: string };
+
 export function GameBoard() {
-  const { points, barPlayer, barComputer, selected, validMoves, selectPoint } = useGameBoard();
+  const { points, barPlayer, barComputer, selected, validMoves, selectPoint, animatingMove } = useGameBoard();
   const validTargets = new Set(validMoves.map(m => m.to));
+
+  const boardRef           = useRef<HTMLDivElement | null>(null);
+  const pointRefs           = useRef<Map<number, HTMLButtonElement>>(new Map());
+  const barPlayerRef        = useRef<HTMLButtonElement | null>(null);
+  const barComputerRef      = useRef<HTMLDivElement | null>(null);
+  const borneOffPlayerRef   = useRef<HTMLButtonElement | null>(null);
+  const borneOffComputerRef = useRef<HTMLDivElement | null>(null);
+
+  const [flight, setFlight] = useState<Flight | null>(null);
+
+  useLayoutEffect(() => {
+    if (!animatingMove || !boardRef.current) { setFlight(null); return; }
+    const slotEl = (idx: number, side: Side): HTMLElement | null => {
+      if (idx === -1) return side === 'player' ? barPlayerRef.current : barComputerRef.current;
+      if (idx === 0) return borneOffPlayerRef.current;
+      if (idx === 25) return borneOffComputerRef.current;
+      return pointRefs.current.get(idx) ?? null;
+    };
+    const fromEl = slotEl(animatingMove.from, animatingMove.side);
+    const toEl = slotEl(animatingMove.to, animatingMove.side);
+    if (!fromEl || !toEl) { setFlight(null); return; }
+    const boardBox = boardRef.current.getBoundingClientRect();
+    const fromBox = fromEl.getBoundingClientRect();
+    const toBox = toEl.getBoundingClientRect();
+    setFlight({
+      x1: fromBox.left - boardBox.left + fromBox.width / 2 - PIECE_W / 2,
+      y1: fromBox.top - boardBox.top + fromBox.height / 2 - PIECE_H / 2,
+      x2: toBox.left - boardBox.left + toBox.width / 2 - PIECE_W / 2,
+      y2: toBox.top - boardBox.top + toBox.height / 2 - PIECE_H / 2,
+      side: animatingMove.side,
+      key: `${animatingMove.from}-${animatingMove.to}-${animatingMove.side}-${Date.now()}`,
+    });
+  }, [animatingMove]);
+
+  // Hide the moving piece at its origin while it's mid-flight so it isn't rendered twice.
+  const displayPoints = animatingMove
+    ? points.map((p, idx) => {
+        if (idx !== animatingMove.from) return p;
+        const p2 = { ...p };
+        if (animatingMove.side === 'player') p2.player = Math.max(0, p2.player - 1);
+        else p2.computer = Math.max(0, p2.computer - 1);
+        return p2;
+      })
+    : points;
+  const displayBarPlayer = animatingMove?.from === -1 && animatingMove.side === 'player' ? barPlayer - 1 : barPlayer;
+  const displayBarComputer = animatingMove?.from === -1 && animatingMove.side === 'computer' ? barComputer - 1 : barComputer;
+
+  const registerPointRef = (i: number) => (el: HTMLButtonElement | null) => {
+    if (el) pointRefs.current.set(i, el); else pointRefs.current.delete(i);
+  };
+
   return (
     /* Walnut outer frame */
     <div
@@ -16,15 +76,15 @@ export function GameBoard() {
       style={{ background: 'linear-gradient(155deg,#92400e 0%,#3b1505 45%,#92400e 100%)' }}
     >
       {/* Felt surface */}
-      <div className="flex bg-[#0b3d1b] rounded-xl overflow-hidden border border-black/40">
+      <div ref={boardRef} className="relative flex bg-[#0b3d1b] rounded-xl overflow-hidden border border-black/40">
 
         {/* Left quad: 13–18 top / 12–7 bottom */}
         <div className="flex flex-col">
           <div className="flex">
             {TOP_POINTS.slice(0, 6).map(i => (
-              <BoardPoint key={i} idx={i} pt={points[i]!} isTop
+              <BoardPoint key={i} idx={i} pt={displayPoints[i]!} isTop
                 isSelected={selected === i} isTarget={validTargets.has(i)}
-                onClick={() => selectPoint(i)} />
+                onClick={() => selectPoint(i)} registerRef={registerPointRef(i)} />
             ))}
           </div>
           <div className="flex-1 flex items-center justify-center min-h-[2rem]">
@@ -32,27 +92,29 @@ export function GameBoard() {
           </div>
           <div className="flex">
             {BOT_POINTS.slice(0, 6).map(i => (
-              <BoardPoint key={i} idx={i} pt={points[i]!} isTop={false}
+              <BoardPoint key={i} idx={i} pt={displayPoints[i]!} isTop={false}
                 isSelected={selected === i} isTarget={validTargets.has(i)}
-                onClick={() => selectPoint(i)} />
+                onClick={() => selectPoint(i)} registerRef={registerPointRef(i)} />
             ))}
           </div>
         </div>
 
         {/* Bar */}
         <Bar
-          playerBar={barPlayer} compBar={barComputer}
+          playerBar={displayBarPlayer} compBar={displayBarComputer}
           isSelected={selected === -1}
           onClickPlayer={() => barPlayer > 0 && selectPoint(-1)}
+          playerRef={(el) => { barPlayerRef.current = el; }}
+          computerRef={(el) => { barComputerRef.current = el; }}
         />
 
         {/* Right quad: 19–24 top / 6–1 bottom */}
         <div className="flex flex-col">
           <div className="flex">
             {TOP_POINTS.slice(6).map(i => (
-              <BoardPoint key={i} idx={i} pt={points[i]!} isTop
+              <BoardPoint key={i} idx={i} pt={displayPoints[i]!} isTop
                 isSelected={selected === i} isTarget={validTargets.has(i)}
-                onClick={() => selectPoint(i)} />
+                onClick={() => selectPoint(i)} registerRef={registerPointRef(i)} />
             ))}
           </div>
           <div className="flex-1 flex items-center justify-center min-h-[2rem]">
@@ -60,20 +122,39 @@ export function GameBoard() {
           </div>
           <div className="flex">
             {BOT_POINTS.slice(6).map(i => (
-              <BoardPoint key={i} idx={i} pt={points[i]!} isTop={false}
+              <BoardPoint key={i} idx={i} pt={displayPoints[i]!} isTop={false}
                 isSelected={selected === i} isTarget={validTargets.has(i)}
-                onClick={() => selectPoint(i)} />
+                onClick={() => selectPoint(i)} registerRef={registerPointRef(i)} />
             ))}
           </div>
         </div>
 
         {/* Borne-off tray */}
         <BorneOff
-          playerCount={points[0]?.player ?? 0}
-          compCount={points[25]?.computer ?? 0}
+          playerCount={displayPoints[0]?.player ?? 0}
+          compCount={displayPoints[25]?.computer ?? 0}
           onBearOff={() => selectPoint(0)}
           isBearOffTarget={validTargets.has(0) && selected !== null}
+          playerRef={(el) => { borneOffPlayerRef.current = el; }}
+          computerRef={(el) => { borneOffComputerRef.current = el; }}
         />
+
+        {/* Flying piece overlay — slides from source to destination before the real state commits */}
+        {flight && (
+          <motion.div
+            key={flight.key}
+            initial={{ x: flight.x1, y: flight.y1 }}
+            animate={{ x: flight.x2, y: flight.y2 }}
+            transition={{ duration: PIECE_MOVE_MS / 1000, ease: 'easeInOut' }}
+            className="absolute top-0 left-0 z-30 pointer-events-none rounded-full border-2 shadow-[0_4px_10px_rgba(0,0,0,0.8)]"
+            style={{
+              width: PIECE_W, height: PIECE_H,
+              ...(flight.side === 'player'
+                ? { background: 'linear-gradient(to bottom right, #fda4af, #f43f5e, #881337)', borderColor: 'rgba(254,205,211,0.6)' }
+                : { background: 'linear-gradient(to bottom right, #ffffff, #f1f5f9, #94a3b8)', borderColor: 'rgba(255,255,255,0.7)' }),
+            }}
+          />
+        )}
       </div>
     </div>
   );

--- a/gamesformykids/app/games/shesh-besh/hooks/useGameBoard.ts
+++ b/gamesformykids/app/games/shesh-besh/hooks/useGameBoard.ts
@@ -2,11 +2,12 @@ import { useSheshBeshStore } from '../sheshBeshGameStore';
 
 /** Board geometry + interaction state */
 export function useGameBoard() {
-  const points      = useSheshBeshStore(s => s.points);
-  const barPlayer   = useSheshBeshStore(s => s.barPlayer);
-  const barComputer = useSheshBeshStore(s => s.barComputer);
-  const selected    = useSheshBeshStore(s => s.selected);
-  const validMoves  = useSheshBeshStore(s => s.validMoves);
-  const selectPoint = useSheshBeshStore(s => s.selectPoint);
-  return { points, barPlayer, barComputer, selected, validMoves, selectPoint };
+  const points       = useSheshBeshStore(s => s.points);
+  const barPlayer    = useSheshBeshStore(s => s.barPlayer);
+  const barComputer  = useSheshBeshStore(s => s.barComputer);
+  const selected     = useSheshBeshStore(s => s.selected);
+  const validMoves   = useSheshBeshStore(s => s.validMoves);
+  const selectPoint  = useSheshBeshStore(s => s.selectPoint);
+  const animatingMove = useSheshBeshStore(s => s.animatingMove);
+  return { points, barPlayer, barComputer, selected, validMoves, selectPoint, animatingMove };
 }

--- a/gamesformykids/app/games/shesh-besh/sheshBeshAI.ts
+++ b/gamesformykids/app/games/shesh-besh/sheshBeshAI.ts
@@ -3,13 +3,15 @@ import {
   rollDie, expandDice, clonePoints,
   computerBestMove, applyMove,
 } from './gameLogic';
+import { PIECE_MOVE_MS, MOVE_STEP_GAP_MS } from './sheshBeshAnimation';
 
 type GetState = () => SheshState;
 type SetState = (partial: Partial<SheshState>) => void;
 type Schedule = (fn: () => void, ms: number) => void;
 
 /**
- * Runs the full computer-turn sequence.
+ * Runs the full computer-turn sequence, one die at a time, animating each
+ * piece sliding to its destination before committing that step's state.
  * `schedule` is injected so the caller controls the timer (no module globals).
  */
 export function runComputerTurn(
@@ -26,41 +28,59 @@ export function runComputerTurn(
     const dice = expandDice(d1, d2);
     setState({ dice, rolledDice: [d1, d2], phase: 'computer', message: `המחשב הטיל ${d1}-${d2}` });
 
-    // Play all moves after a short visual pause
+    // Play moves one at a time after a short visual pause
     schedule(() => {
-      const cur = getState();
-      if (cur.phase !== 'computer') return;
+      const cur0 = getState();
+      if (cur0.phase !== 'computer') return;
 
-      let remaining = [...cur.dice];
-      let pts = clonePoints(cur.points);
-      let barP = cur.barPlayer;
-      let barC = cur.barComputer;
-      const parts: string[] = [];
+      let remaining = [...cur0.dice];
+      let pts = clonePoints(cur0.points);
+      let barP = cur0.barPlayer;
+      let barC = cur0.barComputer;
+      let movedAny = false;
 
-      while (remaining.length > 0) {
-        const move = computerBestMove(pts, barP, barC, remaining);
-        if (!move) break;
-        const r = applyMove(pts, barP, barC, move, 'computer');
-        pts = r.pts; barP = r.barP; barC = r.barC;
-        parts.push(`${move.from < 0 ? 'בר' : move.from}→${move.to >= 25 ? 'סיים' : move.to}`);
-        const dieIdx = remaining.indexOf(move.die);
-        remaining = remaining.filter((_, i) => i !== dieIdx);
-      }
-
-      const msg = parts.length ? `המחשב: ${parts.join(', ')}. תורך!` : 'המחשב לא יכול לזוז. תורך!';
-
-      if (pts[25]!.computer === 15) {
+      const finish = () => {
         setState({
-          points: pts, barPlayer: barP, barComputer: barC, dice: [], phase: 'lost',
-          computerScore: cur.computerScore + 1, message: '😢 המחשב ניצח!',
+          points: pts, barPlayer: barP, barComputer: barC,
+          dice: [], rolledDice: [], currentTurn: 'player', phase: 'rolling',
+          message: movedAny ? 'תורך!' : 'המחשב לא יכול לזוז. תורך!',
         });
-        return;
-      }
+      };
 
-      setState({
-        points: pts, barPlayer: barP, barComputer: barC,
-        dice: [], rolledDice: [], currentTurn: 'player', phase: 'rolling', message: msg,
-      });
-    }, 1000);
+      const step = () => {
+        const move = computerBestMove(pts, barP, barC, remaining);
+        if (!move) { finish(); return; }
+
+        // Show the piece sliding before mutating the board
+        setState({ animatingMove: { from: move.from, to: move.to, side: 'computer' } });
+
+        schedule(() => {
+          const r = applyMove(pts, barP, barC, move, 'computer');
+          pts = r.pts; barP = r.barP; barC = r.barC;
+          movedAny = true;
+          const dieIdx = remaining.indexOf(move.die);
+          remaining = remaining.filter((_, i) => i !== dieIdx);
+
+          if (pts[25]!.computer === 15) {
+            setState({
+              points: pts, barPlayer: barP, barComputer: barC,
+              dice: [], animatingMove: null, phase: 'lost',
+              computerScore: cur0.computerScore + 1, message: '😢 המחשב ניצח!',
+            });
+            return;
+          }
+
+          setState({
+            points: pts, barPlayer: barP, barComputer: barC, animatingMove: null,
+            message: `המחשב: ${move.from < 0 ? 'בר' : move.from}→${move.to >= 25 ? 'סיים' : move.to}`,
+          });
+
+          if (remaining.length > 0) schedule(step, MOVE_STEP_GAP_MS);
+          else finish();
+        }, PIECE_MOVE_MS);
+      };
+
+      step();
+    }, 700);
   }, 600);
 }

--- a/gamesformykids/app/games/shesh-besh/sheshBeshAnimation.ts
+++ b/gamesformykids/app/games/shesh-besh/sheshBeshAnimation.ts
@@ -1,0 +1,5 @@
+/** How long a single piece takes to slide from one point to another. */
+export const PIECE_MOVE_MS = 380;
+
+/** Pause between consecutive computer moves within the same turn, so each step reads clearly. */
+export const MOVE_STEP_GAP_MS = 200;

--- a/gamesformykids/app/games/shesh-besh/sheshBeshGameStore.ts
+++ b/gamesformykids/app/games/shesh-besh/sheshBeshGameStore.ts
@@ -5,6 +5,7 @@ import { INIT } from './sheshBeshTypes';
 import { createTimer } from './sheshBeshTimer';
 import { runComputerTurn } from './sheshBeshAI';
 import { executePlayerMove } from './sheshBeshPlayerMove';
+import { PIECE_MOVE_MS } from './sheshBeshAnimation';
 import {
   rollDie, expandDice, makeInitialPoints,
   computeValidMoves,
@@ -28,12 +29,21 @@ export const useSheshBeshStore = makeStore<SheshState & SheshActions>(
       );
     }
 
-    function execPlayerMove(move: SimpleMove) {
+    function commitPlayerMove(move: SimpleMove) {
       const result = executePlayerMove(get(), move);
-      set(result.next as Partial<SheshState & SheshActions>);
+      set({ ...result.next, animatingMove: null } as Partial<SheshState & SheshActions>);
       if (result.kind === 'computer-turn') {
         scheduleComputerTurn();
       }
+    }
+
+    // Shows the piece sliding to its destination first, then commits the real state change.
+    function animateAndCommitPlayerMove(move: SimpleMove) {
+      set({
+        animatingMove: { from: move.from, to: move.to, side: 'player' },
+        selected: null, validMoves: [],
+      } as Partial<SheshState & SheshActions>);
+      timer.schedule(() => commitPlayerMove(move), PIECE_MOVE_MS);
     }
 
     return {
@@ -57,7 +67,7 @@ export const useSheshBeshStore = makeStore<SheshState & SheshActions>(
 
       rollDice() {
         const s = get();
-        if (s.phase !== 'rolling' || s.currentTurn !== 'player') return;
+        if (s.phase !== 'rolling' || s.currentTurn !== 'player' || s.animatingMove) return;
         const d1 = rollDie(), d2 = rollDie();
         const dice = expandDice(d1, d2);
         const moves = computeValidMoves(s.points, s.barPlayer, s.barComputer, dice, 'player');
@@ -78,7 +88,7 @@ export const useSheshBeshStore = makeStore<SheshState & SheshActions>(
             dice, rolledDice: [d1, d2], phase: 'moving', turnHistory: [],
             message: `הטלת ${d1}-${d2}. מהלך יחיד — מבצע אוטומטית...`,
           } as Partial<SheshState & SheshActions>);
-          timer.schedule(() => execPlayerMove(moves[0]!), 700);
+          timer.schedule(() => animateAndCommitPlayerMove(moves[0]!), 300);
           return;
         }
         set({
@@ -89,13 +99,13 @@ export const useSheshBeshStore = makeStore<SheshState & SheshActions>(
 
       selectPoint(pointIdx: number) {
         const s = get();
-        if (s.phase !== 'moving' || s.currentTurn !== 'player') return;
+        if (s.phase !== 'moving' || s.currentTurn !== 'player' || s.animatingMove) return;
 
         // ── Bear-off zone (0): destination only ───────────────────────────────
         if (pointIdx === 0) {
           if (s.selected !== null) {
             const move = s.validMoves.find(m => m.to === 0);
-            if (move) execPlayerMove(move);
+            if (move) animateAndCommitPlayerMove(move);
           }
           return;
         }
@@ -103,7 +113,7 @@ export const useSheshBeshStore = makeStore<SheshState & SheshActions>(
         // ── Execute move if pointIdx is a valid destination for the selected piece ──
         if (s.selected !== null) {
           const move = s.validMoves.find(m => m.to === pointIdx);
-          if (move) { execPlayerMove(move); return; }
+          if (move) { animateAndCommitPlayerMove(move); return; }
         }
 
         // ── Does this point have the player's own pieces? ─────────────────────
@@ -130,7 +140,7 @@ export const useSheshBeshStore = makeStore<SheshState & SheshActions>(
             // Only one destination — execute automatically
             const uniqueDests = new Set(fromHere.map(m => m.to));
             if (uniqueDests.size === 1) {
-              execPlayerMove(fromHere[0]!);
+              animateAndCommitPlayerMove(fromHere[0]!);
               return;
             }
             set({ selected: pointIdx, validMoves: fromHere, message: 'לאיזו נקודה לזוז?' } as Partial<SheshState & SheshActions>);
@@ -146,7 +156,7 @@ export const useSheshBeshStore = makeStore<SheshState & SheshActions>(
 
       undoMove() {
         const s = get();
-        if (s.phase !== 'moving' || s.currentTurn !== 'player' || s.turnHistory.length === 0) return;
+        if (s.phase !== 'moving' || s.currentTurn !== 'player' || s.animatingMove || s.turnHistory.length === 0) return;
         const newHistory = [...s.turnHistory];
         const prev = newHistory.pop();
         if (!prev) return;

--- a/gamesformykids/app/games/shesh-besh/sheshBeshTypes.ts
+++ b/gamesformykids/app/games/shesh-besh/sheshBeshTypes.ts
@@ -1,6 +1,6 @@
-import type { Side, GamePhase, Die, PointState, SimpleMove, TurnSnapshot } from './types';
+import type { Side, GamePhase, Die, PointState, SimpleMove, TurnSnapshot, AnimatingMove } from './types';
 
-export type { Side, GamePhase, Die, PointState, SimpleMove, TurnSnapshot };
+export type { Side, GamePhase, Die, PointState, SimpleMove, TurnSnapshot, AnimatingMove };
 
 // ─────────────────────── State / Actions types ───────────────
 export interface SheshState {
@@ -17,6 +17,7 @@ export interface SheshState {
   selected: number | null;
   validMoves: SimpleMove[];
   turnHistory: TurnSnapshot[];
+  animatingMove: AnimatingMove | null;
 }
 
 export interface SheshActions {
@@ -37,4 +38,5 @@ export const INIT: SheshState = {
   message: '',
   selected: null, validMoves: [],
   turnHistory: [],
+  animatingMove: null,
 };

--- a/gamesformykids/app/games/shesh-besh/types.ts
+++ b/gamesformykids/app/games/shesh-besh/types.ts
@@ -15,3 +15,6 @@ export type TurnSnapshot = {
   barComputer: number;
   dice: Die[];
 };
+
+/** A move currently in flight visually — real state commits only once this clears. */
+export type AnimatingMove = { from: number; to: number; side: Side };


### PR DESCRIPTION
## Summary
- Backgammon pieces now slide from their source point to their destination instead of teleporting, for both the player and the computer.
- A move first sets `animatingMove` in the store; `GameBoard` renders a flying "ghost" disc (framer-motion) between the measured DOM positions of the two slots (points, bar, bear-off tray), and only after the ~380ms flight does the real board state commit.
- The computer's turn was refactored from applying all of its dice moves in a single batch to stepping through them one at a time (`sheshBeshAI.ts`), so each of its moves is now visibly animated instead of the board jumping straight to the final result.

## Test plan
- [x] `npx tsc --noEmit` — zero errors
- [x] Drove the game with Playwright against the dev server: sampled the ghost disc's `transform` mid-move and confirmed the `translateX` value interpolates smoothly (~390px → ~381px → ~162px) before the real state commits and the ghost disappears — i.e. genuine sliding motion, not an instant jump
- [x] Manually played through player turns (single forced move, multi-choice move, bar entry, bear-off) and a computer turn in the browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)