### PR TITLE
feat(coloring): add 5 new coloring pages + coloring-page-builder agent

### DIFF
--- a/.claude/agents/coloring-page-builder.md
+++ b/.claude/agents/coloring-page-builder.md
@@ -1,0 +1,106 @@
+---
+name: coloring-page-builder
+description: Builds and extends the online coloring-book game (`app/games/coloring/`) for this Next.js/React/TypeScript/Zustand kids' game site — click-to-fill-region SVG coloring pages in the style of sites like yo-yoo.co.il's online coloring. Use proactively when the user wants to add a new coloring picture/template, a new palette color, region grouping (e.g. "fill all windows at once"), or asks about `ColoringCanvas`/`IMAGE_COMPONENTS`/`coloringStore`/click-to-fill coloring mechanics. Also use for coloring-specific bug fixes (region not filling, wrong region ids, "done" celebration not triggering).
+tools: Read, Grep, Glob, Write, Edit, Bash
+model: sonnet
+---
+
+You are the coloring-page specialist for the GamesForMyKids repo (`gamesformykids/`: Next.js 16 App Router, React 19, TypeScript, Zustand, Tailwind v4). You own `app/games/coloring/` — a **Style D custom game** per the root `CLAUDE.md`. Read that file first; this brief only covers what's specific to coloring.
+
+## How the game works
+
+This is a **click-to-fill-region** coloring book, not a flood-fill/raster tool: each picture is a hand-authored SVG where every colorable shape is its own element with an `onClick` handler that fills it with the currently selected palette color. There is no freehand drawing here — that's a separate game (`app/games/drawing/`, don't confuse the two).
+
+```
+app/games/coloring/
+├── ColoringGameClient.tsx        # 'use client' entry — thin wrapper via makeGameClient
+├── constants.ts                  # PALETTE_COLORS, ImageId union, IMAGES picker list
+├── types.ts                      # ImageProps, ImageComponentType, ImageMeta
+├── store/coloringStore.ts        # Zustand: currentImage, selectedColor, allFills, doneImages
+├── useColoringPalette.ts
+└── components/
+    ├── ColoringGame.tsx           # composes the screen
+    ├── ColoringHeader.tsx
+    ├── ColoringImageSelector.tsx  # picker chips (emoji + title), reads IMAGES
+    ├── ColoringCanvas.tsx         # renders the active Image component + region/group buttons
+    ├── ColoringPalette.tsx        # color swatches
+    ├── ColoringActions.tsx
+    ├── imageComponents.ts         # IMAGE_COMPONENTS registry: id → {Component, regions, names, groups?}
+    └── images/<name>.tsx          # one file per picture: the actual SVG + its region ids/names
+```
+
+## Adding a new coloring picture — exact steps
+
+Each picture is its own component. Model every new one on `components/images/cat.tsx` — it's the smallest, clearest example.
+
+1. **`components/images/<name>.tsx`** — new SVG component:
+   ```tsx
+   import type { ImageProps } from '../../types';
+   import { REGION_CLASS } from '../../constants';
+
+   export function BalloonImage({ fills, onFill }: ImageProps) {
+     const f = (id: string, def = '#ffffff') => fills[id] || def;
+     return (
+       <svg viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg" className="w-full h-full">
+         <ellipse cx="100" cy="90" rx="50" ry="60"
+           fill={f('balloon-body')} stroke="#222" strokeWidth={2.5}
+           className={REGION_CLASS} onClick={() => onFill('balloon-body')} />
+         {/* more colorable shapes... */}
+         {/* purely decorative details (eyes, outlines, strings) get style={{ pointerEvents: 'none' }} and NO onClick — they are not regions */}
+       </svg>
+     );
+   }
+
+   export const balloonRegions = ['balloon-body' /* , ... */];
+   export const balloonRegionNames: Record<string, string> = {
+     'balloon-body': 'גוף הבלון',
+   };
+   ```
+   Rules that matter:
+   - Every clickable shape needs `fill={f('region-id')}`, `className={REGION_CLASS}`, `onClick={() => onFill('region-id')}`, and a visible `stroke` (kids need to see the outline before filling it in).
+   - Region ids are kebab-case and prefixed with the picture name (`balloon-body`, not `body`) — ids must be unique across the whole file since `fills`/`names` are flat records keyed by id.
+   - Non-colorable decoration (eyes, whiskers, outlines) must set `pointerEvents: 'none'` inline and must NOT have `onClick`, or clicks will fill decorative elements.
+   - Default fill for a shape that should start non-white (e.g. a nose) is the second arg to `f()`, e.g. `f('cat-nose', '#ffb3ba')`.
+   - Keep the same `viewBox="0 0 200 200"` convention unless there's a reason not to — the canvas wrapper assumes a square aspect (`aspect-square` in `ColoringCanvas.tsx`).
+
+2. **`components/imageComponents.ts`** — register it:
+   ```typescript
+   import { BalloonImage, balloonRegions, balloonRegionNames } from './images/balloon';
+   // ...
+   export const IMAGE_COMPONENTS: Record<ImageId, ImageMeta> = {
+     // ...existing
+     balloon: { Component: BalloonImage, regions: balloonRegions, names: balloonRegionNames },
+   };
+   ```
+   Add a `groups` array only if it makes sense to fill several regions with one tap (e.g. "all windows", "all petals") — see `house`/`sun`/`flower`/`car` entries for the pattern: `{ id, name, members: string[] }`.
+
+3. **`constants.ts`** — extend the `ImageId` union and `IMAGES` picker array:
+   ```typescript
+   export type ImageId = 'cat' | 'house' | /* ... */ | 'balloon';
+   export const IMAGES: { id: ImageId; title: string; emoji: string }[] = [
+     // ...existing
+     { id: 'balloon', title: 'בלון', emoji: '🎈' },
+   ];
+   ```
+
+4. **`store/coloringStore.ts`** — the store hardcodes per-image defaults in two places, both must get the new id or the app crashes on that image (`undefined` fills):
+   ```typescript
+   const EMPTY_FILLS: AllFills = { cat: {}, /* ... */, balloon: {} };
+   // and in the store initializer:
+   doneImages: { cat: false, /* ... */, balloon: false },
+   ```
+
+**Total new files per picture: 1** (`components/images/<name>.tsx`). Everything else is a small addition to 3 existing files (steps 2-4). Do not create a new store, a new canvas component, or a new picker — this game already has one of each and every picture reuses them.
+
+## Scaling to a large picture library (many templates, gallery-style)
+
+If asked to grow this into something closer to a large coloring-book site (dozens/hundreds of templates, searchable gallery, categories) rather than a handful of hand-picked pictures — **stop and confirm with the user before restructuring**, this is a bigger architectural change:
+- `IMAGE_COMPONENTS` as one big `Record` with everything imported eagerly won't scale past maybe 20-30 pictures without bloating the initial bundle — would need per-image `dynamic()` imports keyed by id.
+- `ColoringImageSelector`'s flat wrapped row of chips won't work as a picker past a similar count — would need a scrollable/paginated gallery, possibly grouped by category (animals, vehicles, nature, etc. — mirror `lib/constants/gameCategories.ts` conventions used elsewhere in the app).
+- Hand-authoring every SVG's regions is the real bottleneck (each picture is bespoke artist+dev work, unlike data-driven Style A/B games) — confirm how many new pictures are actually wanted before committing to a large batch, and consider doing 3-5 as a first batch to validate the pattern holds up.
+
+## Before reporting done
+1. `cd gamesformykids && npx tsc --noEmit` — zero TS errors.
+2. `npm run build` — zero build errors.
+3. Manually check `/games/coloring`: new picture appears in the selector, every region fills on click, any group button fills all its members, the "כל הכבוד" celebration triggers once every region has a fill, "צבע שוב" resets it.
+4. Don't touch `app/games/drawing/` — freehand drawing is a separate game/store, not this one.

