### PR TITLE
feat(coloring): add undo for both region-fill and flood-fill modes

### DIFF
--- a/.claude/agents/coloring-page-builder.md
+++ b/.claude/agents/coloring-page-builder.md
@@ -127,6 +127,14 @@ Use this instead of the regions pattern when a picture is too detailed to hand-a
 
 Do not touch `lib/floodFill.ts` or `components/FloodFillCanvas.tsx` for a new scene — they're generic. Only touch them if the *algorithm* needs to change (e.g. tolerance tuning) or you're adding a genuinely new interaction (per-stroke undo, completion detection) — confirm with the user first, these are explicit v1 non-goals.
 
+## Undo
+
+Both picture kinds support "↩️ בטל" (undo), via `coloringStore.undo()`, which branches on `IMAGE_COMPONENTS[currentImage].kind` exactly like `clearImage()` does:
+- **Regions:** `fillHistory: Partial<Record<ImageId, Record<string,string>[]>>` in the store is a per-image undo stack (capped at `MAX_HISTORY = 20`) — `applyFill` (used by both `selectRegion`/`fillGroup`) and `clearImage` each push the *pre-change* `allFills[currentImage]` onto it before mutating, so undo can restore an accidental clear, not just the last single-region fill.
+- **Flood-fill:** history lives as a local `historyRef` (dataURL stack, capped at `MAX_HISTORY = 15`) inside the currently-mounted `FloodFillCanvas`, not in the store — mirrors how `floodFillClear` already works. `registerFloodFillUndo` follows the exact same callback-registration idiom as `registerFloodFillClear`. A reactive `floodFillCanUndo` boolean in the store lets `ColoringActions`'s button disable itself correctly for this mode (region mode instead derives `canUndo` directly from `fillHistory[currentImage]?.length`, since that lives in the store already).
+
+Adding a new picture (either kind) requires **no changes** to make undo work — it's generic infrastructure, same as flood-fill's `clear`.
+
 ## Scaling to a large picture library (many templates, gallery-style)
 
 If asked to grow this into something closer to a large coloring-book site (dozens/hundreds of templates, searchable gallery, categories) rather than a handful of hand-picked pictures — **stop and confirm with the user before restructuring**, this is a bigger architectural change:
