### PR TITLE
Dot-to-dot editor: automatic outline-to-dots detection

### DIFF
--- a/gamesformykids/__tests__/games/dotToDotContour.test.ts
+++ b/gamesformykids/__tests__/games/dotToDotContour.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildSilhouetteMask,
+  traceOuterContour,
+  resampleClosedPolygon,
+  scaleToViewBox,
+  type PixelData,
+} from '@/app/games/dot-to-dot/editor/contourTrace';
+
+/** '#' = dark ink pixel, '.' = white background pixel. All rows must be equal length. */
+function makePixelData(rows: string[]): PixelData {
+  const height = rows.length;
+  const width = rows[0]!.length;
+  const data = new Uint8ClampedArray(width * height * 4);
+  for (let y = 0; y < height; y++) {
+    for (let x = 0; x < width; x++) {
+      const idx = (y * width + x) * 4;
+      const dark = rows[y]![x] === '#';
+      const v = dark ? 0 : 255;
+      data[idx] = v;
+      data[idx + 1] = v;
+      data[idx + 2] = v;
+      data[idx + 3] = 255;
+    }
+  }
+  return { data, width, height };
+}
+
+describe('buildSilhouetteMask', () => {
+  it('fills the white interior enclosed by a dark outline', () => {
+    const mask = buildSilhouetteMask(makePixelData([
+      '.......',
+      '.#####.',
+      '.#...#.',
+      '.#...#.',
+      '.#####.',
+      '.......',
+    ]));
+    // Center of the hollow square was left "white" but is enclosed by the outline.
+    expect(mask[3 * 7 + 3]).toBe(1);
+  });
+
+  it('leaves background outside the outline unmarked', () => {
+    const mask = buildSilhouetteMask(makePixelData([
+      '.......',
+      '.#####.',
+      '.#...#.',
+      '.#...#.',
+      '.#####.',
+      '.......',
+    ]));
+    expect(mask[0]).toBe(0); // top-left corner, clearly outside
+  });
+
+  it('absorbs an internal detail (e.g. a seed) into the solid silhouette instead of leaving it as a separate hole', () => {
+    const mask = buildSilhouetteMask(makePixelData([
+      '........',
+      '.######.',
+      '.#....#.',
+      '.#.##.#.',
+      '.#....#.',
+      '.######.',
+      '........',
+    ]));
+    // The internal "seed" blob's own pixel, and the background immediately around it, are both inside.
+    expect(mask[3 * 8 + 3]).toBe(1); // the seed pixel itself
+    expect(mask[3 * 8 + 2]).toBe(1); // white pixel right next to the seed, still enclosed
+  });
+});
+
+describe('traceOuterContour', () => {
+  it('returns an empty path for a mask with no foreground pixels', () => {
+    const mask = new Uint8Array(9); // 3x3, all zero
+    expect(traceOuterContour(mask, 3, 3)).toEqual([]);
+  });
+
+  it('traces a closed walk where every point lies on the mask and consecutive points are 8-adjacent', () => {
+    const width = 8;
+    const height = 8;
+    const mask = new Uint8Array(width * height);
+    for (let y = 2; y <= 5; y++) {
+      for (let x = 2; x <= 5; x++) mask[y * width + x] = 1;
+    }
+    const path = traceOuterContour(mask, width, height);
+    expect(path.length).toBeGreaterThan(0);
+    for (const p of path) {
+      expect(mask[p.y * width + p.x]).toBe(1);
+    }
+    for (let i = 0; i < path.length; i++) {
+      const a = path[i]!;
+      const b = path[(i + 1) % path.length]!;
+      const dx = Math.abs(a.x - b.x);
+      const dy = Math.abs(a.y - b.y);
+      expect(dx).toBeLessThanOrEqual(1);
+      expect(dy).toBeLessThanOrEqual(1);
+      expect(dx + dy).toBeGreaterThan(0);
+    }
+  });
+
+  it('traces the largest blob, ignoring a smaller disconnected speck that appears earlier in raster order', () => {
+    // A tiny 2x2 "decoration" near the top-left, disconnected from a much
+    // bigger 10x10 "subject" blob lower in the image (mirrors a real picture
+    // with scattered stars/hearts separate from the main silhouette).
+    const width = 20;
+    const height = 20;
+    const mask = new Uint8Array(width * height);
+    for (let y = 1; y <= 2; y++) for (let x = 1; x <= 2; x++) mask[y * width + x] = 1;
+    for (let y = 8; y <= 17; y++) for (let x = 5; x <= 14; x++) mask[y * width + x] = 1;
+
+    const path = traceOuterContour(mask, width, height);
+    const xs = path.map((p) => p.x);
+    const ys = path.map((p) => p.y);
+    expect(Math.min(...xs)).toBeGreaterThanOrEqual(5);
+    expect(Math.max(...xs)).toBeLessThanOrEqual(14);
+    expect(Math.min(...ys)).toBeGreaterThanOrEqual(8);
+    expect(Math.max(...ys)).toBeLessThanOrEqual(17);
+  });
+});
+
+describe('resampleClosedPolygon', () => {
+  it('returns exactly targetCount points', () => {
+    const square = [{ x: 0, y: 0 }, { x: 10, y: 0 }, { x: 10, y: 10 }, { x: 0, y: 10 }];
+    expect(resampleClosedPolygon(square, 8)).toHaveLength(8);
+  });
+
+  it('samples evenly by arc length, landing exactly on known corners', () => {
+    // Perimeter = 40, so 8 samples are spaced every 5 units: k=0 -> dist 0 (first
+    // corner), k=2 -> dist 10 (end of the first edge, the second corner), k=4 ->
+    // dist 20 (third corner).
+    const square = [{ x: 0, y: 0 }, { x: 10, y: 0 }, { x: 10, y: 10 }, { x: 0, y: 10 }];
+    const resampled = resampleClosedPolygon(square, 8);
+    expect(resampled[0]).toEqual({ x: 0, y: 0 });
+    expect(resampled[2]).toEqual({ x: 10, y: 0 });
+    expect(resampled[4]).toEqual({ x: 10, y: 10 });
+  });
+
+  it('returns an empty array for an empty input', () => {
+    expect(resampleClosedPolygon([], 10)).toEqual([]);
+  });
+});
+
+describe('scaleToViewBox', () => {
+  it('uniformly scales by the limiting dimension and centers the shorter axis', () => {
+    const result = scaleToViewBox(
+      [{ x: 0, y: 0 }, { x: 100, y: 50 }],
+      100, 50, 300, 20,
+    );
+    // available = 260; scale = min(260/100, 260/50) = 2.6; offsetX = 20, offsetY = 85.
+    expect(result).toEqual([{ x: 20, y: 85 }, { x: 280, y: 215 }]);
+  });
+});