--- a/gamesformykids/app/games/coloring/components/imageComponents.ts
+++ b/gamesformykids/app/games/coloring/components/imageComponents.ts
@@ -9,6 +9,11 @@ import { FlowerImage, flowerRegions, flowerRegionNames } from './images/flower';
 import { FishImage, fishRegions, fishRegionNames } from './images/fish';
 import { TreeImage, treeRegions, treeRegionNames } from './images/tree';
 import { CarImage, carRegions, carRegionNames } from './images/car';
+import { StarImage, starRegions, starRegionNames } from './images/star';
+import { BalloonImage, balloonRegions, balloonRegionNames } from './images/balloon';
+import { RobotImage, robotRegions, robotRegionNames } from './images/robot';
+import { DogImage, dogRegions, dogRegionNames } from './images/dog';
+import { BoatImage, boatRegions, boatRegionNames } from './images/boat';
 
 export type { ImageComponentType, ImageMeta };
 
@@ -44,5 +49,22 @@ export const IMAGE_COMPONENTS: Record<ImageId, ImageMeta> = {
       { id: 'car-windows-all', name: 'כל החלונות', members: ['car-window-left', 'car-window-right'] },
       { id: 'car-wheels-all', name: 'כל הגלגלים', members: ['car-wheel-left', 'car-wheel-right'] },
     ],
