### PR TITLE
fix(games): wire up personal-safety, coins-match, hebrew-script card games

### DIFF
--- a/gamesformykids/components/shared/GameCardMap.tsx
+++ b/gamesformykids/components/shared/GameCardMap.tsx
@@ -125,6 +125,7 @@ export const GameCardMap: Partial<Record<GameType, ComponentType<GameItemCardPro
   'english-cards': DefaultGameCard,
   'coins-match': DefaultGameCard,
   'hebrew-script': DefaultGameCard,
+  'personal-safety': DefaultGameCard,
 };
 
 /**

--- a/gamesformykids/hooks/shared/game-state/gameHooksMap.ts
+++ b/gamesformykids/hooks/shared/game-state/gameHooksMap.ts
@@ -67,7 +67,8 @@ export type AutoGameType =
   | 'visual-opposites'
   | 'english-cards'
   | 'coins-match'
-  | 'hebrew-script';
+  | 'hebrew-script'
+  | 'personal-safety';
 
 // Reads items from the store at hook-call time — no static game data imported here.
 const g = (type: AutoGameType): AnyGameHookFn =>
@@ -156,6 +157,7 @@ export const GAME_HOOKS_MAP: Record<AutoGameType, AnyGameHookFn> = {
   'english-cards':        g('english-cards'),
   'coins-match':          g('coins-match'),
   'hebrew-script':        g('hebrew-script'),
+  'personal-safety':      g('personal-safety'),
 };
 
 export type GameHookType = AnyGameHookFn;

--- a/gamesformykids/lib/constants/gameItemsLoader.ts
+++ b/gamesformykids/lib/constants/gameItemsLoader.ts
@@ -124,6 +124,9 @@ export async function loadGameItems(gameType: GameType): Promise<BaseGameItem[]>
     case 'number-words':       return (await import('./gameData/numberWords')).NUMBER_WORDS;
     case 'visual-opposites':   return (await import('./gameData/oppositeItems')).OPPOSITES_ITEMS;
     case 'english-cards':      return (await import('./gameData/englishFirst')).ENGLISH_FIRST_ITEMS;
+    case 'personal-safety':    return (await import('./gameData/personalSafety')).ALL_PERSONAL_SAFETY;
+    case 'coins-match':        return (await import('./gameData/coins')).ISRAELI_COINS;
+    case 'hebrew-script':      return (await import('./gameData/hebrewScript')).HEBREW_SCRIPT_ITEMS;
 
     // newGames.ts (mixed exports — use extractItems boundary)
     case 'world-food': return extractItems(await import('./gameData/newGames'), 'WORLD_FOOD_ITEMS');


### PR DESCRIPTION
## Summary
- `personal-safety`, `coins-match`, and `hebrew-script` were registered as playable Style A card games (GameType union, SUPPORTED_GAMES, GAME_ITEMS_MAP, registry, home page grid) but got stuck on the loading/error screen because three separate lookup tables were never filled in for them.
- Adds the missing entries to `GameCardMap.tsx` (CardComponent), `gameHooksMap.ts` (AutoGameType union + GAME_HOOKS_MAP), and `gameItemsLoader.ts` (server-side items loader switch — the actual runtime data source; `coins-match`/`hebrew-script` had been partially fixed for the first two in #1464 but this loader gap meant they were still broken).
- Found via an automated persona-driven Playwright pass that plays each game end-to-end (reads the real challenge word, clicks a wrong card, clicks the correct card) instead of just checking the route doesn't 500.

## Test plan
- [x] `npx tsc --noEmit` — zero errors
- [x] `npm run build` — zero errors
- [x] Verified live at `/games/personal-safety`, `/games/coins-match`, `/games/hebrew-script` via Playwright: each loads, shows the card grid, and both correct-click (advances) and wrong-click (doesn't advance) behave correctly
- [x] Confirmed each game appears in its home page category grid (already registered — unaffected by this change)

Closes #1469

🤖 Generated with [Claude Code](https://claude.com/claude-code)