### PR TITLE
feat(coloring): add zoom in/out controls to the coloring canvas

### DIFF
--- a/gamesformykids/app/games/coloring/components/ColoringCanvas.tsx
+++ b/gamesformykids/app/games/coloring/components/ColoringCanvas.tsx
@@ -1,8 +1,13 @@
 'use client';
 
+import { useEffect, useState } from 'react';
 import { useColoringStore } from '../store/coloringStore';
 import { IMAGE_COMPONENTS } from './imageComponents';
 import { FloodFillCanvas } from './FloodFillCanvas';
+
+const MIN_ZOOM = 1;
+const MAX_ZOOM = 2.5;
+const ZOOM_STEP = 0.25;
 
 export function ColoringCanvas() {
   const currentImage = useColoringStore((s) => s.currentImage);
@@ -13,6 +18,12 @@ export function ColoringCanvas() {
   const clearImage = useColoringStore((s) => s.clearImage);
 
   const meta = IMAGE_COMPONENTS[currentImage];
+
+  const [zoom, setZoom] = useState(1);
+  useEffect(() => setZoom(1), [currentImage]);
+
+  const zoomIn = () => setZoom((z) => Math.min(MAX_ZOOM, +(z + ZOOM_STEP).toFixed(2)));
+  const zoomOut = () => setZoom((z) => Math.max(MIN_ZOOM, +(z - ZOOM_STEP).toFixed(2)));
 
   return (
     <div className="relative bg-white rounded-3xl shadow-xl p-4 mb-4 border-4 border-purple-200">
@@ -29,39 +40,74 @@ export function ColoringCanvas() {
         </div>
       )}
 
-      {meta.kind === 'regions' ? (
-        <>
-          <div className="w-full aspect-square max-w-xs mx-auto">
+      <div className="flex items-center justify-center gap-2 mb-3">
+        <button
+          onClick={zoomOut}
+          disabled={zoom <= MIN_ZOOM}
+          aria-label="הקטן"
+          className="w-9 h-9 rounded-full text-lg font-bold border-2 border-purple-300 bg-white text-purple-700 hover:bg-purple-50 active:scale-95 disabled:opacity-40 disabled:hover:bg-white transition"
+        >
+          🔍−
+        </button>
+        <span className="min-w-[3.5rem] text-center text-sm font-bold text-purple-700">
+          {Math.round(zoom * 100)}%
+        </span>
+        <button
+          onClick={zoomIn}
+          disabled={zoom >= MAX_ZOOM}
+          aria-label="הגדל"
+          className="w-9 h-9 rounded-full text-lg font-bold border-2 border-purple-300 bg-white text-purple-700 hover:bg-purple-50 active:scale-95 disabled:opacity-40 disabled:hover:bg-white transition"
+        >
+          🔍+
+        </button>
+        {zoom !== 1 && (
+          <button
+            onClick={() => setZoom(1)}
+            className="px-3 h-9 rounded-full text-sm font-bold border-2 border-gray-300 bg-white text-gray-600 hover:bg-gray-50 active:scale-95 transition"
+          >
+            ↺ איפוס
+          </button>
+        )}
+      </div>
+
+      <div className="overflow-auto rounded-2xl" style={{ maxHeight: '65vh' }}>
+        {meta.kind === 'regions' ? (
+          <div className="mx-auto aspect-square" style={{ width: `${zoom * 320}px` }}>
             <meta.Component fills={fills} onFill={(id) => selectRegion(id, meta.regions)} />
           </div>
-
-          <div className="flex flex-wrap gap-2 justify-center mt-3">
-            {/* Group buttons – fill all members at once */}
-            {meta.groups?.map(({ id, name, members }) => (
-              <button
-                key={id}
-                onClick={() => fillGroup(members, meta.regions)}
-                className="px-3 py-1.5 rounded-full text-sm font-bold border-2 transition border-purple-400 bg-purple-50 text-purple-700 hover:bg-purple-100 active:scale-95"
-              >
-                ✨ {name}
-              </button>
-            ))}
-            {/* Individual region buttons */}
-            {meta.regions.map((id) => (
-              <button
-                key={id}
-                onClick={() => selectRegion(id, meta.regions)}
-                className="px-3 py-1.5 rounded-full text-sm font-bold border-2 transition border-gray-300 bg-white text-gray-700 hover:border-purple-400 hover:bg-purple-50 active:scale-95"
-                style={fills[id] ? { borderColor: fills[id], color: fills[id] } : undefined}
-              >
-                {meta.names[id]}
-              </button>
-            ))}
+        ) : (
+          <div
+            className="mx-auto"
+            style={{ width: `${zoom * 100}%`, aspectRatio: `${meta.width} / ${meta.height}` }}
+          >
+            <FloodFillCanvas key={currentImage} imageId={currentImage} meta={meta} />
           </div>
-        </>
-      ) : (
-        <div className="w-full mx-auto" style={{ aspectRatio: `${meta.width} / ${meta.height}` }}>
-          <FloodFillCanvas key={currentImage} imageId={currentImage} meta={meta} />
+        )}
+      </div>
+
+      {meta.kind === 'regions' && (
+        <div className="flex flex-wrap gap-2 justify-center mt-3">
+          {/* Group buttons – fill all members at once */}
+          {meta.groups?.map(({ id, name, members }) => (
+            <button
+              key={id}
+              onClick={() => fillGroup(members, meta.regions)}
+              className="px-3 py-1.5 rounded-full text-sm font-bold border-2 transition border-purple-400 bg-purple-50 text-purple-700 hover:bg-purple-100 active:scale-95"
+            >
+              ✨ {name}
+            </button>
+          ))}
+          {/* Individual region buttons */}
+          {meta.regions.map((id) => (
+            <button
+              key={id}
+              onClick={() => selectRegion(id, meta.regions)}
+              className="px-3 py-1.5 rounded-full text-sm font-bold border-2 transition border-gray-300 bg-white text-gray-700 hover:border-purple-400 hover:bg-purple-50 active:scale-95"
+              style={fills[id] ? { borderColor: fills[id], color: fills[id] } : undefined}
+            >
+              {meta.names[id]}
+            </button>
+          ))}
         </div>
       )}
     </div>


### PR DESCRIPTION
## Summary
- Adds 🔍− / 🔍+ / ↺ reset zoom controls above the coloring canvas, from 100% to 250% in 25% steps, in `ColoringCanvas.tsx`.
- Zoom resets to 100% automatically when switching pictures.
- Works for both picture kinds (region-mode SVG and flood-fill canvas) via the same mechanism: the zoomed content is wrapped in an `overflow-auto` scroll container, and the picture's rendered width is driven by the zoom multiplier — no changes needed to the click/fill logic itself, since coordinate math in `FloodFillCanvas.tsx` already derives from the element's actual rendered size (`getBoundingClientRect()`), not a fixed assumption.
- Particularly useful for the densely-detailed flood-fill scenes (e.g. יער החברים), where many small regions were hard to target precisely at 100%.

Closes #1473

## Test plan
- [x] `npx tsc --noEmit` — zero errors
- [x] `npm run build` — zero errors
- [x] Manually verified in browser: zoom in/out/reset works on a region-mode picture (cat) and a flood-fill scene (יער החברים); zoomed content scrolls correctly inside the card; clicking a shape while zoomed in still fills the correct region precisely (tested filling the sun at 150% zoom — no coordinate drift)

🤖 Generated with [Claude Code](https://claude.com/claude-code)