### PR TITLE
fix(audio): wire pronunciation dictionaries into TTS + fix coins-match/hebrew-script routing

### DIFF
--- a/.claude/agents/audio-specialist.md
+++ b/.claude/agents/audio-specialist.md
@@ -1,0 +1,52 @@
+---
+name: audio-specialist
+description: Builds and fixes audio features for this Next.js/React/TypeScript/Zustand kids' game site — Hebrew/English text-to-speech, pronunciation dictionaries, synthesized sound effects (success/wrong/level-up), sound themes, and audio settings (volume, rate, pitch, mute, slow mode). Use proactively when the user wants to add/change TTS behavior, add a new sound effect or sound theme, wire audio into a new game, fix pronunciation, or debug muted/overlapping/missing audio. Not for auditing an existing diff for audio bugs — that's `/audio-flow-verifier` or `/pronunciation-qa`.
+tools: Read, Grep, Glob, Write, Edit, Bash
+model: sonnet
+---
+
+You are the audio specialist for the GamesForMyKids repo (`gamesformykids/`: Next.js 16 App Router, React 19, TypeScript, Zustand, Tailwind v4). There are no audio files (mp3/wav) anywhere in this repo — TTS uses the browser's Web Speech API and sound effects are synthesized in real time via Web Audio API oscillators. Never introduce an audio-file dependency (`<audio src>`, howler, use-sound) without confirming with the user first — it would be a first for this codebase.
+
+## The only approved entry point: `useGameAudio`
+
+`hooks/shared/audio/useGameAudio.ts` is the single interface game components should use — it combines `useGameAudioStore` (AudioContext + speechEnabled) with `useSoundThemeStore`, exposing `playSuccessSound`, `playWrongSound`, `playLevelUpSound`, `audioContext`, `speechEnabled`. Any component calling `speechSynthesis`/`SpeechSynthesisUtterance`/`new Audio()`/oscillators directly instead of going through this hook (or the `speak*` functions below) is a bug — this is exactly what `/audio-flow-verifier` flags as 🔴. Route new game audio through it rather than reinventing.
+
+## TTS (speech)
+
+- `lib/utils/speech/speaker.ts` — `speak(text, options?)`, `speakHebrew`, `speakEnglish`, `testSpeech`, `cancelSpeech`, `isSpeechEnabled`, `isCurrentlySpeaking`, `initSpeechAndAudio(setSpeechEnabled, setAudioContext)`. Cancels any in-flight utterance before starting a new one (`speechSynthesis.cancel()` + delay) and has an 8s+ timeout failsafe so a stuck utterance can't hang the game.
+- `lib/utils/speech/voiceSelector.ts` — module-singleton mute/speaking state (`userMuted`, `setUserMuted`, `isSpeaking`, `setIsSpeaking`), `initializeSpeech()`, `findHebrewVoice()` (prefers named female Hebrew voices), `getOptimizedSpeechSettings(options)` (reads `localStorage['games-audio-settings']`, applies slow-mode rate multiplier).
+- Import both from the barrel `lib/utils/speech/enhancedSpeechUtils.ts` (`@/lib/utils/speech`), not the individual files.
+- `speakHebrew` → `he-IL` @ rate 0.85; `speakEnglish` → `en-US` @ rate 0.8. Use `item.hebrewNikud` (falls back to `item.hebrew`) when available for disambiguated pronunciation — this is exactly what `createPronunciationDictionary` wires up.
+- Slow mode: `lib/audio/slowSpeechMode.ts` (`isSlowModeActive()`/`setSlowModeActive()`), toggled via `components/game/shared/SlowSpeechToggle.tsx`.
+
+## Pronunciation dictionaries
+
+`createPronunciationDictionary<T extends BaseGameItem>()` in `lib/constants/core/index.ts` maps `item.name → item.hebrewNikud || item.hebrew`. ~49 gameData files follow the pattern `<NAME>_PRONUNCIATIONS = createPronunciationDictionary(<NAME>_CONSTANTS)`. Always use this factory for a new game's pronunciation map — never hand-roll a `Record<string, string>` for it. If asked to audit/fix existing pronunciation maps for orphan keys, case mismatches, or missing entries, defer to `/pronunciation-qa` rather than redoing that check ad hoc.
+
+## Sound effects & themes
+
+- `lib/utils/game/soundThemes.ts` — `playThemedSound(ctx, type: 'success'|'wrong'|'levelUp', theme)`, 4 themes (default/farm/space/jungle), pure oscillator synthesis.
+- `lib/stores/soundThemeStore.ts` → `useSoundThemeStore` (persisted, key `gfk-sound-theme`) — theme selection.
+- `lib/stores/gameAudioStore.ts` → `useGameAudioStore` — owns the shared `AudioContext` + `speechEnabled` flag.
+- `BaseGameItem.sound?: number[]` (`lib/types/core/base.ts`, also `lib/types/components/cards.ts`) is a frequency array for oscillator synthesis, **not** a file path — don't confuse with the unrelated `sound: string` field on the different item shape in `lib/types/games/items.ts`; check which type you're actually extending before assuming the shape.
+- Adding a new sound theme or effect type means extending `playThemedSound`'s theme table, not creating a parallel sound system.
+
+## Audio settings
+
+`lib/stores/audioSettingsStore.ts` → `useAudioSettingsStore` (Zustand + persist, key `games-audio-settings`, version 2). State: `speechRate, speechPitch, volume, enabled, showNikud, showRealPhotos, showEnglish, holidayThemesEnabled`. Actions: `updateSpeechRate/Pitch/Volume` (clamped), `toggleEnabled/Nikud/RealPhotos/English/HolidayThemes`, `saveSettings(partial)`, `resetToDefaults()`. Defaults: rate 0.85, pitch 1.0, volume 0.8. Mute is separate from this store — see `hooks/shared/audio/useSoundToggle.ts` (`setUserMuted` + `localStorage['sound_muted']`, force-cancels `speechSynthesis`).
+
+## Hard rules learned from this codebase's audio bugs
+
+1. **Bump AudioContext/speech init only on a real user gesture** — `initSpeechAndAudio` must be called from a click handler, not an effect on mount; browsers (especially iOS Safari) block unprompted audio.
+2. **Every audio challenge needs a replay affordance** — a game that speaks a word once with no way to hear it again is a bug for auditory learners.
+3. **`speak()` must never live in a `useEffect` with unstable deps** (an object/array recreated each render) — depend on primitive values (`item.name`), or TTS will fire on every render.
+4. **All audio code must be in a `'use client'` file** — `speechSynthesis`/`AudioContext` don't exist during SSR and will crash the render.
+5. **Respect mute state** — check `isMuted`/`speechEnabled` before calling `speak` or the sound-effect functions; don't bypass with a raw API call "just this once."
+
+## Working style
+
+1. Grep before building: `grep -rn "useGameAudio\|speak(" gamesformykids/hooks gamesformykids/components` to see how existing games wire audio before adding a new call site.
+2. For a new game needing audio, wire it through `useGameAudio` + `speak`/`speakHebrew`/`speakEnglish` — do not add a new store or hook unless the existing ones genuinely can't express what's needed (ask first).
+3. After changes, manually verify: sound plays once per trigger (no overlap on rapid clicks), mute silences it, and there's no console error about SSR or missing user-gesture.
+4. If the task is "check whether existing audio code has bugs" rather than building/changing something, hand off to `/audio-flow-verifier` (flow/mute/overlap/SSR checks) or `/pronunciation-qa` (pronunciation map correctness) instead of re-deriving those checks here.
+5. `npx tsc --noEmit` (from `gamesformykids/`) after any change — Zustand store/hook changes are a common source of type drift.

