### PR TITLE
Add Dot-to-Dot (נקודה לנקודה) game with printable worksheets

### DIFF
--- a/.claude/agents/dot-to-dot-builder.md
+++ b/.claude/agents/dot-to-dot-builder.md
@@ -1,0 +1,59 @@
+---
+name: dot-to-dot-builder
+description: Adds new "dot to dot" / "נקודה לנקודה" picture pages to the `app/games/dot-to-dot/` game — an ordered-point connect-the-dots activity (click dots 1,2,3... in sequence, a straight-line silhouette is revealed) with a matching printable blank-worksheet mode. Use proactively when the user asks for a new dot-to-dot picture, a new theme's worksheet, or "another page" for this game. One invocation = one new picture added to `app/games/dot-to-dot/data/pictures.ts`. Not for building a brand-new game type (that's a Style D task per the root CLAUDE.md — confirm with the user first) or for touching other creative games like `coloring`/`drawing`.
+tools: Read, Grep, Glob, Write, Edit, Bash
+model: sonnet
+---
+
+You are the content specialist for the dot-to-dot game in the GamesForMyKids repo (`gamesformykids/`: Next.js 16 App Router, React 19, TypeScript, Zustand, Tailwind v4). Your territory is exactly one file: `app/games/dot-to-dot/data/pictures.ts`. The game engine itself (store, board, print button, menu, wiring into `CustomGameRenderer`/`GameType`/registry/categories) already exists and does not need to change for a new picture — do not touch it unless the user explicitly asks for an engine change.
+
+## The data shape you're producing
+
+```ts
+export interface DotPoint { x: number; y: number }
+export type DotToDotTheme = 'space' | 'animals' | 'vehicles'; // add a new theme string here + DOT_TO_DOT_THEMES if the user wants one outside these three
+
+export interface DotToDotPicture {
+  id: string;          // kebab-case, unique — grep DOT_TO_DOT_PICTURES first
+  title: string;        // Hebrew label
+  emoji: string;
+  theme: DotToDotTheme;
+  viewBox: string;       // keep '0 0 300 300' unless you have a reason to deviate
+  points: DotPoint[];    // ordered — index+1 is the printed/clicked dot number
+  closed: boolean;       // true = last dot auto-connects back to the first (silhouette outline)
+}
+```
+
+Read `app/games/dot-to-dot/data/pictures.ts` in full before editing — it holds `DOT_TO_DOT_THEMES` and the `DOT_TO_DOT_PICTURES` array; append your new entry to the array, don't restructure existing ones.
+
+## Designing recognizable points
+
+This is a straight-line dot-to-dot, exactly like a printed kids' worksheet — no curves, no bezier paths, just an ordered polygon walk:
+
+1. **Pick a subject** that reads clearly as a silhouette outline (rocket, animal head, vehicle profile, simple object). Avoid subjects that need concave detail humans can't approximate with ~8-20 straight segments (e.g. a detailed face) — silhouettes with a clear, chunky outline work best (the existing `star`, `rocket`, `cat`, `fish`, `sailboat`, `car` are the calibration examples, all 8-11 points).
+2. **Stay inside the `0 0 300 300` viewBox** with margin — keep coordinates roughly in the `40-260` range on both axes so dots and their number labels don't clip at the SVG edge.
+3. **Walk the outline in one continuous direction** (clockwise or counter-clockwise) — don't jump back and forth across the shape, or the connect-the-dots order won't trace a coherent silhouette.
+4. **8-16 points is the sweet spot** for this age range — enough to be recognizable, not so many it's tedious. Go higher only for a deliberately "harder/advanced" picture and say so in your report.
+5. **`closed: true`** for essentially everything (a full outline reads better than an open zigzag) unless the user specifically wants an open-path shape.
+6. If you want to *compute* points instead of hand-placing them (e.g. a star, a polygon, a spiral), simple polar-coordinate math (`x = cx + r*cos(θ), y = cy + r*sin(θ)`) is fine and matches how the existing `star` entry was built — show your reasoning in the points you pick, don't guess-and-check blindly.
+
+## Task loop for "prepare one page"
+
+1. If the user didn't name a specific subject, ask (or pick one that's clearly missing from the current lineup — check existing `theme`/`id` values first via Grep so you don't duplicate `star`, `rocket`, `cat`, `fish`, `sailboat`, `car`).
+2. Author the `DotToDotPicture` object (id, title, emoji, theme, viewBox, points, closed) and append it to `DOT_TO_DOT_PICTURES` in `app/games/dot-to-dot/data/pictures.ts`. If the subject needs a new theme not in `DotToDotTheme`/`DOT_TO_DOT_THEMES` (`app/games/dot-to-dot/types.ts` + `data/pictures.ts`), add it there too — but confirm with the user first since it's a small scope expansion beyond "one picture."
+3. Run `cd gamesformykids && npx tsc --noEmit` — zero errors.
+4. Report back: the picture's `id`/`title`/`theme`, point count, and a one-line description of the silhouette shape traced (so the user can sanity-check it without opening a browser).
+
+You do **not** need to touch `CustomGameRenderer.tsx`, `gamePageConstants.ts`, `lib/types/core/base.ts`'s `GameType` union, the registry, or `gameCategories.ts` — those were wired once for the whole `dot-to-dot` game type and cover every picture automatically.
+
+## Verification before reporting done
+
+1. `cd gamesformykids && npx tsc --noEmit` — zero TS errors (catches typos in `theme`, duplicate `id` used as a literal type elsewhere, malformed points array).
+2. If you can run the dev server, open `/games/dot-to-dot`, pick the new picture's theme tab, and confirm the dots trace a recognizable shape when connected in order, and that the print button produces a clean numbered-dots-only worksheet.
+3. If you're not able to visually verify (no browser access), say so explicitly in your report rather than claiming the shape looks right — the geometry is the one thing that can't be caught by the type checker.
+
+## Working style
+
+- One picture per invocation unless the user explicitly asks for a batch — this keeps each addition easy to review and revert.
+- Never duplicate an existing `id` or reintroduce a subject that's already in `DOT_TO_DOT_PICTURES` — grep first.
+- Don't add difficulty settings, hint systems, or other engine features while "just adding a picture" — flag those as separate asks if they come up.