+  },
+  star: { Component: StarImage, regions: starRegions, names: starRegionNames },
+  balloon: {
+    Component: BalloonImage, regions: balloonRegions, names: balloonRegionNames,
+    groups: [{ id: 'balloons-all', name: 'כל הבלונים', members: ['balloon-left', 'balloon-right'] }],
+  },
+  robot: {
+    Component: RobotImage, regions: robotRegions, names: robotRegionNames,
+    groups: [{ id: 'robot-arms-all', name: 'כל הידיים', members: ['robot-arm-left', 'robot-arm-right'] }],
+  },
+  dog: {
+    Component: DogImage, regions: dogRegions, names: dogRegionNames,
+    groups: [{ id: 'dog-ears-all', name: 'כל האוזניים', members: ['dog-ear-left', 'dog-ear-right'] }],
+  },
+  boat: {
+    Component: BoatImage, regions: boatRegions, names: boatRegionNames,
+    groups: [{ id: 'boat-sails-all', name: 'כל המפרשים', members: ['boat-sail-main', 'boat-sail-small'] }],
   },
 };

--- a/gamesformykids/app/games/coloring/components/images/balloon.tsx
+++ b/gamesformykids/app/games/coloring/components/images/balloon.tsx
@@ -1,0 +1,30 @@
+import type { ImageProps } from '../../types';
+import { REGION_CLASS } from '../../constants';
+
+export function BalloonImage({ fills, onFill }: ImageProps) {
+  const f = (id: string, def = '#ffffff') => fills[id] || def;
+  return (
+    <svg viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg" className="w-full h-full">
+      <path d="M75,133 Q70,142 78,148 L72,160 Q90,168 100,150 Z" fill="none" stroke="#88888899"
+        strokeWidth="2" style={{ pointerEvents: 'none' }} />
+      <path d="M130,120 Q135,132 125,140 L134,160 Q112,168 100,150 Z" fill="none" stroke="#88888899"
+        strokeWidth="2" style={{ pointerEvents: 'none' }} />
+      <ellipse cx="75" cy="88" rx="38" ry="48"
+        fill={f('balloon-left')} stroke="#222" strokeWidth={2.5}
+        className={REGION_CLASS} onClick={() => onFill('balloon-left')} />
+      <ellipse cx="130" cy="72" rx="36" ry="46"
+        fill={f('balloon-right')} stroke="#222" strokeWidth={2.5}
+        className={REGION_CLASS} onClick={() => onFill('balloon-right')} />
+      <polygon points="94,148 106,148 100,160"
+        fill={f('balloon-knot')} stroke="#222" strokeWidth={2} strokeLinejoin="round"
+        className={REGION_CLASS} onClick={() => onFill('balloon-knot')} />
+      <ellipse cx="62" cy="65" rx="10" ry="16" fill="white" opacity={0.45} style={{ pointerEvents: 'none' }} />
+      <ellipse cx="118" cy="48" rx="9" ry="14" fill="white" opacity={0.45} style={{ pointerEvents: 'none' }} />
+    </svg>
+  );
+}
+
+export const balloonRegions = ['balloon-left', 'balloon-right', 'balloon-knot'];
+export const balloonRegionNames: Record<string, string> = {
+  'balloon-left': 'בלון שמאל', 'balloon-right': 'בלון ימין', 'balloon-knot': 'קשר',
+};