--- a/gamesformykids/app/games/dot-to-dot/editor/DotToDotEditorClient.tsx
+++ b/gamesformykids/app/games/dot-to-dot/editor/DotToDotEditorClient.tsx
@@ -1,12 +1,17 @@
 'use client';
 import { useRef, useState, type ChangeEvent, type MouseEvent } from 'react';
 import Image from 'next/image';
-import { Upload } from 'lucide-react';
+import { Upload, Wand2 } from 'lucide-react';
 import { DOT_TO_DOT_THEMES } from '../data/pictures';
 import type { DotPoint, DotToDotTheme } from '../types';
+import { buildSilhouetteMask, resampleClosedPolygon, scaleToViewBox, traceOuterContour } from './contourTrace';
 
 const VIEW_SIZE = 300;
 const DISPLAY_WIDTH = 500;
+const MAX_WORKING_DIMENSION = 500;
+const MIN_DOTS = 8;
+const MAX_DOTS = 60;
+const DEFAULT_DOTS = 20;
 
 function buildPictureCode(opts: {
   id: string;
@@ -32,8 +37,8 @@ function buildPictureCode(opts: {
 
 export default function DotToDotEditorClient() {
   const inputRef = useRef<HTMLInputElement>(null);
+  const imgElRef = useRef<HTMLImageElement | null>(null);
   const [imageDataUrl, setImageDataUrl] = useState<string | null>(null);
-  const [imageAspect, setImageAspect] = useState(1);
   const [points, setPoints] = useState<DotPoint[]>([]);
   const [closed, setClosed] = useState(true);
   const [id, setId] = useState('');
@@ -41,6 +46,11 @@ export default function DotToDotEditorClient() {
   const [emoji, setEmoji] = useState('');
   const [theme, setTheme] = useState<DotToDotTheme>('animals');
   const [copied, setCopied] = useState(false);
+
+  const [rawContour, setRawContour] = useState<DotPoint[] | null>(null);
+  const [rawSize, setRawSize] = useState<{ width: number; height: number } | null>(null);
+  const [dotCount, setDotCount] = useState(DEFAULT_DOTS);
+  const [isDetecting, setIsDetecting] = useState(false);
 
   const handleFileChange = (e: ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
@@ -50,9 +60,11 @@ export default function DotToDotEditorClient() {
       const dataUrl = ev.target?.result as string;
       const img = new window.Image();
       img.onload = () => {
+        imgElRef.current = img;
         setImageDataUrl(dataUrl);
-        setImageAspect(img.naturalWidth / img.naturalHeight);
         setPoints([]);
+        setRawContour(null);
+        setRawSize(null);
       };
       img.src = dataUrl;
     };
@@ -66,6 +78,43 @@ export default function DotToDotEditorClient() {
     const x = Math.round(relX * VIEW_SIZE);
     const y = Math.round(relY * VIEW_SIZE);
     setPoints((prev) => [...prev, { x, y }]);
+  };
+
+  const applyDotCount = (contour: DotPoint[], size: { width: number; height: number }, count: number) => {
+    const resampled = resampleClosedPolygon(contour, count);
+    setPoints(scaleToViewBox(resampled, size.width, size.height));
+  };
+
+  const handleAutoDetect = () => {
+    const img = imgElRef.current;
+    if (!img) return;
+    setIsDetecting(true);
+    try {
+      const scale = Math.min(1, MAX_WORKING_DIMENSION / Math.max(img.naturalWidth, img.naturalHeight));
+      const workW = Math.max(1, Math.round(img.naturalWidth * scale));
+      const workH = Math.max(1, Math.round(img.naturalHeight * scale));
+      const canvas = document.createElement('canvas');
+      canvas.width = workW;
+      canvas.height = workH;
+      const ctx = canvas.getContext('2d');
+      if (!ctx) return;
+      ctx.drawImage(img, 0, 0, workW, workH);
+      const imageData = ctx.getImageData(0, 0, workW, workH);
+      const mask = buildSilhouetteMask(imageData);
+      const contour = traceOuterContour(mask, workW, workH);
+      const size = { width: workW, height: workH };
+      setRawContour(contour);
+      setRawSize(size);
+      setClosed(true);
+      applyDotCount(contour, size, dotCount);
+    } finally {
+      setIsDetecting(false);
+    }
+  };
+
+  const handleDotCountChange = (count: number) => {
+    setDotCount(count);
+    if (rawContour && rawSize) applyDotCount(rawContour, rawSize, count);
   };
 
   const handleCopy = () => {
@@ -95,8 +144,11 @@ export default function DotToDotEditorClient() {
           <div
             onClick={handleImageClick}
             className="relative bg-white rounded-2xl shadow-xl overflow-hidden cursor-crosshair"
-            style={{ width: DISPLAY_WIDTH, aspectRatio: imageAspect }}
+            style={{ width: DISPLAY_WIDTH, height: DISPLAY_WIDTH }}
           >
+            {/* Square, matching the real game board's aspect-square — object-contain
+                letterboxes non-square source images exactly as they'll appear in-game,
+                so the SVG overlay's 0-300 square viewBox lines up pixel-for-pixel. */}
             <Image src={imageDataUrl} alt="תמונת מקור" fill unoptimized className="object-contain pointer-events-none" />
             <svg viewBox={`0 0 ${VIEW_SIZE} ${VIEW_SIZE}`} className="absolute inset-0 w-full h-full pointer-events-none">
               {points.slice(1).map((p, i) => (
@@ -123,6 +175,28 @@ export default function DotToDotEditorClient() {
                 </g>
               ))}
             </svg>
+          </div>
+
+          <div className="flex flex-wrap items-center justify-center gap-3">
+            <button
+              onClick={handleAutoDetect}
+              disabled={isDetecting}
+              className="inline-flex items-center gap-2 px-4 py-2 rounded-xl text-sm font-bold bg-gradient-to-r from-emerald-500 to-teal-500 hover:from-emerald-600 hover:to-teal-600 text-white disabled:opacity-50 transition-all"
+            >
+              <Wand2 className="w-4 h-4" />
+              {isDetecting ? 'מזהה...' : 'זיהוי קווי מתאר אוטומטי'}
+            </button>
+            <label className="flex items-center gap-2 text-sm text-indigo-200 px-2">
+              כמות נקודות: {dotCount}
+              <input
+                type="range"
+                min={MIN_DOTS}
+                max={MAX_DOTS}
+                value={dotCount}
+                onChange={(e) => handleDotCountChange(Number(e.target.value))}
+                className="w-32"
+              />
+            </label>
           </div>
 
           <div className="flex flex-wrap items-center justify-center gap-3">

--- a/gamesformykids/app/games/dot-to-dot/editor/contourTrace.ts
+++ b/gamesformykids/app/games/dot-to-dot/editor/contourTrace.ts
@@ -1,0 +1,236 @@
+/**
+ * Auto-detect a dot-to-dot picture's outer silhouette from an uploaded image:
+ * threshold to find ink pixels, flood-fill the interior so internal details
+ * (e.g. watermelon seeds) get absorbed rather than traced separately, walk
+ * the resulting silhouette's boundary, then resample to an exact dot count.
+ * Pure functions over plain pixel arrays (no live <canvas>) so this stays
+ * unit-testable under this repo's node-environment Vitest config.
+ */
+import type { DotPoint } from '../types';
+
+export interface PixelData {
+  data: Uint8ClampedArray;
+  width: number;
+  height: number;
+}
+
+const DEFAULT_DARK_THRESHOLD = 200;
+
+function luminance(r: number, g: number, b: number): number {
+  return 0.299 * r + 0.587 * g + 0.114 * b;
+}
+
+/** 1 = inside the silhouette (ink or enclosed by it), 0 = background reachable from the border. */
+export function buildSilhouetteMask(imageData: PixelData, threshold = DEFAULT_DARK_THRESHOLD): Uint8Array {
+  const { data, width, height } = imageData;
+  const size = width * height;
+  const isDark = new Uint8Array(size);
+  for (let i = 0; i < size; i++) {
+    const idx = i * 4;
+    const r = data[idx] ?? 255;
+    const g = data[idx + 1] ?? 255;
+    const b = data[idx + 2] ?? 255;
+    const a = data[idx + 3] ?? 255;
+    isDark[i] = a > 10 && luminance(r, g, b) < threshold ? 1 : 0;
+  }
+
+  const outside = new Uint8Array(size);
+  const stack: number[] = [];
+  const seed = (x: number, y: number) => {
+    const i = y * width + x;
+    if (!isDark[i] && !outside[i]) {
+      outside[i] = 1;
+      stack.push(x, y);
+    }
+  };
+  for (let x = 0; x < width; x++) {
+    seed(x, 0);
+    seed(x, height - 1);
+  }
+  for (let y = 0; y < height; y++) {
+    seed(0, y);
+    seed(width - 1, y);
+  }
+
+  while (stack.length > 0) {
+    const y = stack.pop()!;
+    const x = stack.pop()!;
+    const candidates: Array<[number, number]> = [[x + 1, y], [x - 1, y], [x, y + 1], [x, y - 1]];
+    for (const [nx, ny] of candidates) {
+      if (nx < 0 || ny < 0 || nx >= width || ny >= height) continue;
+      const ni = ny * width + nx;
+      if (isDark[ni] || outside[ni]) continue;
+      outside[ni] = 1;
+      stack.push(nx, ny);
+    }
+  }
+
+  const mask = new Uint8Array(size);
+  for (let i = 0; i < size; i++) mask[i] = outside[i] ? 0 : 1;
+  return mask;
+}
+
+// Clockwise 8-neighborhood starting at West: W, NW, N, NE, E, SE, S, SW.
+const NEIGHBORS_CW: Array<[number, number]> = [
+  [-1, 0], [-1, -1], [0, -1], [1, -1], [1, 0], [1, 1], [0, 1], [-1, 1],
+];
+
+// 8-connected neighborhood, used only for connected-component labeling below.
+const NEIGHBORS_8: Array<[number, number]> = [
+  [1, 0], [1, 1], [0, 1], [-1, 1], [-1, 0], [-1, -1], [0, -1], [1, -1],
+];
+
+/**
+ * A mask can contain several disconnected foreground blobs (e.g. a picture's
+ * main silhouette plus small unrelated decorations scattered around it).
+ * Returns the topmost-then-leftmost pixel of the LARGEST connected blob, so
+ * tracing follows the intended subject instead of whichever speck happens to
+ * appear first in raster-scan order.
+ */
+function findLargestComponentStart(mask: Uint8Array, width: number, height: number): DotPoint | null {
+  const labeled = new Uint8Array(mask.length);
+  let bestSize = 0;
+  let bestStart: DotPoint | null = null;
+
+  for (let y = 0; y < height; y++) {
+    for (let x = 0; x < width; x++) {
+      const i = y * width + x;
+      if (mask[i] !== 1 || labeled[i]) continue;
+
+      // Flood-fill this component, tracking its size and topmost-leftmost pixel.
+      let size = 0;
+      let compStartX = x;
+      let compStartY = y;
+      const stack: number[] = [x, y];
+      labeled[i] = 1;
+      while (stack.length > 0) {
+        const cy = stack.pop()!;
+        const cx = stack.pop()!;
+        size++;
+        if (cy < compStartY || (cy === compStartY && cx < compStartX)) {
+          compStartX = cx;
+          compStartY = cy;
+        }
+        for (const [dx, dy] of NEIGHBORS_8) {
+          const nx = cx + dx;
+          const ny = cy + dy;
+          if (nx < 0 || ny < 0 || nx >= width || ny >= height) continue;
+          const ni = ny * width + nx;
+          if (mask[ni] !== 1 || labeled[ni]) continue;
+          labeled[ni] = 1;
+          stack.push(nx, ny);
+        }
+      }
+
+      if (size > bestSize) {
+        bestSize = size;
+        bestStart = { x: compStartX, y: compStartY };
+      }
+    }
+  }
+
+  return bestStart;
+}
+
+/** Moore-neighbor boundary trace of a mask's largest connected blob, as an ordered (open) point list. */
+export function traceOuterContour(mask: Uint8Array, width: number, height: number): DotPoint[] {
+  const at = (x: number, y: number) => x >= 0 && y >= 0 && x < width && y < height && mask[y * width + x] === 1;
+
+  const start = findLargestComponentStart(mask, width, height);
+  if (!start) return [];
+  const { x: startX, y: startY } = start;
+
+  const boundary: DotPoint[] = [{ x: startX, y: startY }];
+
+  let hasNeighbor = false;
+  for (const [dx, dy] of NEIGHBORS_CW) {
+    if (at(startX + dx, startY + dy)) { hasNeighbor = true; break; }
+  }
+  if (!hasNeighbor) return boundary;
+
+  let cx = startX;
+  let cy = startY;
+  let entryIdx = 0; // arrived from the West by convention (start is topmost-then-leftmost)
+  const maxSteps = width * height * 4;
+
+  for (let steps = 0; steps < maxSteps; steps++) {
+    let moved = false;
+    for (let k = 1; k <= 8; k++) {
+      const idx = (entryIdx + k) % 8;
+      const [dx, dy] = NEIGHBORS_CW[idx]!;
+      const nx = cx + dx;
+      const ny = cy + dy;
+      if (at(nx, ny)) {
+        cx = nx;
+        cy = ny;
+        entryIdx = (idx + 4) % 8;
+        moved = true;
+        break;
+      }
+    }
+    if (!moved) break;
+    if (cx === startX && cy === startY) break;
+    boundary.push({ x: cx, y: cy });
+  }
+
+  return boundary;
+}
+
+/** Resample a closed polygon (last point implicitly connects to the first) to exactly targetCount points, evenly spaced by arc length. */
+export function resampleClosedPolygon(points: DotPoint[], targetCount: number): DotPoint[] {
+  if (points.length === 0 || targetCount <= 0) return [];
+  if (points.length === 1) return Array.from({ length: targetCount }, () => ({ ...points[0]! }));
+
+  const n = points.length;
+  const segLengths: number[] = [];
+  let perimeter = 0;
+  for (let i = 0; i < n; i++) {
+    const a = points[i]!;
+    const b = points[(i + 1) % n]!;
+    const d = Math.hypot(b.x - a.x, b.y - a.y);
+    segLengths.push(d);
+    perimeter += d;
+  }
+  if (perimeter === 0) return Array.from({ length: targetCount }, () => ({ ...points[0]! }));
+
+  const result: DotPoint[] = [];
+  const step = perimeter / targetCount;
+  let segIdx = 0;
+  let segStart = 0;
+  for (let k = 0; k < targetCount; k++) {
+    const targetDist = k * step;
+    while (segIdx < n - 1 && segStart + segLengths[segIdx]! < targetDist) {
+      segStart += segLengths[segIdx]!;
+      segIdx++;
+    }
+    const a = points[segIdx]!;
+    const b = points[(segIdx + 1) % n]!;
+    const segLen = segLengths[segIdx]!;
+    const t = segLen > 0 ? (targetDist - segStart) / segLen : 0;
+    result.push({
+      x: Math.round(a.x + (b.x - a.x) * t),
+      y: Math.round(a.y + (b.y - a.y) * t),
+    });
+  }
+  return result;
+}
+
+/** Uniform-scale-and-center points from source pixel space into the picture's square viewBox. */
+export function scaleToViewBox(
+  points: DotPoint[],
+  srcWidth: number,
+  srcHeight: number,
+  viewSize = 300,
+  margin = 20,
+): DotPoint[] {
+  const available = viewSize - margin * 2;
+  const scale = Math.min(available / srcWidth, available / srcHeight);
+  const scaledWidth = srcWidth * scale;
+  const scaledHeight = srcHeight * scale;
+  const offsetX = (viewSize - scaledWidth) / 2;
+  const offsetY = (viewSize - scaledHeight) / 2;
+  return points.map((p) => ({
+    x: Math.round(p.x * scale + offsetX),
+    y: Math.round(p.y * scale + offsetY),
+  }));
+}


### PR DESCRIPTION
## Summary
- New pure module `contourTrace.ts`: threshold → flood-fill the interior (so internal details like a watermelon's seeds get absorbed into the solid silhouette rather than traced separately) → find the **largest connected blob** (ignoring smaller disconnected decorations elsewhere in the image, e.g. stray stars/hearts around a butterfly) → Moore-neighbor boundary trace → resample to an exact, slider-controlled dot count.
- Editor UI gets a "זיהוי קווי מתאר אוטומטי" button + a דot-count slider (8-60, default 20). Manual click-to-place is untouched and still works as a complement/fallback.
- **Bug fix along the way**: the editor's preview container was sized to the uploaded image's own aspect ratio, but the SVG dot/line overlay always used a fixed square `0 0 300 300` viewBox — the mismatch double-letterboxed the display and squeezed all points toward the center regardless of where they actually were. Fixed by making the preview container a fixed square (matching the real game board's `aspect-square`), so `object-contain` letterboxes the source image exactly as it'll appear in-game, and the overlay lines up pixel-for-pixel.

Closes #1498

## Test plan
- [x] `npx tsc --noEmit` — zero errors
- [x] `npm run build` — succeeds
- [x] `npx vitest run __tests__/games/dotToDotContour.test.ts` — 10/10 passing, including a regression test for the largest-blob selection bug (two disconnected mask regions of different sizes — traces the bigger one)
- [x] `npx vitest run __tests__/stores/dotToDotStore.test.ts` — 7/7 passing, unaffected
- [x] Manually verified against a local production build (temporary auth bypass, reverted before commit — diffed clean against the original): uploaded the real butterfly reference image, ran auto-detect, confirmed the traced dots follow the actual outer wing/antennae silhouette (not a stray decoration, not clustered in the center), and confirmed the slider live-updates the dot count (tested 20 and 40)

🤖 Generated with [Claude Code](https://claude.com/claude-code)