### PR TITLE
Fix colorblind-mode gaps and design-system bypasses in shared cards

### DIFF
--- a/gamesformykids/app/games/checkers/components/DamkaMenuScreen.tsx
+++ b/gamesformykids/app/games/checkers/components/DamkaMenuScreen.tsx
@@ -22,7 +22,7 @@ export default function DamkaMenuScreen() {
           <span>⚪ מחשב: {computerScore}</span>
         </div>
       )}
-      <div className="bg-amber-50 rounded-xl p-4 text-gray-600 text-sm space-y-1">
+      <div className="bg-amber-50 rounded-2xl p-4 text-gray-600 text-sm space-y-1">
         <p className="font-bold text-gray-700 mb-2">כללים:</p>
         <p>🔴 האסימונים שלך = אדום (מלמטה↑)</p>
         <p>⚪ המחשב = לבן (מלמעלה↓)</p>

--- a/gamesformykids/app/games/chess/components/ChessGameOver.tsx
+++ b/gamesformykids/app/games/chess/components/ChessGameOver.tsx
@@ -39,7 +39,7 @@ export default function ChessGameOver() {
         {/* Trophy / emoji */}
         <div
           className="text-8xl mb-4 inline-block"
-          style={{ animation: playerWon ? 'bounce 0.8s infinite alternate' : 'none' }}
+          style={{ animation: playerWon ? 'chess-victory-bounce 0.8s infinite alternate' : 'none' }}
         >
           {playerWon ? '🏆' : isDraw ? '🤝' : '😢'}
         </div>
@@ -90,7 +90,7 @@ export default function ChessGameOver() {
       </button>
 
       <style>{`
-        @keyframes bounce {
+        @keyframes chess-victory-bounce {
           from { transform: translateY(0) scale(1); }
           to { transform: translateY(-12px) scale(1.1); }
         }

--- a/gamesformykids/app/games/chess/components/ChessTitleCard.tsx
+++ b/gamesformykids/app/games/chess/components/ChessTitleCard.tsx
@@ -23,7 +23,7 @@ export default function ChessTitleCard() {
       <div className="relative z-10">
         <div
           className="text-7xl mb-3 inline-block"
-          style={{ animation: 'float 3s ease-in-out infinite', filter: 'drop-shadow(0 0 16px rgba(251,191,36,0.4))' }}
+          style={{ animation: 'chess-float 3s ease-in-out infinite', filter: 'drop-shadow(0 0 16px rgba(251,191,36,0.4))' }}
         >
           ♟
         </div>
@@ -46,7 +46,7 @@ export default function ChessTitleCard() {
       </div>
 
       <style>{`
-        @keyframes float {
+        @keyframes chess-float {
           0%, 100% { transform: translateY(0) rotate(-4deg); }
           50% { transform: translateY(-10px) rotate(4deg); }
         }

--- a/gamesformykids/app/games/find-in-scene/components/SceneCanvas.tsx
+++ b/gamesformykids/app/games/find-in-scene/components/SceneCanvas.tsx
@@ -27,7 +27,7 @@ export default function SceneCanvas({ scene, targetIds, foundIds, wrongId, onTap
               isFound
                 ? 'opacity-40 cursor-default scale-90'
                 : isWrong
-                ? 'animate-[shake_0.4s_ease-in-out]'
+                ? 'animate-[scene-shake_0.4s_ease-in-out]'
                 : isTarget
                 ? 'hover:scale-125 active:scale-110 cursor-pointer drop-shadow-[0_0_8px_rgba(251,191,36,0.8)]'
                 : 'hover:scale-115 active:scale-110 cursor-pointer'
@@ -48,7 +48,7 @@ export default function SceneCanvas({ scene, targetIds, foundIds, wrongId, onTap
       })}
 
       <style>{`
-        @keyframes shake {
+        @keyframes scene-shake {
           0%, 100% { transform: translate(-50%, -50%) rotate(0deg); }
           25% { transform: translate(calc(-50% + 6px), -50%) rotate(-6deg); }
           75% { transform: translate(calc(-50% - 6px), -50%) rotate(6deg); }

--- a/gamesformykids/app/games/israel-map/components/IsraelSVG.tsx
+++ b/gamesformykids/app/games/israel-map/components/IsraelSVG.tsx
@@ -111,23 +111,28 @@ export default function IsraelSVG({ current, foundIds, allLocations, onTap, last
       {/* Current target marker */}
       {current && (
         <g>
+          {/* fill/stroke use currentColor driven by the text-green-600/text-red-600
+              classes below so the [data-colorblind="true"] CSS override in globals.css
+              (which remaps those exact classes to the Paul Tol palette) applies here too —
+              a raw hex fill/stroke would be invisible to that override. */}
           <circle
             cx={current.x}
             cy={current.y}
             r={current.radius}
-            fill={lastResult === 'correct' ? '#bbf7d0' : lastResult === 'wrong' ? '#fecaca' : 'none'}
-            stroke={lastResult === 'correct' ? '#16a34a' : lastResult === 'wrong' ? '#dc2626' : 'none'}
+            fill={lastResult === 'correct' || lastResult === 'wrong' ? 'currentColor' : 'none'}
+            stroke={lastResult === 'correct' || lastResult === 'wrong' ? 'currentColor' : 'none'}
             strokeWidth="1.5"
             opacity="0.5"
+            className={lastResult === 'correct' ? 'text-green-600' : lastResult === 'wrong' ? 'text-red-600' : ''}
           />
           <circle
             cx={current.x}
             cy={current.y}
             r={5}
-            fill={lastResult === 'wrong' ? '#fca5a5' : '#fde68a'}
-            stroke={lastResult === 'wrong' ? '#dc2626' : '#d97706'}
+            fill={lastResult === 'wrong' ? 'currentColor' : '#fde68a'}
+            stroke={lastResult === 'wrong' ? 'currentColor' : '#d97706'}
             strokeWidth="1.5"
-            className="animate-pulse"
+            className={`animate-pulse ${lastResult === 'wrong' ? 'text-red-600' : ''}`}
           />
         </g>
       )}

--- a/gamesformykids/app/games/letter-race/components/LetterRacePlayScreen.tsx
+++ b/gamesformykids/app/games/letter-race/components/LetterRacePlayScreen.tsx
@@ -27,7 +27,7 @@ export default function LetterRacePlayScreen() {
       {/* Question card */}
       <div className={`w-full max-w-sm bg-white rounded-3xl p-8 text-center shadow-2xl mb-5 transition duration-150 ${
         feedback === 'correct' ? 'bg-green-50 ring-4 ring-green-400 scale-105' :
-        feedback === 'wrong'   ? 'bg-amber-50 ring-4 ring-amber-400' : ''
+        feedback === 'wrong'   ? 'bg-red-50 ring-4 ring-red-400' : ''
       }`}>
         <button
           onClick={() => speakHebrew(`בְּאֵיזוֹ אוֹת מַתְחִיל ${q.word}?`)}
@@ -39,7 +39,7 @@ export default function LetterRacePlayScreen() {
         <p className="text-2xl font-black text-gray-700 mb-1">{q.word}</p>
         <p className="text-base text-violet-500 font-semibold">באיזו אות מתחיל?</p>
         {feedback && (
-          <p className={`text-2xl mt-3 font-bold ${feedback === 'correct' ? 'text-green-500' : 'text-amber-600'}`}>
+          <p className={`text-2xl mt-3 font-bold ${feedback === 'correct' ? 'text-green-500' : 'text-red-600'}`}>
             {feedback === 'correct' ? `✅ ${streak >= 3 ? 'בום! +20' : 'נכון! +10'}` : `❌ האות: ${q.answer}`}
           </p>
         )}

--- a/gamesformykids/app/games/math-race/components/MathRaceQuestion.tsx
+++ b/gamesformykids/app/games/math-race/components/MathRaceQuestion.tsx
@@ -18,11 +18,11 @@ export default function MathRaceQuestion({ q, feedback, streak, onTap }: Props) 
     <>
       <div className={`w-full max-w-sm bg-white rounded-3xl p-8 text-center shadow-2xl mb-5 transition duration-150 ${
         feedback === 'correct' ? 'bg-green-50 ring-4 ring-green-400 scale-105' :
-        feedback === 'wrong' ? 'bg-amber-50 ring-4 ring-amber-400' : ''
+        feedback === 'wrong' ? 'bg-red-50 ring-4 ring-red-400' : ''
       }`}>
         <p className="text-4xl font-black text-gray-700">{q.text}</p>
         {feedback && (
-          <p className={`text-2xl mt-3 font-bold ${feedback === 'correct' ? 'text-green-500' : 'text-amber-600'}`}>
+          <p className={`text-2xl mt-3 font-bold ${feedback === 'correct' ? 'text-green-500' : 'text-red-600'}`}>
             {feedback === 'correct' ? `✅ ${streak >= 3 ? 'בום! +20' : 'נכון! +10'}` : `❌ התשובה: ${q.answer}`}
           </p>
         )}

--- a/gamesformykids/app/games/soccer/components/SoccerQuestionCard.tsx
+++ b/gamesformykids/app/games/soccer/components/SoccerQuestionCard.tsx
@@ -11,7 +11,7 @@ export default function SoccerQuestionCard() {
       <div className="text-6xl mb-3">{currentQuestion.emoji}</div>
       <p className="text-lg font-bold text-gray-800 leading-relaxed">{currentQuestion.question}</p>
       {isAnswered && (
-        <div className={`mt-4 p-3 rounded-xl text-sm leading-relaxed ${isCorrect ? 'bg-green-100 text-green-800' : 'bg-orange-100 text-orange-800'}`}>
+        <div className={`mt-4 p-3 rounded-xl text-sm leading-relaxed ${isCorrect ? 'bg-green-100 text-green-800' : 'bg-red-100 text-red-800'}`}>
           <p className="font-bold">
             {isCorrect ? '✅ שאל אחד!' : `❌ התשובה: ${currentQuestion.answers[currentQuestion.correctIndex]}`}
           </p>

--- a/gamesformykids/app/games/taki/components/TakiMenuScreen.tsx
+++ b/gamesformykids/app/games/taki/components/TakiMenuScreen.tsx
@@ -22,7 +22,7 @@ export default function TakiMenuScreen() {
           <span>🤖 מחשב: {computerScore}</span>
         </div>
       )}
-      <div className="bg-green-50 rounded-xl p-4 text-gray-600 text-sm space-y-1">
+      <div className="bg-green-50 rounded-2xl p-4 text-gray-600 text-sm space-y-1">
         <p className="font-bold text-gray-700 mb-2">כללים בקצרה:</p>
         <p>🃏 <strong>טאקי</strong> — שחק קלפים באותו צבע ולחץ &ldquo;סגור&rdquo;</p>
         <p>✋ <strong>עצור</strong> — המתנגד מדלג תור</p>

--- a/gamesformykids/app/games/transport/components/TransportQuestion.tsx
+++ b/gamesformykids/app/games/transport/components/TransportQuestion.tsx
@@ -31,7 +31,7 @@ export default function TransportQuestion({
           <div className="inline-block px-3 py-1 rounded-full text-sm font-bold text-white bg-blue-400 mb-3">{currentQuestion.type}</div>
           <p className="text-lg font-bold text-gray-800">{currentQuestion.question}</p>
           {answered && (
-            <div className={`mt-4 p-3 rounded-xl text-sm ${isCorrect ? 'bg-green-100 text-green-700 font-bold' : 'bg-orange-100 text-orange-700'}`}>
+            <div className={`mt-4 p-3 rounded-xl text-sm ${isCorrect ? 'bg-green-100 text-green-700 font-bold' : 'bg-red-100 text-red-700'}`}>
               {isCorrect ? '✅ מעולה!' : `❌ התשובה: ${currentQuestion.answers[currentQuestion.correctIndex]}`}
               <br /><span className="text-xs font-normal">💡 {currentQuestion.funFact}</span>
             </div>

--- a/gamesformykids/app/games/true-false/components/TrueFalsePlayScreen.tsx
+++ b/gamesformykids/app/games/true-false/components/TrueFalsePlayScreen.tsx
@@ -26,12 +26,12 @@ export default function TrueFalsePlayScreen() {
       </div>
       <div className={`w-full max-w-sm bg-white rounded-3xl p-6 text-center shadow-2xl mb-6 transition duration-200 ${
         feedback === 'correct' ? 'ring-4 ring-green-400 bg-green-50' :
-        feedback === 'wrong'   ? 'ring-4 ring-amber-400 bg-amber-50' : ''
+        feedback === 'wrong'   ? 'ring-4 ring-red-400 bg-red-50' : ''
       }`}>
         <div className="text-5xl mb-4">{q?.emoji}</div>
         <p className="text-xl font-bold text-gray-700 leading-relaxed">{q?.fact}</p>
         {feedback && (
-          <p className={`text-3xl mt-3 ${feedback === 'correct' ? 'text-green-500' : 'text-amber-600'}`}>
+          <p className={`text-3xl mt-3 ${feedback === 'correct' ? 'text-green-500' : 'text-red-600'}`}>
             {feedback === 'correct' ? '✅ נכון!' : q?.answer ? '❌ אוי! זה נכון' : '❌ אוי! זה לא נכון'}
           </p>
         )}

--- a/gamesformykids/app/games/word-clicker/components/WordClickerScreen.tsx
+++ b/gamesformykids/app/games/word-clicker/components/WordClickerScreen.tsx
@@ -74,7 +74,7 @@ export default function WordClickerScreen() {
         {/* Feedback banner */}
         {feedback && (
           <div className={`text-center font-black text-xl mb-3 py-2 rounded-xl ${
-            feedback === 'correct' ? 'bg-green-100 text-green-700' : 'bg-amber-50 text-amber-700'
+            feedback === 'correct' ? 'bg-green-100 text-green-700' : 'bg-red-100 text-red-700'
           }`}>
             {feedback === 'correct' ? '✅ נכון!' : '💙 נסה שוב!'}
           </div>

--- a/gamesformykids/components/game/quiz/QuizFeedback.tsx
+++ b/gamesformykids/components/game/quiz/QuizFeedback.tsx
@@ -52,7 +52,7 @@ export function QuizFeedback({
         role="status"
         aria-live="polite"
         className={`rounded-2xl p-3 mb-4 text-center ${
-          isCorrect ? 'bg-green-50 text-green-700' : 'bg-amber-50 text-amber-700'
+          isCorrect ? 'bg-green-50 text-green-700' : 'bg-red-100 text-red-700'
         }`}
       >
         <p className="font-bold text-lg">{message}</p>

--- a/gamesformykids/components/game/quiz/QuizQuestionCard.tsx
+++ b/gamesformykids/components/game/quiz/QuizQuestionCard.tsx
@@ -57,7 +57,7 @@ export default function QuizQuestionCard({
       </div>
 
       {answered && (
-        <div className={`rounded-2xl p-4 mb-5 text-center font-bold text-lg ${isCorrect ? 'bg-green-100 text-green-700' : 'bg-orange-100 text-orange-700'}`}>
+        <div className={`rounded-2xl p-4 mb-5 text-center font-bold text-lg ${isCorrect ? 'bg-green-100 text-green-700' : 'bg-red-100 text-red-700'}`}>
           {isCorrect ? correctMessage : `💙 התשובה הנכונה: "${answers[correctIndex]}"`}
         </div>
       )}

--- a/gamesformykids/components/game/quiz/screens/RiddleProQuestion.tsx
+++ b/gamesformykids/components/game/quiz/screens/RiddleProQuestion.tsx
@@ -60,7 +60,7 @@ export default function RiddleProQuestion({
 
       {/* Feedback */}
       {waiting && (
-        <div className={`rounded-2xl p-3 mb-3 text-center text-xl font-bold ${lastCorrect ? 'bg-green-50 text-green-700' : 'bg-amber-50 text-amber-700'}`}>
+        <div className={`rounded-2xl p-3 mb-3 text-center text-xl font-bold ${lastCorrect ? 'bg-green-50 text-green-700' : 'bg-red-50 text-red-700'}`}>
           {lastCorrect
             ? `✅ נכון! +${lastPoints} ${lastPoints === 3 ? '🌟🌟🌟' : lastPoints === 2 ? '🌟🌟' : '🌟'}`
             : `💙 כמעט! הנכון: ${current.answer}`}

--- a/gamesformykids/components/shared/cards/ColoredShapeCard.tsx
+++ b/gamesformykids/components/shared/cards/ColoredShapeCard.tsx
@@ -8,6 +8,7 @@ import { Volume2 } from 'lucide-react';
 import { SHAPE_ICON_MAP } from '@/lib/constants/ui/shapes';
 import { useUniversalGame } from '@/hooks/shared/game-state/useUniversalGame';
 import { ComponentTypes } from '@/lib/types';
+import { hoverClasses } from './cardStyleMaps';
 
 type ColoredShapeCardProps = ComponentTypes.ColoredShapeCardProps;
 
@@ -31,7 +32,7 @@ export default function ColoredShapeCard({
       aria-label={item.hebrew}
       className={`
         relative group bg-white rounded-3xl p-8 shadow-xl
-        hover:shadow-2xl hover:scale-105
+        hover:shadow-2xl ${hoverClasses['scale-sm']}
         transform transition-[transform,box-shadow] duration-300 cursor-pointer
         border-2 border-gray-100 hover:border-gray-200 w-full
         ${className}

--- a/gamesformykids/components/shared/cards/FlagsGameCard.tsx
+++ b/gamesformykids/components/shared/cards/FlagsGameCard.tsx
@@ -1,6 +1,7 @@
 "use client";
 import Image from "next/image";
 import { GameItemCardProps } from "@/lib/types/components/cards";
+import { aspectClasses, borderRadiusClasses, hoverClasses, shadowClasses } from "./cardStyleMaps";
 
 const NAME_TO_CODE: Record<string, string> = {
   france: "fr",
@@ -43,8 +44,8 @@ export default function FlagsGameCard({ item, onClick, isSelected }: GameItemCar
     <button
       onClick={() => onClick(item)}
       className={`
-        w-full aspect-square rounded-3xl cursor-pointer transition-[transform,box-shadow] duration-300
-        transform hover:scale-110 shadow-xl hover:shadow-2xl
+        w-full ${aspectClasses.square} ${borderRadiusClasses['3xl']} cursor-pointer transition-[transform,box-shadow] duration-300
+        transform ${hoverClasses.scale} ${shadowClasses.xl} ${hoverClasses.glow}
         bg-white flex flex-col items-center justify-center p-3 gap-2
         border-8 ${isSelected ? "border-green-400 ring-4 ring-green-400 ring-offset-4" : "border-white"}
       `}

--- a/gamesformykids/components/shared/cards/GameCardGrid.tsx
+++ b/gamesformykids/components/shared/cards/GameCardGrid.tsx
@@ -3,6 +3,7 @@
 import { useState, useCallback, useRef, useEffect } from 'react';
 import { ComponentTypes } from "@/lib/types";
 import { useGridFillers } from "@/hooks";
+import { aspectClasses, borderRadiusClasses, hoverClasses, shadowClasses } from "./cardStyleMaps";
 
 type GameItemType = ComponentTypes.GameItemType;
 type GameCardGridProps<T extends GameItemType> = ComponentTypes.GameCardGridProps<T>;
@@ -125,8 +126,8 @@ export function GameCardGrid<T extends GameItemType>({
                   : itemKey
                 }
                 className={`
-                  w-full aspect-square rounded-3xl cursor-pointer transition-[transform,box-shadow]
-                  duration-300 hover:scale-110 shadow-xl hover:shadow-2xl
+                  w-full ${aspectClasses.square} ${borderRadiusClasses['3xl']} cursor-pointer transition-[transform,box-shadow]
+                  duration-300 ${hoverClasses.scale} ${shadowClasses.xl} ${hoverClasses.glow}
                   bg-linear-to-br from-gray-400 to-gray-600
                   border-8 border-white
                   ${isCorrect ? "ring-4 ring-green-400 ring-offset-4" : ""}

--- a/gamesformykids/components/shared/cards/GeographyGameCard.tsx
+++ b/gamesformykids/components/shared/cards/GeographyGameCard.tsx
@@ -1,6 +1,7 @@
 "use client";
 import Image from 'next/image';
 import { GameItemCardProps } from "@/lib/types/components/cards";
+import { aspectClasses, borderRadiusClasses, hoverClasses, shadowClasses } from "./cardStyleMaps";
 
 export default function GeographyGameCard({ item, onClick, isSelected }: GameItemCardProps) {
   const iso2 = item.id ?? item.name;
@@ -10,8 +11,8 @@ export default function GeographyGameCard({ item, onClick, isSelected }: GameIte
     <button
       onClick={() => onClick(item)}
       className={`
-        w-full aspect-square rounded-3xl cursor-pointer transition-[transform,box-shadow] duration-300
-        transform hover:scale-110 shadow-xl hover:shadow-2xl
+        w-full ${aspectClasses.square} ${borderRadiusClasses['3xl']} cursor-pointer transition-[transform,box-shadow] duration-300
+        transform ${hoverClasses.scale} ${shadowClasses.xl} ${hoverClasses.glow}
         bg-white flex flex-col items-center justify-center p-3 gap-2
         border-8 ${isSelected ? "border-green-400 ring-4 ring-green-400 ring-offset-4" : "border-white"}
       `}

--- a/gamesformykids/components/shared/cards/GeographyTextCard.tsx
+++ b/gamesformykids/components/shared/cards/GeographyTextCard.tsx
@@ -1,13 +1,14 @@
 "use client";
 import { GameItemCardProps } from "@/lib/types/components/cards";
+import { aspectClasses, borderRadiusClasses, hoverClasses, shadowClasses } from "./cardStyleMaps";
 
 export default function GeographyTextCard({ item, onClick, isSelected }: GameItemCardProps) {
   return (
     <button
       onClick={() => onClick(item)}
       className={`
-        w-full aspect-square rounded-3xl cursor-pointer transition-[transform,box-shadow] duration-300
-        transform hover:scale-110 shadow-xl hover:shadow-2xl
+        w-full ${aspectClasses.square} ${borderRadiusClasses['3xl']} cursor-pointer transition-[transform,box-shadow] duration-300
+        transform ${hoverClasses.scale} ${shadowClasses.xl} ${hoverClasses.glow}
         bg-white flex items-center justify-center p-4
         border-8 ${isSelected ? "border-green-400 ring-4 ring-green-400 ring-offset-4" : "border-blue-200"}
       `}

--- a/gamesformykids/components/shared/cards/MathGameCard.tsx
+++ b/gamesformykids/components/shared/cards/MathGameCard.tsx
@@ -2,6 +2,7 @@
 
 import { useGameSessionStore } from "@/lib/stores/gameSessionStore";
 import { GameItemCardProps } from "@/lib/types/components/cards";
+import { hoverClasses } from "./cardStyleMaps";
 
 const COLORS = [
   { bg: "bg-orange-400", hover: "hover:bg-orange-500", border: "border-orange-300" },
@@ -32,7 +33,7 @@ export default function MathGameCard({ item, onClick }: GameItemCardProps) {
         border-4 rounded-3xl p-4 w-full aspect-square
         flex flex-col items-center justify-center gap-2
         shadow-lg hover:shadow-xl
-        transform hover:scale-105 active:scale-95
+        transform ${hoverClasses['scale-sm']} active:scale-95
         transition-[transform,box-shadow] duration-200 cursor-pointer
       `}
     >

--- a/gamesformykids/components/shared/cards/PhotoGameCard.tsx
+++ b/gamesformykids/components/shared/cards/PhotoGameCard.tsx
@@ -8,6 +8,7 @@ import {
   PhotoCardConfig,
   PhotoCardGameType,
 } from "@/lib/constants/ui/photoCardConfigs";
+import { aspectClasses, borderRadiusClasses, hoverClasses, shadowClasses } from "./cardStyleMaps";
 
 // ─── Generic Component ────────────────────────────────────────────────────────
 
@@ -29,8 +30,8 @@ function PhotoGameCard({ item, onClick, isSelected, config }: PhotoGameCardProps
     <button
       onClick={() => onClick(item)}
       className={`
-        w-full aspect-square rounded-3xl cursor-pointer transition-[transform,box-shadow] duration-300
-        transform hover:scale-110 shadow-xl hover:shadow-2xl
+        w-full ${aspectClasses.square} ${borderRadiusClasses['3xl']} cursor-pointer transition-[transform,box-shadow] duration-300
+        transform ${hoverClasses.scale} ${shadowClasses.xl} ${hoverClasses.glow}
         ${cardBg} flex flex-col items-center justify-center overflow-hidden
         border-8 ${border}
       `}

--- a/gamesformykids/components/shared/cards/cardStyleMaps.ts
+++ b/gamesformykids/components/shared/cards/cardStyleMaps.ts
@@ -18,6 +18,7 @@ export const animationClasses: Record<string, string> = {
 
 export const hoverClasses: Record<string, string> = {
   scale: 'hover:scale-110',
+  'scale-sm': 'hover:scale-105',
   lift: 'hover:-translate-y-2',
   glow: 'hover:shadow-2xl',
   none: '',


### PR DESCRIPTION
## Summary

**Accessibility (headline fix)**
- Several "wrong answer" feedback UIs used amber/orange Tailwind classes instead of `red-*` for the wrong-answer signal. The `[data-colorblind="true"]` override in `app/globals.css` only remaps `green-*`/`red-*` classes to the Paul Tol-safe palette — amber/orange bypassed it entirely, so colorblind-mode users saw no distinguishable color between "correct" and "wrong". Fixed in the two shared quiz primitives (`QuizFeedback.tsx`, `QuizQuestionCard.tsx`) plus 7 games that had the same pattern independently (letter-race, math-race, true-false, word-clicker, soccer, transport, riddles-pro).
- `IsraelSVG.tsx`'s correct/wrong region fill/stroke were raw hex values set directly as SVG attributes — invisible to the class-based colorblind override regardless of mode. Converted them to `currentColor`, driven by a `text-green-600`/`text-red-600` class on the element, so the existing CSS override (which already remaps that exact class range) now covers this component too, with no new override logic needed.

**Design-system consistency**
- `FlagsGameCard`, `GeographyGameCard`, `GeographyTextCard`, `PhotoGameCard`, and `GameCardGrid` hand-rolled an identical `w-full aspect-square rounded-3xl ... hover:scale-110 shadow-xl hover:shadow-2xl` class string instead of composing it from `components/shared/cards/cardStyleMaps.ts`. Switched all five to import and compose from the shared style maps (`aspectClasses`, `borderRadiusClasses`, `hoverClasses`, `shadowClasses`) — same visual output, one source of truth going forward.
- `ColoredShapeCard` and `MathGameCard` use `hover:scale-105`, while `cardStyleMaps.ts`'s `hoverClasses.scale` was hardcoded to `hover:scale-110`. Rather than forcing them to 110% (which would change their designed behavior), added a `'scale-sm': 'hover:scale-105'` entry to `hoverClasses` and switched both components to reference it.
- Two ad-hoc component `<style>` tags injected global `@keyframes` that collided by name with `app/globals.css` keyframes: Chess's title-card `float` and Find-in-Scene's `shake`. Renamed to `chess-float` / `scene-shake` (their easing differs from the global versions, so they're kept as distinct, non-colliding keyframes rather than merged). Also renamed Chess's victory-screen `bounce` keyframe to `chess-victory-bounce`, since it collided with Tailwind's built-in `animate-bounce` keyframe name.
- Checkers (`DamkaMenuScreen`) and Taki (`TakiMenuScreen`) rules boxes used `rounded-xl p-4` with no shadow, while nearby menu cards used `rounded-3xl`. Rather than applying the literal `rounded-3xl shadow-xl p-8` (which is sized for a standalone top-level card), these boxes are nested *inside* `GameMenuCard`'s own `rounded-3xl shadow-2xl` white card — surveying similar nested info/rules boxes elsewhere (`pong/PongResultOverlay`, `snakes-ladders`, `tzadikim/ResultView`, `market-game`, `robot-coder`) showed the actual plurality convention is `rounded-2xl`, no added shadow. Standardized both to `rounded-2xl` to match that convention instead.

**Skipped / lower priority (not done)**
- CSS Module keyframe duplication in `tzedakah/charity.module.css` and `drawing/drawing.module.css` (no runtime collision since they're scoped modules — flagged as optional cleanup, left as-is to avoid risking those games' visuals).
- `MascotCharacter.tsx`'s `mascot-idle` keyframe — doesn't collide by name and isn't exactly equivalent to `.animate-bounce-gentle` (different amplitude/timing), so left untouched per the audit's own guidance.
- Heading-size drift and the `colors` game's pastel-vs-white header (findings H/I) — explicitly out of scope per audit notes (lower-confidence/subjective).

## Verification
- `npx tsc --noEmit` — zero errors
- `npm run build` — zero build errors, all 499 static pages generated successfully

## Test plan
- [ ] Toggle colorblind mode in Settings and confirm wrong-answer states across the fixed quiz games now show the same blue/orange Paul Tol palette as correct/wrong states elsewhere
- [ ] Visit `/games/israel-map`, tap a wrong region, confirm the marker still turns visually distinct in colorblind mode
- [ ] Visit `/games/chess` and `/games/find-in-scene`, confirm the title-card float animation and wrong-tap shake animation still play correctly (renamed keyframes)
- [ ] Spot-check `/games/checkers` and `/games/taki` menu screens for the rules-box corner radius