### PR TITLE
feat(coloring): add flood-fill paint-bucket engine + forest scene

### DIFF
--- a/.claude/agents/coloring-page-builder.md
+++ b/.claude/agents/coloring-page-builder.md
@@ -1,6 +1,6 @@
 ---
 name: coloring-page-builder
-description: Builds and extends the online coloring-book game (`app/games/coloring/`) for this Next.js/React/TypeScript/Zustand kids' game site — click-to-fill-region SVG coloring pages in the style of sites like yo-yoo.co.il's online coloring. Use proactively when the user wants to add a new coloring picture/template, a new palette color, region grouping (e.g. "fill all windows at once"), or asks about `ColoringCanvas`/`IMAGE_COMPONENTS`/`coloringStore`/click-to-fill coloring mechanics. Also use for coloring-specific bug fixes (region not filling, wrong region ids, "done" celebration not triggering).
+description: Builds and extends the online coloring-book game (`app/games/coloring/`) for this Next.js/React/TypeScript/Zustand kids' game site — both click-to-fill-region SVG pictures (simple pictures, 3-7 named regions) and canvas-based flood-fill/paint-bucket scenes (busy, richly-detailed pictures) in the style of sites like yo-yoo.co.il's online coloring. Use proactively when the user wants to add a new coloring picture/scene, a new palette color, region grouping (e.g. "fill all windows at once"), or asks about `ColoringCanvas`/`IMAGE_COMPONENTS`/`coloringStore`/`FloodFillCanvas`/click-to-fill or bucket-fill coloring mechanics. Also use for coloring-specific bug fixes (region not filling, wrong region ids, flood fill leaking/not stopping at outlines, "done" celebration not triggering).
 tools: Read, Grep, Glob, Write, Edit, Bash
 model: sonnet
 ---