--- a/gamesformykids/app/games/coloring/components/images/boat.tsx
+++ b/gamesformykids/app/games/coloring/components/images/boat.tsx
@@ -1,0 +1,30 @@
+import type { ImageProps } from '../../types';
+import { REGION_CLASS } from '../../constants';
+
+export function BoatImage({ fills, onFill }: ImageProps) {
+  const f = (id: string, def = '#ffffff') => fills[id] || def;
+  return (
+    <svg viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg" className="w-full h-full">
+      <path d="M35,168 Q55,178 75,168 Q95,178 115,168 Q135,178 155,168"
+        fill="none" stroke="#7FDBFF" strokeWidth="3" strokeLinecap="round" style={{ pointerEvents: 'none' }} />
+      <line x1="100" y1="120" x2="100" y2="28" stroke="#6b4423" strokeWidth={4} style={{ pointerEvents: 'none' }} />
+      <polygon points="97,55 97,115 55,115"
+        fill={f('boat-sail-small')} stroke="#222" strokeWidth={2.5} strokeLinejoin="round"
+        className={REGION_CLASS} onClick={() => onFill('boat-sail-small')} />
+      <polygon points="103,35 103,115 155,115"
+        fill={f('boat-sail-main')} stroke="#222" strokeWidth={2.5} strokeLinejoin="round"
+        className={REGION_CLASS} onClick={() => onFill('boat-sail-main')} />
+      <polygon points="100,30 100,42 118,36"
+        fill={f('boat-flag')} stroke="#222" strokeWidth={2} strokeLinejoin="round"
+        className={REGION_CLASS} onClick={() => onFill('boat-flag')} />
+      <path d="M30,150 Q100,182 170,150 L155,120 L45,120 Z"
+        fill={f('boat-hull')} stroke="#222" strokeWidth={2.5} strokeLinejoin="round"
+        className={REGION_CLASS} onClick={() => onFill('boat-hull')} />
+    </svg>
+  );
+}
+
+export const boatRegions = ['boat-hull', 'boat-sail-main', 'boat-sail-small', 'boat-flag'];
+export const boatRegionNames: Record<string, string> = {
+  'boat-hull': 'גוף הסירה', 'boat-sail-main': 'מפרש גדול', 'boat-sail-small': 'מפרש קטן', 'boat-flag': 'דגל',
+};

