### PR TITLE
Dot-to-dot: show reference image as full-opacity board background

### DIFF
--- a/gamesformykids/app/games/dot-to-dot/DotToDotClient.tsx
+++ b/gamesformykids/app/games/dot-to-dot/DotToDotClient.tsx
@@ -28,18 +28,7 @@ export default function DotToDotClient() {
 
       {phase === 'complete' && <GameCompletionCelebration />}
 
-      <div className="flex flex-col sm:flex-row items-center sm:items-start gap-4">
-        <DotToDotBoard picture={picture} connected={connected} onDotClick={clickDot} />
-
-        {phase === 'playing' && picture.imageSrc && (
-          <div className="flex flex-col items-center gap-1 bg-white/10 rounded-2xl p-3">
-            <span className="text-xs text-indigo-200">לא בטוחים מה מציירים? ככה זה אמור להיראות:</span>
-            <div className="relative w-28 h-28 rounded-xl overflow-hidden bg-white">
-              <Image src={picture.imageSrc} alt={picture.title} fill sizes="112px" className="object-contain" />
-            </div>
-          </div>
-        )}
-      </div>
+      <DotToDotBoard picture={picture} connected={connected} onDotClick={clickDot} />
 
       {phase === 'complete' ? (
         <div className="flex flex-col items-center gap-3">

--- a/gamesformykids/app/games/dot-to-dot/components/DotToDotBoard.tsx
+++ b/gamesformykids/app/games/dot-to-dot/components/DotToDotBoard.tsx
@@ -18,6 +18,8 @@ export default function DotToDotBoard({ picture, connected, onDotClick }: Props)
   const centroidX = points.reduce((sum, p) => sum + p.x, 0) / points.length;
   const centroidY = points.reduce((sum, p) => sum + p.y, 0) / points.length;
 
+  const [, , vbWidth, vbHeight] = picture.viewBox.split(' ').map(Number);
+
   return (
     <svg
       viewBox={picture.viewBox}
@@ -25,6 +27,15 @@ export default function DotToDotBoard({ picture, connected, onDotClick }: Props)
       role="img"
       aria-label={picture.title}
     >
+      {picture.imageSrc && (
+        <image
+          href={picture.imageSrc}
+          x={0} y={0}
+          width={vbWidth} height={vbHeight}
+          preserveAspectRatio="xMidYMid meet"
+        />
+      )}
+
       {segments.map(([a, b]) => (
         <line
           key={`${a}-${b}`}


### PR DESCRIPTION
## Summary
- `DotToDotBoard.tsx` now renders the picture's `imageSrc` (when set) as a full-opacity SVG `<image>` layer behind the dots/lines, sized to the viewBox so it lines up exactly with the point coordinates.
- Removes the now-redundant small side-panel "here's what you're drawing" guide from `DotToDotClient.tsx`'s playing phase — the full image sitting directly behind the dots makes that separate box unnecessary.
- The editor (`DotToDotEditorClient.tsx`) already showed its uploaded image behind the dots being placed — this brings the actual game board to the same behavior, so it's now consistent on both screens as requested.

Closes #1531

## Test plan
- [x] `npx tsc --noEmit` — zero errors
- [x] `npm run build` — succeeds
- [x] `npx vitest run __tests__/stores/dotToDotStore.test.ts __tests__/games/dotToDotContour.test.ts` — 22/22 passing (unaffected, this is rendering-only)
- [x] Rendered the board with the butterfly picture and a partial-progress state (15/24 dots connected) to visually confirm the full reference image shows clearly behind the connected/pending dots

🤖 Generated with [Claude Code](https://claude.com/claude-code)