### PR TITLE
fix(tts): use hebrewNikud for speech pronunciation when available

### DIFF
--- a/gamesformykids/lib/constants/core/index.ts
+++ b/gamesformykids/lib/constants/core/index.ts
@@ -94,8 +94,10 @@ export const createItemsList = <T extends BaseGameItem>(constants: Record<string
 export const createPronunciationDictionary = <T extends BaseGameItem>(
   constants: Record<string, T>
 ): Record<string, string> => {
+  // hebrewNikud (when present) gives the TTS engine explicit vowel points,
+  // which disambiguates Hebrew words that would otherwise be mispronounced.
   return Object.fromEntries(
-    Object.values(constants).map(item => [item.name, item.hebrew])
+    Object.values(constants).map(item => [item.name, item.hebrewNikud || item.hebrew])
   );
 };
 


### PR DESCRIPTION
## Summary
- `createPronunciationDictionary` (used by ~50 game-data categories to build the text fed into `speechSynthesis`) always spoke the plain, unvocalized `item.hebrew` string, even for items that already define a vowel-pointed `item.hebrewNikud`.
- Hebrew without niqqud is frequently ambiguous to read aloud (the same letters can represent multiple words/pronunciations), so the TTS engine would sometimes guess the wrong pronunciation for words it had a clear, vowel-pointed spelling for.
- Fix: prefer `item.hebrewNikud` when present, falling back to `item.hebrew` otherwise — one-line change in the shared factory, so it takes effect for every category without touching per-game data files.
- Immediately improves the 5 categories that already define `hebrewNikud`: animals, fruits, clothing, body parts, and colors.

## Test plan
- [x] `npx tsc --noEmit` — zero errors
- [ ] Manually play a game from one of the 5 affected categories (e.g. `/games/animals`) and confirm the spoken pronunciation sounds correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)