--- a/gamesformykids/app/games/coloring/components/images/dog.tsx
+++ b/gamesformykids/app/games/coloring/components/images/dog.tsx
@@ -1,0 +1,42 @@
+import type { ImageProps } from '../../types';
+import { REGION_CLASS } from '../../constants';
+
+export function DogImage({ fills, onFill }: ImageProps) {
+  const f = (id: string, def = '#ffffff') => fills[id] || def;
+  return (
+    <svg viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg" className="w-full h-full">
+      <path d="M148,150 Q176,142 172,112 Q164,132 144,144 Z"
+        fill={f('dog-tail')} stroke="#222" strokeWidth={2.5} strokeLinejoin="round"
+        className={REGION_CLASS} onClick={() => onFill('dog-tail')} />
+      <path d="M64,58 Q38,90 54,132 Q76,112 76,68 Z"
+        fill={f('dog-ear-left')} stroke="#222" strokeWidth={2.5} strokeLinejoin="round"
+        className={REGION_CLASS} onClick={() => onFill('dog-ear-left')} />
+      <path d="M136,58 Q162,90 146,132 Q124,112 124,68 Z"
+        fill={f('dog-ear-right')} stroke="#222" strokeWidth={2.5} strokeLinejoin="round"
+        className={REGION_CLASS} onClick={() => onFill('dog-ear-right')} />
+      <ellipse cx="100" cy="158" rx="48" ry="38"
+        fill={f('dog-body')} stroke="#222" strokeWidth={2.5}
+        className={REGION_CLASS} onClick={() => onFill('dog-body')} />
+      <circle cx="100" cy="88" r="42"
+        fill={f('dog-head')} stroke="#222" strokeWidth={2.5}
+        className={REGION_CLASS} onClick={() => onFill('dog-head')} />
+      <ellipse cx="100" cy="112" rx="7" ry="5"
+        fill={f('dog-nose', '#3a2a1a')} stroke="#222" strokeWidth={1.5}
+        className={REGION_CLASS} onClick={() => onFill('dog-nose')} />
+      <circle cx="84" cy="80" r="7" fill="#222" style={{ pointerEvents: 'none' }} />
+      <circle cx="116" cy="80" r="7" fill="#222" style={{ pointerEvents: 'none' }} />
+      <circle cx="86" cy="78" r="2.5" fill="white" style={{ pointerEvents: 'none' }} />
+      <circle cx="118" cy="78" r="2.5" fill="white" style={{ pointerEvents: 'none' }} />
+      <path d="M100,117 Q100,124 92,127" fill="none" stroke="#555" strokeWidth="2"
+        strokeLinecap="round" style={{ pointerEvents: 'none' }} />
+      <path d="M100,117 Q100,124 108,127" fill="none" stroke="#555" strokeWidth="2"
+        strokeLinecap="round" style={{ pointerEvents: 'none' }} />
+    </svg>
+  );
+}
+
+export const dogRegions = ['dog-ear-left', 'dog-ear-right', 'dog-head', 'dog-body', 'dog-nose', 'dog-tail'];
+export const dogRegionNames: Record<string, string> = {
+  'dog-ear-left': 'אוזן שמאל', 'dog-ear-right': 'אוזן ימין', 'dog-head': 'ראש',
+  'dog-body': 'גוף', 'dog-nose': 'אף', 'dog-tail': 'זנב',
+};

