### PR TITLE
fix(letters): speak full letter names instead of bare glyphs

### DIFF
--- a/gamesformykids/hooks/games/useGenericGame.ts
+++ b/gamesformykids/hooks/games/useGenericGame.ts
@@ -3,13 +3,21 @@
 import { useBaseGame } from "@/hooks/shared/game-state/useBaseGame";
 import { BaseGameItem, GameType } from "@/lib/types/core/base";
 import { useGameDifficulty } from '@/lib/stores/gameDifficultyStore';
+import { LETTER_HEBREW_PRONUNCIATIONS } from "@/lib/constants/gameData/basicData/letters";
 
 const DIFFICULTY_BASE_COUNT: Record<string, number> = { easy: 3, medium: 4, hard: 6 };
 
+// Some game types can't just speak item.hebrew as-is (e.g. a bare letter glyph
+// is unclear or silent in Hebrew TTS) — they need a dedicated pronunciation per item.
+const PRONUNCIATION_OVERRIDES: Partial<Record<GameType, Record<string, string>>> = {
+  letters: LETTER_HEBREW_PRONUNCIATIONS,
+};
+
 export function useGenericGame(items: BaseGameItem[], gameType: GameType) {
   const { difficulty } = useGameDifficulty();
+  const overrides = PRONUNCIATION_OVERRIDES[gameType];
   const pronunciations = items.reduce<Record<string, string>>((acc, item) => {
-    acc[item.name] = item.hebrew;
+    acc[item.name] = overrides?.[item.name] ?? item.hebrew;
     return acc;
   }, {});
 

--- a/gamesformykids/lib/constants/gameData/basicData/letters.ts
+++ b/gamesformykids/lib/constants/gameData/basicData/letters.ts
@@ -1,5 +1,5 @@
 import { BaseGameItem } from "@/lib/types/core/base";
-import { createGameConfig, createItemsList, createPronunciationDictionary } from "@/lib/constants/core";
+import { createGameConfig, createItemsList } from "@/lib/constants/core";
 
 export const LETTER_CONSTANTS: Record<string, BaseGameItem> = {
   ALEF: { name: "alef", hebrew: "א", english: "A", emoji: "א", color: "", sound: [440, 550, 660] },
@@ -27,5 +27,32 @@ export const LETTER_CONSTANTS: Record<string, BaseGameItem> = {
 };
 
 export const ALL_LETTERS = createItemsList(LETTER_CONSTANTS);
-export const LETTER_HEBREW_PRONUNCIATIONS = createPronunciationDictionary(LETTER_CONSTANTS);
+
+// Reading out the bare glyph (e.g. "ב") often comes out unclear or silent in Hebrew TTS,
+// since several letters are also one-letter words/prefixes. Speak the full letter name instead.
+export const LETTER_HEBREW_PRONUNCIATIONS: Record<string, string> = {
+  alef: "אָלֶף",
+  bet: "בֵּית",
+  gimel: "גִּימֶל",
+  dalet: "דָּלֶת",
+  hey: "הֵא",
+  vav: "וָאו",
+  zayin: "זַיִן",
+  het: "חֵת",
+  tet: "טֵת",
+  yud: "יוֹד",
+  kaf: "כַּף",
+  lamed: "לָמֶד",
+  mem: "מֵם",
+  nun: "נוּן",
+  samech: "סָמֶך",
+  ayin: "עַיִן",
+  pey: "פֵּא",
+  tzadi: "צַדִּי",
+  kuf: "קוֹף",
+  resh: "רֵישׁ",
+  shin: "שִׁין",
+  tav: "תָּו",
+};
+
 export const LETTER_GAME_CONSTANTS = createGameConfig(6, 2, 3);


### PR DESCRIPTION
## Summary
- The letters game (`משחק אותיות`, `/games/letters`) spoke each letter's raw glyph (e.g. "ב", "ו", "ל"). Several Hebrew TTS voices mispronounce or nearly swallow bare glyphs since those characters double as one-letter prefix words, making the letters hard to hear.
- Added a proper full-name pronunciation per letter (e.g. "בֵּית", "וָאו", "לָמֶד"), matching the naming already used by the letter-tracing game.
- Wired a per-game-type pronunciation override into `useGenericGame` so the letters game uses these names instead of falling back to `item.hebrew`.

## Test plan
- [x] `npx tsc --noEmit` — no errors
- [ ] Manually play `/games/letters` and confirm each letter is now spoken clearly by its full name

🤖 Generated with [Claude Code](https://claude.com/claude-code)