### PR TITLE
fix(memory): fix invisible start button and win-screen crash

### DIFF
--- a/gamesformykids/app/games/memory/components/MemoryStartScreen.tsx
+++ b/gamesformykids/app/games/memory/components/MemoryStartScreen.tsx
@@ -32,6 +32,7 @@ export default function MemoryStartScreen() {
       title="משחק הזיכרון"
       description="מצאו את הזוגות הזהים על הלוח!"
       gradientClass="from-pink-100 via-purple-100 to-indigo-200"
+      buttonClass="from-purple-500 to-pink-500"
       hint={hint}
       onStart={handleStart}
       startLabel="🧠 התחל!"

--- a/gamesformykids/app/games/memory/components/WinAchievements.tsx
+++ b/gamesformykids/app/games/memory/components/WinAchievements.tsx
@@ -1,7 +1,19 @@
+import { useMemo } from "react";
 import { useMemoryStore } from "../stores/useMemoryStore";
+import { getWinAchievements } from "../stores/memoryDisplayHelpers";
 
 export default function WinAchievements() {
-  const achievements = useMemoryStore((s) => s.getWinAchievements());
+  const score = useMemoryStore((s) => s.gameStats.score);
+  const moves = useMemoryStore((s) => s.gameStats.moves);
+  const streak = useMemoryStore((s) => s.gameStats.streak);
+  const perfectMatches = useMemoryStore((s) => s.gameStats.perfectMatches);
+  const timeLeft = useMemoryStore((s) => s.timeLeft);
+  const totalPairs = useMemoryStore((s) => s.getDifficultyConfig().pairs);
+
+  const achievements = useMemo(
+    () => getWinAchievements(score, moves, streak, perfectMatches, timeLeft, totalPairs),
+    [score, moves, streak, perfectMatches, timeLeft, totalPairs],
+  );
 
   if (achievements.length === 0) return null;
 

--- a/gamesformykids/app/games/memory/stores/memoryStoreTypes.ts
+++ b/gamesformykids/app/games/memory/stores/memoryStoreTypes.ts
@@ -1,7 +1,7 @@
 import { AnimalData } from '@/lib/types/games';
 import { MEMORY_GAME_ANIMALS, MEMORY_GAME_CONSTANTS } from '@/lib/constants';
 import { DifficultyLevel, MemoryCard, GameStats, MemoryPhase } from '../types/memory';
-import { DifficultyOption, PerformanceLevel, WinAchievement } from '../types/memoryDisplay';
+import { DifficultyOption, PerformanceLevel } from '../types/memoryDisplay';
 
 // ─── Initial values ───────────────────────────────────────────────────────────
 
@@ -93,7 +93,6 @@ export interface MemoryStoreActions {
   getFormattedTimeLeft: () => string;
   getTimeColor: () => string;
   getPerformanceLevel: () => PerformanceLevel;
-  getWinAchievements: () => WinAchievement[];
 }
 
 // ─── Initial store state ──────────────────────────────────────────────────────

--- a/gamesformykids/app/games/memory/stores/useMemoryStore.ts
+++ b/gamesformykids/app/games/memory/stores/useMemoryStore.ts
@@ -7,7 +7,7 @@ import {
 import { MEMORY_GAME_ANIMALS } from '@/lib/constants/gameData/natureData/animals';
 import { MEMORY_GAME_CONSTANTS } from '@/lib/constants/gameData/special';
 import { MemoryCard } from '../types/memory';
-import { getDifficultyOptions, getPerformanceLevel, getWinAchievements } from './memoryDisplayHelpers';
+import { getDifficultyOptions, getPerformanceLevel } from './memoryDisplayHelpers';
 import {
   MemoryStoreState,
   MemoryStoreActions,
@@ -92,12 +92,6 @@ export const useMemoryStore = makeStore<MemoryStoreState & MemoryStoreActions>(
     getPerformanceLevel: () => {
       const { gameStats, timeLeft } = get();
       return getPerformanceLevel(gameStats.score, gameStats.moves, timeLeft, formatTime);
-    },
-
-    getWinAchievements: () => {
-      const { gameStats, timeLeft, getGameProgress } = get();
-      const { totalPairs } = getGameProgress();
-      return getWinAchievements(gameStats.score, gameStats.moves, gameStats.streak, gameStats.perfectMatches, timeLeft, totalPairs);
     },
 
     // ─── Timer actions ───────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- `MemoryStartScreen` wasn't passing `buttonClass` to `GameMenuCard`, so the start button rendered with `bg-gradient-to-r` and no color stops — invisible white-on-white, leaving only the floating 🧠 emoji visible with no clickable-looking button.
- `WinAchievements` selected `s.getWinAchievements()` directly inside a Zustand selector, which built a brand-new array on every snapshot read. React's `useSyncExternalStore` never saw a stable snapshot, threw "Maximum update depth exceeded", and the error boundary caught it — showing a generic error screen the moment the player finished the game instead of the win screen. Fixed by selecting primitive state (score, moves, streak, etc.) and computing the achievements list via `useMemo`. Removed the now-unused `getWinAchievements` store method that caused the footgun.

Closes #1447

## Test plan
- [x] `npx tsc --noEmit` — zero errors
- [x] Verified visually: start button now renders as a proper purple/pink gradient button
- [x] Automated Playwright run: played a full easy/medium game to completion — win screen renders cleanly, zero console errors, zero page errors, no error text
- [x] Automated run confirms the pairs progress counter updates correctly during play

🤖 Generated with [Claude Code](https://claude.com/claude-code)