--- a/gamesformykids/app/games/coloring/components/images/robot.tsx
+++ b/gamesformykids/app/games/coloring/components/images/robot.tsx
@@ -1,0 +1,37 @@
+import type { ImageProps } from '../../types';
+import { REGION_CLASS } from '../../constants';
+
+export function RobotImage({ fills, onFill }: ImageProps) {
+  const f = (id: string, def = '#ffffff') => fills[id] || def;
+  return (
+    <svg viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg" className="w-full h-full">
+      <line x1="100" y1="30" x2="100" y2="21" stroke="#222" strokeWidth={3} style={{ pointerEvents: 'none' }} />
+      <circle cx="100" cy="15" r="8"
+        fill={f('robot-antenna')} stroke="#222" strokeWidth={2}
+        className={REGION_CLASS} onClick={() => onFill('robot-antenna')} />
+      <rect x="25" y="95" width="25" height="50" rx="8"
+        fill={f('robot-arm-left')} stroke="#222" strokeWidth={2.5}
+        className={REGION_CLASS} onClick={() => onFill('robot-arm-left')} />
+      <rect x="150" y="95" width="25" height="50" rx="8"
+        fill={f('robot-arm-right')} stroke="#222" strokeWidth={2.5}
+        className={REGION_CLASS} onClick={() => onFill('robot-arm-right')} />
+      <rect x="55" y="85" width="90" height="70" rx="12"
+        fill={f('robot-body')} stroke="#222" strokeWidth={2.5}
+        className={REGION_CLASS} onClick={() => onFill('robot-body')} />
+      <rect x="70" y="30" width="60" height="50" rx="10"
+        fill={f('robot-head')} stroke="#222" strokeWidth={2.5}
+        className={REGION_CLASS} onClick={() => onFill('robot-head')} />
+      <rect x="82" y="46" width="10" height="10" fill="#222" style={{ pointerEvents: 'none' }} />
+      <rect x="108" y="46" width="10" height="10" fill="#222" style={{ pointerEvents: 'none' }} />
+      <line x1="88" y1="66" x2="112" y2="66" stroke="#222" strokeWidth="2.5" strokeLinecap="round" style={{ pointerEvents: 'none' }} />
+      <line x1="75" y1="105" x2="125" y2="105" stroke="#88888899" strokeWidth="2" style={{ pointerEvents: 'none' }} />
+      <line x1="75" y1="118" x2="125" y2="118" stroke="#88888899" strokeWidth="2" style={{ pointerEvents: 'none' }} />
+    </svg>
+  );
+}
+
+export const robotRegions = ['robot-head', 'robot-body', 'robot-arm-left', 'robot-arm-right', 'robot-antenna'];
+export const robotRegionNames: Record<string, string> = {
+  'robot-head': 'ראש', 'robot-body': 'גוף', 'robot-arm-left': 'יד שמאל',
+  'robot-arm-right': 'יד ימין', 'robot-antenna': 'אנטנה',
+};

--- a/gamesformykids/app/games/coloring/components/images/star.tsx
+++ b/gamesformykids/app/games/coloring/components/images/star.tsx
@@ -1,0 +1,28 @@
+import type { ImageProps } from '../../types';
+import { REGION_CLASS } from '../../constants';
+
+export function StarImage({ fills, onFill }: ImageProps) {
+  const f = (id: string, def = '#ffffff') => fills[id] || def;
+  return (
+    <svg viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg" className="w-full h-full">
+      <polygon points="100,20 122,74 180,74 132,109 151,163 100,130 49,163 68,109 20,74 78,74"
+        fill={f('star-body')} stroke="#222" strokeWidth={2.5} strokeLinejoin="round"
+        className={REGION_CLASS} onClick={() => onFill('star-body')} />
+      <polygon points="35,31 39,41 49,45 39,49 35,59 31,49 21,45 31,41"
+        fill={f('star-sparkle-left')} stroke="#222" strokeWidth={2}
+        className={REGION_CLASS} onClick={() => onFill('star-sparkle-left')} />
+      <polygon points="165,31 169,41 179,45 169,49 165,59 161,49 151,45 161,41"
+        fill={f('star-sparkle-right')} stroke="#222" strokeWidth={2}
+        className={REGION_CLASS} onClick={() => onFill('star-sparkle-right')} />
+      <circle cx="85" cy="90" r="6" fill="#222" style={{ pointerEvents: 'none' }} />
+      <circle cx="115" cy="90" r="6" fill="#222" style={{ pointerEvents: 'none' }} />
+      <path d="M82,105 Q100,118 118,105" fill="none" stroke="#555" strokeWidth="2.5"
+        strokeLinecap="round" style={{ pointerEvents: 'none' }} />
+    </svg>
+  );
+}
+
+export const starRegions = ['star-body', 'star-sparkle-left', 'star-sparkle-right'];
+export const starRegionNames: Record<string, string> = {
+  'star-body': 'כוכב', 'star-sparkle-left': 'נצנוץ שמאל', 'star-sparkle-right': 'נצנוץ ימין',
+};

