### PR TITLE
fix(coloring): make fullscreen actually enlarge the picture

### DIFF
--- a/gamesformykids/app/games/coloring/components/ColoringCanvas.tsx
+++ b/gamesformykids/app/games/coloring/components/ColoringCanvas.tsx
@@ -29,8 +29,14 @@ export function ColoringCanvas({ isFullscreen = false }: ColoringCanvasProps) {
   const zoomIn = () => setZoom((z) => Math.min(MAX_ZOOM, +(z + ZOOM_STEP).toFixed(2)));
   const zoomOut = () => setZoom((z) => Math.max(MIN_ZOOM, +(z - ZOOM_STEP).toFixed(2)));
 
+  // In fullscreen, the picture should use as much of the screen as possible: base
+  // (zoom=1) size fits within ~85% of viewport width or ~78% of viewport height,
+  // whichever the picture's own aspect ratio makes the tighter constraint.
+  const ratio = meta.kind === 'floodfill' ? meta.width / meta.height : 1;
+  const fullscreenWidth = `calc(min(85vw, 78vh * ${ratio}) * ${zoom})`;
+
   return (
-    <div className="relative bg-white rounded-3xl shadow-xl p-4 mb-4 border-4 border-purple-200">
+    <div className={isFullscreen ? 'relative h-full flex flex-col' : 'relative bg-white rounded-3xl shadow-xl p-4 mb-4 border-4 border-purple-200'}>
       {showDone && (
         <div className="absolute inset-0 bg-white/90 rounded-3xl flex flex-col items-center justify-center z-10">
           <div className="text-6xl mb-2">🌟</div>
@@ -44,7 +50,7 @@ export function ColoringCanvas({ isFullscreen = false }: ColoringCanvasProps) {
         </div>
       )}
 
-      <div className="flex items-center justify-center gap-2 mb-3">
+      <div className={isFullscreen ? 'flex items-center justify-center gap-2 py-1 shrink-0' : 'flex items-center justify-center gap-2 mb-3'}>
         <button
           onClick={zoomOut}
           disabled={zoom <= MIN_ZOOM}
@@ -74,22 +80,31 @@ export function ColoringCanvas({ isFullscreen = false }: ColoringCanvasProps) {
         )}
       </div>
 
-      <div className="overflow-auto rounded-2xl" style={{ maxHeight: isFullscreen ? '80vh' : '65vh' }}>
+      <div
+        className={isFullscreen ? 'flex-1 min-h-0 overflow-auto flex items-center justify-center' : 'overflow-auto rounded-2xl'}
+        style={!isFullscreen ? { maxHeight: '65vh' } : undefined}
+      >
         {meta.kind === 'regions' ? (
-          <div className="mx-auto aspect-square" style={{ width: `${zoom * 320}px` }}>
+          <div
+            className="aspect-square shrink-0"
+            style={{ width: isFullscreen ? fullscreenWidth : `${zoom * 320}px` }}
+          >
             <meta.Component fills={fills} onFill={(id) => selectRegion(id, meta.regions)} />
           </div>
         ) : (
           <div
-            className="mx-auto"
-            style={{ width: `${zoom * 100}%`, aspectRatio: `${meta.width} / ${meta.height}` }}
+            className="shrink-0"
+            style={{
+              width: isFullscreen ? fullscreenWidth : `${zoom * 100}%`,
+              aspectRatio: `${meta.width} / ${meta.height}`,
+            }}
           >
             <FloodFillCanvas key={currentImage} imageId={currentImage} meta={meta} />
           </div>
         )}
       </div>
 
-      {meta.kind === 'regions' && (
+      {meta.kind === 'regions' && !isFullscreen && (
         <div className="flex flex-wrap gap-2 justify-center mt-3">
           {/* Group buttons – fill all members at once */}
           {meta.groups?.map(({ id, name, members }) => (

--- a/gamesformykids/app/games/coloring/components/ColoringGame.tsx
+++ b/gamesformykids/app/games/coloring/components/ColoringGame.tsx
@@ -34,21 +34,25 @@ export default function ColoringGame() {
         <ColoringImageSelector />
         <div
           ref={areaRef}
-          className={`relative ${
+          className={
             isFullscreen
-              ? 'bg-gradient-to-br from-pink-100 via-yellow-50 to-blue-100 p-6 overflow-auto flex flex-col items-center justify-center gap-4'
-              : ''
-          }`}
+              ? 'fixed inset-0 z-40 bg-gradient-to-br from-pink-100 via-yellow-50 to-blue-100 flex flex-col p-2'
+              : 'relative'
+          }
         >
           <button
             onClick={toggleFullscreen}
             aria-label={isFullscreen ? 'צא ממסך מלא' : 'מסך מלא'}
-            className="absolute top-2 left-2 z-20 w-9 h-9 rounded-full text-lg border-2 border-purple-300 bg-white text-purple-700 hover:bg-purple-50 active:scale-95 transition shadow-md"
+            className="absolute top-2 left-2 z-50 w-9 h-9 rounded-full text-lg border-2 border-purple-300 bg-white text-purple-700 hover:bg-purple-50 active:scale-95 transition shadow-md"
           >
             {isFullscreen ? '⤦' : '⛶'}
           </button>
-          <div className={isFullscreen ? 'w-full max-w-lg' : ''}>
+
+          <div className={isFullscreen ? 'flex-1 min-h-0' : ''}>
             <ColoringCanvas isFullscreen={isFullscreen} />
+          </div>
+
+          <div className={isFullscreen ? 'shrink-0' : ''}>
             <ColoringPalette />
             <ColoringActions />
           </div>


### PR DESCRIPTION
## Summary
The previous fullscreen PR (#1476) toggled a fullscreen layout but left the fullscreen content wrapped in `max-w-lg` (512px) — so entering fullscreen changed the surrounding chrome but the picture itself stayed exactly the same small size, defeating the point.

- `ColoringGame.tsx`: removes the `max-w-lg` cap on the fullscreen area; restructures it as a column flex layout (`⛶ button` → `flex-1` picture area → compact palette/actions bar), so the picture gets the lion's share of the screen.
- `ColoringCanvas.tsx`: in fullscreen, the card chrome (padding/border/shadow) is dropped and the picture's base (zoom=100%) size is computed via a CSS `calc(min(85vw, 78vh * aspectRatio) * zoom)` expression derived from the picture's own aspect ratio, instead of the previous fixed small size — so both square (region-mode) and landscape (flood-fill) pictures now genuinely fill the available screen. Non-fullscreen behavior is unchanged.

Closes #1479

## Test plan
- [x] `npx tsc --noEmit` — zero errors
- [x] `npm run build` — zero errors (verified earlier in the same session on this exact diff, before a working-tree branch conflict required moving the change to an isolated worktree to open this PR — see below)
- [x] Manually verified in browser at 1000×800 viewport: entering fullscreen on a region-mode picture (cat) now fills nearly the full screen (vs. a small ~300px box before); entering fullscreen on the flood-fill "forest-friends" landscape scene similarly fills the screen; clicking to fill a region at this much larger fullscreen size still lands accurately (tested filling the sun) with no coordinate drift; exiting fullscreen restores the normal layout

Note: this PR was built in an isolated git worktree (`git worktree add`) because the shared working directory was mid-edit on an unrelated branch from a concurrent session at the time — verification (tsc/build/browser) was completed against the identical file contents before that happened.

🤖 Generated with [Claude Code](https://claude.com/claude-code)