--- a/gamesformykids/__tests__/stores/dotToDotStore.test.ts
+++ b/gamesformykids/__tests__/stores/dotToDotStore.test.ts
@@ -1,0 +1,72 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { useDotToDotStore } from '@/app/games/dot-to-dot/dotToDotStore';
+import { getPictureById } from '@/app/games/dot-to-dot/data/pictures';
+
+const store = useDotToDotStore;
+
+beforeEach(() => {
+  store.setState({ phase: 'menu', pictureId: null, connected: 0 });
+});
+
+describe('dotToDotStore', () => {
+  describe('selectPicture', () => {
+    it('sets the picture, resets connected count, and enters playing phase', () => {
+      store.getState().selectPicture('star');
+      const { phase, pictureId, connected } = store.getState();
+      expect(phase).toBe('playing');
+      expect(pictureId).toBe('star');
+      expect(connected).toBe(0);
+    });
+  });
+
+  describe('clickDot', () => {
+    it('advances connected count when clicking the next expected dot', () => {
+      store.getState().selectPicture('star');
+      store.getState().clickDot(0);
+      expect(store.getState().connected).toBe(1);
+    });
+
+    it('ignores out-of-order clicks', () => {
+      store.getState().selectPicture('star');
+      store.getState().clickDot(5);
+      expect(store.getState().connected).toBe(0);
+    });
+
+    it('is a no-op if no picture is selected', () => {
+      store.getState().clickDot(0);
+      expect(store.getState().connected).toBe(0);
+      expect(store.getState().phase).toBe('menu');
+    });
+
+    it('flips phase to complete once every dot is connected', () => {
+      store.getState().selectPicture('star');
+      const total = getPictureById('star')!.points.length;
+      for (let i = 0; i < total; i++) store.getState().clickDot(i);
+      expect(store.getState().connected).toBe(total);
+      expect(store.getState().phase).toBe('complete');
+    });
+  });
+
+  describe('reset', () => {
+    it('replays the same picture from zero without returning to the menu', () => {
+      store.getState().selectPicture('cat');
+      store.getState().clickDot(0);
+      store.getState().reset();
+      const { phase, pictureId, connected } = store.getState();
+      expect(phase).toBe('playing');
+      expect(pictureId).toBe('cat');
+      expect(connected).toBe(0);
+    });
+  });
+
+  describe('backToMenu', () => {
+    it('clears the picture and returns to the menu phase', () => {
+      store.getState().selectPicture('fish');
+      store.getState().backToMenu();
+      const { phase, pictureId, connected } = store.getState();
+      expect(phase).toBe('menu');
+      expect(pictureId).toBeNull();
+      expect(connected).toBe(0);
+    });
+  });
+});

