### PR TITLE
feat(shesh-besh): fluid, kid-friendly responsive board

### DIFF
--- a/gamesformykids/app/games/shesh-besh/SheshBeshGame.tsx
+++ b/gamesformykids/app/games/shesh-besh/SheshBeshGame.tsx
@@ -20,7 +20,7 @@ export default function SheshBeshGame() {
       {(phase === 'won' || phase === 'lost') && <GameOverScreen />}
 
       {isPlaying && (
-        <div className="flex flex-col items-center gap-2 w-full" style={{ maxWidth: 580 }}>
+        <div className="flex flex-col items-center gap-2 w-full" style={{ maxWidth: 720 }}>
           <Scoreboard />
           <GameBoard />
           <ActionButtons />

--- a/gamesformykids/app/games/shesh-besh/components/ActionButtons.tsx
+++ b/gamesformykids/app/games/shesh-besh/components/ActionButtons.tsx
@@ -7,26 +7,26 @@ export function ActionButtons() {
   return (
     <>
       {/* Status message */}
-      <div className="h-7 flex items-center justify-center w-full">
+      <div className="min-h-8 tablet:min-h-9 flex items-center justify-center w-full">
         {message && (
-          <p className="text-amber-200/80 text-xs font-medium bg-black/50 border border-amber-900/40 rounded-full py-1 px-5 text-center max-w-xs truncate">
+          <p className="text-amber-200/80 text-xs tablet:text-sm font-medium bg-black/50 border border-amber-900/40 rounded-full py-1.5 px-5 text-center max-w-sm truncate">
             {message}
           </p>
         )}
       </div>
 
       {/* Roll / Undo buttons */}
-      <div className="h-12 flex items-center justify-center gap-3">
+      <div className="min-h-14 flex items-center justify-center gap-3">
         {phase === 'rolling' && currentTurn === 'player' && (
           <button
             onClick={rollDice}
             className={[
               'relative bg-gradient-to-b from-amber-300 to-amber-500 hover:from-amber-200 hover:to-amber-400',
-              'active:scale-95 text-gray-900 font-extrabold px-10 py-3 rounded-xl',
+              'active:scale-95 text-gray-900 font-extrabold px-10 tablet:px-14 py-3.5 tablet:py-4 rounded-xl',
               'shadow-[0_4px_0_#92400e,0_6px_20px_rgba(251,191,36,0.3)]',
               'hover:shadow-[0_4px_0_#92400e,0_6px_24px_rgba(251,191,36,0.4)]',
               'active:shadow-[0_1px_0_#92400e] active:translate-y-[3px]',
-              'transition duration-150 text-base',
+              'transition duration-150 text-base tablet:text-lg min-h-11',
             ].join(' ')}
           >
             🎲 הטל קובייות
@@ -37,7 +37,7 @@ export function ActionButtons() {
             onClick={undoMove}
             className={[
               'bg-slate-700 hover:bg-slate-600 active:scale-95 text-slate-200 font-bold',
-              'px-5 py-2.5 rounded-xl transition duration-150 text-sm',
+              'px-5 py-3 rounded-xl transition duration-150 text-sm min-h-11',
               'border border-slate-500 shadow-[0_3px_0_#0f172a]',
               'active:shadow-none active:translate-y-[2px]',
             ].join(' ')}

--- a/gamesformykids/app/games/shesh-besh/components/Bar.tsx
+++ b/gamesformykids/app/games/shesh-besh/components/Bar.tsx
@@ -15,8 +15,8 @@ const disc = (isPlayer: boolean) =>
 export function Bar({ playerBar, compBar, isSelected, onClickPlayer, playerRef, computerRef }: BarProps) {
   return (
     <div
-      className="flex flex-col items-center justify-between w-10 border-x-2 border-amber-900/60 relative"
-      style={{ background: 'linear-gradient(180deg,#92400e 0%,#3b1505 50%,#92400e 100%)' }}
+      className="flex flex-col items-center justify-between h-full border-x-2 border-amber-900/60 relative"
+      style={{ flex: '40 40 0%', background: 'linear-gradient(180deg,#92400e 0%,#3b1505 50%,#92400e 100%)' }}
     >
       {/* Wood-grain lines */}
       <div
@@ -25,17 +25,17 @@ export function Bar({ playerBar, compBar, isSelected, onClickPlayer, playerRef, 
       />
 
       {/* Computer bar pieces (top) */}
-      <div ref={computerRef} className="relative z-10 flex flex-col items-center gap-[3px] pt-2 flex-1 justify-start">
+      <div ref={computerRef} className="relative z-10 flex flex-col items-center gap-[10%] pt-2 flex-1 justify-start w-full">
         {Array.from({ length: Math.min(compBar, 5) }).map((_, i) => (
-          <div key={i} className={['w-[26px] h-[15px] rounded-full border-2 shadow-[0_2px_5px_rgba(0,0,0,.7)]', disc(false)].join(' ')} />
+          <div key={i} className={['w-[72%] aspect-[26/15] rounded-full border-2 shadow-[0_2px_5px_rgba(0,0,0,.7)]', disc(false)].join(' ')} />
         ))}
-        {compBar > 5 && <span className="text-[9px] text-gray-300 font-bold mt-0.5">×{compBar}</span>}
+        {compBar > 5 && <span className="text-[clamp(7px,1.6vw,10px)] text-gray-300 font-bold mt-0.5">×{compBar}</span>}
       </div>
 
       {/* Center label */}
       <div className="relative z-10 flex flex-col items-center gap-0.5 py-1">
         <div className="w-px h-3 bg-amber-400/50 rounded-full" />
-        <span className="text-amber-400/80 text-[9px] font-bold">בר</span>
+        <span className="text-amber-400/80 text-[clamp(7px,1.6vw,10px)] font-bold">בר</span>
         <div className="w-px h-3 bg-amber-400/50 rounded-full" />
       </div>
 
@@ -45,14 +45,14 @@ export function Bar({ playerBar, compBar, isSelected, onClickPlayer, playerRef, 
         onClick={onClickPlayer}
         aria-label="bar player"
         className={[
-          'relative z-10 flex flex-col-reverse items-center gap-[3px] pb-2 flex-1 justify-start w-full rounded transition',
+          'relative z-10 flex flex-col-reverse items-center gap-[10%] pb-2 flex-1 justify-start w-full rounded transition',
           isSelected ? 'ring-2 ring-yellow-400 ring-inset bg-yellow-400/10' : '',
         ].join(' ')}
       >
         {Array.from({ length: Math.min(playerBar, 5) }).map((_, i) => (
-          <div key={i} className={['w-[26px] h-[15px] rounded-full border-2 shadow-[0_2px_5px_rgba(0,0,0,.7)]', disc(true)].join(' ')} />
+          <div key={i} className={['w-[72%] aspect-[26/15] rounded-full border-2 shadow-[0_2px_5px_rgba(0,0,0,.7)]', disc(true)].join(' ')} />
         ))}
-        {playerBar > 5 && <span className="text-[9px] text-rose-300 font-bold mt-0.5">×{playerBar}</span>}
+        {playerBar > 5 && <span className="text-[clamp(7px,1.6vw,10px)] text-rose-300 font-bold mt-0.5">×{playerBar}</span>}
       </button>
     </div>
   );

--- a/gamesformykids/app/games/shesh-besh/components/BoardPoint.tsx
+++ b/gamesformykids/app/games/shesh-besh/components/BoardPoint.tsx
@@ -22,11 +22,10 @@ export function BoardPoint({ idx, pt, isTop, isSelected, isTarget, onClick, regi
       tabIndex={0}
       aria-label={`point ${idx}`}
       className={[
-        'relative flex flex-col items-center w-10 cursor-pointer select-none outline-none',
+        'relative flex flex-col items-center flex-1 min-w-0 h-full cursor-pointer select-none outline-none',
         'transition duration-150 overflow-hidden',
-        isTop ? 'justify-start pt-0.5' : 'justify-end pb-0.5',
+        isTop ? 'justify-start pt-[2%]' : 'justify-end pb-[2%]',
       ].join(' ')}
-      style={{ height: '7.5rem' }}
     >
       {/* SVG triangle — crisp, no aliasing artifacts */}
       <svg
@@ -39,22 +38,22 @@ export function BoardPoint({ idx, pt, isTop, isSelected, isTarget, onClick, regi
           : <polygon points="1,120 39,120 20,7" fill={fillColor} opacity="0.9" />}
       </svg>
 
-      {/* Highlight overlays */}
+      {/* Highlight overlays — thick, high-contrast rings so kids can spot tappable spots at a glance */}
       {isTarget && (
-        <div className="absolute inset-0 bg-emerald-400/20 ring-[2px] ring-inset ring-emerald-400/70 animate-pulse pointer-events-none" />
+        <div className="absolute inset-0 bg-emerald-400/25 ring-[3px] ring-inset ring-emerald-400/90 animate-pulse pointer-events-none" />
       )}
       {isSelected && (
-        <div className="absolute inset-0 bg-amber-400/20 ring-[2px] ring-inset ring-amber-400/75 pointer-events-none" />
+        <div className="absolute inset-0 bg-amber-400/25 ring-[3px] ring-inset ring-amber-400/90 pointer-events-none" />
       )}
 
       {/* Point number */}
       <span className={[
-        'absolute text-[8px] text-white/25 font-mono z-10 leading-none select-none',
+        'absolute text-[clamp(7px,1.6vw,11px)] text-white/25 font-mono z-10 leading-none select-none',
         isTop ? 'bottom-[2px]' : 'top-[2px]',
       ].join(' ')}>{idx}</span>
 
       {/* Pieces */}
-      <div className="relative z-10">
+      <div className="relative z-10 w-full flex flex-col items-center">
         {pt.player   > 0 && <PieceStack count={pt.player}   isPlayer isTop={isTop} />}
         {pt.computer > 0 && <PieceStack count={pt.computer} isPlayer={false} isTop={isTop} />}
       </div>

--- a/gamesformykids/app/games/shesh-besh/components/BorneOff.tsx
+++ b/gamesformykids/app/games/shesh-besh/components/BorneOff.tsx
@@ -12,8 +12,8 @@ const TOTAL = 15;
 export function BorneOff({ playerCount, compCount, onBearOff, isBearOffTarget, playerRef, computerRef }: BorneOffProps) {
   return (
     <div
-      className="flex flex-col items-center justify-between border-l-2 border-amber-900/60 px-1.5 py-3 w-16 h-full gap-2 relative"
-      style={{ background: 'linear-gradient(180deg,#92400e 0%,#3b1505 50%,#92400e 100%)' }}
+      className="flex flex-col items-center justify-between border-l-2 border-amber-900/60 px-1.5 py-3 h-full gap-2 relative"
+      style={{ flex: '64 64 0%', background: 'linear-gradient(180deg,#92400e 0%,#3b1505 50%,#92400e 100%)' }}
     >
       {/* Wood-grain lines */}
       <div
@@ -23,12 +23,12 @@ export function BorneOff({ playerCount, compCount, onBearOff, isBearOffTarget, p
 
       {/* Computer borne off */}
       <div ref={computerRef} className="relative z-10 flex flex-col items-center gap-1.5 w-full">
-        <span className="text-[8px] text-gray-400 font-bold">מחשב</span>
+        <span className="text-[clamp(7px,1.6vw,10px)] text-gray-400 font-bold">מחשב</span>
         <div className="flex flex-wrap gap-[3px] justify-center w-full">
           {Array.from({ length: TOTAL }).map((_, i) => (
             <div
               key={i}
-              className={`w-3 h-[8px] rounded-full transition-colors ${
+              className={`w-[clamp(7px,2vw,13px)] aspect-[3/2] rounded-full transition-colors ${
                 i < compCount
                   ? 'bg-gradient-to-br from-white to-slate-300 shadow-sm'
                   : 'bg-black/40'
@@ -36,7 +36,7 @@ export function BorneOff({ playerCount, compCount, onBearOff, isBearOffTarget, p
             />
           ))}
         </div>
-        <span className="text-gray-300 text-[11px] font-extrabold leading-none">{compCount}/15</span>
+        <span className="text-gray-300 text-[clamp(9px,2.2vw,13px)] font-extrabold leading-none">{compCount}/15</span>
       </div>
 
       <div className="relative z-10 w-3/4 border-t border-amber-700/40" />
@@ -55,7 +55,7 @@ export function BorneOff({ playerCount, compCount, onBearOff, isBearOffTarget, p
           {Array.from({ length: TOTAL }).map((_, i) => (
             <div
               key={i}
-              className={`w-3 h-[8px] rounded-full transition-colors ${
+              className={`w-[clamp(7px,2vw,13px)] aspect-[3/2] rounded-full transition-colors ${
                 i < playerCount
                   ? 'bg-gradient-to-br from-rose-300 to-rose-600 shadow-sm shadow-rose-900/50'
                   : 'bg-black/40'
@@ -63,8 +63,8 @@ export function BorneOff({ playerCount, compCount, onBearOff, isBearOffTarget, p
             />
           ))}
         </div>
-        <span className="text-rose-300 text-[11px] font-extrabold leading-none">{playerCount}/15</span>
-        <span className="text-[8px] text-rose-400/70 font-bold">
+        <span className="text-rose-300 text-[clamp(9px,2.2vw,13px)] font-extrabold leading-none">{playerCount}/15</span>
+        <span className="text-[clamp(7px,1.6vw,10px)] text-rose-400/70 font-bold">
           {isBearOffTarget ? '✓ צא' : 'שלך'}
         </span>
       </button>

--- a/gamesformykids/app/games/shesh-besh/components/DieChip.tsx
+++ b/gamesformykids/app/games/shesh-besh/components/DieChip.tsx
@@ -17,7 +17,7 @@ export function DieChip({ face, used }: DieChipProps) {
   const dots = DOT_POSITIONS[face] ?? [];
   return (
     <div className={[
-      'w-11 h-11 rounded-xl border-2 p-1.5 transition duration-300 select-none',
+      'w-12 h-12 tablet:w-14 tablet:h-14 rounded-xl border-2 p-1.5 transition duration-300 select-none',
       used
         ? 'bg-gray-800 border-gray-700 opacity-25 scale-90'
         : 'bg-white border-gray-200 scale-100 shadow-[0_4px_0_#111,0_2px_10px_rgba(0,0,0,0.6)]',
@@ -30,7 +30,7 @@ export function DieChip({ face, used }: DieChipProps) {
           return (
             <div key={i} className="flex items-center justify-center">
               {hasDot && (
-                <div className={`w-2 h-2 rounded-full ${used ? 'bg-gray-500' : 'bg-gray-900'}`} />
+                <div className={`w-2 h-2 tablet:w-2.5 tablet:h-2.5 rounded-full ${used ? 'bg-gray-500' : 'bg-gray-900'}`} />
               )}
             </div>
           );

--- a/gamesformykids/app/games/shesh-besh/components/GameBoard.tsx
+++ b/gamesformykids/app/games/shesh-besh/components/GameBoard.tsx
@@ -10,10 +10,11 @@ import type { Side } from '../types';
 const TOP_POINTS = [13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24];
 const BOT_POINTS = [12, 11, 10,  9,  8,  7,  6,  5,  4,  3,  2,  1];
 
-const PIECE_W = 28;
-const PIECE_H = 17;
+// Natural board proportions (12 points @ 1 unit + bar 0.33 + tray 0.53 wide; 2 point-rows + label row tall).
+const BOARD_ASPECT = '584 / 272';
+const PIECE_ASPECT = 17 / 28; // matches PieceStack's disc aspect ratio
 
-type Flight = { x1: number; y1: number; x2: number; y2: number; side: Side; key: string };
+type Flight = { x1: number; y1: number; x2: number; y2: number; w: number; h: number; side: Side; key: string };
 
 export function GameBoard() {
   const { points, barPlayer, barComputer, selected, validMoves, selectPoint, animatingMove } = useGameBoard();
@@ -42,11 +43,16 @@ export function GameBoard() {
     const boardBox = boardRef.current.getBoundingClientRect();
     const fromBox = fromEl.getBoundingClientRect();
     const toBox = toEl.getBoundingClientRect();
+    // Size the flying disc relative to the actual rendered slot size, so it matches
+    // the board at any viewport width instead of a fixed pixel size.
+    const w = Math.max(14, Math.min(fromBox.width, toBox.width) * 0.7);
+    const h = w * PIECE_ASPECT;
     setFlight({
-      x1: fromBox.left - boardBox.left + fromBox.width / 2 - PIECE_W / 2,
-      y1: fromBox.top - boardBox.top + fromBox.height / 2 - PIECE_H / 2,
-      x2: toBox.left - boardBox.left + toBox.width / 2 - PIECE_W / 2,
-      y2: toBox.top - boardBox.top + toBox.height / 2 - PIECE_H / 2,
+      x1: fromBox.left - boardBox.left + fromBox.width / 2 - w / 2,
+      y1: fromBox.top - boardBox.top + fromBox.height / 2 - h / 2,
+      x2: toBox.left - boardBox.left + toBox.width / 2 - w / 2,
+      y2: toBox.top - boardBox.top + toBox.height / 2 - h / 2,
+      w, h,
       side: animatingMove.side,
       key: `${animatingMove.from}-${animatingMove.to}-${animatingMove.side}-${Date.now()}`,
     });
@@ -72,25 +78,29 @@ export function GameBoard() {
   return (
     /* Walnut outer frame */
     <div
-      className="rounded-2xl p-[7px] shadow-[0_24px_64px_rgba(0,0,0,0.9)] ring-1 ring-black/60"
+      className="w-full rounded-2xl p-[1.2%] shadow-[0_24px_64px_rgba(0,0,0,0.9)] ring-1 ring-black/60"
       style={{ background: 'linear-gradient(155deg,#92400e 0%,#3b1505 45%,#92400e 100%)' }}
     >
-      {/* Felt surface */}
-      <div ref={boardRef} className="relative flex bg-[#0b3d1b] rounded-xl overflow-hidden border border-black/40">
+      {/* Felt surface — fixed aspect ratio so it scales fluidly with the wrapper's width */}
+      <div
+        ref={boardRef}
+        className="relative flex w-full bg-[#0b3d1b] rounded-xl overflow-hidden border border-black/40"
+        style={{ aspectRatio: BOARD_ASPECT }}
+      >
 
         {/* Left quad: 13–18 top / 12–7 bottom */}
-        <div className="flex flex-col">
-          <div className="flex">
+        <div className="flex flex-col h-full" style={{ flex: '480 480 0%' }}>
+          <div className="flex" style={{ flex: '120 120 0%' }}>
             {TOP_POINTS.slice(0, 6).map(i => (
               <BoardPoint key={i} idx={i} pt={displayPoints[i]!} isTop
                 isSelected={selected === i} isTarget={validTargets.has(i)}
                 onClick={() => selectPoint(i)} registerRef={registerPointRef(i)} />
             ))}
           </div>
-          <div className="flex-1 flex items-center justify-center min-h-[2rem]">
-            <span className="text-[9px] text-amber-700/40 font-bold select-none">← מחשב</span>
+          <div className="flex items-center justify-center" style={{ flex: '32 32 0%' }}>
+            <span className="text-[clamp(6px,1.4vw,10px)] text-amber-700/40 font-bold select-none">← מחשב</span>
           </div>
-          <div className="flex">
+          <div className="flex" style={{ flex: '120 120 0%' }}>
             {BOT_POINTS.slice(0, 6).map(i => (
               <BoardPoint key={i} idx={i} pt={displayPoints[i]!} isTop={false}
                 isSelected={selected === i} isTarget={validTargets.has(i)}
@@ -109,18 +119,18 @@ export function GameBoard() {
         />
 
         {/* Right quad: 19–24 top / 6–1 bottom */}
-        <div className="flex flex-col">
-          <div className="flex">
+        <div className="flex flex-col h-full" style={{ flex: '480 480 0%' }}>
+          <div className="flex" style={{ flex: '120 120 0%' }}>
             {TOP_POINTS.slice(6).map(i => (
               <BoardPoint key={i} idx={i} pt={displayPoints[i]!} isTop
                 isSelected={selected === i} isTarget={validTargets.has(i)}
                 onClick={() => selectPoint(i)} registerRef={registerPointRef(i)} />
             ))}
           </div>
-          <div className="flex-1 flex items-center justify-center min-h-[2rem]">
-            <span className="text-[9px] text-amber-700/40 font-bold select-none">אתה →</span>
+          <div className="flex items-center justify-center" style={{ flex: '32 32 0%' }}>
+            <span className="text-[clamp(6px,1.4vw,10px)] text-amber-700/40 font-bold select-none">אתה →</span>
           </div>
-          <div className="flex">
+          <div className="flex" style={{ flex: '120 120 0%' }}>
             {BOT_POINTS.slice(6).map(i => (
               <BoardPoint key={i} idx={i} pt={displayPoints[i]!} isTop={false}
                 isSelected={selected === i} isTarget={validTargets.has(i)}
@@ -148,7 +158,7 @@ export function GameBoard() {
             transition={{ duration: PIECE_MOVE_MS / 1000, ease: 'easeInOut' }}
             className="absolute top-0 left-0 z-30 pointer-events-none rounded-full border-2 shadow-[0_4px_10px_rgba(0,0,0,0.8)]"
             style={{
-              width: PIECE_W, height: PIECE_H,
+              width: flight.w, height: flight.h,
               ...(flight.side === 'player'
                 ? { background: 'linear-gradient(to bottom right, #fda4af, #f43f5e, #881337)', borderColor: 'rgba(254,205,211,0.6)' }
                 : { background: 'linear-gradient(to bottom right, #ffffff, #f1f5f9, #94a3b8)', borderColor: 'rgba(255,255,255,0.7)' }),

--- a/gamesformykids/app/games/shesh-besh/components/PieceStack.tsx
+++ b/gamesformykids/app/games/shesh-besh/components/PieceStack.tsx
@@ -20,14 +20,14 @@ export function PieceStack({ count, isPlayer, isTop }: PieceStackProps) {
   const textColor = isPlayer ? 'text-white drop-shadow-sm' : 'text-slate-700';
 
   return (
-    <div className={['flex items-center gap-[2px]', isTop ? 'flex-col' : 'flex-col-reverse'].join(' ')}>
+    <div className={['flex items-center gap-[3%] w-full', isTop ? 'flex-col' : 'flex-col-reverse'].join(' ')}>
       {Array.from({ length: visible }).map((_, i) => {
         const isTopPiece = isTop ? i === 0 : i === visible - 1;
         return (
           <div
             key={i}
             className={[
-              'w-7 h-[17px] rounded-full border-2 flex items-center justify-center',
+              'w-[78%] aspect-[28/17] rounded-full border-2 flex items-center justify-center mx-auto',
               'relative overflow-hidden shadow-[0_2px_6px_rgba(0,0,0,0.75)]',
               disc,
             ].join(' ')}
@@ -35,7 +35,7 @@ export function PieceStack({ count, isPlayer, isTop }: PieceStackProps) {
             {/* Specular highlight */}
             <div className={['absolute inset-0 rounded-full', shine].join(' ')} />
             {count > 1 && isTopPiece && (
-              <span className={['relative z-10 text-[9px] font-black leading-none', textColor].join(' ')}>
+              <span className={['relative z-10 text-[clamp(7px,1.8vw,11px)] font-black leading-none', textColor].join(' ')}>
                 {count}
               </span>
             )}


### PR DESCRIPTION
## Summary
- The board previously had a fixed 584px width (`w-10` per point, fixed heights), which overflowed horizontally on essentially every phone screen. It now scales fluidly: points, the bar, and the bear-off tray use `flex-grow` ratios inside an `aspect-ratio`-locked felt container, so the board fits any viewport width without horizontal scroll.
- The board also grows bigger on larger screens — max width raised from 580px to 720px — for a friendlier, easier-to-tap board for kids on tablets/desktop.
- Piece discs (`PieceStack`, `Bar`, `BorneOff`) now size as a percentage of their slot's width instead of fixed pixels, so they scale with the board.
- The flying-piece move animation (from the previous PR) now measures its ghost disc's size from the actual rendered slot at animation time instead of a hardcoded constant, so it still matches at any screen size.
- Selection/target highlight rings were thickened (2px → 3px) and made higher-contrast so kids can spot tappable spots more easily.
- Bigger touch targets: roll-dice button, dice chips, and the undo button got larger padding/min-heights, with extra size on tablet+ breakpoints.

## Test plan
- [x] `npx tsc --noEmit` — zero errors
- [x] Playwright checks at 360px, 414px, 820px, and 1280px viewports: no horizontal overflow at any width (previously the fixed-width board would overflow on all phone sizes); board renders at 336px (small phone) up to 703px (tablet/desktop)
- [x] Re-verified the piece-slide animation from the prior PR still works after the resize: ghost disc scales proportionally (e.g. ~17.6×10.7px on a 390px-wide phone vs ~28×17px on desktop) and still interpolates smoothly before the real move commits
- [x] Manually reviewed screenshots at phone and desktop widths — board, pieces, bar, and bear-off tray render correctly at both sizes

🤖 Generated with [Claude Code](https://claude.com/claude-code)