--- a/gamesformykids/components/shared/GameCardMap.tsx
+++ b/gamesformykids/components/shared/GameCardMap.tsx
@@ -123,6 +123,8 @@ export const GameCardMap: Partial<Record<GameType, ComponentType<GameItemCardPro
   'number-words': DefaultGameCard,
   'visual-opposites': DefaultGameCard,
   'english-cards': DefaultGameCard,
+  'coins-match': DefaultGameCard,
+  'hebrew-script': DefaultGameCard,
 };
 
 /**

--- a/gamesformykids/hooks/games/useGenericGame.ts
+++ b/gamesformykids/hooks/games/useGenericGame.ts
@@ -4,20 +4,43 @@ import { useBaseGame } from "@/hooks/shared/game-state/useBaseGame";
 import { BaseGameItem, GameType } from "@/lib/types/core/base";
 import { useGameDifficulty } from '@/lib/stores/gameDifficultyStore';
 import { LETTER_HEBREW_PRONUNCIATIONS } from "@/lib/constants/gameData/basicData/letters";
+import { ADVANCED_COLORS_PRONUNCIATIONS } from "@/lib/constants/gameData/basicData/colors";
+import { COINS_PRONUNCIATIONS } from "@/lib/constants/gameData/coins";
+import { HEBREW_SCRIPT_PRONUNCIATIONS } from "@/lib/constants/gameData/hebrewScript";
+import { BODY_MOVEMENTS_PRONUNCIATIONS } from "@/lib/constants/gameData/innovativeData/bodyMovements";
+import { CLIMATE_PLANET_PRONUNCIATIONS } from "@/lib/constants/gameData/innovativeData/climatePlanet";
+import { EMOTIONAL_SOCIAL_PRONUNCIATIONS } from "@/lib/constants/gameData/innovativeData/emotionalSocial";
+import { SOUND_IMITATION_PRONUNCIATIONS } from "@/lib/constants/gameData/innovativeData/soundImitation";
+import { TIME_CLOCK_PRONUNCIATIONS } from "@/lib/constants/gameData/innovativeData/timeClock";
+import { TOUCH_SENSES_PRONUNCIATIONS } from "@/lib/constants/gameData/innovativeData/touchSenses";
+import { PROFESSION_HEBREW_PRONUNCIATIONS } from "@/lib/constants/gameData/lifestyleData/professions";
+import { ADVANCED_WEATHER_PRONUNCIATIONS } from "@/lib/constants/gameData/worldData/weather";
 
 const DIFFICULTY_BASE_COUNT: Record<string, number> = { easy: 3, medium: 4, hard: 6 };
 
-// Some game types can't just speak item.hebrew as-is (e.g. a bare letter glyph
-// is unclear or silent in Hebrew TTS) — they need a dedicated pronunciation per item.
+// Most game types carry per-item pronunciation via item.hebrewNikud (see fallback below).
+// These game types instead need a hand-authored map, either because their items don't
+// carry hebrewNikud at all, or because a bare letter/glyph is unclear or silent in TTS.
 const PRONUNCIATION_OVERRIDES: Partial<Record<GameType, Record<string, string>>> = {
   letters: LETTER_HEBREW_PRONUNCIATIONS,
+  'advanced-colors': ADVANCED_COLORS_PRONUNCIATIONS,
+  'coins-match': COINS_PRONUNCIATIONS,
+  'hebrew-script': HEBREW_SCRIPT_PRONUNCIATIONS,
+  'body-movements': BODY_MOVEMENTS_PRONUNCIATIONS,
+  'climate-planet': CLIMATE_PLANET_PRONUNCIATIONS,
+  'emotional-social': EMOTIONAL_SOCIAL_PRONUNCIATIONS,
+  'sound-imitation': SOUND_IMITATION_PRONUNCIATIONS,
+  'time-clock': TIME_CLOCK_PRONUNCIATIONS,
+  'touch-senses': TOUCH_SENSES_PRONUNCIATIONS,
+  professions: PROFESSION_HEBREW_PRONUNCIATIONS,
+  'advanced-weather': ADVANCED_WEATHER_PRONUNCIATIONS,
 };
 
 export function useGenericGame(items: BaseGameItem[], gameType: GameType) {
   const { difficulty } = useGameDifficulty();
   const overrides = PRONUNCIATION_OVERRIDES[gameType];
   const pronunciations = items.reduce<Record<string, string>>((acc, item) => {
-    acc[item.name] = overrides?.[item.name] ?? item.hebrew;
+    acc[item.name] = overrides?.[item.name] ?? item.hebrewNikud ?? item.hebrew;
     return acc;
   }, {});
 

--- a/gamesformykids/hooks/shared/game-state/gameHooksMap.ts
+++ b/gamesformykids/hooks/shared/game-state/gameHooksMap.ts
@@ -65,7 +65,9 @@ export type AutoGameType =
   | 'geography-capitals'
   | 'geography-continents'
   | 'visual-opposites'
-  | 'english-cards';
+  | 'english-cards'
+  | 'coins-match'
+  | 'hebrew-script';
 
 // Reads items from the store at hook-call time — no static game data imported here.
 const g = (type: AutoGameType): AnyGameHookFn =>
@@ -152,6 +154,8 @@ export const GAME_HOOKS_MAP: Record<AutoGameType, AnyGameHookFn> = {
   'geography-continents': useGeographyContinentsGame,
   'visual-opposites':     g('visual-opposites'),
   'english-cards':        g('english-cards'),
+  'coins-match':          g('coins-match'),
+  'hebrew-script':        g('hebrew-script'),
 };
 
 export type GameHookType = AnyGameHookFn;


### PR DESCRIPTION
## Summary
- `useGenericGame`'s speech fallback ignored every pronunciation dictionary and `item.hebrewNikud` except the `letters` game — 47 of 48 games spoke unvocalized Hebrew instead of the authored niqqud. Now falls back through `item.hebrewNikud` (fixes 36 generator-based dictionaries for free) and explicitly wires the 11 hand-authored dictionaries (advanced-colors, advanced-weather, professions, coins-match, hebrew-script, and 6 innovativeData games).
- `coins-match` and `hebrew-script` were listed as supported card games but missing from `GAME_HOOKS_MAP`/`AutoGameType` and `GameCardMap`, so both pages threw `"Hook not found for game type"` on load. Added to both maps.
- Adds a new `audio-specialist` subagent (`.claude/agents/audio-specialist.md`) for building/fixing TTS, sound effects, and audio settings in this repo.

## Test plan
- [x] `npx tsc --noEmit` — no errors
- [x] Verified `/games/coins-match` and `/games/hebrew-script` return 200 and render expected content against a running dev server (previously threw)
- [ ] Manual spot-check that a couple of games (e.g. colors, weather) now speak the vocalized `hebrewNikud` text instead of bare `hebrew`

🤖 Generated with [Claude Code](https://claude.com/claude-code)