@@ -137,6 +145,6 @@ If asked to grow this into something closer to a large coloring-book site (dozen
 ## Before reporting done
 1. `cd gamesformykids && npx tsc --noEmit` — zero TS errors.
 2. `npm run build` — zero build errors.
-3. **Regions picture:** new picture appears in the selector, every region fills on click, any group button fills all its members, the "כל הכבוד" celebration triggers once every region has a fill, "צבע שוב" resets it.
-4. **Flood-fill scene:** new scene appears in the selector; clicking inside an enclosed shape fills only that shape; clicking exactly on a black outline is a no-op; re-clicking an already-filled shape with a new color re-floods it without leaking into neighbors; a shape adjacent to a differently-filled shape doesn't bleed across their shared outline; "🗑️ נקה" resets the scene to pristine blank line art; filling a few shapes then switching to another picture and back preserves the flood-fill progress.
+3. **Regions picture:** new picture appears in the selector, every region fills on click, any group button fills all its members, the "כל הכבוד" celebration triggers once every region has a fill, "צבע שוב"/"🗑️ נקה" resets it, "↩️ בטל" undoes fills one step at a time and disables itself when there's nothing left to undo, and can also undo a "🗑️ נקה" clear.
+4. **Flood-fill scene:** new scene appears in the selector; clicking inside an enclosed shape fills only that shape; clicking exactly on a black outline is a no-op; re-clicking an already-filled shape with a new color re-floods it without leaking into neighbors; a shape adjacent to a differently-filled shape doesn't bleed across their shared outline; "🗑️ נקה" resets the scene to pristine blank line art; "↩️ בטל" undoes the last fill (or restores a "🗑️ נקה" clear) and disables itself with nothing to undo; filling a few shapes then switching to another picture and back preserves the flood-fill progress (but resets the undo history for that scene, by design).
 5. Don't touch `app/games/drawing/` — freehand drawing is a separate game/store, not this one.

--- a/gamesformykids/app/games/coloring/components/ColoringActions.tsx
+++ b/gamesformykids/app/games/coloring/components/ColoringActions.tsx
@@ -1,12 +1,26 @@
 'use client';
 
 import { useColoringStore } from '../store/coloringStore';
+import { IMAGE_COMPONENTS } from './imageComponents';
 
 export function ColoringActions() {
+  const currentImage = useColoringStore((s) => s.currentImage);
   const clearImage = useColoringStore((s) => s.clearImage);
+  const undo = useColoringStore((s) => s.undo);
+  const regionHistoryLength = useColoringStore((s) => s.fillHistory[s.currentImage]?.length ?? 0);
+  const floodFillCanUndo = useColoringStore((s) => s.floodFillCanUndo);
+
+  const canUndo = IMAGE_COMPONENTS[currentImage].kind === 'regions' ? regionHistoryLength > 0 : floodFillCanUndo;
 
   return (
     <div className="flex gap-3 justify-center">
+      <button
+        onClick={undo}
+        disabled={!canUndo}
+        className="bg-purple-400 hover:bg-purple-500 text-white px-6 py-2 rounded-full font-bold transition-colors shadow-md disabled:opacity-40 disabled:hover:bg-purple-400"
+      >
+        ↩️ בטל
+      </button>
       <button
         onClick={clearImage}
         className="bg-red-400 hover:bg-red-500 text-white px-6 py-2 rounded-full font-bold transition-colors shadow-md"

--- a/gamesformykids/app/games/coloring/components/FloodFillCanvas.tsx
+++ b/gamesformykids/app/games/coloring/components/FloodFillCanvas.tsx
@@ -6,6 +6,9 @@ import { floodFill, hexToRgba } from '../lib/floodFill';
 import type { FloodFillImageMeta } from '../types';
 import type { ImageId } from '../constants';
 
+/** Max undo steps kept in memory per mounted scene (dataURL snapshots). */
+const MAX_HISTORY = 15;
+
 interface FloodFillCanvasProps {
   imageId: ImageId;
   meta: FloodFillImageMeta;
@@ -13,9 +16,18 @@ interface FloodFillCanvasProps {
 
 export function FloodFillCanvas({ imageId, meta }: FloodFillCanvasProps) {
   const canvasRef = useRef<HTMLCanvasElement>(null);
+  const historyRef = useRef<string[]>([]);
   const selectedColor = useColoringStore((s) => s.selectedColor);
   const registerFloodFillClear = useColoringStore((s) => s.registerFloodFillClear);
+  const registerFloodFillUndo = useColoringStore((s) => s.registerFloodFillUndo);
+  const setFloodFillCanUndo = useColoringStore((s) => s.setFloodFillCanUndo);
   const saveFloodFillSnapshot = useColoringStore((s) => s.saveFloodFillSnapshot);
+
+  const pushHistory = (dataUrl: string) => {
+    historyRef.current.push(dataUrl);
+    if (historyRef.current.length > MAX_HISTORY) historyRef.current.shift();
+    setFloodFillCanUndo(true);
+  };
 
   // Load the pristine source (or a saved snapshot) once on mount.
   useEffect(() => {
@@ -30,12 +42,29 @@ export function FloodFillCanvas({ imageId, meta }: FloodFillCanvasProps) {
       img.src = src;
     };
 
+    historyRef.current = [];
+    setFloodFillCanUndo(false);
+
     const snapshot = useColoringStore.getState().floodFillSnapshots[imageId];
     drawSrc(snapshot ?? meta.src);
 
-    registerFloodFillClear(() => drawSrc(meta.src));
+    registerFloodFillClear(() => {
+      if (canvasRef.current) pushHistory(canvasRef.current.toDataURL('image/png'));
+      drawSrc(meta.src);
+    });
 
-    return () => registerFloodFillClear(() => {});
+    registerFloodFillUndo(() => {
+      const previous = historyRef.current.pop();
+      if (!previous) return;
+      setFloodFillCanUndo(historyRef.current.length > 0);
+      drawSrc(previous);
+      saveFloodFillSnapshot(imageId, previous);
+    });
+
+    return () => {
+      registerFloodFillClear(() => {});
+      registerFloodFillUndo(() => {});
+    };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [imageId]);
 
@@ -53,6 +82,8 @@ export function FloodFillCanvas({ imageId, meta }: FloodFillCanvasProps) {
     const imageData = ctx.getImageData(0, 0, canvas.width, canvas.height);
     const changed = floodFill(imageData, x, y, hexToRgba(selectedColor));
     if (!changed) return;
+
+    pushHistory(canvas.toDataURL('image/png'));
 
     ctx.putImageData(imageData, 0, 0);
     saveFloodFillSnapshot(imageId, canvas.toDataURL('image/png'));

--- a/gamesformykids/app/games/coloring/store/coloringStore.ts
+++ b/gamesformykids/app/games/coloring/store/coloringStore.ts
@@ -19,6 +19,9 @@ const EMPTY_FILLS: AllFills = {
   star: {}, balloon: {}, robot: {}, dog: {}, boat: {}, forest: {}, 'forest-friends': {},
 };
 
+/** Max undo steps kept per image, for either picture kind. */
+const MAX_HISTORY = 20;
+
 // ── Store ─────────────────────────────────────────────────────────────────────
 
 interface ColoringState {
@@ -26,10 +29,15 @@ interface ColoringState {
   selectedColor: string;
   allFills: AllFills;
   doneImages: Record<ImageId, boolean>;
+  /** region-mode undo stack: previous allFills[image] states, most recent last */
+  fillHistory: Partial<Record<ImageId, Record<string, string>[]>>;
   /** dataURL snapshot per flood-fill image, so switching pictures doesn't lose progress */
   floodFillSnapshots: Partial<Record<ImageId, string>>;
-  /** imperative reset registered by the currently-mounted FloodFillCanvas */
+  /** imperative reset/undo registered by the currently-mounted FloodFillCanvas */
   floodFillClear: () => void;
+  floodFillUndo: () => void;
+  /** reactive flag so the Undo button can disable itself in flood-fill mode */
+  floodFillCanUndo: boolean;
 }
 
 interface ColoringActions {
@@ -38,24 +46,33 @@ interface ColoringActions {
   /** מצבע אזור מיד בצבע הנבחר */
   selectRegion: (id: string, colorableIds: string[]) => void;  /** מצבע קבוצת אזורים בצבע הנבחר */
   fillGroup: (memberIds: string[], colorableIds: string[]) => void;  clearImage: () => void;
+  /** מבטל את הפעולה האחרונה (מילוי אזור/דלי צבע/ניקוי) */
+  undo: () => void;
   registerFloodFillClear: (fn: () => void) => void;
+  registerFloodFillUndo: (fn: () => void) => void;
+  setFloodFillCanUndo: (can: boolean) => void;
   saveFloodFillSnapshot: (id: ImageId, dataUrl: string) => void;
 }
 
 export const useColoringStore = makeStore<ColoringState & ColoringActions>(
   'ColoringStore',
   (set, get) => {
-    /** מעדכן allFills+doneImages עבור התמונה הנוכחית ובודק אם הושלמה */
+    /** מעדכן allFills+doneImages עבור התמונה הנוכחית ובודק אם הושלמה, ושומר את המצב הקודם לביטול */
     const applyFill = (updated: Record<string, string>, colorableIds: string[], actionName: string) => {
       const { currentImage } = get();
       const isDone = colorableIds.every((rid) => updated[rid]);
       set(
-        (state) => ({
-          allFills: { ...state.allFills, [currentImage]: updated },
-          doneImages: isDone
-            ? { ...state.doneImages, [currentImage]: true }
-            : state.doneImages,
-        }),
+        (state) => {
+          const previous = state.allFills[currentImage];
+          const history = [...(state.fillHistory[currentImage] ?? []), previous].slice(-MAX_HISTORY);
+          return {
+            allFills: { ...state.allFills, [currentImage]: updated },
+            fillHistory: { ...state.fillHistory, [currentImage]: history },
+            doneImages: isDone
+              ? { ...state.doneImages, [currentImage]: true }
+              : state.doneImages,
+          };
+        },
         false,
         actionName,
       );
@@ -69,8 +86,11 @@ export const useColoringStore = makeStore<ColoringState & ColoringActions>(
         cat: false, house: false, sun: false, butterfly: false, flower: false, fish: false, tree: false, car: false,
         star: false, balloon: false, robot: false, dog: false, boat: false, forest: false, 'forest-friends': false,
       },
+      fillHistory: {},
       floodFillSnapshots: {},
       floodFillClear: () => {},
+      floodFillUndo: () => {},
+      floodFillCanUndo: false,
 
       selectImage: (id) =>
         set({ currentImage: id }, false, 'selectImage'),
@@ -106,16 +126,45 @@ export const useColoringStore = makeStore<ColoringState & ColoringActions>(
           return;
         }
         set(
-          (state) => ({
-            allFills: { ...state.allFills, [currentImage]: {} },
-            doneImages: { ...state.doneImages, [currentImage]: false },
-          }),
+          (state) => {
+            const previous = state.allFills[currentImage];
+            const history = [...(state.fillHistory[currentImage] ?? []), previous].slice(-MAX_HISTORY);
+            return {
+              allFills: { ...state.allFills, [currentImage]: {} },
+              fillHistory: { ...state.fillHistory, [currentImage]: history },
+              doneImages: { ...state.doneImages, [currentImage]: false },
+            };
+          },
           false,
           'clearImage/regions',
         );
       },
 
+      undo: () => {
+        const { currentImage } = get();
+        if (IMAGE_COMPONENTS[currentImage].kind === 'floodfill') {
+          get().floodFillUndo();
+          return;
+        }
+        set(
+          (state) => {
+            const history = state.fillHistory[currentImage] ?? [];
+            if (history.length === 0) return state;
+            const previous = history[history.length - 1]!;
+            return {
+              allFills: { ...state.allFills, [currentImage]: previous },
+              fillHistory: { ...state.fillHistory, [currentImage]: history.slice(0, -1) },
+              doneImages: { ...state.doneImages, [currentImage]: false },
+            };
+          },
+          false,
+          'undo/regions',
+        );
+      },
+
       registerFloodFillClear: (fn) => set({ floodFillClear: fn }, false, 'registerFloodFillClear'),
+      registerFloodFillUndo: (fn) => set({ floodFillUndo: fn }, false, 'registerFloodFillUndo'),
+      setFloodFillCanUndo: (can) => set({ floodFillCanUndo: can }, false, 'setFloodFillCanUndo'),
 
       saveFloodFillSnapshot: (id, dataUrl) =>
         set(


### PR DESCRIPTION
## Summary
- Adds an "↩️ בטל" (undo) button to `ColoringActions`, next to the existing "🗑️ נקה" (clear) button, disabled when there's nothing to undo.
- **Region mode:** `coloringStore` keeps a per-image undo stack (`fillHistory`, capped at 20 steps), pushed to before every `selectRegion`/`fillGroup`/`clearImage` call — so undo also recovers an accidental clear, not just the last single-region fill.
- **Flood-fill mode:** `FloodFillCanvas` keeps its own local dataURL history stack (capped at 15 steps) and registers an undo callback into the store via the same callback-registration idiom already used for `clear` (`registerFloodFillClear`/`registerFloodFillUndo`). A reactive `floodFillCanUndo` flag lets the button disable itself correctly for this mode too.
- Updated the `coloring-page-builder` subagent doc with how undo works for both modes, so it's documented alongside the flood-fill/fullscreen mechanisms from earlier PRs.

Closes #1483

## Test plan
- [x] `npx tsc --noEmit` — zero errors
- [x] `npm run build` — zero errors
- [x] Manually verified in browser:
  - Region mode (cat): fill two regions, undo twice restores both to blank one step at a time, button correctly disables when empty; fill a region, clear, undo restores the fill (clear itself is undoable)
  - Flood-fill mode (יער החברים): fill the sun, undo restores it to blank line art, button disables correctly
  - Undo button correctly starts disabled on a fresh picture in both modes

🤖 Generated with [Claude Code](https://claude.com/claude-code)