### PR TITLE
feat(homepage): debounced search URL sync, live count, keyboard shortcuts & a11y

### DIFF
--- a/gamesformykids/components/game/GameSearchBar.tsx
+++ b/gamesformykids/components/game/GameSearchBar.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useEffect, useRef, useState } from 'react';
 import { Search, X } from 'lucide-react';
 import { GAME_CATEGORIES } from '@/lib/constants/gameCategories';
 import { useAgeFilterStore, type AgeRange } from '@/lib/stores/ageFilterStore';
@@ -18,6 +19,7 @@ interface Props {
   onCatChange: (cat: string | null) => void;
   hasFilter: boolean;
   onClear: () => void;
+  resultsCount: number;
 }
 
 export function GameSearchBar({
@@ -27,9 +29,76 @@ export function GameSearchBar({
   onCatChange,
   hasFilter,
   onClear,
+  resultsCount,
 }: Props) {
   const ageRange = useAgeFilterStore((s) => s.ageRange);
   const setAgeRange = useAgeFilterStore((s) => s.setAgeRange);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const chipsRef = useRef<HTMLDivElement>(null);
+  const [hasOverflow, setHasOverflow] = useState(false);
+
+  // "/" focuses the search input from anywhere on the page, unless the user
+  // is already typing in a text field (input/textarea/contenteditable).
+  // Listens on keyup (not keydown): moving focus while the key's own
+  // keydown->text-insertion is still pending can leak the "/" character
+  // into the newly-focused input in some browsers. By keyup that
+  // insertion (or its prevention) against the original target is already
+  // fully resolved, so it's safe to move focus.
+  useEffect(() => {
+    const handleKeyUp = (e: KeyboardEvent) => {
+      if (e.key !== '/') return;
+      const target = e.target as HTMLElement | null;
+      const tag = target?.tagName;
+      const isEditable =
+        tag === 'INPUT' || tag === 'TEXTAREA' || target?.isContentEditable;
+      if (isEditable) return;
+      e.preventDefault();
+      inputRef.current?.focus();
+    };
+    window.addEventListener('keyup', handleKeyUp);
+    return () => window.removeEventListener('keyup', handleKeyUp);
+  }, []);
+
+  // Track whether the category chip row overflows so the edge fade only
+  // shows up when there's actually more content off-screen.
+  useEffect(() => {
+    const el = chipsRef.current;
+    if (!el) return;
+    const checkOverflow = () => setHasOverflow(el.scrollWidth > el.clientWidth + 1);
+    checkOverflow();
+    const resizeObserver = new ResizeObserver(checkOverflow);
+    resizeObserver.observe(el);
+    window.addEventListener('resize', checkOverflow);
+    return () => {
+      resizeObserver.disconnect();
+      window.removeEventListener('resize', checkOverflow);
+    };
+  }, []);
+
+  // Let vertical mouse-wheel scroll the chip row horizontally, since most
+  // desktop users won't think to drag it.
+  useEffect(() => {
+    const el = chipsRef.current;
+    if (!el) return;
+    const handleWheel = (e: WheelEvent) => {
+      if (Math.abs(e.deltaY) <= Math.abs(e.deltaX)) return;
+      // In RTL, modern browsers use negative scrollLeft values going
+      // "forward" (toward later items), so the delta must be inverted.
+      const isRtl = getComputedStyle(el).direction === 'rtl';
+      el.scrollLeft += isRtl ? -e.deltaY : e.deltaY;
+      e.preventDefault();
+    };
+    el.addEventListener('wheel', handleWheel, { passive: false });
+    return () => el.removeEventListener('wheel', handleWheel);
+  }, []);
+
+  const handleInputKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Escape') {
+      e.preventDefault();
+      onClear();
+      inputRef.current?.blur();
+    }
+  };
 
   return (
     <div dir="rtl" className="mb-4 md:mb-6 space-y-3">
@@ -38,23 +107,43 @@ export function GameSearchBar({
           <Search className="w-4 h-4" />
         </span>
         <input
+          ref={inputRef}
           type="search"
           value={query}
           onChange={(e) => onQueryChange(e.target.value)}
+          onKeyDown={handleInputKeyDown}
           placeholder="חפש משחק..."
           aria-label="חיפוש משחקים"
-          className="w-full pe-10 ps-10 py-2.5 rounded-full border border-gray-200 dark:border-gray-600 bg-white dark:bg-gray-700 shadow-sm text-sm text-gray-800 dark:text-gray-100 placeholder:text-gray-400 dark:placeholder:text-gray-400 focus:outline-none focus:ring-2 focus:ring-purple-400 focus:border-transparent"
+          aria-keyshortcuts="/"
+          className="peer w-full pe-10 ps-10 py-2.5 rounded-full border border-gray-200 dark:border-gray-600 bg-white dark:bg-gray-700 shadow-sm text-sm text-gray-800 dark:text-gray-100 placeholder:text-gray-400 dark:placeholder:text-gray-400 transition-shadow focus:outline-none focus:ring-4 focus:ring-purple-400/40 dark:focus:ring-purple-300/30 focus:border-purple-400 dark:focus:border-purple-300 focus:shadow-md"
         />
-        {hasFilter && (
+        {hasFilter ? (
           <button
             onClick={onClear}
             aria-label="נקה חיפוש"
-            className="absolute end-3 top-1/2 -translate-y-1/2 text-gray-400 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-300 transition-colors"
+            className="absolute end-3 top-1/2 -translate-y-1/2 text-gray-400 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-300 transition-colors rounded-full focus:outline-none focus-visible:ring-2 focus-visible:ring-purple-400 dark:focus-visible:ring-purple-300"
           >
             <X className="w-4 h-4" />
           </button>
+        ) : (
+          <kbd
+            aria-hidden="true"
+            className="hidden sm:flex absolute end-3 top-1/2 -translate-y-1/2 items-center justify-center min-w-[1.25rem] px-1 py-0.5 text-[10px] font-mono text-gray-400 dark:text-gray-500 border border-gray-300 dark:border-gray-600 rounded pointer-events-none peer-focus:hidden"
+          >
+            /
+          </kbd>
         )}
       </div>
+
+      {/* Live result count: visible while typing, announced to screen readers */}
+      <p
+        aria-live="polite"
+        className={`text-center text-xs font-medium text-gray-500 dark:text-gray-400 ${
+          hasFilter ? '' : 'sr-only'
+        }`}
+      >
+        {hasFilter ? `${resultsCount} משחקים נמצאו` : ''}
+      </p>
 
       {/* Age filter active badge */}
       {ageRange !== 'all' && (
@@ -71,26 +160,39 @@ export function GameSearchBar({
         </div>
       )}
 
-      <div
-        className="flex gap-2 overflow-x-auto pb-1 px-1"
-        style={{ scrollbarWidth: 'none' }}
-        role="group"
-        aria-label="סינון לפי קטגוריה"
-      >
-        {Object.entries(GAME_CATEGORIES).map(([key, cat]) => (
-          <button
-            key={key}
-            onClick={() => onCatChange(activeCat === key ? null : key)}
-            aria-pressed={activeCat === key}
-            className={`flex-shrink-0 px-3 py-2.5 min-h-11 rounded-full text-sm font-semibold transition-colors duration-200 ${
-              activeCat === key
-                ? 'bg-purple-600 text-white shadow-md'
-                : 'bg-white dark:bg-gray-700 text-gray-600 dark:text-gray-300 hover:bg-purple-50 dark:hover:bg-gray-600 shadow-sm border border-gray-200 dark:border-gray-600'
-            }`}
-          >
-            {cat.title}
-          </button>
-        ))}
+      <div className="relative">
+        <div
+          ref={chipsRef}
+          className="flex gap-2 overflow-x-auto pb-1 px-1"
+          style={
+            hasOverflow
+              ? {
+                  scrollbarWidth: 'none',
+                  WebkitMaskImage:
+                    'linear-gradient(to right, transparent, black 20px, black calc(100% - 20px), transparent)',
+                  maskImage:
+                    'linear-gradient(to right, transparent, black 20px, black calc(100% - 20px), transparent)',
+                }
+              : { scrollbarWidth: 'none' }
+          }
+          role="group"
+          aria-label="סינון לפי קטגוריה"
+        >
+          {Object.entries(GAME_CATEGORIES).map(([key, cat]) => (
+            <button
+              key={key}
+              onClick={() => onCatChange(activeCat === key ? null : key)}
+              aria-pressed={activeCat === key}
+              className={`flex-shrink-0 px-3 py-2.5 min-h-11 rounded-full text-sm font-semibold transition-all duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-purple-500 dark:focus-visible:ring-purple-300 focus-visible:ring-offset-2 dark:focus-visible:ring-offset-gray-800 ${
+                activeCat === key
+                  ? 'bg-purple-600 text-white shadow-lg'
+                  : 'bg-white dark:bg-gray-700 text-gray-600 dark:text-gray-300 hover:bg-purple-50 dark:hover:bg-gray-600 hover:shadow-md shadow-sm border border-gray-200 dark:border-gray-600'
+              }`}
+            >
+              {cat.title}
+            </button>
+          ))}
+        </div>
       </div>
     </div>
   );

--- a/gamesformykids/components/marketing/CategorizedGamesGrid.tsx
+++ b/gamesformykids/components/marketing/CategorizedGamesGrid.tsx
@@ -25,6 +25,7 @@ const CategorizedGamesGrid = () => {
         onCatChange={setActiveCat}
         hasFilter={hasFilter}
         onClear={clearFilters}
+        resultsCount={filteredGames.length}
       />
       <CategoryNavigation />
       {!selectedCategory && !showAllGames && !showFavorites && <CategoriesView />}

--- a/gamesformykids/hooks/shared/search/useGameSearch.ts
+++ b/gamesformykids/hooks/shared/search/useGameSearch.ts
@@ -1,10 +1,12 @@
 'use client';
-import { useState, useEffect, useMemo, useCallback } from 'react';
+import { useState, useEffect, useMemo, useCallback, useRef } from 'react';
 import { useRouter } from 'next/navigation';
 import { GamesRegistry, GameRegistration } from '@/lib/registry/gamesRegistry';
 import { GAME_CATEGORIES } from '@/lib/constants/gameCategories';
 import { useHomePageStore } from '@/lib/stores';
 import { useAgeFilterStore, isAgeAppropriate } from '@/lib/stores/ageFilterStore';
+
+const URL_SYNC_DEBOUNCE_MS = 300;
 
 export function useGameSearch() {
   const router = useRouter();
@@ -12,6 +14,7 @@ export function useGameSearch() {
   const ageRange = useAgeFilterStore((s) => s.ageRange);
   const [query, setQueryState] = useState('');
   const [activeCat, setActiveCatState] = useState<string | null>(null);
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useEffect(() => {
     const params = new URLSearchParams(window.location.search);
@@ -23,7 +26,14 @@ export function useGameSearch() {
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  const updateURL = useCallback(
+  // Clear any pending debounced URL sync on unmount.
+  useEffect(() => {
+    return () => {
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+    };
+  }, []);
+
+  const writeURL = useCallback(
     (q: string, cat: string | null) => {
       const params = new URLSearchParams();
       if (q) params.set('q', q);
@@ -35,6 +45,17 @@ export function useGameSearch() {
       router.replace(url, { scroll: false });
     },
     [router],
+  );
+
+  // Debounced so fast typing doesn't push a router.replace on every keystroke.
+  const updateURL = useCallback(
+    (q: string, cat: string | null) => {
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+      debounceRef.current = setTimeout(() => {
+        writeURL(q, cat);
+      }, URL_SYNC_DEBOUNCE_MS);
+    },
+    [writeURL],
   );
 
   const setQuery = useCallback(
@@ -58,8 +79,9 @@ export function useGameSearch() {
   const clearFilters = useCallback(() => {
     setQueryState('');
     setActiveCatState(null);
-    updateURL('', null);
-  }, [updateURL]);
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    writeURL('', null);
+  }, [writeURL]);
 
   const allGames = useMemo(() => GamesRegistry.getAllGameRegistrations(), []);
 


### PR DESCRIPTION
## Summary
- Debounce the search box's URL sync (`router.replace`) to 300ms — typing itself and `filteredGames` stay instant/uncontrolled; only the URL/navigation write is delayed so fast typing doesn't spam history. `clearFilters` bypasses the debounce (clearing feels instant).
- Add a live "N משחקים נמצאו" result count next to the input while typing (`aria-live="polite"`), so feedback isn't limited to after landing on the "all games" view.
- Add a `/` keyboard shortcut to focus the search input from anywhere on the page (skipped while focus is already in an input/textarea/contenteditable — implemented on `keyup`, not `keydown`, to avoid the shortcut key itself leaking into the newly-focused input). `Escape` inside the input clears it and blurs.
- Add an RTL-aware edge fade + wheel-scroll to the horizontally-scrolling category filter chip row (only applied when there's real overflow, via `ResizeObserver`; wheel delta is direction-inverted in RTL since Chromium uses negative `scrollLeft` there).
- Add visible `focus-visible` rings to the chips and clear button, and strengthen the input's own focus ring, matching the shadow/ring weight established in the recent home-page dark-mode polish pass (#1457).

Search scoring algorithm in `useGameSearch.ts` is unchanged — only the URL-sync timing was touched there.

Closes #1481

## Test plan
- [x] `npx tsc --noEmit` — 0 errors
- [x] `npm run build` — compiled successfully, all 495 static pages generated (verified in isolation from an unrelated concurrent-process file change in this shared working tree)
- [x] Verified live in Chromium against `next build && next start` (not dev mode, to rule out HMR noise): debounced URL update fires once ~300ms after the last keystroke; live count matches `filteredGames.length`; `/` focuses from outside any input without leaking a literal `/`, and does not intercept `/` while already typing inside the box; Escape clears and blurs; wheel-scrolling the chip row moves it the correct RTL direction; edge fade only appears when the row actually overflows
- [x] Checked light mode, dark mode, desktop (1280px), and mobile (375px)
- [x] Tab-through screenshots confirm visible focus rings on chips and the clear button

🤖 Generated with [Claude Code](https://claude.com/claude-code)