### PR TITLE
perf: optimize flags images, clean up stray directives/logging

### DIFF
--- a/gamesformykids/app/api/story-agent/route.ts
+++ b/gamesformykids/app/api/story-agent/route.ts
@@ -32,7 +32,6 @@ export interface StoryAgentResponse {
 
 async function awardPointsToUser(points: number) {
   // TODO: replace with real DB update, e.g. Supabase RPC
-  console.log(`[Story Agent] Awarding ${points} points to user`);
   return { status: 'success', newPointsBalance: points };
 }
 

--- a/gamesformykids/app/games/crossword/data/puzzles.ts
+++ b/gamesformykids/app/games/crossword/data/puzzles.ts
@@ -1,5 +1,3 @@
-'use client';
-
 export interface CrosswordClue {
   number: number;
   direction: 'across' | 'down';

--- a/gamesformykids/app/games/hangman/data/wordCategories.ts
+++ b/gamesformykids/app/games/hangman/data/wordCategories.ts
@@ -1,5 +1,3 @@
-'use client';
-
 export type WordEntry = {
   word: string;
   hint: string;

--- a/gamesformykids/app/games/israel-map/data/locations.ts
+++ b/gamesformykids/app/games/israel-map/data/locations.ts
@@ -1,5 +1,3 @@
-'use client';
-
 export type Location = {
   id: string;
   name: string;

--- a/gamesformykids/app/games/kids-songs/data/songs.ts
+++ b/gamesformykids/app/games/kids-songs/data/songs.ts
@@ -1,5 +1,3 @@
-'use client';
-
 export type ComprehensionQuestion = {
   question: string;
   options: [string, string, string, string];

--- a/gamesformykids/components/shared/cards/FlagsGameCard.tsx
+++ b/gamesformykids/components/shared/cards/FlagsGameCard.tsx
@@ -1,4 +1,5 @@
 "use client";
+import Image from "next/image";
 import { GameItemCardProps } from "@/lib/types/components/cards";
 
 const NAME_TO_CODE: Record<string, string> = {
@@ -49,13 +50,13 @@ export default function FlagsGameCard({ item, onClick, isSelected }: GameItemCar
       `}
     >
       {/* Flag image */}
-      <div className="flex-1 w-full flex items-center justify-center overflow-hidden rounded-xl">
-        {/* eslint-disable-next-line @next/next/no-img-element */}
-        <img
+      <div className="relative flex-1 w-full flex items-center justify-center overflow-hidden rounded-xl">
+        <Image
           src={flagUrl}
           alt={item.english || item.name}
-          className="w-full h-full object-cover rounded-xl"
-          loading="lazy"
+          fill
+          sizes="(max-width: 768px) 33vw, 160px"
+          className="object-cover rounded-xl"
           referrerPolicy="no-referrer"
         />
       </div>


### PR DESCRIPTION
## Summary
- `FlagsGameCard` used a raw `<img>` for flag images even though `flagcdn.com` is already whitelisted in `next.config.ts` — switched to `next/image` for automatic AVIF/WebP + responsive sizing.
- Four pure data/type files (`crossword/data/puzzles.ts`, `hangman/data/wordCategories.ts`, `israel-map/data/locations.ts`, `kids-songs/data/songs.ts`) carried a stray `'use client'` directive despite containing no hooks or browser APIs — removed.
- `app/api/story-agent/route.ts` had a leftover `console.log` firing on every request inside a TODO stub (`awardPointsToUser`) — removed.

Found via a general perf/quality scan (TypeScript + ESLint clean already; searched for raw `<img>` tags, stray client directives, debug logging, and memoization anti-patterns).

## Test plan
- [x] `npx tsc --noEmit` — zero errors
- [x] `npx eslint .` — zero errors/warnings
- [ ] Manually verify `/games/flags` renders flag images correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)