### PR TITLE
fix(homepage): stop search input from scrolling to top while typing

### DIFF
--- a/gamesformykids/hooks/shared/search/useGameSearch.ts
+++ b/gamesformykids/hooks/shared/search/useGameSearch.ts
@@ -1,6 +1,5 @@
 'use client';
 import { useState, useEffect, useMemo, useCallback, useRef } from 'react';
-import { useRouter } from 'next/navigation';
 import { GamesRegistry, GameRegistration } from '@/lib/registry/gamesRegistry';
 import { GAME_CATEGORIES } from '@/lib/constants/gameCategories';
 import { useHomePageStore } from '@/lib/stores';
@@ -9,7 +8,6 @@ import { useAgeFilterStore, isAgeAppropriate } from '@/lib/stores/ageFilterStore
 const URL_SYNC_DEBOUNCE_MS = 300;
 
 export function useGameSearch() {
-  const router = useRouter();
   const showAllGamesView = useHomePageStore((s) => s.showAllGamesView);
   const ageRange = useAgeFilterStore((s) => s.ageRange);
   const [query, setQueryState] = useState('');
@@ -33,19 +31,27 @@ export function useGameSearch() {
     };
   }, []);
 
-  const writeURL = useCallback(
-    (q: string, cat: string | null) => {
-      const params = new URLSearchParams();
-      if (q) params.set('q', q);
-      if (cat) params.set('cat', cat);
-      const search = params.toString();
-      const url = search
-        ? `${window.location.pathname}?${search}`
-        : window.location.pathname;
-      router.replace(url, { scroll: false });
-    },
-    [router],
-  );
+  // Writes the URL directly via the native History API instead of
+  // next/navigation's router.replace(). This route never needs a server
+  // re-render for `q`/`cat` (filtering is entirely client-side via
+  // filteredGames below) — it's purely for shareable/bookmarkable links and
+  // back/forward support. Next's router.replace(url, { scroll: false })
+  // still resets window.scrollY to 0 a few hundred ms after the call in
+  // this app's Next 16 setup (verified live: the reset lands right after
+  // router.replace's internal history.replaceState, well after any
+  // content-height change, so it isn't a layout-driven scroll clamp — it's
+  // the router itself, and `scroll: false` doesn't suppress it here).
+  // Bypassing the router for this URL-only sync avoids that reset entirely.
+  const writeURL = useCallback((q: string, cat: string | null) => {
+    const params = new URLSearchParams();
+    if (q) params.set('q', q);
+    if (cat) params.set('cat', cat);
+    const search = params.toString();
+    const url = search
+      ? `${window.location.pathname}?${search}`
+      : window.location.pathname;
+    window.history.replaceState(window.history.state, '', url);
+  }, []);
 
   // Debounced so fast typing doesn't push a router.replace on every keystroke.
   const updateURL = useCallback(


### PR DESCRIPTION
## Summary
- Root cause (verified live with instrumented Playwright timing, not guessed): `useGameSearch`'s debounced URL sync called `router.replace(url, { scroll: false })` from `next/navigation`. In this app's Next 16 setup, that call still resets `window.scrollY` to 0 shortly after firing, even with `scroll: false`. Confirmed via timestamped in-page logging that the reset lands immediately after `router.replace`'s internal `history.replaceState` — well after any results-grid height change, ruling out a layout/height-collapse-driven scroll clamp as the cause.
- Since this URL write is purely for shareable/bookmarkable links and back/forward support (filtering is 100% client-side via `filteredGames`, no server re-render depends on `q`/`cat`), bypass `next/navigation`'s router entirely for it and call `window.history.replaceState` directly. Sidesteps the router's scroll-reset behavior without any `scrollTo` hack.

Closes #1486

## Test plan
- [x] Verified live: `scrollY` stays pinned across a full typing session (both a narrowing and a non-narrowing query) — previously snapped to 0 on the first keystroke of every search
- [x] Smoke-tested unaffected: debounced URL sync, live result count, `/` focus shortcut, Escape-to-clear, category chip filtering
- [x] `npx tsc --noEmit` — clean
- [x] `npm run build` — clean (verified in an isolated git worktree to avoid unrelated concurrent-process noise in this shared repo)

🤖 Generated with [Claude Code](https://claude.com/claude-code)