### PR TITLE
fix(cards): shared card UI — nikud/english sync, safe classes, real keyboard focus

### DIFF
--- a/gamesformykids/components/shared/cards/GameCardGrid.tsx
+++ b/gamesformykids/components/shared/cards/GameCardGrid.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useCallback, useRef } from 'react';
+import { useState, useCallback, useRef, useEffect } from 'react';
 import { ComponentTypes } from "@/lib/types";
 import { useGridFillers } from "@/hooks";
 
@@ -29,6 +29,15 @@ export function GameCardGrid<T extends GameItemType>({
   const [tooltipKey, setTooltipKey] = useState<string | null>(null);
   const longPressRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const hoverRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const itemRefs = useRef<Array<HTMLDivElement | null>>([]);
+
+  // Keep real DOM/AT focus in sync with the virtual arrow-key focus ring,
+  // so Tab order and arrow-key navigation don't visibly disagree.
+  useEffect(() => {
+    if (typeof focusedIdx === 'number' && focusedIdx >= 0) {
+      itemRefs.current[focusedIdx]?.focus();
+    }
+  }, [focusedIdx]);
 
   const getTooltipHandlers = useCallback((key: string) => ({
     onMouseEnter: () => { hoverRef.current = setTimeout(() => setTooltipKey(key), 200); },
@@ -89,7 +98,10 @@ export function GameCardGrid<T extends GameItemType>({
         return (
           <div
             key={itemKey}
-            className={`relative ${isFocused ? 'ring-4 ring-blue-400 ring-offset-2 rounded-3xl' : ''}`}
+            ref={(el) => { itemRefs.current[idx] = el; }}
+            tabIndex={-1}
+            aria-current={isFocused ? 'true' : undefined}
+            className={`relative outline-none ${isFocused ? 'ring-4 ring-blue-400 ring-offset-2 rounded-3xl' : ''}`}
             {...(englishLabel ? getTooltipHandlers(itemKey) : {})}
           >
             {tooltipKey === itemKey && englishLabel && (

--- a/gamesformykids/components/shared/cards/PhotoGameCard.tsx
+++ b/gamesformykids/components/shared/cards/PhotoGameCard.tsx
@@ -2,6 +2,7 @@
 
 import { useState, ComponentType } from "react";
 import { GameItemCardProps } from "@/lib/types/components/cards";
+import { useAudioSettingsStore } from "@/lib/stores/audioSettingsStore";
 import {
   PHOTO_CARD_CONFIGS,
   PhotoCardConfig,
@@ -16,10 +17,13 @@ interface PhotoGameCardProps extends GameItemCardProps {
 
 function PhotoGameCard({ item, onClick, isSelected, config }: PhotoGameCardProps) {
   const [imageError, setImageError] = useState(false);
+  const showNikud = useAudioSettingsStore((s) => s.showNikud);
+  const showEnglish = useAudioSettingsStore((s) => s.showEnglish);
 
   const imageUrl = config.imageUrls[item.name];
   const cardBg = config.cardBgMap?.[item.name] ?? config.cardBg;
   const border = isSelected ? config.selectedBorder : config.defaultBorder;
+  const resolvedHebrew = showNikud && item.hebrewNikud ? item.hebrewNikud : item.hebrew;
 
   return (
     <button
@@ -55,8 +59,16 @@ function PhotoGameCard({ item, onClick, isSelected, config }: PhotoGameCardProps
         <span
           className={`text-xs md:text-sm font-bold ${config.labelText} text-center block leading-tight`}
         >
-          {item.hebrew}
+          {resolvedHebrew}
         </span>
+        {showEnglish && item.english && (
+          <span
+            className={`text-xs ${config.labelText} text-center block leading-tight opacity-80`}
+            dir="ltr"
+          >
+            {item.english}
+          </span>
+        )}
       </div>
     </button>
   );

--- a/gamesformykids/components/shared/cards/SimpleCard.tsx
+++ b/gamesformykids/components/shared/cards/SimpleCard.tsx
@@ -1,6 +1,7 @@
 import { Volume2 } from "lucide-react";
 import { ComponentTypes } from "@/lib/types";
 import { useAudioSettingsStore } from "@/lib/stores/audioSettingsStore";
+import { shadowClasses, borderWidthClasses } from "./cardStyleMaps";
 
 type SimpleCardProps = Pick<
   ComponentTypes.UnifiedCardProps,
@@ -62,7 +63,7 @@ export function SimpleCard({
       type="button"
       className={`
         ${sizeClasses[size]} ${shapeClasses[shape]}
-        shadow-${shadow} ${color} ${textColor} border-${borderWidth} ${borderColor}
+        ${shadowClasses[shadow] ?? "shadow-lg"} ${color} ${textColor} ${borderWidthClasses[borderWidth] ?? "border-4"} ${borderColor}
         transform ${hoverEffect === "scale" ? "hover:scale-110" : ""}
         transition-[transform,box-shadow] duration-300 cursor-pointer
         flex flex-col items-center justify-center p-2

--- a/gamesformykids/components/shared/screens/AutoStartScreen.tsx
+++ b/gamesformykids/components/shared/screens/AutoStartScreen.tsx
@@ -54,7 +54,7 @@ export default function AutoStartScreen() {
             variant="simple"
             item={item}
             hebrewText={item.hebrew || ''}
-            color={item.color || '#000'}
+            color={item.color}
             icon={<span className="text-3xl">{item.emoji || '🎯'}</span>}
             shape="circle"
             size="large"


### PR DESCRIPTION
## Summary
- `PhotoGameCard` now reads `useAudioSettingsStore` and swaps in `hebrewNikud`/`english` the same way `SimpleCard`/`AdvancedCard` already do — the global nikud/English toggle previously had zero effect on the ~14 games routed through `createPhotoCard` (butterflies, dog/cat breeds, NBA teams, tech logos, dinosaurs, world landmarks, etc.).
- `SimpleCard` now builds its shadow/border classes through the shared `cardStyleMaps.ts` lookup instead of raw template literals, matching `AdvancedCard`'s pattern (avoids Tailwind purge risk and unconstrained `borderWidth` values).
- `AutoStartScreen` no longer passes a CSS hex string (`'#000'`) into `color`, a prop that expects a Tailwind background class — items with no `item.color` now correctly fall back to `SimpleCard`'s own default instead of silently losing their background.
- `GameCardGrid`'s arrow-key focus ring now moves real DOM focus (via a ref per item + `.focus()`) and sets `aria-current` on the focused card, instead of only toggling a ring class with no assistive-tech signal.

Closes #1449

## Test plan
- [x] `npx tsc --noEmit` — zero errors
- [x] `npm run build` — zero errors
- [ ] Manually verify nikud/English toggle affects a photo-quiz game (e.g. `/games/butterflies`)
- [ ] Manually verify arrow-key navigation on a card game grid (e.g. `/games/animals`) moves visible focus consistently with Tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)