### PR TITLE
fix(homepage): dark-mode contrast, alignment & visual-family consistency

### DIFF
--- a/gamesformykids/components/game/AgeGroupCard.tsx
+++ b/gamesformykids/components/game/AgeGroupCard.tsx
@@ -9,13 +9,13 @@ export default function AgeGroupCard({ ageKey }: { ageKey: string }) {
 
   if (!ageGroup) return null;
   return (
-    <div className="bg-white rounded-2xl p-4 md:p-6 shadow-lg hover:shadow-xl transition-shadow duration-300">
+    <div className="bg-white dark:bg-gray-800 rounded-2xl p-4 md:p-6 shadow-lg hover:shadow-xl transition-shadow duration-300">
       {/* Header — horizontal on mobile, centered on desktop */}
       <div className="flex items-center gap-3 sm:flex-col sm:items-center sm:text-center mb-3 md:mb-4">
         <div className="text-4xl sm:mb-1">{ageGroup.icon}</div>
         <div>
-          <h3 className="text-base md:text-xl font-bold text-gray-800 mb-0.5">{ageGroup.title}</h3>
-          <p className="text-xs text-gray-600 sm:hidden md:block">{ageGroup.description}</p>
+          <h3 className="text-base md:text-xl font-bold text-gray-800 dark:text-gray-100 mb-0.5">{ageGroup.title}</h3>
+          <p className="text-xs text-gray-600 dark:text-gray-400 sm:hidden md:block">{ageGroup.description}</p>
         </div>
       </div>
 
@@ -23,29 +23,29 @@ export default function AgeGroupCard({ ageKey }: { ageKey: string }) {
         {ageGroup.recommendedGames.length > 0 ? (
           ageGroup.recommendedGames.map((game) => (
             <Link key={game.id} href={game.href} prefetch={false}>
-              <div className="flex items-center p-2.5 md:p-3 bg-gradient-to-r from-gray-50 to-gray-100/50 rounded-xl hover:from-purple-50 hover:to-blue-50 transition-shadow duration-300 cursor-pointer shadow-sm hover:shadow-md border border-gray-100">
+              <div className="flex items-center p-2.5 md:p-3 bg-gradient-to-r from-gray-50 to-gray-100/50 dark:from-gray-700 dark:to-gray-700/50 rounded-xl hover:from-purple-50 hover:to-blue-50 dark:hover:from-gray-600 dark:hover:to-gray-600 transition-shadow duration-300 cursor-pointer shadow-sm hover:shadow-md border border-gray-100 dark:border-gray-600">
                 <div className="flex-shrink-0 ms-3">
-                  <div className="bg-gradient-to-br from-purple-100 to-blue-100 p-1.5 rounded-lg">
-                    <game.icon className="w-6 h-6 md:w-7 md:h-7 text-purple-600" />
+                  <div className="bg-gradient-to-br from-purple-100 to-blue-100 dark:from-purple-900/50 dark:to-blue-900/50 p-1.5 rounded-lg">
+                    <game.icon className="w-6 h-6 md:w-7 md:h-7 text-purple-600 dark:text-purple-300" />
                   </div>
                 </div>
                 <div className="flex-1 min-w-0">
-                  <h4 className="font-semibold text-gray-800 text-base">{game.title}</h4>
-                  <p className="text-sm text-gray-500 sm:hidden md:block">{game.description}</p>
+                  <h4 className="font-semibold text-gray-800 dark:text-gray-100 text-base">{game.title}</h4>
+                  <p className="text-sm text-gray-500 dark:text-gray-400 sm:hidden md:block">{game.description}</p>
                 </div>
               </div>
             </Link>
           ))
         ) : (
-          <div className="text-center py-4 text-gray-500">
+          <div className="text-center py-4 text-gray-500 dark:text-gray-400">
             <div className="text-2xl mb-2">🔄</div>
             <p className="text-sm">משחקים בהכנה...</p>
           </div>
         )}
       </div>
 
-      <div className="mt-3 md:mt-4 pt-3 md:pt-4 border-t border-gray-200">
-        <div className="flex items-center justify-center gap-3 text-xs text-gray-500">
+      <div className="mt-3 md:mt-4 pt-3 md:pt-4 border-t border-gray-200 dark:border-gray-700">
+        <div className="flex items-center justify-center gap-3 text-xs text-gray-500 dark:text-gray-400">
           <div className="flex items-center">
             <Users className="w-3.5 h-3.5 ms-1" />
             <span>מותאם לגיל</span>

--- a/gamesformykids/components/game/AllGamesView.tsx
+++ b/gamesformykids/components/game/AllGamesView.tsx
@@ -23,8 +23,8 @@ export default function AllGamesView({ games: gamesProp, isFiltered = false }: P
     return (
       <div className="text-center py-16" dir="rtl">
         <div className="text-5xl mb-4">🔍</div>
-        <p className="text-xl font-bold text-gray-600 mb-2">לא נמצאו משחקים</p>
-        <p className="text-gray-400 text-sm">נסה מילות חיפוש שונות או קטגוריה אחרת</p>
+        <p className="text-xl font-bold text-gray-600 dark:text-gray-300 mb-2">לא נמצאו משחקים</p>
+        <p className="text-gray-400 dark:text-gray-500 text-sm">נסה מילות חיפוש שונות או קטגוריה אחרת</p>
       </div>
     );
   }
@@ -32,7 +32,7 @@ export default function AllGamesView({ games: gamesProp, isFiltered = false }: P
   if (!hydrated) {
     return (
       <div>
-        <div className="h-9 w-48 bg-gray-200 animate-pulse rounded-xl mx-auto mb-6" />
+        <div className="h-9 w-48 bg-gray-200 dark:bg-gray-700 animate-pulse rounded-xl mx-auto mb-6" />
         <GameCardSkeletonGrid count={12} />
       </div>
     );
@@ -40,7 +40,7 @@ export default function AllGamesView({ games: gamesProp, isFiltered = false }: P
 
   return (
     <div>
-      <h2 className="text-2xl md:text-3xl font-bold text-center text-gray-800 mb-5 md:mb-8">
+      <h2 className="text-2xl md:text-3xl font-bold text-center text-gray-800 dark:text-gray-100 mb-5 md:mb-8">
         {isFiltered
           ? `נמצאו ${games.length} משחקים`
           : `כל המשחקים (${games.length})`}

--- a/gamesformykids/components/game/CategoriesView.tsx
+++ b/gamesformykids/components/game/CategoriesView.tsx
@@ -18,7 +18,7 @@ export default function CategoriesView() {
 
   return (
     <div>
-      <h2 className="text-2xl md:text-3xl font-bold text-center text-gray-800 mb-5 md:mb-8">
+      <h2 className="text-2xl md:text-3xl font-bold text-center text-gray-800 dark:text-gray-100 mb-5 md:mb-8">
         בחר קטגוריה 📚
       </h2>
       <div className="grid grid-cols-2 md:grid-cols-3 gap-3 md:gap-4 lg:gap-6">

--- a/gamesformykids/components/game/CategoryGamesView.tsx
+++ b/gamesformykids/components/game/CategoryGamesView.tsx
@@ -62,19 +62,19 @@ export default function CategoryGamesView() {
       <div className="text-center mb-4 md:mb-6">
         <button
           onClick={backToCategories}
-          className="mb-3 md:mb-4 px-4 py-2 bg-gray-200 hover:bg-gray-300 text-gray-700 rounded-full font-medium transition-colors text-sm md:text-base"
+          className="mb-3 md:mb-4 px-4 py-2 bg-gray-200 hover:bg-gray-300 dark:bg-gray-700 dark:hover:bg-gray-600 text-gray-700 dark:text-gray-200 rounded-full font-medium transition-colors text-sm md:text-base"
         >
           חזור לקטגוריות →
         </button>
-        <h2 className="text-2xl md:text-3xl font-bold text-gray-800 mb-1 md:mb-2">
+        <h2 className="text-2xl md:text-3xl font-bold text-gray-800 dark:text-gray-100 mb-1 md:mb-2">
           {category.title}
         </h2>
-        <p className="text-sm md:text-lg text-gray-600 mb-2 md:mb-3 hidden sm:block">
+        <p className="text-sm md:text-lg text-gray-600 dark:text-gray-400 mb-2 md:mb-3 hidden sm:block">
           {category.description}
         </p>
         <div className="flex flex-wrap items-center justify-center gap-3 mb-1">
-          <div className="inline-block bg-blue-100 rounded-full px-3 py-1 md:px-4 md:py-2">
-            <span className="text-blue-800 font-semibold text-sm md:text-base">
+          <div className="inline-block bg-blue-100 dark:bg-blue-900/40 rounded-full px-3 py-1 md:px-4 md:py-2">
+            <span className="text-blue-800 dark:text-blue-200 font-semibold text-sm md:text-base">
               {categoryGames.length} משחקים
               ({availableGames.length} זמינים)
             </span>
@@ -103,8 +103,8 @@ export default function CategoryGamesView() {
         ) : (
           <div className="col-span-full text-center py-8 md:py-12">
             <div className="text-5xl md:text-6xl mb-3 md:mb-4">🎮</div>
-            <h3 className="text-xl md:text-2xl font-bold text-gray-600 mb-2">אין עדיין משחקים בקטגוריה זו</h3>
-            <p className="text-gray-500 text-sm md:text-base">המשחקים בקטגוריה זו עדיין בפיתוח</p>
+            <h3 className="text-xl md:text-2xl font-bold text-gray-600 dark:text-gray-300 mb-2">אין עדיין משחקים בקטגוריה זו</h3>
+            <p className="text-gray-500 dark:text-gray-400 text-sm md:text-base">המשחקים בקטגוריה זו עדיין בפיתוח</p>
           </div>
         )}
       </div>

--- a/gamesformykids/components/game/FavoritesView.tsx
+++ b/gamesformykids/components/game/FavoritesView.tsx
@@ -17,14 +17,14 @@ export default function FavoritesView() {
 
   return (
     <div>
-      <h2 className="text-2xl md:text-3xl font-bold text-center text-gray-800 mb-5 md:mb-8">
+      <h2 className="text-2xl md:text-3xl font-bold text-center text-gray-800 dark:text-gray-100 mb-5 md:mb-8">
         ⭐ המשחקים המועדפים שלי ({favoriteGames.length})
       </h2>
       {favoriteGames.length === 0 ? (
         <div className="text-center py-12 md:py-16">
           <div className="text-6xl mb-4">⭐</div>
-          <h3 className="text-xl md:text-2xl font-bold text-gray-600 mb-2">עדיין אין משחקים מועדפים</h3>
-          <p className="text-gray-500 text-sm md:text-base">
+          <h3 className="text-xl md:text-2xl font-bold text-gray-600 dark:text-gray-300 mb-2">עדיין אין משחקים מועדפים</h3>
+          <p className="text-gray-500 dark:text-gray-400 text-sm md:text-base">
             לחץ על הכוכב ⭐ על משחק כלשהו כדי להוסיף אותו לכאן
           </p>
         </div>

--- a/gamesformykids/components/game/GameCardSkeleton.tsx
+++ b/gamesformykids/components/game/GameCardSkeleton.tsx
@@ -4,10 +4,10 @@ export function GameCardSkeleton() {
   return (
     <div
       aria-hidden="true"
-      className="rounded-2xl md:rounded-3xl shadow-lg overflow-hidden bg-gray-200 animate-pulse"
+      className="rounded-2xl md:rounded-3xl shadow-lg overflow-hidden bg-gray-200 dark:bg-gray-700 animate-pulse"
       style={{ minHeight: '140px' }}
     >
-      <div className="h-full w-full bg-gradient-to-br from-gray-200 to-gray-300" />
+      <div className="h-full w-full bg-gradient-to-br from-gray-200 to-gray-300 dark:from-gray-700 dark:to-gray-600" />
     </div>
   );
 }

--- a/gamesformykids/components/game/GameSearchBar.tsx
+++ b/gamesformykids/components/game/GameSearchBar.tsx
@@ -49,7 +49,7 @@ export function GameSearchBar({
           <button
             onClick={onClear}
             aria-label="נקה חיפוש"
-            className="absolute end-3 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-600 transition-colors"
+            className="absolute end-3 top-1/2 -translate-y-1/2 text-gray-400 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-300 transition-colors"
           >
             <X className="w-4 h-4" />
           </button>
@@ -61,7 +61,7 @@ export function GameSearchBar({
         <div className="flex justify-center">
           <button
             onClick={() => setAgeRange('all')}
-            className="inline-flex items-center gap-1.5 px-3 py-1 rounded-full bg-purple-100 text-purple-700 text-xs font-semibold hover:bg-purple-200 transition-colors"
+            className="inline-flex items-center gap-1.5 px-3 py-1 rounded-full bg-purple-100 dark:bg-purple-900/40 text-purple-700 dark:text-purple-300 text-xs font-semibold hover:bg-purple-200 dark:hover:bg-purple-900/60 transition-colors"
             aria-label="הסר סינון גיל"
           >
             <span>🔧</span>

--- a/gamesformykids/components/game/RecommendationsHeader.tsx
+++ b/gamesformykids/components/game/RecommendationsHeader.tsx
@@ -5,8 +5,8 @@ import { ComponentTypes } from "@/lib/types";
 export default function RecommendationsHeader({ title, description }: ComponentTypes.RecommendationsHeaderProps) {
   return (
     <div className="text-center mb-4 md:mb-8">
-      <h2 className="text-xl md:text-3xl font-bold text-gray-800 mb-1 md:mb-2">{title}</h2>
-      <p className="text-sm md:text-lg text-gray-600 hidden sm:block">{description}</p>
+      <h2 className="text-xl md:text-3xl font-bold text-gray-800 dark:text-gray-100 mb-1 md:mb-2">{title}</h2>
+      <p className="text-sm md:text-lg text-gray-600 dark:text-gray-400 hidden sm:block">{description}</p>
     </div>
   );
 }

--- a/gamesformykids/components/layout/Footer.tsx
+++ b/gamesformykids/components/layout/Footer.tsx
@@ -8,66 +8,66 @@ function Footer() {
   const gamesInDevelopment = totalGamesCount - availableGamesCount;
   
   return (
-    <footer className="mt-8 md:mt-16 py-6 md:py-12 bg-gradient-to-br from-purple-50 to-pink-50">
+    <footer className="mt-8 md:mt-16 py-6 md:py-12 bg-gradient-to-br from-purple-50 to-pink-50 dark:from-gray-900 dark:to-gray-900 dark:border-t dark:border-gray-800">
       <div className="max-w-6xl mx-auto px-4">
         {/* Stats section */}
         <div className="grid grid-cols-3 gap-3 md:gap-6 mb-6 md:mb-8">
-          <div className="text-center bg-white rounded-2xl p-3 md:p-6 shadow-lg">
-            <div className="text-2xl md:text-4xl font-bold text-purple-600 mb-1 md:mb-2">{availableGamesCount}</div>
-            <div className="text-xs md:text-lg font-semibold text-gray-700">משחקים</div>
-            <div className="text-xs text-gray-500 hidden sm:block">מוכנים לשחק!</div>
+          <div className="text-center bg-white dark:bg-gray-800 rounded-2xl p-3 md:p-6 shadow-lg">
+            <div className="text-2xl md:text-4xl font-bold text-purple-600 dark:text-purple-400 mb-1 md:mb-2">{availableGamesCount}</div>
+            <div className="text-xs md:text-lg font-semibold text-gray-700 dark:text-gray-200">משחקים</div>
+            <div className="text-xs text-gray-500 dark:text-gray-400 hidden sm:block">מוכנים לשחק!</div>
           </div>
-          
-          <div className="text-center bg-white rounded-2xl p-3 md:p-6 shadow-lg">
-            <div className="text-2xl md:text-4xl font-bold text-pink-600 mb-1 md:mb-2">3-10</div>
-            <div className="text-xs md:text-lg font-semibold text-gray-700">גילאי מטרה</div>
-            <div className="text-xs text-gray-500 hidden sm:block">שנים</div>
+
+          <div className="text-center bg-white dark:bg-gray-800 rounded-2xl p-3 md:p-6 shadow-lg">
+            <div className="text-2xl md:text-4xl font-bold text-pink-600 dark:text-pink-400 mb-1 md:mb-2">3-10</div>
+            <div className="text-xs md:text-lg font-semibold text-gray-700 dark:text-gray-200">גילאי מטרה</div>
+            <div className="text-xs text-gray-500 dark:text-gray-400 hidden sm:block">שנים</div>
           </div>
-          
+
           {gamesInDevelopment > 0 && (
-            <div className="text-center bg-white rounded-2xl p-3 md:p-6 shadow-lg">
-              <div className="text-2xl md:text-4xl font-bold text-orange-600 mb-1 md:mb-2">{gamesInDevelopment}</div>
-              <div className="text-xs md:text-lg font-semibold text-gray-700">בפיתוח</div>
-              <div className="text-xs text-gray-500 hidden sm:block">בקרוב!</div>
+            <div className="text-center bg-white dark:bg-gray-800 rounded-2xl p-3 md:p-6 shadow-lg">
+              <div className="text-2xl md:text-4xl font-bold text-orange-600 dark:text-orange-400 mb-1 md:mb-2">{gamesInDevelopment}</div>
+              <div className="text-xs md:text-lg font-semibold text-gray-700 dark:text-gray-200">בפיתוח</div>
+              <div className="text-xs text-gray-500 dark:text-gray-400 hidden sm:block">בקרוב!</div>
             </div>
           )}
         </div>
-        
+
         {/* Main footer content */}
         <div className="text-center">
           <div className="text-3xl md:text-4xl mb-2 md:mb-4">💜</div>
-          <p className="text-base md:text-xl font-semibold text-purple-700 mb-1 md:mb-2">נוצר במיוחד לילדים בגיל 3-10</p>
-          <p className="text-sm text-gray-600 mb-3 md:mb-4 hidden sm:block">משחקים בטוחים, חינוכיים ומהנים לכל המשפחה</p>
-          
+          <p className="text-base md:text-xl font-semibold text-purple-700 dark:text-purple-300 mb-1 md:mb-2">נוצר במיוחד לילדים בגיל 3-10</p>
+          <p className="text-sm text-gray-600 dark:text-gray-400 mb-3 md:mb-4 hidden sm:block">משחקים בטוחים, חינוכיים ומהנים לכל המשפחה</p>
+
           {/* Features list */}
-          <div className="flex flex-wrap justify-center gap-2 md:gap-4 text-xs md:text-sm text-gray-600">
-            <span className="bg-purple-100 px-2 md:px-3 py-1 rounded-full">🔒 בטוח</span>
-            <span className="bg-blue-100 px-2 md:px-3 py-1 rounded-full">📱 נייד</span>
-            <span className="bg-green-100 px-2 md:px-3 py-1 rounded-full">🎯 חינוכי</span>
-            <span className="bg-yellow-100 px-2 md:px-3 py-1 rounded-full">🎮 מהנה</span>
+          <div className="flex flex-wrap justify-center gap-2 md:gap-4 text-xs md:text-sm text-gray-600 dark:text-gray-300">
+            <span className="bg-purple-100 dark:bg-purple-900/40 dark:text-purple-200 px-2 md:px-3 py-1 rounded-full">🔒 בטוח</span>
+            <span className="bg-blue-100 dark:bg-blue-900/40 dark:text-blue-200 px-2 md:px-3 py-1 rounded-full">📱 נייד</span>
+            <span className="bg-green-100 dark:bg-green-900/40 dark:text-green-200 px-2 md:px-3 py-1 rounded-full">🎯 חינוכי</span>
+            <span className="bg-yellow-100 dark:bg-yellow-900/40 dark:text-yellow-200 px-2 md:px-3 py-1 rounded-full">🎮 מהנה</span>
           </div>
 
           {/* Section links */}
           <div className="flex flex-wrap justify-center gap-3 md:gap-5 text-sm mt-5 md:mt-6">
-            <Link href="/tools"          className="text-teal-600 hover:text-teal-800 font-medium transition-colors">🎲 כלי כיתה</Link>
-            <Link href="/creative"       className="text-purple-600 hover:text-purple-800 font-medium transition-colors">🎨 יצירה</Link>
-            <Link href="/riddles"        className="text-orange-600 hover:text-orange-800 font-medium transition-colors">🤣 חידות</Link>
-            <Link href="/learning-paths" className="text-indigo-600 hover:text-indigo-800 font-medium transition-colors">🗺️ מסלולי למידה</Link>
-            <Link href="/"               className="text-blue-600 hover:text-blue-800 font-medium transition-colors">🎮 משחקים</Link>
+            <Link href="/tools"          className="text-teal-600 dark:text-teal-400 hover:text-teal-800 dark:hover:text-teal-300 font-medium transition-colors">🎲 כלי כיתה</Link>
+            <Link href="/creative"       className="text-purple-600 dark:text-purple-400 hover:text-purple-800 dark:hover:text-purple-300 font-medium transition-colors">🎨 יצירה</Link>
+            <Link href="/riddles"        className="text-orange-600 dark:text-orange-400 hover:text-orange-800 dark:hover:text-orange-300 font-medium transition-colors">🤣 חידות</Link>
+            <Link href="/learning-paths" className="text-indigo-600 dark:text-indigo-400 hover:text-indigo-800 dark:hover:text-indigo-300 font-medium transition-colors">🗺️ מסלולי למידה</Link>
+            <Link href="/"               className="text-blue-600 dark:text-blue-400 hover:text-blue-800 dark:hover:text-blue-300 font-medium transition-colors">🎮 משחקים</Link>
           </div>
-          
+
           {/* Developer credit */}
-          <div className="mt-6 pt-6 border-t border-gray-300">
-            <p className="text-sm text-gray-600 mb-2">פותח באהבה על ידי</p>
-            <a 
-              href="https://www.linkedin.com/in/davidchen-benshabbat" 
-              target="_blank" 
+          <div className="mt-6 pt-6 border-t border-gray-300 dark:border-gray-700">
+            <p className="text-sm text-gray-600 dark:text-gray-400 mb-2">פותח באהבה על ידי</p>
+            <a
+              href="https://www.linkedin.com/in/davidchen-benshabbat"
+              target="_blank"
               rel="noopener noreferrer"
-              className="text-lg font-semibold text-purple-700 hover:text-purple-800 transition-colors underline decoration-2 underline-offset-4"
+              className="text-lg font-semibold text-purple-700 dark:text-purple-300 hover:text-purple-800 dark:hover:text-purple-200 transition-colors underline decoration-2 underline-offset-4"
             >
               דוד-חן בן שבת
             </a>
-            <div className="text-xs text-gray-500 mt-1">💼 LinkedIn Profile</div>
+            <div className="text-xs text-gray-500 dark:text-gray-500 mt-1">💼 LinkedIn Profile</div>
           </div>
         </div>
       </div>

--- a/gamesformykids/components/layout/header/FeatureHighlights.tsx
+++ b/gamesformykids/components/layout/header/FeatureHighlights.tsx
@@ -11,10 +11,10 @@ export function FeatureHighlights() {
       <div className="max-w-4xl mx-auto mb-4 md:mb-8 hidden md:block">
         <div className="grid grid-cols-1 md:grid-cols-3 gap-4 px-4">
           {FEATURES.map(({ emoji, ariaLabel, title, description }) => (
-            <div key={title} className="bg-white/70 rounded-2xl p-4 shadow-md">
+            <div key={title} className="bg-white/70 dark:bg-gray-800/70 rounded-2xl p-4 shadow-md">
               <div className="text-3xl mb-2" role="img" aria-label={ariaLabel}>{emoji}</div>
-              <h2 className="font-bold text-purple-800">{title}</h2>
-              <p className="text-sm text-purple-600">{description}</p>
+              <h2 className="font-bold text-purple-800 dark:text-purple-300">{title}</h2>
+              <p className="text-sm text-purple-600 dark:text-purple-400">{description}</p>
             </div>
           ))}
         </div>
@@ -23,7 +23,7 @@ export function FeatureHighlights() {
       {/* Mobile: compact badges */}
       <div className="flex justify-center gap-2 md:hidden mb-2">
         {FEATURES.map(({ emoji, title }) => (
-          <span key={title} className="bg-white/70 rounded-full px-3 py-1 text-xs font-bold text-purple-700 shadow-sm">
+          <span key={title} className="bg-white/70 dark:bg-gray-800/70 rounded-full px-3 py-1 text-xs font-bold text-purple-700 dark:text-purple-300 shadow-sm">
             {emoji} {title}
           </span>
         ))}

--- a/gamesformykids/components/marketing/ClientOnlyFeaturedGame.tsx
+++ b/gamesformykids/components/marketing/ClientOnlyFeaturedGame.tsx
@@ -8,12 +8,12 @@ const FeaturedGameContent = dynamic(() => import('./FeaturedGameContent'), {
   loading: () => (
     <div className="max-w-6xl mx-auto px-4 mb-12">
       <div className="text-center mb-6">
-        <h2 className="text-3xl font-bold text-gray-800 mb-2">⭐ משחק היום ⭐</h2>
-        <p className="text-lg text-gray-600">המשחק המומלץ שלנו עבורכם היום!</p>
+        <h2 className="text-3xl font-bold text-gray-800 dark:text-gray-100 mb-2">⭐ משחק היום ⭐</h2>
+        <p className="text-lg text-gray-600 dark:text-gray-400">המשחק המומלץ שלנו עבורכם היום!</p>
       </div>
-      
+
       <div className="relative max-w-2xl mx-auto">
-        <div className="relative bg-gradient-to-br from-gray-300 via-gray-300 to-gray-300 rounded-3xl p-8 shadow-2xl animate-pulse">
+        <div className="relative bg-gradient-to-br from-gray-300 via-gray-300 to-gray-300 dark:from-gray-700 dark:via-gray-700 dark:to-gray-700 rounded-3xl p-8 shadow-2xl animate-pulse">
           <div className="flex flex-col md:flex-row items-center gap-8">
             <div className="relative bg-white bg-opacity-20 rounded-2xl p-6 backdrop-blur-sm">
               <div className="w-16 h-16 bg-gray-400 rounded-lg animate-pulse"></div>

--- a/gamesformykids/components/marketing/ContinueBanner.tsx
+++ b/gamesformykids/components/marketing/ContinueBanner.tsx
@@ -16,25 +16,27 @@ export default function ContinueBanner() {
   if (!reg) return null;
 
   return (
-    <div dir="rtl" className="mx-4 mt-3 rounded-2xl bg-linear-to-l from-purple-500 to-indigo-600 text-white shadow-lg flex items-center gap-3 px-4 py-3">
-      {avatarEmoji ? (
-        <span className="text-3xl">{avatarEmoji}</span>
-      ) : (
-        <span className="text-3xl">{reg.emoji}</span>
-      )}
-      <div className="flex-1 min-w-0">
-        <p className="text-xs opacity-80 font-medium">ממשיכים מאיפה שעצרת</p>
-        <p className="font-bold truncate">{reg.title}</p>
+    <div dir="rtl" className="max-w-6xl mx-auto px-4 mt-3">
+      <div className="rounded-2xl bg-linear-to-l from-purple-500 to-indigo-600 text-white shadow-lg flex items-center gap-3 px-4 py-3">
+        {avatarEmoji ? (
+          <span className="text-3xl">{avatarEmoji}</span>
+        ) : (
+          <span className="text-3xl">{reg.emoji}</span>
+        )}
+        <div className="flex-1 min-w-0">
+          <p className="text-xs opacity-80 font-medium">ממשיכים מאיפה שעצרת</p>
+          <p className="font-bold truncate">{reg.title}</p>
+        </div>
+        <Link
+          href={reg.href}
+          className="shrink-0 bg-white text-purple-600 font-bold text-sm px-4 py-1.5 rounded-xl hover:bg-purple-50 active:scale-95 transition-transform"
+        >
+          ▶ המשך
+        </Link>
+        <button onClick={dismiss} aria-label="סגור" className="shrink-0 opacity-70 hover:opacity-100">
+          <X className="w-4 h-4" />
+        </button>
       </div>
-      <Link
-        href={reg.href}
-        className="shrink-0 bg-white text-purple-600 font-bold text-sm px-4 py-1.5 rounded-xl hover:bg-purple-50 active:scale-95 transition-transform"
-      >
-        ▶ המשך
-      </Link>
-      <button onClick={dismiss} aria-label="סגור" className="shrink-0 opacity-70 hover:opacity-100">
-        <X className="w-4 h-4" />
-      </button>
     </div>
   );
 }

--- a/gamesformykids/components/marketing/DailyChallenge.tsx
+++ b/gamesformykids/components/marketing/DailyChallenge.tsx
@@ -13,25 +13,27 @@ export default function DailyChallenge() {
   if (!reg) return null;
 
   return (
-    <div dir="rtl" className="mx-4 mt-3 rounded-2xl bg-linear-to-l from-amber-400 to-orange-500 text-white shadow-lg px-4 py-3">
-      <p className="text-xs opacity-80 font-bold mb-1">🎯 אתגר יומי</p>
-      <div className="flex items-center gap-3">
-        <span className="text-3xl">{reg.emoji}</span>
-        <div className="flex-1 min-w-0">
-          <p className="font-bold truncate">{reg.title}</p>
-          <p className="text-xs opacity-80">שחק את משחק היום!</p>
+    <div dir="rtl" className="max-w-6xl mx-auto px-4 mt-3">
+      <div className="rounded-2xl bg-linear-to-l from-emerald-500 to-teal-600 text-white shadow-lg px-4 py-3">
+        <p className="text-xs opacity-80 font-bold mb-1">🎯 אתגר יומי</p>
+        <div className="flex items-center gap-3">
+          <span className="text-3xl">{reg.emoji}</span>
+          <div className="flex-1 min-w-0">
+            <p className="font-bold truncate">{reg.title}</p>
+            <p className="text-xs opacity-80">שחק את משחק היום!</p>
+          </div>
+          {done ? (
+            <span className="shrink-0 bg-white text-green-600 font-bold text-sm px-4 py-1.5 rounded-xl">✅ עשית!</span>
+          ) : (
+            <Link
+              href={reg.href}
+              onClick={markDone}
+              className="shrink-0 bg-white text-emerald-600 font-bold text-sm px-4 py-1.5 rounded-xl hover:bg-emerald-50 active:scale-95 transition-transform"
+            >
+              שחק עכשיו
+            </Link>
+          )}
         </div>
-        {done ? (
-          <span className="shrink-0 bg-white text-green-600 font-bold text-sm px-4 py-1.5 rounded-xl">✅ עשית!</span>
-        ) : (
-          <Link
-            href={reg.href}
-            onClick={markDone}
-            className="shrink-0 bg-white text-orange-600 font-bold text-sm px-4 py-1.5 rounded-xl hover:bg-orange-50 active:scale-95 transition-transform"
-          >
-            שחק עכשיו
-          </Link>
-        )}
       </div>
     </div>
   );

--- a/gamesformykids/components/marketing/FactOfTheDay.tsx
+++ b/gamesformykids/components/marketing/FactOfTheDay.tsx
@@ -21,28 +21,30 @@ export default function FactOfTheDay() {
   }
 
   return (
-    <div dir="rtl" className="mx-4 mt-3 rounded-2xl bg-linear-to-l from-sky-400 to-indigo-500 text-white shadow-lg overflow-hidden">
-      <div className="px-4 py-3">
-        <p className="text-xs opacity-80 font-bold mb-2">💡 ידעת?</p>
-        <div className="flex items-start gap-3">
-          <span className="text-4xl shrink-0 leading-none mt-0.5">{fact.emoji}</span>
-          <div className="flex-1 min-w-0">
-            <p className="font-bold text-sm leading-snug">{fact.he}</p>
-            <div className="mt-2 flex gap-2">
-              <button
-                onClick={handleTTS}
-                aria-label="האזן לעובדה"
-                className="bg-white/20 hover:bg-white/30 active:scale-95 transition-[transform,background-color] text-white text-xs font-bold px-3 py-1.5 rounded-xl"
-              >
-                🔊 האזן
-              </button>
-              <button
-                onClick={shareWhatsApp}
-                className="flex items-center gap-1 bg-green-500 hover:bg-green-600 active:scale-95 transition-[transform,background-color] text-white text-xs font-bold px-3 py-1.5 rounded-xl"
-              >
-                <span>📲</span>
-                <span>שתף</span>
-              </button>
+    <div dir="rtl" className="max-w-6xl mx-auto px-4 mt-3">
+      <div className="rounded-2xl bg-linear-to-l from-sky-400 to-indigo-500 text-white shadow-lg overflow-hidden">
+        <div className="px-4 py-3">
+          <p className="text-xs opacity-80 font-bold mb-2">💡 ידעת?</p>
+          <div className="flex items-start gap-3">
+            <span className="text-4xl shrink-0 leading-none mt-0.5">{fact.emoji}</span>
+            <div className="flex-1 min-w-0">
+              <p className="font-bold text-sm leading-snug">{fact.he}</p>
+              <div className="mt-2 flex gap-2">
+                <button
+                  onClick={handleTTS}
+                  aria-label="האזן לעובדה"
+                  className="bg-white/20 hover:bg-white/30 active:scale-95 transition-[transform,background-color] text-white text-xs font-bold px-3 py-1.5 rounded-xl"
+                >
+                  🔊 האזן
+                </button>
+                <button
+                  onClick={shareWhatsApp}
+                  className="flex items-center gap-1 bg-green-500 hover:bg-green-600 active:scale-95 transition-[transform,background-color] text-white text-xs font-bold px-3 py-1.5 rounded-xl"
+                >
+                  <span>📲</span>
+                  <span>שתף</span>
+                </button>
+              </div>
             </div>
           </div>
         </div>

--- a/gamesformykids/components/marketing/FeaturedGameContent.tsx
+++ b/gamesformykids/components/marketing/FeaturedGameContent.tsx
@@ -12,12 +12,12 @@ const FeaturedGameContent = () => {
     return (
       <div className="max-w-6xl mx-auto px-4 mb-12">
         <div className="text-center mb-6">
-          <h2 className="text-3xl font-bold text-gray-800 mb-2">⭐ משחק היום ⭐</h2>
-          <p className="text-lg text-gray-600">המשחק המומלץ שלנו עבורכם היום!</p>
+          <h2 className="text-3xl font-bold text-gray-800 dark:text-gray-100 mb-2">⭐ משחק היום ⭐</h2>
+          <p className="text-lg text-gray-600 dark:text-gray-400">המשחק המומלץ שלנו עבורכם היום!</p>
         </div>
-        
+
         <div className="relative max-w-2xl mx-auto">
-          <div className="relative bg-gradient-to-br from-gray-300 via-gray-300 to-gray-300 rounded-3xl p-8 shadow-2xl animate-pulse">
+          <div className="relative bg-gradient-to-br from-gray-300 via-gray-300 to-gray-300 dark:from-gray-700 dark:via-gray-700 dark:to-gray-700 rounded-3xl p-8 shadow-2xl animate-pulse">
             <div className="flex flex-col md:flex-row items-center gap-8">
               <div className="relative bg-white bg-opacity-20 rounded-2xl p-6 backdrop-blur-sm">
                 <div className="w-16 h-16 bg-gray-400 rounded-lg animate-pulse"></div>
@@ -39,8 +39,8 @@ const FeaturedGameContent = () => {
   return (
     <div className="max-w-6xl mx-auto px-4 mb-12">
       <div className="text-center mb-6">
-        <h2 className="text-3xl font-bold text-gray-800 mb-2">⭐ משחק היום ⭐</h2>
-        <p className="text-lg text-gray-600">המשחק המומלץ שלנו עבורכם היום!</p>
+        <h2 className="text-3xl font-bold text-gray-800 dark:text-gray-100 mb-2">⭐ משחק היום ⭐</h2>
+        <p className="text-lg text-gray-600 dark:text-gray-400">המשחק המומלץ שלנו עבורכם היום!</p>
       </div>
       
       <div className="relative max-w-2xl mx-auto">

--- a/gamesformykids/components/marketing/GamesTodayBadge.tsx
+++ b/gamesformykids/components/marketing/GamesTodayBadge.tsx
@@ -17,12 +17,12 @@ export default function GamesTodayBadge() {
     : null;
 
   return (
-    <div dir="rtl" className="mx-4 mt-2 flex items-center gap-2">
+    <div dir="rtl" className="max-w-6xl mx-auto px-4 mt-2 flex items-center gap-2">
       <span className="text-sm font-bold text-gray-600 dark:text-gray-300">
         🔥 היום שיחקת {count} משחקים
       </span>
       {milestoneText && (
-        <span className="text-xs bg-yellow-100 text-yellow-700 font-bold px-2 py-0.5 rounded-full">
+        <span className="text-xs bg-yellow-100 dark:bg-yellow-900/40 text-yellow-700 dark:text-yellow-300 font-bold px-2 py-0.5 rounded-full">
           {milestoneText}
         </span>
       )}

--- a/gamesformykids/components/marketing/JokeOfTheDay.tsx
+++ b/gamesformykids/components/marketing/JokeOfTheDay.tsx
@@ -24,35 +24,37 @@ export default function JokeOfTheDay() {
   }
 
   return (
-    <div dir="rtl" className="mx-4 mt-3 rounded-2xl bg-linear-to-l from-yellow-400 to-amber-500 text-white shadow-lg overflow-hidden">
-      <div className="px-4 py-3">
-        <p className="text-xs opacity-80 font-bold mb-2">😂 בדיחה של היום</p>
-        <div className="flex items-start gap-3">
-          <span className="text-4xl shrink-0 leading-none mt-0.5">{joke.emoji}</span>
-          <div className="flex-1 min-w-0">
-            <p className="font-bold text-sm leading-snug">{joke.setup}</p>
+    <div dir="rtl" className="max-w-6xl mx-auto px-4 mt-3">
+      <div className="rounded-2xl bg-linear-to-l from-yellow-400 to-amber-500 text-white shadow-lg overflow-hidden">
+        <div className="px-4 py-3">
+          <p className="text-xs opacity-80 font-bold mb-2">😂 בדיחה של היום</p>
+          <div className="flex items-start gap-3">
+            <span className="text-4xl shrink-0 leading-none mt-0.5">{joke.emoji}</span>
+            <div className="flex-1 min-w-0">
+              <p className="font-bold text-sm leading-snug">{joke.setup}</p>
 
-            {revealed ? (
-              <div className="mt-2 animate-fade-in-up">
-                <p className="text-sm font-semibold bg-white/20 rounded-xl px-3 py-2 leading-snug">
-                  {joke.punchline}
-                </p>
+              {revealed ? (
+                <div className="mt-2 animate-fade-in-up">
+                  <p className="text-sm font-semibold bg-white/20 rounded-xl px-3 py-2 leading-snug">
+                    {joke.punchline}
+                  </p>
+                  <button
+                    onClick={shareWhatsApp}
+                    className="mt-2 flex items-center gap-1.5 bg-green-500 hover:bg-green-600 active:scale-95 transition-transform text-white text-xs font-bold px-3 py-1.5 rounded-xl"
+                  >
+                    <span>📲</span>
+                    <span>שתף בוואצאפ</span>
+                  </button>
+                </div>
+              ) : (
                 <button
-                  onClick={shareWhatsApp}
-                  className="mt-2 flex items-center gap-1.5 bg-green-500 hover:bg-green-600 active:scale-95 transition-transform text-white text-xs font-bold px-3 py-1.5 rounded-xl"
+                  onClick={reveal}
+                  className="mt-2 shrink-0 bg-white text-amber-600 font-bold text-sm px-4 py-1.5 rounded-xl hover:bg-amber-50 active:scale-95 transition-transform"
                 >
-                  <span>📲</span>
-                  <span>שתף בוואצאפ</span>
+                  לחץ לתשובה 👇
                 </button>
-              </div>
-            ) : (
-              <button
-                onClick={reveal}
-                className="mt-2 shrink-0 bg-white text-amber-600 font-bold text-sm px-4 py-1.5 rounded-xl hover:bg-amber-50 active:scale-95 transition-transform"
-              >
-                לחץ לתשובה 👇
-              </button>
-            )}
+              )}
+            </div>
           </div>
         </div>
       </div>

--- a/gamesformykids/components/marketing/RecentlyPlayedRow.tsx
+++ b/gamesformykids/components/marketing/RecentlyPlayedRow.tsx
@@ -9,7 +9,7 @@ export default function RecentlyPlayedRow() {
   if (items.length === 0) return null;
 
   return (
-    <div dir="rtl" className="mx-4 mt-3">
+    <div dir="rtl" className="max-w-6xl mx-auto px-4 mt-3">
       <p className="text-sm font-bold text-gray-600 dark:text-gray-300 mb-2 px-1">🕓 שיחקת לאחרונה</p>
       <div className="overflow-x-auto scrollbar-hide">
         <div className="flex gap-2 min-w-max pb-1">

--- a/gamesformykids/components/marketing/RiddleOfTheDay.tsx
+++ b/gamesformykids/components/marketing/RiddleOfTheDay.tsx
@@ -24,35 +24,37 @@ export default function RiddleOfTheDay() {
   }
 
   return (
-    <div dir="rtl" className="mx-4 mt-3 rounded-2xl bg-linear-to-l from-violet-500 to-purple-600 text-white shadow-lg overflow-hidden">
-      <div className="px-4 py-3">
-        <p className="text-xs opacity-80 font-bold mb-2">🤔 חידה של היום</p>
-        <div className="flex items-start gap-3">
-          <span className="text-4xl shrink-0 leading-none mt-0.5">{riddle.emoji}</span>
-          <div className="flex-1 min-w-0">
-            <p className="font-bold text-sm leading-snug">{riddle.riddle}</p>
+    <div dir="rtl" className="max-w-6xl mx-auto px-4 mt-3">
+      <div className="rounded-2xl bg-linear-to-l from-violet-500 to-purple-600 text-white shadow-lg overflow-hidden">
+        <div className="px-4 py-3">
+          <p className="text-xs opacity-80 font-bold mb-2">🤔 חידה של היום</p>
+          <div className="flex items-start gap-3">
+            <span className="text-4xl shrink-0 leading-none mt-0.5">{riddle.emoji}</span>
+            <div className="flex-1 min-w-0">
+              <p className="font-bold text-sm leading-snug">{riddle.riddle}</p>
 
-            {revealed ? (
-              <div className="mt-2 animate-fade-in-up">
-                <p className="text-sm font-semibold bg-white/20 rounded-xl px-3 py-2 leading-snug">
-                  ✅ {riddle.answer}
-                </p>
+              {revealed ? (
+                <div className="mt-2 animate-fade-in-up">
+                  <p className="text-sm font-semibold bg-white/20 rounded-xl px-3 py-2 leading-snug">
+                    ✅ {riddle.answer}
+                  </p>
+                  <button
+                    onClick={shareWhatsApp}
+                    className="mt-2 flex items-center gap-1.5 bg-green-500 hover:bg-green-600 active:scale-95 transition-transform text-white text-xs font-bold px-3 py-1.5 rounded-xl"
+                  >
+                    <span>📲</span>
+                    <span>שתף בוואצאפ</span>
+                  </button>
+                </div>
+              ) : (
                 <button
-                  onClick={shareWhatsApp}
-                  className="mt-2 flex items-center gap-1.5 bg-green-500 hover:bg-green-600 active:scale-95 transition-transform text-white text-xs font-bold px-3 py-1.5 rounded-xl"
+                  onClick={reveal}
+                  className="mt-2 shrink-0 bg-white text-purple-600 font-bold text-sm px-4 py-1.5 rounded-xl hover:bg-purple-50 active:scale-95 transition-transform"
                 >
-                  <span>📲</span>
-                  <span>שתף בוואצאפ</span>
+                  גלה תשובה 👇
                 </button>
-              </div>
-            ) : (
-              <button
-                onClick={reveal}
-                className="mt-2 shrink-0 bg-white text-purple-600 font-bold text-sm px-4 py-1.5 rounded-xl hover:bg-purple-50 active:scale-95 transition-transform"
-              >
-                גלה תשובה 👇
-              </button>
-            )}
+              )}
+            </div>
           </div>
         </div>
       </div>

--- a/gamesformykids/components/marketing/VocabularyOfTheDay.tsx
+++ b/gamesformykids/components/marketing/VocabularyOfTheDay.tsx
@@ -14,11 +14,11 @@ export default function VocabularyOfTheDay() {
       onClick={dismiss}
       className="fixed top-20 inset-x-4 z-50 mx-auto max-w-sm cursor-pointer"
     >
-      <div className="bg-white/95 backdrop-blur-sm rounded-2xl shadow-xl border border-purple-200 px-6 py-4 text-center animate-fade-in-up">
-        <p className="text-xs text-purple-500 font-medium mb-1">המילה של היום</p>
+      <div className="bg-white/95 dark:bg-gray-800/95 backdrop-blur-sm rounded-2xl shadow-xl border border-purple-200 dark:border-purple-700 px-6 py-4 text-center animate-fade-in-up">
+        <p className="text-xs text-purple-500 dark:text-purple-400 font-medium mb-1">המילה של היום</p>
         <p className="text-5xl mb-2">{word.emoji}</p>
-        <p className="text-2xl font-bold text-purple-800">{word.hebrew}</p>
-        <p className="text-xs text-gray-400 mt-2">לחץ לסגירה</p>
+        <p className="text-2xl font-bold text-purple-800 dark:text-purple-300">{word.hebrew}</p>
+        <p className="text-xs text-gray-400 dark:text-gray-500 mt-2">לחץ לסגירה</p>
       </div>
     </div>
   );

--- a/gamesformykids/components/user/UserProfile.tsx
+++ b/gamesformykids/components/user/UserProfile.tsx
@@ -44,26 +44,26 @@ export function UserProfile() {
       <button onClick={toggleMenu} className="flex items-center space-x-2 space-x-reverse">
         <Image src={avatarSrc} alt="תמונת פרופיל" width={32} height={32}
           className="w-8 h-8 rounded-full border-2 border-purple-300" />
-        <span className="text-sm text-gray-700 hidden sm:block">{displayName}</span>
+        <span className="text-sm text-gray-700 dark:text-gray-200 hidden sm:block">{displayName}</span>
       </button>
 
       {isMenuOpen && (
-        <div className="absolute start-0 mt-2 w-48 bg-white border border-gray-200 rounded-lg shadow-lg z-50">
+        <div className="absolute start-0 mt-2 w-48 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg shadow-lg z-50">
           <div className="py-1">
-            <div className="px-4 py-2 text-sm text-gray-700 border-b">
+            <div className="px-4 py-2 text-sm text-gray-700 dark:text-gray-200 border-b dark:border-gray-700">
               <div className="font-medium">{user.user_metadata?.full_name || L.defaultName}</div>
-              <div className="text-gray-500">{user.email}</div>
+              <div className="text-gray-500 dark:text-gray-400">{user.email}</div>
             </div>
             <Link href={R.profile} onClick={closeMenu}
-              className="block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100">
+              className="block px-4 py-2 text-sm text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-700">
               {L.profile}
             </Link>
             <Link href={R.settings} onClick={closeMenu}
-              className="block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100">
+              className="block px-4 py-2 text-sm text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-700">
               {L.settings}
             </Link>
             <button onClick={handleSignOut}
-              className="block w-full text-start px-4 py-2 text-sm text-red-600 hover:bg-gray-100">
+              className="block w-full text-start px-4 py-2 text-sm text-red-600 dark:text-red-400 hover:bg-gray-100 dark:hover:bg-gray-700">
               {L.signOut}
             </button>
           </div>


### PR DESCRIPTION
## Summary
- Add missing `dark:` Tailwind variants across ~20 home-page components (Footer, AgeGroupCard, category/recommendation views, feature highlights, search bar, skeletons) that had near-unreadable contrast in dark mode.
- Wrap `ContinueBanner`, `DailyChallenge`, `JokeOfTheDay`, `FactOfTheDay`, `RiddleOfTheDay`, `RecentlyPlayedRow`, `GamesTodayBadge` in `max-w-6xl mx-auto px-4` so they align with sibling sections (`HolidayLane`, `FeaturedGame`, `CategorizedGamesGrid`) instead of bleeding edge-to-edge on wide screens.
- Recolor `DailyChallenge` from amber/orange to emerald/teal so the four "content of the day" cards (Challenge/Joke/Fact/Riddle) read as visually distinct instead of blurring into consecutive warm-toned blocks.

Styling-only — no logic, data, or route changes.

Closes #1456

## Test plan
- [x] `npx tsc --noEmit` — clean (verified independently, not just self-reported)
- [x] `npm run build` — clean, all 493 pages generated, `/` static
- [x] Manually reviewed in browser at desktop (1400px) and mobile (375px), light and dark mode, on both the `games` tab and one other content tab (`creative`/`riddles`)
- [x] Confirmed no JSX/structural regressions by reading full post-edit source of every wrapped widget
- [ ] Not visually exercised (no bug found, just no live state to render): `UserProfile` dropdown (needs auth), `ContinueBanner`/`RecentlyPlayedRow`/`GamesTodayBadge` (need prior play history) — diff-reviewed only

🤖 Generated with [Claude Code](https://claude.com/claude-code)