### PR TITLE
fix(math): MathGameCard crashes every card on /games/math

### DIFF
--- a/gamesformykids/components/shared/cards/MathGameCard.tsx
+++ b/gamesformykids/components/shared/cards/MathGameCard.tsx
@@ -17,8 +17,8 @@ const COLORS = [
 export default function MathGameCard({ item, onClick }: GameItemCardProps) {
   const currentChallenge = useGameSessionStore((s) => s.currentChallenge);
   const emoji = currentChallenge?.emoji || "⭐";
-  const count = Number(item.name);
-  const colorIndex = Math.abs(count) % COLORS.length;
+  const count = Number(item.digit ?? item.name);
+  const colorIndex = Number.isFinite(count) ? Math.abs(count) % COLORS.length : 0;
   const { bg, hover, border } = COLORS[colorIndex]!;
 
   // Clamp emoji repetitions to avoid huge grids


### PR DESCRIPTION
## Summary
- `MathGameCard` computed `Number(item.name)` to pick a card color, but the `'math'` game type's real item data (`ALL_NUMBERS`) has spelled-out names (`"zero"`..`"ten"`), not numeric strings — `Number("one")` is `NaN`, so `COLORS[NaN]` is `undefined`, and the non-null-asserted destructure (`const { bg, hover, border } = COLORS[colorIndex]!`) threw a `TypeError` on every card render, crashing `/games/math`.
- Fixed by reading `item.digit` (the field `BaseGameItem` already reserves for numeric display) instead of parsing `item.name`, with a safe fallback color index if the value is ever non-numeric.

Closes #1451

## Test plan
- [x] `npx tsc --noEmit` — zero errors
- [x] `npm run build` — zero errors
- [ ] Manually verify `/games/math` renders cards without crashing

🤖 Generated with [Claude Code](https://claude.com/claude-code)