### PR TITLE
feat(coloring): add fullscreen mode to the coloring canvas

### DIFF
--- a/gamesformykids/app/games/coloring/components/ColoringCanvas.tsx
+++ b/gamesformykids/app/games/coloring/components/ColoringCanvas.tsx
@@ -9,7 +9,11 @@ const MIN_ZOOM = 1;
 const MAX_ZOOM = 2.5;
 const ZOOM_STEP = 0.25;
 
-export function ColoringCanvas() {
+interface ColoringCanvasProps {
+  isFullscreen?: boolean;
+}
+
+export function ColoringCanvas({ isFullscreen = false }: ColoringCanvasProps) {
   const currentImage = useColoringStore((s) => s.currentImage);
   const fills = useColoringStore((s) => s.allFills[s.currentImage]);
   const showDone = useColoringStore((s) => s.doneImages[s.currentImage]);
@@ -70,7 +74,7 @@ export function ColoringCanvas() {
         )}
       </div>
 
-      <div className="overflow-auto rounded-2xl" style={{ maxHeight: '65vh' }}>
+      <div className="overflow-auto rounded-2xl" style={{ maxHeight: isFullscreen ? '80vh' : '65vh' }}>
         {meta.kind === 'regions' ? (
           <div className="mx-auto aspect-square" style={{ width: `${zoom * 320}px` }}>
             <meta.Component fills={fills} onFill={(id) => selectRegion(id, meta.regions)} />

--- a/gamesformykids/app/games/coloring/components/ColoringGame.tsx
+++ b/gamesformykids/app/games/coloring/components/ColoringGame.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useEffect, useRef, useState } from 'react';
 import { ColoringHeader } from './ColoringHeader';
 import { ColoringImageSelector } from './ColoringImageSelector';
 import { ColoringCanvas } from './ColoringCanvas';
@@ -7,6 +8,23 @@ import { ColoringPalette } from './ColoringPalette';
 import { ColoringActions } from './ColoringActions';
 
 export default function ColoringGame() {
+  const areaRef = useRef<HTMLDivElement>(null);
+  const [isFullscreen, setIsFullscreen] = useState(false);
+
+  useEffect(() => {
+    const onChange = () => setIsFullscreen(!!document.fullscreenElement);
+    document.addEventListener('fullscreenchange', onChange);
+    return () => document.removeEventListener('fullscreenchange', onChange);
+  }, []);
+
+  const toggleFullscreen = () => {
+    if (document.fullscreenElement) {
+      document.exitFullscreen();
+    } else {
+      areaRef.current?.requestFullscreen();
+    }
+  };
+
   return (
     <div
       className="min-h-screen bg-gradient-to-br from-pink-100 via-yellow-50 to-blue-100 p-4"
@@ -14,9 +32,27 @@ export default function ColoringGame() {
       <div className="max-w-lg mx-auto">
         <ColoringHeader />
         <ColoringImageSelector />
-        <ColoringCanvas />
-        <ColoringPalette />
-        <ColoringActions />
+        <div
+          ref={areaRef}
+          className={`relative ${
+            isFullscreen
+              ? 'bg-gradient-to-br from-pink-100 via-yellow-50 to-blue-100 p-6 overflow-auto flex flex-col items-center justify-center gap-4'
+              : ''
+          }`}
+        >
+          <button
+            onClick={toggleFullscreen}
+            aria-label={isFullscreen ? 'צא ממסך מלא' : 'מסך מלא'}
+            className="absolute top-2 left-2 z-20 w-9 h-9 rounded-full text-lg border-2 border-purple-300 bg-white text-purple-700 hover:bg-purple-50 active:scale-95 transition shadow-md"
+          >
+            {isFullscreen ? '⤦' : '⛶'}
+          </button>
+          <div className={isFullscreen ? 'w-full max-w-lg' : ''}>
+            <ColoringCanvas isFullscreen={isFullscreen} />
+            <ColoringPalette />
+            <ColoringActions />
+          </div>
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- Adds a fullscreen toggle (⛶ / ⤦) to the coloring game, using the native Fullscreen API (`requestFullscreen`/`exitFullscreen`), synced via the `fullscreenchange` event so it also updates correctly if the user exits with Esc.
- The fullscreen area wraps the canvas, color palette, and clear button (`ColoringGame.tsx`) — everything needed to actually color — while the header and picture picker stay outside it. Switching to a different picture requires exiting fullscreen first; this mirrors how fullscreen viewers/players typically work and keeps the fullscreen view uncluttered.
- `ColoringCanvas` takes a new optional `isFullscreen` prop to relax its scroll-area height cap (65vh → 80vh) so zoomed-in content has more room to breathe when fullscreen.
- Combines with the zoom controls from the previous PR — verified filling a region works correctly with accurate click coordinates while in fullscreen.

Closes #1475

## Test plan
- [x] `npx tsc --noEmit` — zero errors
- [x] `npm run build` — zero errors
- [x] Manually verified in browser: enter fullscreen (canvas+palette+clear button visible, header/picker hidden), fill a region while fullscreen (correct target, correct color), exit fullscreen (`document.fullscreenElement` correctly toggles both ways), layout returns to normal with the fill preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)