--- a/gamesformykids/app/games/coloring/constants.ts
+++ b/gamesformykids/app/games/coloring/constants.ts
@@ -25,7 +25,8 @@ export const PALETTE_COLORS = [
   { hex: '#01FF70', hebrew: 'ירוק בהיר' },
 ] as const;
 
-export type ImageId = 'cat' | 'house' | 'sun' | 'butterfly' | 'flower' | 'fish' | 'tree' | 'car';
+export type ImageId = 'cat' | 'house' | 'sun' | 'butterfly' | 'flower' | 'fish' | 'tree' | 'car'
+  | 'star' | 'balloon' | 'robot' | 'dog' | 'boat';
 
 export const IMAGES: { id: ImageId; title: string; emoji: string }[] = [
   { id: 'cat', title: 'חתול', emoji: '🐱' },
@@ -36,4 +37,9 @@ export const IMAGES: { id: ImageId; title: string; emoji: string }[] = [
   { id: 'fish', title: 'דג', emoji: '🐟' },
   { id: 'tree', title: 'עץ', emoji: '🌳' },
   { id: 'car', title: 'מכונית', emoji: '🚗' },
+  { id: 'star', title: 'כוכב', emoji: '⭐' },
+  { id: 'balloon', title: 'בלונים', emoji: '🎈' },
+  { id: 'robot', title: 'רובוט', emoji: '🤖' },
+  { id: 'dog', title: 'כלב', emoji: '🐶' },
+  { id: 'boat', title: 'סירה', emoji: '⛵' },
 ];

--- a/gamesformykids/app/games/coloring/store/coloringStore.ts
+++ b/gamesformykids/app/games/coloring/store/coloringStore.ts
@@ -15,6 +15,7 @@ type AllFills = Record<ImageId, Record<string, string>>;
 
 const EMPTY_FILLS: AllFills = {
   cat: {}, house: {}, sun: {}, butterfly: {}, flower: {}, fish: {}, tree: {}, car: {},
+  star: {}, balloon: {}, robot: {}, dog: {}, boat: {},
 };
 
 // ── Store ─────────────────────────────────────────────────────────────────────
@@ -57,7 +58,10 @@ export const useColoringStore = makeStore<ColoringState & ColoringActions>(
       currentImage: 'cat',
       selectedColor: PALETTE_COLORS[0].hex,
       allFills: EMPTY_FILLS,
-      doneImages: { cat: false, house: false, sun: false, butterfly: false, flower: false, fish: false, tree: false, car: false },
+      doneImages: {
+        cat: false, house: false, sun: false, butterfly: false, flower: false, fish: false, tree: false, car: false,
+        star: false, balloon: false, robot: false, dog: false, boat: false,
+      },
 
       selectImage: (id) =>
         set({ currentImage: id }, false, 'selectImage'),


### PR DESCRIPTION
## Summary
- Adds 5 new click-to-fill SVG coloring pages: star (כוכב), balloon (בלונים), robot (רובוט), dog (כלב), boat (סירה) — each with multiple clickable regions and, where relevant, a "fill all" group button, following the existing per-picture pattern in `app/games/coloring/components/images/`.
- Adds a `coloring-page-builder` subagent (`.claude/agents/coloring-page-builder.md`) documenting the exact steps/conventions for adding a new coloring picture, plus guidance on what would need to change to scale to a much larger gallery-style library.

Closes #1462

## Test plan
- [x] `npx tsc --noEmit` — zero errors
- [x] `npm run build` — zero errors
- [x] Manually verified in browser at `/games/coloring`: all 5 new pictures appear in the selector, render with visible outlines, every region fills on click, group "fill all" buttons work, and the completion celebration still triggers correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)