@@ -9,27 +9,33 @@ You are the coloring-page specialist for the GamesForMyKids repo (`gamesformykid
 
 ## How the game works
 
-This is a **click-to-fill-region** coloring book, not a flood-fill/raster tool: each picture is a hand-authored SVG where every colorable shape is its own element with an `onClick` handler that fills it with the currently selected palette color. There is no freehand drawing here — that's a separate game (`app/games/drawing/`, don't confuse the two).
+There are **two picture kinds**, both dispatched from the same `IMAGE_COMPONENTS` registry via a `kind` discriminant on `ImageMeta` (`app/games/coloring/types.ts`):
+- **`kind: 'regions'`** — click-to-fill-region: a hand-authored SVG React component where every colorable shape is its own element with an `onClick` handler that fills it with the selected palette color. Best for simple pictures (3-7 named regions).
+- **`kind: 'floodfill'`** — click-to-bucket-fill: a static line-art image (SVG or raster) rasterized once onto a `<canvas>`; clicking runs a real flood-fill/paint-bucket algorithm (`app/games/coloring/lib/floodFill.ts`) that fills the enclosed area under the click, stopping at black outlines — no named regions at all. Use this for busy/richly-detailed scenes where hand-authoring dozens of named regions would be impractical (see the `forest` scene for a working example).
+
+There is no freehand drawing here either way — that's a separate game (`app/games/drawing/`, don't confuse the two).
 
 ```
 app/games/coloring/
 ├── ColoringGameClient.tsx        # 'use client' entry — thin wrapper via makeGameClient
 ├── constants.ts                  # PALETTE_COLORS, ImageId union, IMAGES picker list
-├── types.ts                      # ImageProps, ImageComponentType, ImageMeta
-├── store/coloringStore.ts        # Zustand: currentImage, selectedColor, allFills, doneImages
+├── types.ts                      # ImageProps, ImageComponentType, RegionImageMeta, FloodFillImageMeta, ImageMeta (union)
+├── store/coloringStore.ts        # Zustand: currentImage, selectedColor, allFills, doneImages, floodFillSnapshots, floodFillClear
 ├── useColoringPalette.ts
+├── lib/floodFill.ts              # pure flood-fill algorithm (stack-based, tolerance + dark-line guard) — no framework deps
 └── components/
     ├── ColoringGame.tsx           # composes the screen
     ├── ColoringHeader.tsx
     ├── ColoringImageSelector.tsx  # picker chips (emoji + title), reads IMAGES
-    ├── ColoringCanvas.tsx         # renders the active Image component + region/group buttons
+    ├── ColoringCanvas.tsx         # branches on meta.kind: SVG+region/group buttons, OR <FloodFillCanvas>
+    ├── FloodFillCanvas.tsx        # owns the <canvas>, loads image, click → floodFill() → putImageData
     ├── ColoringPalette.tsx        # color swatches
     ├── ColoringActions.tsx
-    ├── imageComponents.ts         # IMAGE_COMPONENTS registry: id → {Component, regions, names, groups?}
-    └── images/<name>.tsx          # one file per picture: the actual SVG + its region ids/names
+    ├── imageComponents.ts         # IMAGE_COMPONENTS registry: id → RegionImageMeta | FloodFillImageMeta
+    └── images/<name>.tsx          # one file per REGION picture: the actual SVG + its region ids/names
 ```
 
-## Adding a new coloring picture — exact steps
+## Adding a new REGION picture (`kind: 'regions'`) — exact steps
 
 Each picture is its own component. Model every new one on `components/images/cat.tsx` — it's the smallest, clearest example.
 
@@ -63,13 +69,13 @@ Each picture is its own component. Model every new one on `components/images/cat
    - Default fill for a shape that should start non-white (e.g. a nose) is the second arg to `f()`, e.g. `f('cat-nose', '#ffb3ba')`.
    - Keep the same `viewBox="0 0 200 200"` convention unless there's a reason not to — the canvas wrapper assumes a square aspect (`aspect-square` in `ColoringCanvas.tsx`).
 
-2. **`components/imageComponents.ts`** — register it:
+2. **`components/imageComponents.ts`** — register it (note the required `kind: 'regions'` tag — `ImageMeta` is a discriminated union, this is what tells `ColoringCanvas` to render the SVG+region-buttons path instead of `FloodFillCanvas`):
    ```typescript
    import { BalloonImage, balloonRegions, balloonRegionNames } from './images/balloon';
    // ...
    export const IMAGE_COMPONENTS: Record<ImageId, ImageMeta> = {
      // ...existing
-     balloon: { Component: BalloonImage, regions: balloonRegions, names: balloonRegionNames },
+     balloon: { kind: 'regions', Component: BalloonImage, regions: balloonRegions, names: balloonRegionNames },
    };
    ```
    Add a `groups` array only if it makes sense to fill several regions with one tap (e.g. "all windows", "all petals") — see `house`/`sun`/`flower`/`car` entries for the pattern: `{ id, name, members: string[] }`.
@@ -92,6 +98,32 @@ Each picture is its own component. Model every new one on `components/images/cat
 
 **Total new files per picture: 1** (`components/images/<name>.tsx`). Everything else is a small addition to 3 existing files (steps 2-4). Do not create a new store, a new canvas component, or a new picker — this game already has one of each and every picture reuses them.
 
+## Adding a flood-fill scene (`kind: 'floodfill'`) — busy/complex pictures
+
+Use this instead of the regions pattern when a picture is too detailed to hand-author named regions for every shape (many small leaves/objects/characters — the `forest` scene, `public/images/coloring-scenes/forest.svg`, is the reference example). The engine is generic (`lib/floodFill.ts` + `components/FloodFillCanvas.tsx`) — adding a new scene is data-only, no new component code.
+
+1. **New line-art file** under `public/images/coloring-scenes/<name>.svg` (or `.png`). It is a **static file**, not a React component — pure black outlines on an opaque white background, loaded into a `<canvas>` via `new Image()` + `drawImage`, not rendered inline as JSX.
+
+   **Authoring rules — required for the flood-fill algorithm to work correctly, not optional style:**
+   - `viewBox="0 0 W H"` must exactly match the `width`/`height` you register in `imageComponents.ts` (see step 2) — this is the canvas's native raster resolution.
+   - First element must be `<rect width="W" height="H" fill="#ffffff"/>` — guarantees full opacity everywhere so the algorithm's RGB-only tolerance check can safely ignore alpha.
+   - All strokes must be pure `stroke="#000000"` — **not** `#222` (used in region-mode SVGs). The dark-line "don't flood the outline itself" guard in `floodFill.ts` checks `luminance < 12`, which only reliably catches pure black.
+   - `stroke-width` of at least `4-6` at the scene's resolution, especially at corners/pinch-points — a single anti-aliased 1px gap in a boundary lets a fill leak into the neighboring shape.
+   - Every fillable region must be a genuinely **closed** loop in the rendered raster. Prefer non-overlapping or cleanly-nested closed shapes (a small closed shape entirely inside a larger one, like a flower center inside its petals, or eyes inside a body) over overlapping painter's-algorithm shapes — two shapes that overlap without a stroked boundary at the overlap won't produce a correctly separated raster region.
+   - A single stroked path that touches both opposite edges of the canvas (e.g. a ground line from `x=0` to `x=W`) cleanly separates the canvas into two background zones (e.g. sky/ground) without needing an explicit border rect — the canvas's own edges close the loop.
+
+2. **`components/imageComponents.ts`** — register it:
+   ```typescript
+   forest: { kind: 'floodfill', src: '/images/coloring-scenes/forest.svg', width: 800, height: 800 },
+   ```
+   No `Component`/`regions`/`names`/`groups` — that's the entire point of this mode.
+
+3. **`constants.ts`** — same as the regions pattern: add the id to `ImageId` and one entry to `IMAGES`.
+
+4. **`store/coloringStore.ts`** — same mechanical defaults as any picture: add the id to `EMPTY_FILLS` (unused for floodfill images but must exist to avoid `undefined` lookups) and to the `doneImages` initializer (also unused — flood-fill scenes never trigger the "done" celebration in v1, since nothing calls `selectRegion`/`fillGroup` for them; this is intentional, not a bug).
+
+Do not touch `lib/floodFill.ts` or `components/FloodFillCanvas.tsx` for a new scene — they're generic. Only touch them if the *algorithm* needs to change (e.g. tolerance tuning) or you're adding a genuinely new interaction (per-stroke undo, completion detection) — confirm with the user first, these are explicit v1 non-goals.
+
 ## Scaling to a large picture library (many templates, gallery-style)
 
 If asked to grow this into something closer to a large coloring-book site (dozens/hundreds of templates, searchable gallery, categories) rather than a handful of hand-picked pictures — **stop and confirm with the user before restructuring**, this is a bigger architectural change:
@@ -102,5 +134,6 @@ If asked to grow this into something closer to a large coloring-book site (dozen
 ## Before reporting done
 1. `cd gamesformykids && npx tsc --noEmit` — zero TS errors.
 2. `npm run build` — zero build errors.
-3. Manually check `/games/coloring`: new picture appears in the selector, every region fills on click, any group button fills all its members, the "כל הכבוד" celebration triggers once every region has a fill, "צבע שוב" resets it.
-4. Don't touch `app/games/drawing/` — freehand drawing is a separate game/store, not this one.
+3. **Regions picture:** new picture appears in the selector, every region fills on click, any group button fills all its members, the "כל הכבוד" celebration triggers once every region has a fill, "צבע שוב" resets it.
+4. **Flood-fill scene:** new scene appears in the selector; clicking inside an enclosed shape fills only that shape; clicking exactly on a black outline is a no-op; re-clicking an already-filled shape with a new color re-floods it without leaking into neighbors; a shape adjacent to a differently-filled shape doesn't bleed across their shared outline; "🗑️ נקה" resets the scene to pristine blank line art; filling a few shapes then switching to another picture and back preserves the flood-fill progress.
+5. Don't touch `app/games/drawing/` — freehand drawing is a separate game/store, not this one.

--- a/gamesformykids/app/games/coloring/components/ColoringCanvas.tsx
+++ b/gamesformykids/app/games/coloring/components/ColoringCanvas.tsx
@@ -2,6 +2,7 @@
 
 import { useColoringStore } from '../store/coloringStore';
 import { IMAGE_COMPONENTS } from './imageComponents';
+import { FloodFillCanvas } from './FloodFillCanvas';
 
 export function ColoringCanvas() {
   const currentImage = useColoringStore((s) => s.currentImage);
@@ -11,7 +12,7 @@ export function ColoringCanvas() {
   const fillGroup = useColoringStore((s) => s.fillGroup);
   const clearImage = useColoringStore((s) => s.clearImage);
 
-  const { Component, regions, names, groups } = IMAGE_COMPONENTS[currentImage];
+  const meta = IMAGE_COMPONENTS[currentImage];
 
   return (
     <div className="relative bg-white rounded-3xl shadow-xl p-4 mb-4 border-4 border-purple-200">
@@ -28,36 +29,41 @@ export function ColoringCanvas() {
         </div>
       )}
 
-      <div className="w-full aspect-square max-w-xs mx-auto">
-        <Component
-          fills={fills}
-          onFill={(id) => selectRegion(id, regions)}
-        />
-      </div>
+      {meta.kind === 'regions' ? (
+        <>
+          <div className="w-full aspect-square max-w-xs mx-auto">
+            <meta.Component fills={fills} onFill={(id) => selectRegion(id, meta.regions)} />
+          </div>
 
-      <div className="flex flex-wrap gap-2 justify-center mt-3">
-        {/* Group buttons – fill all members at once */}
-        {groups?.map(({ id, name, members }) => (
-          <button
-            key={id}
-            onClick={() => fillGroup(members, regions)}
-            className="px-3 py-1.5 rounded-full text-sm font-bold border-2 transition border-purple-400 bg-purple-50 text-purple-700 hover:bg-purple-100 active:scale-95"
-          >
-            ✨ {name}
-          </button>
-        ))}
-        {/* Individual region buttons */}
-        {regions.map((id) => (
-          <button
-            key={id}
-            onClick={() => selectRegion(id, regions)}
-            className="px-3 py-1.5 rounded-full text-sm font-bold border-2 transition border-gray-300 bg-white text-gray-700 hover:border-purple-400 hover:bg-purple-50 active:scale-95"
-            style={fills[id] ? { borderColor: fills[id], color: fills[id] } : undefined}
-          >
-            {names[id]}
-          </button>
-        ))}
-      </div>
+          <div className="flex flex-wrap gap-2 justify-center mt-3">
+            {/* Group buttons – fill all members at once */}
+            {meta.groups?.map(({ id, name, members }) => (
+              <button
+                key={id}
+                onClick={() => fillGroup(members, meta.regions)}
+                className="px-3 py-1.5 rounded-full text-sm font-bold border-2 transition border-purple-400 bg-purple-50 text-purple-700 hover:bg-purple-100 active:scale-95"
+              >
+                ✨ {name}
+              </button>
+            ))}
+            {/* Individual region buttons */}
+            {meta.regions.map((id) => (
+              <button
+                key={id}
+                onClick={() => selectRegion(id, meta.regions)}
+                className="px-3 py-1.5 rounded-full text-sm font-bold border-2 transition border-gray-300 bg-white text-gray-700 hover:border-purple-400 hover:bg-purple-50 active:scale-95"
+                style={fills[id] ? { borderColor: fills[id], color: fills[id] } : undefined}
+              >
+                {meta.names[id]}
+              </button>
+            ))}
+          </div>
+        </>
+      ) : (
+        <div className="w-full aspect-square max-w-xs mx-auto">
+          <FloodFillCanvas key={currentImage} imageId={currentImage} meta={meta} />
+        </div>
+      )}
     </div>
   );
 }

--- a/gamesformykids/app/games/coloring/components/FloodFillCanvas.tsx
+++ b/gamesformykids/app/games/coloring/components/FloodFillCanvas.tsx
@@ -1,0 +1,70 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+import { useColoringStore } from '../store/coloringStore';
+import { floodFill, hexToRgba } from '../lib/floodFill';
+import type { FloodFillImageMeta } from '../types';
+import type { ImageId } from '../constants';
+
+interface FloodFillCanvasProps {
+  imageId: ImageId;
+  meta: FloodFillImageMeta;
+}
+
+export function FloodFillCanvas({ imageId, meta }: FloodFillCanvasProps) {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const selectedColor = useColoringStore((s) => s.selectedColor);
+  const registerFloodFillClear = useColoringStore((s) => s.registerFloodFillClear);
+  const saveFloodFillSnapshot = useColoringStore((s) => s.saveFloodFillSnapshot);
+
+  // Load the pristine source (or a saved snapshot) once on mount.
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext('2d', { willReadFrequently: true });
+    if (!ctx) return;
+
+    const drawSrc = (src: string) => {
+      const img = new Image();
+      img.onload = () => ctx.drawImage(img, 0, 0, meta.width, meta.height);
+      img.src = src;
+    };
+
+    const snapshot = useColoringStore.getState().floodFillSnapshots[imageId];
+    drawSrc(snapshot ?? meta.src);
+
+    registerFloodFillClear(() => drawSrc(meta.src));
+
+    return () => registerFloodFillClear(() => {});
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [imageId]);
+
+  const handleClick = (e: React.MouseEvent<HTMLCanvasElement>) => {
+    const canvas = canvasRef.current;
+    const ctx = canvas?.getContext('2d', { willReadFrequently: true });
+    if (!canvas || !ctx) return;
+
+    const rect = canvas.getBoundingClientRect();
+    const scaleX = canvas.width / rect.width;
+    const scaleY = canvas.height / rect.height;
+    const x = Math.floor((e.clientX - rect.left) * scaleX);
+    const y = Math.floor((e.clientY - rect.top) * scaleY);
+
+    const imageData = ctx.getImageData(0, 0, canvas.width, canvas.height);
+    const changed = floodFill(imageData, x, y, hexToRgba(selectedColor));
+    if (!changed) return;
+
+    ctx.putImageData(imageData, 0, 0);
+    saveFloodFillSnapshot(imageId, canvas.toDataURL('image/png'));
+  };
+
+  return (
+    <canvas
+      ref={canvasRef}
+      width={meta.width}
+      height={meta.height}
+      onClick={handleClick}
+      className="w-full h-full cursor-pointer"
+    />
+  );
+}

--- a/gamesformykids/app/games/coloring/components/imageComponents.ts
+++ b/gamesformykids/app/games/coloring/components/imageComponents.ts
@@ -1,4 +1,4 @@
-import type { ImageId } from '../store/coloringStore';
+import type { ImageId } from '../constants';
 import type { ImageComponentType, ImageMeta } from '../types';
 
 import { CatImage, catRegions, catRegionNames } from './images/cat';
@@ -18,53 +18,54 @@ import { BoatImage, boatRegions, boatRegionNames } from './images/boat';
 export type { ImageComponentType, ImageMeta };
 
 export const IMAGE_COMPONENTS: Record<ImageId, ImageMeta> = {
-  cat: { Component: CatImage, regions: catRegions, names: catRegionNames },
+  cat: { kind: 'regions', Component: CatImage, regions: catRegions, names: catRegionNames },
   house: {
-    Component: HouseImage, regions: houseRegions, names: houseRegionNames,
+    kind: 'regions', Component: HouseImage, regions: houseRegions, names: houseRegionNames,
     groups: [{ id: 'house-windows-all', name: 'כל החלונות', members: ['house-window-left', 'house-window-right'] }],
   },
   sun: {
-    Component: SunImage, regions: sunRegions, names: sunRegionNames,
+    kind: 'regions', Component: SunImage, regions: sunRegions, names: sunRegionNames,
     groups: [{ id: 'sun-rays-all', name: 'כל הקרניים', members: SUN_RAY_IDS }],
   },
   butterfly: {
-    Component: ButterflyImage, regions: butterflyRegions, names: butterflyRegionNames,
+    kind: 'regions', Component: ButterflyImage, regions: butterflyRegions, names: butterflyRegionNames,
     groups: [
       { id: 'butterfly-wings-top', name: 'כנפיים עליונות', members: ['butterfly-wing-top-left', 'butterfly-wing-top-right'] },
       { id: 'butterfly-wings-bottom', name: 'כנפיים תחתונות', members: ['butterfly-wing-bottom-left', 'butterfly-wing-bottom-right'] },
     ],
   },
   flower: {
-    Component: FlowerImage, regions: flowerRegions, names: flowerRegionNames,
+    kind: 'regions', Component: FlowerImage, regions: flowerRegions, names: flowerRegionNames,
     groups: [{ id: 'flower-petals-all', name: 'כל העלים', members: ['flower-petal-0', 'flower-petal-60', 'flower-petal-120', 'flower-petal-180', 'flower-petal-240', 'flower-petal-300'] }],
   },
-  fish: { Component: FishImage, regions: fishRegions, names: fishRegionNames },
+  fish: { kind: 'regions', Component: FishImage, regions: fishRegions, names: fishRegionNames },
   tree: {
-    Component: TreeImage, regions: treeRegions, names: treeRegionNames,
+    kind: 'regions', Component: TreeImage, regions: treeRegions, names: treeRegionNames,
     groups: [{ id: 'tree-crown-all', name: 'כל הכתר', members: ['tree-crown-left', 'tree-crown-right', 'tree-crown-top'] }],
   },
   car: {
-    Component: CarImage, regions: carRegions, names: carRegionNames,
+    kind: 'regions', Component: CarImage, regions: carRegions, names: carRegionNames,
     groups: [
       { id: 'car-windows-all', name: 'כל החלונות', members: ['car-window-left', 'car-window-right'] },
       { id: 'car-wheels-all', name: 'כל הגלגלים', members: ['car-wheel-left', 'car-wheel-right'] },
     ],
   },
-  star: { Component: StarImage, regions: starRegions, names: starRegionNames },
+  star: { kind: 'regions', Component: StarImage, regions: starRegions, names: starRegionNames },
   balloon: {
-    Component: BalloonImage, regions: balloonRegions, names: balloonRegionNames,
+    kind: 'regions', Component: BalloonImage, regions: balloonRegions, names: balloonRegionNames,
     groups: [{ id: 'balloons-all', name: 'כל הבלונים', members: ['balloon-left', 'balloon-right'] }],
   },
   robot: {
-    Component: RobotImage, regions: robotRegions, names: robotRegionNames,
+    kind: 'regions', Component: RobotImage, regions: robotRegions, names: robotRegionNames,
     groups: [{ id: 'robot-arms-all', name: 'כל הידיים', members: ['robot-arm-left', 'robot-arm-right'] }],
   },
   dog: {
-    Component: DogImage, regions: dogRegions, names: dogRegionNames,
+    kind: 'regions', Component: DogImage, regions: dogRegions, names: dogRegionNames,
     groups: [{ id: 'dog-ears-all', name: 'כל האוזניים', members: ['dog-ear-left', 'dog-ear-right'] }],
   },
   boat: {
-    Component: BoatImage, regions: boatRegions, names: boatRegionNames,
+    kind: 'regions', Component: BoatImage, regions: boatRegions, names: boatRegionNames,
     groups: [{ id: 'boat-sails-all', name: 'כל המפרשים', members: ['boat-sail-main', 'boat-sail-small'] }],
   },
+  forest: { kind: 'floodfill', src: '/images/coloring-scenes/forest.svg', width: 800, height: 800 },
 };

--- a/gamesformykids/app/games/coloring/constants.ts
+++ b/gamesformykids/app/games/coloring/constants.ts
@@ -26,7 +26,7 @@ export const PALETTE_COLORS = [
 ] as const;
 
 export type ImageId = 'cat' | 'house' | 'sun' | 'butterfly' | 'flower' | 'fish' | 'tree' | 'car'
-  | 'star' | 'balloon' | 'robot' | 'dog' | 'boat';
+  | 'star' | 'balloon' | 'robot' | 'dog' | 'boat' | 'forest';
 
 export const IMAGES: { id: ImageId; title: string; emoji: string }[] = [
   { id: 'cat', title: 'חתול', emoji: '🐱' },
@@ -42,4 +42,5 @@ export const IMAGES: { id: ImageId; title: string; emoji: string }[] = [
   { id: 'robot', title: 'רובוט', emoji: '🤖' },
   { id: 'dog', title: 'כלב', emoji: '🐶' },
   { id: 'boat', title: 'סירה', emoji: '⛵' },
+  { id: 'forest', title: 'יער קסום', emoji: '🌲' },
 ];

--- a/gamesformykids/app/games/coloring/lib/floodFill.ts
+++ b/gamesformykids/app/games/coloring/lib/floodFill.ts
@@ -1,0 +1,84 @@
+/**
+ * Paint-bucket flood fill over canvas ImageData.
+ * Stack-based (not recursive) to avoid call-stack overflow on large fills.
+ * Matches pixels against the clicked pixel's OWN original color (not a fixed
+ * white), so it correctly stops at both black outlines and at already
+ * differently-colored neighboring regions.
+ */
+
+/** Max per-channel diff to still count as "the same color" as the clicked pixel. */
+const COLOR_TOLERANCE = 32;
+
+/** Luminance below which a clicked pixel is treated as "on the outline" (no-op). */
+const DARK_LINE_LUMINANCE = 12;
+
+export function hexToRgba(hex: string): [number, number, number, number] {
+  const clean = hex.replace('#', '');
+  const r = parseInt(clean.slice(0, 2), 16);
+  const g = parseInt(clean.slice(2, 4), 16);
+  const b = parseInt(clean.slice(4, 6), 16);
+  return [r, g, b, 255];
+}
+
+function luminance(r: number, g: number, b: number): number {
+  return 0.299 * r + 0.587 * g + 0.114 * b;
+}
+
+/** Returns false if the fill was a no-op (clicked on a line, or already the target color). */
+export function floodFill(
+  imageData: ImageData,
+  startX: number,
+  startY: number,
+  fillRgba: [number, number, number, number],
+): boolean {
+  const { width, height, data } = imageData;
+  if (startX < 0 || startY < 0 || startX >= width || startY >= height) return false;
+
+  const startIdx = (startY * width + startX) * 4;
+  const targetR = data[startIdx] ?? 0;
+  const targetG = data[startIdx + 1] ?? 0;
+  const targetB = data[startIdx + 2] ?? 0;
+
+  if (luminance(targetR, targetG, targetB) < DARK_LINE_LUMINANCE) return false;
+
+  const [fillR, fillG, fillB, fillA] = fillRgba;
+  if (
+    Math.abs(targetR - fillR) <= COLOR_TOLERANCE &&
+    Math.abs(targetG - fillG) <= COLOR_TOLERANCE &&
+    Math.abs(targetB - fillB) <= COLOR_TOLERANCE
+  ) {
+    return false;
+  }
+
+  const matches = (idx: number) =>
+    Math.abs((data[idx] ?? 0) - targetR) <= COLOR_TOLERANCE &&
+    Math.abs((data[idx + 1] ?? 0) - targetG) <= COLOR_TOLERANCE &&
+    Math.abs((data[idx + 2] ?? 0) - targetB) <= COLOR_TOLERANCE;
+
+  const visited = new Uint8Array(width * height);
+  const stack: number[] = [startX, startY];
+  let changed = false;
+
+  while (stack.length > 0) {
+    const y = stack.pop()!;
+    const x = stack.pop()!;
+    if (x < 0 || y < 0 || x >= width || y >= height) continue;
+
+    const pixelPos = y * width + x;
+    if (visited[pixelPos]) continue;
+    visited[pixelPos] = 1;
+
+    const idx = pixelPos * 4;
+    if (!matches(idx)) continue;
+
+    data[idx] = fillR;
+    data[idx + 1] = fillG;
+    data[idx + 2] = fillB;
+    data[idx + 3] = fillA;
+    changed = true;
+
+    stack.push(x + 1, y, x - 1, y, x, y + 1, x, y - 1);
+  }
+
+  return changed;
+}

--- a/gamesformykids/app/games/coloring/store/coloringStore.ts
+++ b/gamesformykids/app/games/coloring/store/coloringStore.ts
@@ -5,6 +5,7 @@
  */
 import { makeStore } from '@/lib/stores/createStore';
 import { PALETTE_COLORS, IMAGES, type ImageId } from '../constants';
+import { IMAGE_COMPONENTS } from '../components/imageComponents';
 
 export type { ImageId };
 export { PALETTE_COLORS, IMAGES };
@@ -15,7 +16,7 @@ type AllFills = Record<ImageId, Record<string, string>>;
 
 const EMPTY_FILLS: AllFills = {
   cat: {}, house: {}, sun: {}, butterfly: {}, flower: {}, fish: {}, tree: {}, car: {},
-  star: {}, balloon: {}, robot: {}, dog: {}, boat: {},
+  star: {}, balloon: {}, robot: {}, dog: {}, boat: {}, forest: {},
 };
 
 // ── Store ─────────────────────────────────────────────────────────────────────
@@ -25,6 +26,10 @@ interface ColoringState {
   selectedColor: string;
   allFills: AllFills;
   doneImages: Record<ImageId, boolean>;
+  /** dataURL snapshot per flood-fill image, so switching pictures doesn't lose progress */
+  floodFillSnapshots: Partial<Record<ImageId, string>>;
+  /** imperative reset registered by the currently-mounted FloodFillCanvas */
+  floodFillClear: () => void;
 }
 
 interface ColoringActions {
@@ -33,6 +38,8 @@ interface ColoringActions {
   /** מצבע אזור מיד בצבע הנבחר */
   selectRegion: (id: string, colorableIds: string[]) => void;  /** מצבע קבוצת אזורים בצבע הנבחר */
   fillGroup: (memberIds: string[], colorableIds: string[]) => void;  clearImage: () => void;
+  registerFloodFillClear: (fn: () => void) => void;
+  saveFloodFillSnapshot: (id: ImageId, dataUrl: string) => void;
 }
 
 export const useColoringStore = makeStore<ColoringState & ColoringActions>(
@@ -60,8 +67,10 @@ export const useColoringStore = makeStore<ColoringState & ColoringActions>(
       allFills: EMPTY_FILLS,
       doneImages: {
         cat: false, house: false, sun: false, butterfly: false, flower: false, fish: false, tree: false, car: false,
-        star: false, balloon: false, robot: false, dog: false, boat: false,
+        star: false, balloon: false, robot: false, dog: false, boat: false, forest: false,
       },
+      floodFillSnapshots: {},
+      floodFillClear: () => {},
 
       selectImage: (id) =>
         set({ currentImage: id }, false, 'selectImage'),
@@ -83,15 +92,37 @@ export const useColoringStore = makeStore<ColoringState & ColoringActions>(
 
       clearImage: () => {
         const { currentImage } = get();
+        if (IMAGE_COMPONENTS[currentImage].kind === 'floodfill') {
+          get().floodFillClear();
+          set(
+            (state) => {
+              const next = { ...state.floodFillSnapshots };
+              delete next[currentImage];
+              return { floodFillSnapshots: next };
+            },
+            false,
+            'clearImage/floodfill',
+          );
+          return;
+        }
         set(
           (state) => ({
             allFills: { ...state.allFills, [currentImage]: {} },
             doneImages: { ...state.doneImages, [currentImage]: false },
           }),
           false,
-          'clearImage',
+          'clearImage/regions',
         );
       },
+
+      registerFloodFillClear: (fn) => set({ floodFillClear: fn }, false, 'registerFloodFillClear'),
+
+      saveFloodFillSnapshot: (id, dataUrl) =>
+        set(
+          (state) => ({ floodFillSnapshots: { ...state.floodFillSnapshots, [id]: dataUrl } }),
+          false,
+          'saveFloodFillSnapshot',
+        ),
     };
   },
 );

--- a/gamesformykids/app/games/coloring/types.ts
+++ b/gamesformykids/app/games/coloring/types.ts
@@ -9,11 +9,25 @@ export interface ImageProps {
 /** React component type matching ImageProps */
 export type ImageComponentType = ComponentType<ImageProps>;
 
-/** Metadata per image: component, region ids, Hebrew region names */
-export interface ImageMeta {
+/** Click-to-fill-region picture: hand-authored SVG with named colorable shapes */
+export interface RegionImageMeta {
+  kind: 'regions';
   Component: ImageComponentType;
   regions: string[];
   names: Record<string, string>;
   /** Optional region groups — one click fills all members */
   groups?: { id: string; name: string; members: string[] }[];
 }
+
+/** Flood-fill (paint-bucket) picture: static line-art image rasterized onto a canvas */
+export interface FloodFillImageMeta {
+  kind: 'floodfill';
+  /** public/ path to the line-art image */
+  src: string;
+  /** native canvas raster resolution (not CSS display size) */
+  width: number;
+  height: number;
+}
+
+/** Metadata per image — either a named-region SVG or a flood-fill scene */
+export type ImageMeta = RegionImageMeta | FloodFillImageMeta;

--- a/gamesformykids/public/images/coloring-scenes/forest.svg
+++ b/gamesformykids/public/images/coloring-scenes/forest.svg
@@ -1,0 +1,51 @@
+<svg viewBox="0 0 800 800" xmlns="http://www.w3.org/2000/svg">
+  <rect width="800" height="800" fill="#ffffff"/>
+
+  <!-- ground line: separates sky (top) from grass (bottom); touches both edges -->
+  <path d="M0,580 Q200,540 400,560 T800,550" fill="none" stroke="#000000" stroke-width="6"/>
+
+  <!-- sun -->
+  <circle cx="650" cy="120" r="60" fill="#ffffff" stroke="#000000" stroke-width="5"/>
+  <line x1="650" y1="35" x2="650" y2="10" stroke="#000000" stroke-width="4"/>
+  <line x1="650" y1="205" x2="650" y2="230" stroke="#000000" stroke-width="4"/>
+  <line x1="565" y1="120" x2="540" y2="120" stroke="#000000" stroke-width="4"/>
+  <line x1="735" y1="120" x2="760" y2="120" stroke="#000000" stroke-width="4"/>
+  <line x1="590" y1="60" x2="572" y2="42" stroke="#000000" stroke-width="4"/>
+  <line x1="710" y1="180" x2="728" y2="198" stroke="#000000" stroke-width="4"/>
+
+  <!-- cloud A -->
+  <path d="M90,110 Q70,90 90,70 Q95,40 130,45 Q145,20 175,35 Q205,25 210,55
+           Q235,60 225,85 Q235,110 205,115 Q195,135 165,120 Q140,135 115,120
+           Q90,130 90,110 Z" fill="#ffffff" stroke="#000000" stroke-width="5"/>
+
+  <!-- cloud B -->
+  <path d="M440,80 Q425,65 440,50 Q445,30 470,35 Q485,15 510,28 Q530,20 535,42
+           Q555,48 545,68 Q555,85 530,88 Q522,102 500,92 Q480,105 460,92
+           Q440,98 440,80 Z" fill="#ffffff" stroke="#000000" stroke-width="5"/>
+
+  <!-- tree -->
+  <rect x="160" y="455" width="44" height="115" rx="6" fill="#ffffff" stroke="#000000" stroke-width="5"/>
+  <path d="M110,460 Q70,430 85,390 Q65,360 95,325 Q90,285 140,275 Q160,240 210,255
+           Q250,230 280,270 Q315,275 305,320 Q335,345 310,380 Q325,415 285,435
+           Q290,465 245,460 Q220,480 180,465 Q145,485 110,460 Z"
+        fill="#ffffff" stroke="#000000" stroke-width="5"/>
+
+  <!-- bush -->
+  <path d="M600,640 Q585,615 610,600 Q615,575 650,580 Q675,565 695,585 Q720,580 715,605
+           Q735,615 715,635 Q720,655 690,650 Q670,665 640,655 Q615,665 600,640 Z"
+        fill="#ffffff" stroke="#000000" stroke-width="5"/>
+
+  <!-- flower -->
+  <path d="M320,700 Q305,680 320,665 Q315,645 340,645 Q350,625 375,635 Q395,620 410,640
+           Q430,635 425,660 Q445,670 425,685 Q430,705 405,700 Q400,720 375,710
+           Q355,725 335,710 Q310,715 320,700 Z" fill="#ffffff" stroke="#000000" stroke-width="4"/>
+  <circle cx="372" cy="672" r="14" fill="#ffffff" stroke="#000000" stroke-width="4"/>
+
+  <!-- owl -->
+  <polygon points="500,635 490,600 515,630" fill="#ffffff" stroke="#000000" stroke-width="4"/>
+  <polygon points="580,635 590,600 565,630" fill="#ffffff" stroke="#000000" stroke-width="4"/>
+  <ellipse cx="540" cy="690" rx="55" ry="65" fill="#ffffff" stroke="#000000" stroke-width="5"/>
+  <circle cx="520" cy="655" r="10" fill="#ffffff" stroke="#000000" stroke-width="3"/>
+  <circle cx="560" cy="655" r="10" fill="#ffffff" stroke="#000000" stroke-width="3"/>
+  <polygon points="533,662 547,662 540,677" fill="#ffffff" stroke="#000000" stroke-width="3"/>
+</svg>


### PR DESCRIPTION
## Summary
- Adds a canvas-based **flood-fill / paint-bucket** coloring mode alongside the existing click-to-fill-region SVG mode. `ImageMeta` is now a discriminated union (`kind: 'regions' | 'floodfill'`); all 13 existing pictures get `kind: 'regions'` with zero behavior change.
- New pure algorithm `app/games/coloring/lib/floodFill.ts` — stack-based (not recursive), matches pixels against the clicked pixel's own original color (so it stops at both black outlines and already-differently-colored neighbors), with a dark-line guard so clicking exactly on an outline is a no-op.
- New `FloodFillCanvas.tsx` component: loads a static line-art image onto a canvas, handles click → coordinate scaling → flood fill → repaint, and persists in-progress work as a per-picture dataURL snapshot in the store (mirrors how region fills already persist per picture), so switching pictures and back doesn't lose progress.
- New demo scene: `public/images/coloring-scenes/forest.svg` (יער קסום 🌲) — a forest scene with sun, clouds, tree, bush, flower, and an owl, proving the engine handles arbitrary continuous line art with no named regions.
- Updated the `coloring-page-builder` subagent with the new pattern (when to use flood-fill vs regions, SVG authoring rules required for the algorithm to work, expanded manual-test checklist).

Closes #1465

## Test plan
- [x] `npx tsc --noEmit` — zero errors
- [x] `npm run build` — zero errors
- [x] Manually verified in browser at `/games/coloring` (יער קסום scene): clicking inside enclosed shapes (sun, tree crown, trunk, flower center) fills only that shape; clicking near/on the ground-line outline behaves correctly (sky/ground are correctly separated background zones); re-flooding an already-filled shape with a new color works without leaking into neighbors; "🗑️ נקה" resets to pristine line art; filling shapes then switching to another picture and back preserves progress
- [x] Regression: existing region-mode pictures (cat single-region fill, house group "fill all windows") still work exactly as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)