--- a/gamesformykids/app/games/[gameType]/CustomGameRenderer.tsx
+++ b/gamesformykids/app/games/[gameType]/CustomGameRenderer.tsx
@@ -17,6 +17,7 @@ const GAME_CLIENTS = {
   'color-tap':       dynamic(() => import('../color-tap/ColorTapClient'),                     { ssr: false }),
   coloring:          dynamic(() => import('../coloring/ColoringGameClient')),
   'dino-runner':     dynamic(() => import('../dino-runner/DinoRunnerClient'),                 { ssr: false }),
+  'dot-to-dot':      dynamic(() => import('../dot-to-dot/DotToDotClient'),                   { ssr: false }),
   drawing:           dynamic(() => import('../drawing/components/DrawingGameClient'),          { ssr: false }),
   'emoji-math':      dynamic(() => import('../emoji-math/EmojiMathClient'),                   { ssr: false }),
   'flappy-bird':     dynamic(() => import('../flappy-bird/FlappyBirdClient'),                 { ssr: false }),

--- a/gamesformykids/app/games/[gameType]/gamePageConstants.ts
+++ b/gamesformykids/app/games/[gameType]/gamePageConstants.ts
@@ -29,7 +29,7 @@ export const SUPPORTED_GAMES = [
 
   // ── משחקים מותאמים (CustomGameRenderer) ──────────────────────────────────
   'arithmetic', 'balloon-pop', 'brick-breaker', 'bubbles', 'building',
-  'catch-fruit', 'checkers', 'chess', 'color-tap', 'coloring', 'dino-runner',
+  'catch-fruit', 'checkers', 'chess', 'color-tap', 'coloring', 'dino-runner', 'dot-to-dot',
   'drawing', 'emoji-math', 'flappy-bird', 'frogger', 'hebrew-letters', 'jumper',
   'math-race', 'memory', 'meteor-dodge', 'multiplication', 'number-bubbles', 'pong',
   'puzzles', 'reflex', 'shesh-besh', 'simon', 'snake', 'space-defender',
@@ -123,7 +123,7 @@ export type SupportedGameType = typeof SUPPORTED_GAMES[number];
 
 export const CUSTOM_GAME_TYPES = new Set<CustomGameId>([
   'arithmetic', 'balloon-pop', 'brick-breaker', 'bubbles', 'building',
-  'catch-fruit', 'checkers', 'chess', 'color-tap', 'coloring', 'dino-runner',
+  'catch-fruit', 'checkers', 'chess', 'color-tap', 'coloring', 'dino-runner', 'dot-to-dot',
   'drawing', 'emoji-math', 'flappy-bird', 'frogger', 'hebrew-letters', 'jumper',
   'math-race', 'memory', 'meteor-dodge', 'multiplication', 'number-bubbles', 'pong',
   'puzzles', 'reflex', 'shesh-besh', 'simon', 'snake', 'space-defender',

--- a/gamesformykids/app/games/dot-to-dot/DotToDotClient.tsx
+++ b/gamesformykids/app/games/dot-to-dot/DotToDotClient.tsx
@@ -1,0 +1,55 @@
+'use client';
+import { useDotToDot } from './useDotToDot';
+import DotToDotMenu from './components/DotToDotMenu';
+import DotToDotBoard from './components/DotToDotBoard';
+import DotToDotPrintButton from './components/DotToDotPrintButton';
+import { GameCompletionCelebration } from '@/components/game/shared/GameCompletionCelebration';
+
+export default function DotToDotClient() {
+  const { phase, picture, connected, selectPicture, clickDot, backToMenu, reset } = useDotToDot();
+
+  if (phase === 'menu' || !picture) {
+    return <DotToDotMenu onSelectPicture={selectPicture} />;
+  }
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-indigo-900 to-purple-900 flex flex-col items-center p-4 gap-4" dir="rtl">
+      <div className="flex items-center justify-between w-full max-w-sm pt-2">
+        <button
+          onClick={backToMenu}
+          className="px-3 py-1.5 rounded-xl text-sm font-semibold bg-white/10 text-indigo-200 hover:bg-white/20 transition-all"
+        >
+          ⬅️ תפריט
+        </button>
+        <span className="text-white font-bold">{picture.emoji} {picture.title}</span>
+        <DotToDotPrintButton picture={picture} />
+      </div>
+
+      {phase === 'complete' && <GameCompletionCelebration />}
+
+      <DotToDotBoard picture={picture} connected={connected} onDotClick={clickDot} />
+
+      {phase === 'complete' ? (
+        <div className="flex flex-col items-center gap-3">
+          <h2 className="text-2xl font-black text-yellow-300">🎉 כל הכבוד!</h2>
+          <div className="flex gap-3">
+            <button
+              onClick={reset}
+              className="px-6 py-3 bg-yellow-400 hover:bg-yellow-300 text-yellow-900 font-black rounded-2xl shadow-lg transition-transform active:scale-95"
+            >
+              🔄 שחק שוב
+            </button>
+            <button
+              onClick={backToMenu}
+              className="px-6 py-3 bg-white/10 hover:bg-white/20 text-white font-black rounded-2xl shadow-lg transition-transform active:scale-95"
+            >
+              🖼️ תמונה אחרת
+            </button>
+          </div>
+        </div>
+      ) : (
+        <p className="text-sm text-indigo-300">חברו את הנקודה הבאה: {connected + 1}/{picture.points.length}</p>
+      )}
+    </div>
+  );
+}

--- a/gamesformykids/app/games/dot-to-dot/components/DotToDotBoard.tsx
+++ b/gamesformykids/app/games/dot-to-dot/components/DotToDotBoard.tsx
@@ -1,0 +1,79 @@
+'use client';
+import type { DotToDotPicture } from '../types';
+
+interface Props {
+  picture: DotToDotPicture;
+  connected: number;
+  onDotClick: (index: number) => void;
+}
+
+export default function DotToDotBoard({ picture, connected, onDotClick }: Props) {
+  const { points, closed } = picture;
+  const isComplete = connected === points.length;
+
+  const segments: [number, number][] = [];
+  for (let i = 0; i < connected - 1; i++) segments.push([i, i + 1]);
+  if (isComplete && closed) segments.push([points.length - 1, 0]);
+
+  const centroidX = points.reduce((sum, p) => sum + p.x, 0) / points.length;
+  const centroidY = points.reduce((sum, p) => sum + p.y, 0) / points.length;
+
+  return (
+    <svg
+      viewBox={picture.viewBox}
+      className="w-full max-w-sm aspect-square bg-white rounded-3xl shadow-lg select-none"
+      role="img"
+      aria-label={picture.title}
+    >
+      {segments.map(([a, b]) => (
+        <line
+          key={`${a}-${b}`}
+          x1={points[a]!.x} y1={points[a]!.y}
+          x2={points[b]!.x} y2={points[b]!.y}
+          stroke="#7c3aed" strokeWidth={3} strokeLinecap="round"
+        />
+      ))}
+
+      {isComplete && (
+        <text
+          x={centroidX}
+          y={centroidY}
+          textAnchor="middle"
+          dominantBaseline="central"
+          fontSize={48}
+        >
+          {picture.emoji}
+        </text>
+      )}
+
+      {points.map((p, i) => {
+        const isDone = i < connected;
+        const isNext = i === connected;
+        return (
+          <g key={i} onClick={() => onDotClick(i)} className="cursor-pointer">
+            <circle
+              cx={p.x} cy={p.y}
+              r={isNext ? 14 : 10}
+              fill={isDone ? '#a78bfa' : '#fff'}
+              stroke="#7c3aed"
+              strokeWidth={2}
+              className={isNext ? 'animate-pulse' : undefined}
+            />
+            {!isDone && (
+              <text
+                x={p.x} y={p.y}
+                textAnchor="middle"
+                dominantBaseline="central"
+                fontSize={12}
+                fontWeight="bold"
+                fill="#4c1d95"
+              >
+                {i + 1}
+              </text>
+            )}
+          </g>
+        );
+      })}
+    </svg>
+  );
+}

--- a/gamesformykids/app/games/dot-to-dot/components/DotToDotMenu.tsx
+++ b/gamesformykids/app/games/dot-to-dot/components/DotToDotMenu.tsx
@@ -1,0 +1,53 @@
+'use client';
+import { useState } from 'react';
+import { DOT_TO_DOT_THEMES, getPicturesByTheme } from '../data/pictures';
+import type { DotToDotTheme } from '../types';
+import DotToDotPrintButton from './DotToDotPrintButton';
+
+interface Props {
+  onSelectPicture: (id: string) => void;
+}
+
+export default function DotToDotMenu({ onSelectPicture }: Props) {
+  const [theme, setTheme] = useState<DotToDotTheme>('space');
+  const pictures = getPicturesByTheme(theme);
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-indigo-900 to-purple-900 flex flex-col items-center p-6 gap-6" dir="rtl">
+      <div className="text-6xl">🔢</div>
+      <h1 className="text-4xl font-black text-white text-center">נקודה לנקודה</h1>
+      <p className="text-lg text-indigo-200 text-center max-w-xs">
+        חברו בין הנקודות לפי הסדר וגלו תמונה מפתיעה!
+      </p>
+
+      <div className="flex gap-2">
+        {DOT_TO_DOT_THEMES.map((t) => (
+          <button
+            key={t.id}
+            onClick={() => setTheme(t.id)}
+            className={`px-4 py-2 rounded-xl font-bold text-sm transition-all ${
+              theme === t.id
+                ? 'bg-yellow-400 text-yellow-900'
+                : 'bg-white/10 text-indigo-200 hover:bg-white/20'
+            }`}
+          >
+            {t.emoji} {t.title}
+          </button>
+        ))}
+      </div>
+
+      <div className="grid grid-cols-2 sm:grid-cols-3 gap-4 w-full max-w-lg">
+        {pictures.map((p) => (
+          <div key={p.id} className="bg-white rounded-2xl shadow-lg p-4 flex flex-col items-center gap-2">
+            <button onClick={() => onSelectPicture(p.id)} className="flex flex-col items-center gap-2 w-full">
+              <span className="text-5xl">{p.emoji}</span>
+              <span className="font-bold text-purple-900">{p.title}</span>
+              <span className="text-xs text-gray-500">{p.points.length} נקודות</span>
+            </button>
+            <DotToDotPrintButton picture={p} />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/gamesformykids/app/games/dot-to-dot/components/DotToDotPrintButton.tsx
+++ b/gamesformykids/app/games/dot-to-dot/components/DotToDotPrintButton.tsx
@@ -1,0 +1,71 @@
+'use client';
+import { Printer } from 'lucide-react';
+import type { DotToDotPicture } from '../types';
+
+function buildWorksheetHtml(picture: DotToDotPicture): string {
+  const safeTitle = picture.title.replace(/</g, '&lt;').replace(/>/g, '&gt;');
+  const dots = picture.points
+    .map(
+      (p, i) => `
+      <circle cx="${p.x}" cy="${p.y}" r="6" fill="#fff" stroke="#4c1d95" stroke-width="2" />
+      <text x="${p.x}" y="${p.y - 12}" text-anchor="middle" font-size="14" font-weight="bold" fill="#4c1d95">${i + 1}</text>`,
+    )
+    .join('');
+
+  return `<!DOCTYPE html>
+<html dir="rtl" lang="he">
+<head>
+  <meta charset="UTF-8">
+  <title>דף עבודה — נקודה לנקודה — ${safeTitle}</title>
+  <style>
+    * { box-sizing: border-box; }
+    body {
+      font-family: Rubik, 'Segoe UI', Arial, sans-serif;
+      direction: rtl;
+      margin: 0;
+      padding: 20px;
+      background: #fff;
+      color: #1a1a1a;
+      text-align: center;
+    }
+    h1 { font-size: 24px; font-weight: 700; margin: 0 0 16px; color: #4f46e5; }
+    svg { width: 100%; max-width: 500px; }
+    @media print {
+      @page { margin: 12mm; size: A4 portrait; }
+      body { padding: 0; }
+    }
+  </style>
+</head>
+<body>
+  <h1>${picture.emoji} נקודה לנקודה — ${safeTitle}</h1>
+  <svg viewBox="${picture.viewBox}">${dots}</svg>
+  <script>window.onload = function () { window.print(); };</script>
+</body>
+</html>`;
+}
+
+interface Props {
+  picture: DotToDotPicture;
+}
+
+export default function DotToDotPrintButton({ picture }: Props) {
+  const handlePrint = () => {
+    const win = window.open('', '_blank', 'width=800,height=900');
+    if (!win) return;
+    win.document.write(buildWorksheetHtml(picture));
+    win.document.close();
+  };
+
+  return (
+    <button
+      type="button"
+      onClick={handlePrint}
+      title="הדפס דף עבודה"
+      aria-label="הדפס דף עבודה"
+      className="flex items-center gap-2 px-3 py-1.5 rounded-xl text-sm font-semibold transition-all border-2 bg-white border-purple-300 text-purple-700 hover:bg-purple-50 select-none"
+    >
+      <Printer className="w-4 h-4" aria-hidden="true" />
+      <span>הדפס</span>
+    </button>
+  );
+}

--- a/gamesformykids/app/games/dot-to-dot/data/pictures.ts
+++ b/gamesformykids/app/games/dot-to-dot/data/pictures.ts
@@ -1,0 +1,93 @@
+import type { DotToDotPicture, DotToDotTheme } from '../types';
+
+export const DOT_TO_DOT_THEMES: { id: DotToDotTheme; title: string; emoji: string }[] = [
+  { id: 'space', title: 'חלל', emoji: '🚀' },
+  { id: 'animals', title: 'חיות', emoji: '🐱' },
+  { id: 'vehicles', title: 'כלי רכב', emoji: '🚗' },
+];
+
+export const DOT_TO_DOT_PICTURES: DotToDotPicture[] = [
+  {
+    id: 'rocket',
+    title: 'רקטה',
+    emoji: '🚀',
+    theme: 'space',
+    viewBox: '0 0 300 300',
+    closed: true,
+    points: [
+      { x: 150, y: 30 }, { x: 180, y: 100 }, { x: 180, y: 180 }, { x: 215, y: 240 },
+      { x: 180, y: 210 }, { x: 165, y: 230 }, { x: 135, y: 230 }, { x: 120, y: 210 },
+      { x: 85, y: 240 }, { x: 120, y: 180 }, { x: 120, y: 100 },
+    ],
+  },
+  {
+    id: 'star',
+    title: 'כוכב',
+    emoji: '⭐',
+    theme: 'space',
+    viewBox: '0 0 300 300',
+    closed: true,
+    points: [
+      { x: 150, y: 40 }, { x: 176, y: 114 }, { x: 255, y: 116 }, { x: 193, y: 164 },
+      { x: 215, y: 239 }, { x: 150, y: 195 }, { x: 85, y: 239 }, { x: 107, y: 164 },
+      { x: 45, y: 116 }, { x: 124, y: 114 },
+    ],
+  },
+  {
+    id: 'cat',
+    title: 'חתול',
+    emoji: '🐱',
+    theme: 'animals',
+    viewBox: '0 0 300 300',
+    closed: true,
+    points: [
+      { x: 150, y: 230 }, { x: 95, y: 205 }, { x: 85, y: 150 }, { x: 90, y: 50 },
+      { x: 118, y: 105 }, { x: 150, y: 85 }, { x: 182, y: 105 }, { x: 210, y: 50 },
+      { x: 215, y: 150 }, { x: 205, y: 205 },
+    ],
+  },
+  {
+    id: 'fish',
+    title: 'דג',
+    emoji: '🐟',
+    theme: 'animals',
+    viewBox: '0 0 300 300',
+    closed: true,
+    points: [
+      { x: 50, y: 120 }, { x: 100, y: 150 }, { x: 50, y: 180 }, { x: 110, y: 175 },
+      { x: 190, y: 190 }, { x: 240, y: 150 }, { x: 190, y: 110 }, { x: 110, y: 125 },
+    ],
+  },
+  {
+    id: 'sailboat',
+    title: 'סירת מפרש',
+    emoji: '⛵',
+    theme: 'vehicles',
+    viewBox: '0 0 300 300',
+    closed: true,
+    points: [
+      { x: 150, y: 40 }, { x: 200, y: 170 }, { x: 230, y: 175 }, { x: 255, y: 220 },
+      { x: 150, y: 235 }, { x: 45, y: 220 }, { x: 70, y: 175 }, { x: 100, y: 170 },
+    ],
+  },
+  {
+    id: 'car',
+    title: 'מכונית',
+    emoji: '🚗',
+    theme: 'vehicles',
+    viewBox: '0 0 300 300',
+    closed: true,
+    points: [
+      { x: 50, y: 200 }, { x: 50, y: 160 }, { x: 90, y: 130 }, { x: 140, y: 105 },
+      { x: 190, y: 105 }, { x: 230, y: 130 }, { x: 260, y: 160 }, { x: 260, y: 200 },
+    ],
+  },
+];
+
+export function getPicturesByTheme(theme: DotToDotTheme): DotToDotPicture[] {
+  return DOT_TO_DOT_PICTURES.filter((p) => p.theme === theme);
+}
+
+export function getPictureById(id: string): DotToDotPicture | undefined {
+  return DOT_TO_DOT_PICTURES.find((p) => p.id === id);
+}

--- a/gamesformykids/app/games/dot-to-dot/dotToDotStore.ts
+++ b/gamesformykids/app/games/dot-to-dot/dotToDotStore.ts
@@ -1,0 +1,51 @@
+'use client';
+import { create } from 'zustand';
+import { getPictureById } from './data/pictures';
+
+export type DotToDotPhase = 'menu' | 'playing' | 'complete';
+
+interface DotToDotState {
+  phase: DotToDotPhase;
+  pictureId: string | null;
+  connected: number;
+}
+
+interface DotToDotActions {
+  selectPicture: (id: string) => void;
+  clickDot: (index: number) => void;
+  backToMenu: () => void;
+  reset: () => void;
+}
+
+export const useDotToDotStore = create<DotToDotState & DotToDotActions>((set, get) => ({
+  phase: 'menu',
+  pictureId: null,
+  connected: 0,
+
+  selectPicture: (id) => {
+    set({ pictureId: id, connected: 0, phase: 'playing' });
+  },
+
+  clickDot: (index) => {
+    const { pictureId, connected, phase } = get();
+    if (phase !== 'playing' || !pictureId) return;
+    if (index !== connected) return;
+
+    const picture = getPictureById(pictureId);
+    if (!picture) return;
+
+    const nextConnected = connected + 1;
+    set({
+      connected: nextConnected,
+      phase: nextConnected === picture.points.length ? 'complete' : 'playing',
+    });
+  },
+
+  backToMenu: () => {
+    set({ phase: 'menu', pictureId: null, connected: 0 });
+  },
+
+  reset: () => {
+    set({ connected: 0, phase: 'playing' });
+  },
+}));

--- a/gamesformykids/app/games/dot-to-dot/types.ts
+++ b/gamesformykids/app/games/dot-to-dot/types.ts
@@ -1,0 +1,17 @@
+export interface DotPoint {
+  x: number;
+  y: number;
+}
+
+export type DotToDotTheme = 'space' | 'animals' | 'vehicles';
+
+export interface DotToDotPicture {
+  id: string;
+  title: string;
+  emoji: string;
+  theme: DotToDotTheme;
+  viewBox: string;
+  points: DotPoint[];
+  /** Whether the last point connects back to the first to close the outline. */
+  closed: boolean;
+}

--- a/gamesformykids/app/games/dot-to-dot/useDotToDot.ts
+++ b/gamesformykids/app/games/dot-to-dot/useDotToDot.ts
@@ -1,0 +1,14 @@
+'use client';
+import { useDotToDotStore } from './dotToDotStore';
+import { getPictureById } from './data/pictures';
+
+export function useDotToDot() {
+  const phase = useDotToDotStore((s) => s.phase);
+  const pictureId = useDotToDotStore((s) => s.pictureId);
+  const connected = useDotToDotStore((s) => s.connected);
+  const { selectPicture, clickDot, backToMenu, reset } = useDotToDotStore();
+
+  const picture = pictureId ? getPictureById(pictureId) : undefined;
+
+  return { phase, picture, connected, selectPicture, clickDot, backToMenu, reset };
+}

--- a/gamesformykids/lib/constants/gameCategories.ts
+++ b/gamesformykids/lib/constants/gameCategories.ts
@@ -38,7 +38,7 @@ export const GAME_CATEGORIES: Record<string, GameCategory> = {
     icon: Palette,
     color: "bg-purple-500",
     gradient: "from-purple-400 to-purple-600",
-    gameIds: ["instruments","puzzles","drawing","coloring","building","tetris","magic-fairy-tales","circus-show","logic-games","art-craft","superheroes","fairy-tale-chars","famous-paintings","tech-logos","color-mix","puppet-story","melody-maker","craft-guide","avatar-maker"],
+    gameIds: ["instruments","puzzles","drawing","coloring","dot-to-dot","building","tetris","magic-fairy-tales","circus-show","logic-games","art-craft","superheroes","fairy-tale-chars","famous-paintings","tech-logos","color-mix","puppet-story","melody-maker","craft-guide","avatar-maker"],
   },
   nature: {
     title: "טבע ואוכל",

--- a/gamesformykids/lib/registry/registryData/batch5.ts
+++ b/gamesformykids/lib/registry/registryData/batch5.ts
@@ -29,6 +29,7 @@ import {
   Pencil,
   Grid2x2,
   Hash,
+  Dot,
 } from "lucide-react";
 import type { GameRegistration } from "@/lib/types/games/base";
 
@@ -633,5 +634,18 @@ export const gamesRegistryBatch5: GameRegistration[] = [
     available: true,
     order: 222,
     ageMin: 6,
+  },
+  {
+    id: "dot-to-dot",
+    title: "נקודה לנקודה",
+    description: "חבר בין הנקודות לפי הסדר וגלה תמונה מפתיעה!",
+    icon: Dot,
+    emoji: "🔢",
+    color: "bg-purple-400 hover:bg-purple-500",
+    href: "/games/dot-to-dot",
+    available: true,
+    order: 223,
+    ageMin: 4,
+    contentType: "creative" as const,
   },
 ];

--- a/gamesformykids/lib/types/core/base.ts
+++ b/gamesformykids/lib/types/core/base.ts
@@ -139,7 +139,7 @@ export type GameType =
   | 'math-race' | 'number-bubbles' | 'skip-counting' | 'division'
   // Memory & puzzle
   | 'memory' | 'bubbles' | 'puzzles' | 'building' | 'tetris'
-  | 'drawing' | 'coloring'
+  | 'drawing' | 'coloring' | 'dot-to-dot'
   // Expanded topic games
   | 'sports' | 'kitchen' | 'body-parts' | 'family' | 'dinosaurs'
   | 'world-food' | 'recycling' | 'medicine' | 'nature-sounds'


### PR DESCRIPTION
## Summary
- New interactive "connect the dots" game at `/games/dot-to-dot`: click numbered dots in order to reveal a straight-line silhouette, with 6 starting pictures across space/animals/vehicles themes (Style D custom game, mirrors `maze`'s Zustand-store + phase-based client wiring).
- Each picture also has a printable blank-worksheet mode (numbered dots only, no lines), reusing the repo's existing print-window pattern.
- Wired into `GameType`, `SUPPORTED_GAMES`/`CUSTOM_GAME_TYPES`, `CustomGameRenderer`, the registry (`batch5.ts`), and the "יצירתיות ואומנות" (creative) home-page category.
- Adds `.claude/agents/dot-to-dot-builder.md` — a subagent that appends one new picture to `data/pictures.ts` per invocation, for growing the picture library over time.

Closes #1460

## Test plan
- [x] `npx tsc --noEmit` — zero errors
- [x] `npm run build` — succeeds
- [x] `npx vitest run __tests__/stores/dotToDotStore.test.ts` — 7/7 passing (dot-sequencing logic: correct-order advance, out-of-order no-op, completion phase transition, reset, back-to-menu)
- [x] Verified `/games/dot-to-dot` route serves and its client bundle loads with no runtime errors
- [ ] Manual click-through in a browser (menu → play → print button) recommended before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)