### PR TITLE
Split DotToDotEditorClient into hook + focused components

### DIFF
--- a/.claude/agents/component-splitter.md
+++ b/.claude/agents/component-splitter.md
@@ -1,0 +1,88 @@
+---
+name: component-splitter
+description: Splits large, multi-concern files (React components, hooks, stores, screens) into smaller focused files that follow this repo's game-folder conventions. Use proactively when a file exceeds ~250 lines or mixes state/logic/JSX in one place, or when the user asks to "split", "break up", "extract components from", or "refactor" a large file. Preserves behavior exactly — no logic changes.
+tools: Read, Grep, Glob, Edit, Write, Bash
+model: sonnet
+---
+
+You are a file-decomposition specialist for the GamesForMyKids repo (`gamesformykids/`: Next.js 16 App Router, React 19, TypeScript, Zustand, Tailwind v4). You split oversized files into smaller ones **without changing behavior** — this is a pure structural refactor, not a rewrite.
+
+Read `CLAUDE.md` at the repo root before starting — it defines the folder shapes (Style A–E) and shared factories this repo already has. Splitting must follow those shapes, not invent new ones.
+
+---
+
+## Phase 1 — Decide if and how to split
+
+1. Read the **entire** target file first — never split from a partial read.
+2. Identify the distinct concerns mixed together:
+   - **State/logic** — `useState`/`useReducer`/Zustand `create()` calls, effects, callbacks, a state machine (`phase: 'menu' | 'playing' | 'result'`).
+   - **Presentation** — JSX blocks that render one coherent screen/section (menu screen, question screen, result screen, a card, a grid item).
+   - **Data/constants** — literal arrays/objects (questions, items, config) that don't change at runtime.
+   - **Types** — interfaces/types used only by this file vs. shared ones that belong in `lib/types/`.
+3. Check for an existing factory or pattern before creating new structure — grep the DRY table in `CLAUDE.md` (`createChallengeStore`, `makeQuizGame`, `GenericQuizGame`, `createPhaseGameHook`, `makeGameClient`, etc.). If the file being split is a game that could collapse onto an existing factory instead of just being split into peer files, say so and ask before doing the bigger rewrite — that's a different task than splitting.
+4. **Don't split on line count alone.** A 400-line file that's one cohesive `switch` over an enum is not automatically wrong. Split along concern boundaries — each new file should have one reason to change.
+5. **Don't over-split.** Three lines used once each don't need three files. A screen with one small helper sub-render doesn't need its own file unless that sub-render is independently reusable or the parent is still too large after the obvious extractions.
+
+---
+
+## Phase 2 — Target shape (match repo conventions)
+
+For a custom game client file that's grown too large, prefer Style D's shape from `CLAUDE.md`:
+
+```
+app/games/<game>/
+├── <Game>Client.tsx        # 'use client' entry point — composes the pieces, stays thin
+├── <game>Store.ts          # Zustand store (state + actions only)
+├── use<Game>.ts            # logic hook (derives values, wires store to component)
+└── components/
+    ├── <Game>Screen.tsx    # main play area
+    └── <Game>Menu.tsx      # start/menu screen
+```
+
+For a quiz screen file that's grown too large, prefer Style C's shape:
+
+```
+lib/quiz/use<Game>Game.ts                          # state machine hook
+components/game/quiz/screens/<Game>MenuScreen.tsx
+components/game/quiz/screens/<Game>Question.tsx
+```
+
+For a generic oversized component (not a game entry point): extract each distinct JSX section into `components/<ParentName>/<Section>.tsx` (or a sibling file if there's no natural subfolder yet), extract inline data literals into `data.ts` or `lib/constants/gameData/`, and extract local-only types into a `types.ts` beside the component — but move truly shared types (like `GameType`) to their existing home in `lib/types/core/base.ts` instead of duplicating.
+
+Naming: components stay PascalCase, hooks stay camelCase prefixed with `use`, one default export per component file, named exports for hooks/stores/utils — match whatever the surrounding directory already does (check a sibling file before deciding).
+
+---
+
+## Phase 3 — Extract mechanically
+
+1. Create each new file with only the code that concern needs — copy, don't retype, to avoid transcription bugs.
+2. Move imports along with the code that uses them; don't leave unused imports behind in the original file.
+3. Wire the original file to import from the new ones and compose them — it should shrink to orchestration only (imports + JSX composition, or imports + hook calls).
+4. If a Zustand store is being pulled out of a component file, follow the existing selector-per-field convention (`useStore(s => s.score)`), not a single whole-store subscription — check `CLAUDE.md`'s performance section reasoning if unsure.
+5. Keep prop interfaces explicit at each new component boundary — don't pass a giant "everything" props object through if the child only needs 2 of 8 fields.
+6. Do not change any conditional logic, event handler behavior, styling, or copy text while moving code. If you spot an actual bug while splitting, note it in your report — do not fix it inline unless asked.
+
+---
+
+## Phase 4 — Verify
+
+```bash
+cd gamesformykids && npx tsc --noEmit
+```
+
+Fix only type errors introduced by the split (missing imports, wrong prop types) — do not use this step to "improve" typing beyond what the original file had.
+
+If the split touched a game's entry point, confirm the game is still registered correctly (`CustomGameRenderer.tsx`, `gamePageConstants.ts`, or the relevant quiz registry) — moving a file's location must not silently break a dynamic `import()` path.
+
+---
+
+## Phase 5 — Report
+
+Output exactly:
+
+1. **Original file** — path, line count before
+2. **New files created** — path + line count for each
+3. **Original file** — line count after
+4. **What moved where** — one line per new file (e.g., "menu screen JSX → `components/MyGameMenu.tsx`")
+5. **Verification** — `tsc --noEmit` result
+6. Anything you deliberately did **not** split and why (e.g., "kept the reducer in the client file — it's 30 lines and only used there")

--- a/gamesformykids/app/games/dot-to-dot/editor/DotToDotEditorClient.tsx
+++ b/gamesformykids/app/games/dot-to-dot/editor/DotToDotEditorClient.tsx
@@ -1,134 +1,37 @@
 'use client';
-import { useRef, useState, type ChangeEvent, type MouseEvent } from 'react';
-import Image from 'next/image';
-import { Upload, Wand2 } from 'lucide-react';
-import { DOT_TO_DOT_THEMES } from '../data/pictures';
-import type { DotPoint, DotToDotTheme } from '../types';
-import { buildSilhouetteMask, resampleClosedPolygon, scaleToViewBox, simplifyPolygon, traceOuterContour } from './contourTrace';
-
-const VIEW_SIZE = 300;
-const DISPLAY_WIDTH = 500;
-const MAX_WORKING_DIMENSION = 500;
-const MIN_DOTS = 8;
-const MAX_DOTS = 60;
-const DEFAULT_DOTS = 20;
-const SIMPLIFY_EPSILON_RATIO = 0.03;
-
-function buildPictureCode(opts: {
-  id: string;
-  title: string;
-  emoji: string;
-  theme: DotToDotTheme;
-  closed: boolean;
-  points: DotPoint[];
-}): string {
-  const { id, title, emoji, theme, closed, points } = opts;
-  const pointsStr = points.map((p) => `{ x: ${p.x}, y: ${p.y} }`).join(', ');
-  return `{
-    id: '${id || 'my-picture'}',
-    title: '${title}',
-    emoji: '${emoji}',
-    theme: '${theme}',
-    viewBox: '0 0 300 300',
-    closed: ${closed},
-    imageSrc: '/images/dot-to-dot/${id || 'my-picture'}.png',
-    points: [${pointsStr}],
-  },`;
-}
+import { Upload } from 'lucide-react';
+import { buildPictureCode } from './buildPictureCode';
+import EditorControls from './components/EditorControls';
+import ExportPanel from './components/ExportPanel';
+import MetadataForm from './components/MetadataForm';
+import PointCanvas from './components/PointCanvas';
+import { useDotToDotEditor } from './useDotToDotEditor';
 
 export default function DotToDotEditorClient() {
-  const inputRef = useRef<HTMLInputElement>(null);
-  const imgElRef = useRef<HTMLImageElement | null>(null);
-  const [imageDataUrl, setImageDataUrl] = useState<string | null>(null);
-  const [points, setPoints] = useState<DotPoint[]>([]);
-  const [closed, setClosed] = useState(true);
-  const [id, setId] = useState('');
-  const [title, setTitle] = useState('');
-  const [emoji, setEmoji] = useState('');
-  const [theme, setTheme] = useState<DotToDotTheme>('animals');
-  const [copied, setCopied] = useState(false);
-
-  const [rawContour, setRawContour] = useState<DotPoint[] | null>(null);
-  const [rawSize, setRawSize] = useState<{ width: number; height: number } | null>(null);
-  const [dotCount, setDotCount] = useState(DEFAULT_DOTS);
-  const [isDetecting, setIsDetecting] = useState(false);
-
-  const handleFileChange = (e: ChangeEvent<HTMLInputElement>) => {
-    const file = e.target.files?.[0];
-    if (!file) return;
-    const reader = new FileReader();
-    reader.onload = (ev) => {
-      const dataUrl = ev.target?.result as string;
-      const img = new window.Image();
-      img.onload = () => {
-        imgElRef.current = img;
-        setImageDataUrl(dataUrl);
-        setPoints([]);
-        setRawContour(null);
-        setRawSize(null);
-      };
-      img.src = dataUrl;
-    };
-    reader.readAsDataURL(file);
-  };
-
-  const handleImageClick = (e: MouseEvent<HTMLDivElement>) => {
-    const rect = e.currentTarget.getBoundingClientRect();
-    const relX = (e.clientX - rect.left) / rect.width;
-    const relY = (e.clientY - rect.top) / rect.height;
-    const x = Math.round(relX * VIEW_SIZE);
-    const y = Math.round(relY * VIEW_SIZE);
-    setPoints((prev) => [...prev, { x, y }]);
-  };
-
-  const applyDotCount = (contour: DotPoint[], size: { width: number; height: number }, count: number) => {
-    const resampled = resampleClosedPolygon(contour, count);
-    setPoints(scaleToViewBox(resampled, size.width, size.height));
-  };
-
-  const handleAutoDetect = () => {
-    const img = imgElRef.current;
-    if (!img) return;
-    setIsDetecting(true);
-    try {
-      const scale = Math.min(1, MAX_WORKING_DIMENSION / Math.max(img.naturalWidth, img.naturalHeight));
-      const workW = Math.max(1, Math.round(img.naturalWidth * scale));
-      const workH = Math.max(1, Math.round(img.naturalHeight * scale));
-      const canvas = document.createElement('canvas');
-      canvas.width = workW;
-      canvas.height = workH;
-      const ctx = canvas.getContext('2d');
-      if (!ctx) return;
-      ctx.drawImage(img, 0, 0, workW, workH);
-      const imageData = ctx.getImageData(0, 0, workW, workH);
-      const mask = buildSilhouetteMask(imageData);
-      const rawTrace = traceOuterContour(mask, workW, workH);
-      // Smooth away fine wiggly detail (e.g. a spiral antenna curl) whose
-      // perimeter is disproportionately large for its size — otherwise even
-      // arc-length resampling "spends" most of the dot budget there instead
-      // of the main silhouette.
-      const epsilon = Math.max(1, Math.hypot(workW, workH) * SIMPLIFY_EPSILON_RATIO);
-      const contour = simplifyPolygon(rawTrace, epsilon);
-      const size = { width: workW, height: workH };
-      setRawContour(contour);
-      setRawSize(size);
-      setClosed(true);
-      applyDotCount(contour, size, dotCount);
-    } finally {
-      setIsDetecting(false);
-    }
-  };
-
-  const handleDotCountChange = (count: number) => {
-    setDotCount(count);
-    if (rawContour && rawSize) applyDotCount(rawContour, rawSize, count);
-  };
-
-  const handleCopy = () => {
-    navigator.clipboard.writeText(buildPictureCode({ id, title, emoji, theme, closed, points }));
-    setCopied(true);
-    setTimeout(() => setCopied(false), 2000);
-  };
+  const {
+    inputRef,
+    imageDataUrl,
+    points,
+    setPoints,
+    closed,
+    setClosed,
+    id,
+    setId,
+    title,
+    setTitle,
+    emoji,
+    setEmoji,
+    theme,
+    setTheme,
+    copied,
+    dotCount,
+    isDetecting,
+    handleFileChange,
+    handleImageClick,
+    handleAutoDetect,
+    handleDotCountChange,
+    handleCopy,
+  } = useDotToDotEditor();
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-indigo-900 to-purple-900 p-6 flex flex-col items-center gap-6" dir="rtl">
@@ -148,138 +51,39 @@ export default function DotToDotEditorClient() {
 
       {imageDataUrl && (
         <>
-          <div
-            onClick={handleImageClick}
-            className="relative bg-white rounded-2xl shadow-xl overflow-hidden cursor-crosshair"
-            style={{ width: DISPLAY_WIDTH, height: DISPLAY_WIDTH }}
-          >
-            {/* Square, matching the real game board's aspect-square — object-contain
-                letterboxes non-square source images exactly as they'll appear in-game,
-                so the SVG overlay's 0-300 square viewBox lines up pixel-for-pixel. */}
-            <Image src={imageDataUrl} alt="תמונת מקור" fill unoptimized className="object-contain pointer-events-none" />
-            <svg viewBox={`0 0 ${VIEW_SIZE} ${VIEW_SIZE}`} className="absolute inset-0 w-full h-full pointer-events-none">
-              {points.slice(1).map((p, i) => (
-                <line
-                  key={i}
-                  x1={points[i]!.x} y1={points[i]!.y}
-                  x2={p.x} y2={p.y}
-                  stroke="#7c3aed" strokeWidth={3} strokeLinecap="round"
-                />
-              ))}
-              {closed && points.length > 2 && (
-                <line
-                  x1={points[points.length - 1]!.x} y1={points[points.length - 1]!.y}
-                  x2={points[0]!.x} y2={points[0]!.y}
-                  stroke="#7c3aed" strokeWidth={2} strokeDasharray="6 4"
-                />
-              )}
-              {points.map((p, i) => (
-                <g key={i}>
-                  <circle cx={p.x} cy={p.y} r={8} fill="#fff" stroke="#7c3aed" strokeWidth={2} />
-                  <text x={p.x} y={p.y} textAnchor="middle" dominantBaseline="central" fontSize={10} fontWeight="bold" fill="#4c1d95">
-                    {i + 1}
-                  </text>
-                </g>
-              ))}
-            </svg>
-          </div>
+          <PointCanvas imageDataUrl={imageDataUrl} points={points} closed={closed} onImageClick={handleImageClick} />
 
-          <div className="flex flex-wrap items-center justify-center gap-3">
-            <button
-              onClick={handleAutoDetect}
-              disabled={isDetecting}
-              className="inline-flex items-center gap-2 px-4 py-2 rounded-xl text-sm font-bold bg-gradient-to-r from-emerald-500 to-teal-500 hover:from-emerald-600 hover:to-teal-600 text-white disabled:opacity-50 transition-all"
-            >
-              <Wand2 className="w-4 h-4" />
-              {isDetecting ? 'מזהה...' : 'זיהוי קווי מתאר אוטומטי'}
-            </button>
-            <label className="flex items-center gap-2 text-sm text-indigo-200 px-2">
-              כמות נקודות: {dotCount}
-              <input
-                type="range"
-                min={MIN_DOTS}
-                max={MAX_DOTS}
-                value={dotCount}
-                onChange={(e) => handleDotCountChange(Number(e.target.value))}
-                className="w-32"
-              />
-            </label>
-          </div>
+          <EditorControls
+            dotCount={dotCount}
+            isDetecting={isDetecting}
+            pointCount={points.length}
+            closed={closed}
+            imageDataUrl={imageDataUrl}
+            id={id}
+            onAutoDetect={handleAutoDetect}
+            onDotCountChange={handleDotCountChange}
+            onUndo={() => setPoints((prev) => prev.slice(0, -1))}
+            onClear={() => setPoints([])}
+            onClosedChange={setClosed}
+          />
 
-          <div className="flex flex-wrap items-center justify-center gap-3">
-            <button
-              onClick={() => setPoints((prev) => prev.slice(0, -1))}
-              disabled={points.length === 0}
-              className="px-4 py-2 rounded-xl text-sm font-semibold bg-white/10 text-indigo-200 hover:bg-white/20 disabled:opacity-40 transition-all"
-            >
-              ↩️ בטל נקודה אחרונה
-            </button>
-            <button
-              onClick={() => setPoints([])}
-              disabled={points.length === 0}
-              className="px-4 py-2 rounded-xl text-sm font-semibold bg-white/10 text-indigo-200 hover:bg-white/20 disabled:opacity-40 transition-all"
-            >
-              🗑️ נקה הכל
-            </button>
-            <label className="flex items-center gap-2 text-sm text-indigo-200 px-2">
-              <input type="checkbox" checked={closed} onChange={(e) => setClosed(e.target.checked)} />
-              צורה סגורה
-            </label>
-            <span className="text-sm text-indigo-300">{points.length} נקודות</span>
-            <a
-              href={imageDataUrl}
-              download={`${id || 'picture'}.png`}
-              className="px-4 py-2 rounded-xl text-sm font-semibold bg-white/10 text-indigo-200 hover:bg-white/20 transition-all"
-            >
-              💾 הורד תמונה (לשמירה ב-public/images/dot-to-dot/)
-            </a>
-          </div>
+          <MetadataForm
+            id={id}
+            title={title}
+            emoji={emoji}
+            theme={theme}
+            onIdChange={setId}
+            onTitleChange={setTitle}
+            onEmojiChange={setEmoji}
+            onThemeChange={setTheme}
+          />
 
-          <div className="grid grid-cols-2 sm:grid-cols-4 gap-3 w-full max-w-2xl">
-            <input
-              value={id}
-              onChange={(e) => setId(e.target.value)}
-              placeholder="id (kebab-case)"
-              className="rounded-xl px-3 py-2 text-sm bg-white/90"
-            />
-            <input
-              value={title}
-              onChange={(e) => setTitle(e.target.value)}
-              placeholder="כותרת בעברית"
-              className="rounded-xl px-3 py-2 text-sm bg-white/90"
-            />
-            <input
-              value={emoji}
-              onChange={(e) => setEmoji(e.target.value)}
-              placeholder="אימוג'י"
-              className="rounded-xl px-3 py-2 text-sm bg-white/90"
-            />
-            <select
-              value={theme}
-              onChange={(e) => setTheme(e.target.value as DotToDotTheme)}
-              className="rounded-xl px-3 py-2 text-sm bg-white/90"
-            >
-              {DOT_TO_DOT_THEMES.map((t) => (
-                <option key={t.id} value={t.id}>{t.emoji} {t.title}</option>
-              ))}
-            </select>
-          </div>
-
-          <div className="w-full max-w-2xl flex flex-col gap-2">
-            <div className="flex items-center justify-between">
-              <span className="text-sm text-indigo-200 font-semibold">קוד מיוצא</span>
-              <button
-                onClick={handleCopy}
-                disabled={points.length === 0}
-                className="px-4 py-1.5 rounded-xl text-sm font-semibold bg-yellow-400 hover:bg-yellow-300 text-yellow-900 disabled:opacity-40 transition-all"
-              >
-                {copied ? '✅ הועתק' : '📋 העתק קוד'}
-              </button>
-            </div>
-            <pre className="bg-black/40 text-indigo-100 text-xs rounded-xl p-4 overflow-x-auto whitespace-pre-wrap" dir="ltr">
-              {buildPictureCode({ id, title, emoji, theme, closed, points })}
-            </pre>
-          </div>
+          <ExportPanel
+            code={buildPictureCode({ id, title, emoji, theme, closed, points })}
+            copied={copied}
+            disabled={points.length === 0}
+            onCopy={handleCopy}
+          />
         </>
       )}
     </div>

--- a/gamesformykids/app/games/dot-to-dot/editor/buildPictureCode.ts
+++ b/gamesformykids/app/games/dot-to-dot/editor/buildPictureCode.ts
@@ -1,0 +1,23 @@
+import type { DotPoint, DotToDotTheme } from '../types';
+
+export function buildPictureCode(opts: {
+  id: string;
+  title: string;
+  emoji: string;
+  theme: DotToDotTheme;
+  closed: boolean;
+  points: DotPoint[];
+}): string {
+  const { id, title, emoji, theme, closed, points } = opts;
+  const pointsStr = points.map((p) => `{ x: ${p.x}, y: ${p.y} }`).join(', ');
+  return `{
+    id: '${id || 'my-picture'}',
+    title: '${title}',
+    emoji: '${emoji}',
+    theme: '${theme}',
+    viewBox: '0 0 300 300',
+    closed: ${closed},
+    imageSrc: '/images/dot-to-dot/${id || 'my-picture'}.png',
+    points: [${pointsStr}],
+  },`;
+}

--- a/gamesformykids/app/games/dot-to-dot/editor/components/EditorControls.tsx
+++ b/gamesformykids/app/games/dot-to-dot/editor/components/EditorControls.tsx
@@ -1,0 +1,87 @@
+'use client';
+import { Wand2 } from 'lucide-react';
+import type { ChangeEvent } from 'react';
+import { MAX_DOTS, MIN_DOTS } from '../editorConstants';
+
+interface Props {
+  dotCount: number;
+  isDetecting: boolean;
+  pointCount: number;
+  closed: boolean;
+  imageDataUrl: string;
+  id: string;
+  onAutoDetect: () => void;
+  onDotCountChange: (count: number) => void;
+  onUndo: () => void;
+  onClear: () => void;
+  onClosedChange: (closed: boolean) => void;
+}
+
+export default function EditorControls({
+  dotCount,
+  isDetecting,
+  pointCount,
+  closed,
+  imageDataUrl,
+  id,
+  onAutoDetect,
+  onDotCountChange,
+  onUndo,
+  onClear,
+  onClosedChange,
+}: Props) {
+  return (
+    <>
+      <div className="flex flex-wrap items-center justify-center gap-3">
+        <button
+          onClick={onAutoDetect}
+          disabled={isDetecting}
+          className="inline-flex items-center gap-2 px-4 py-2 rounded-xl text-sm font-bold bg-gradient-to-r from-emerald-500 to-teal-500 hover:from-emerald-600 hover:to-teal-600 text-white disabled:opacity-50 transition-all"
+        >
+          <Wand2 className="w-4 h-4" />
+          {isDetecting ? 'מזהה...' : 'זיהוי קווי מתאר אוטומטי'}
+        </button>
+        <label className="flex items-center gap-2 text-sm text-indigo-200 px-2">
+          כמות נקודות: {dotCount}
+          <input
+            type="range"
+            min={MIN_DOTS}
+            max={MAX_DOTS}
+            value={dotCount}
+            onChange={(e: ChangeEvent<HTMLInputElement>) => onDotCountChange(Number(e.target.value))}
+            className="w-32"
+          />
+        </label>
+      </div>
+
+      <div className="flex flex-wrap items-center justify-center gap-3">
+        <button
+          onClick={onUndo}
+          disabled={pointCount === 0}
+          className="px-4 py-2 rounded-xl text-sm font-semibold bg-white/10 text-indigo-200 hover:bg-white/20 disabled:opacity-40 transition-all"
+        >
+          ↩️ בטל נקודה אחרונה
+        </button>
+        <button
+          onClick={onClear}
+          disabled={pointCount === 0}
+          className="px-4 py-2 rounded-xl text-sm font-semibold bg-white/10 text-indigo-200 hover:bg-white/20 disabled:opacity-40 transition-all"
+        >
+          🗑️ נקה הכל
+        </button>
+        <label className="flex items-center gap-2 text-sm text-indigo-200 px-2">
+          <input type="checkbox" checked={closed} onChange={(e) => onClosedChange(e.target.checked)} />
+          צורה סגורה
+        </label>
+        <span className="text-sm text-indigo-300">{pointCount} נקודות</span>
+        <a
+          href={imageDataUrl}
+          download={`${id || 'picture'}.png`}
+          className="px-4 py-2 rounded-xl text-sm font-semibold bg-white/10 text-indigo-200 hover:bg-white/20 transition-all"
+        >
+          💾 הורד תמונה (לשמירה ב-public/images/dot-to-dot/)
+        </a>
+      </div>
+    </>
+  );
+}

--- a/gamesformykids/app/games/dot-to-dot/editor/components/ExportPanel.tsx
+++ b/gamesformykids/app/games/dot-to-dot/editor/components/ExportPanel.tsx
@@ -1,0 +1,28 @@
+'use client';
+
+interface Props {
+  code: string;
+  copied: boolean;
+  disabled: boolean;
+  onCopy: () => void;
+}
+
+export default function ExportPanel({ code, copied, disabled, onCopy }: Props) {
+  return (
+    <div className="w-full max-w-2xl flex flex-col gap-2">
+      <div className="flex items-center justify-between">
+        <span className="text-sm text-indigo-200 font-semibold">קוד מיוצא</span>
+        <button
+          onClick={onCopy}
+          disabled={disabled}
+          className="px-4 py-1.5 rounded-xl text-sm font-semibold bg-yellow-400 hover:bg-yellow-300 text-yellow-900 disabled:opacity-40 transition-all"
+        >
+          {copied ? '✅ הועתק' : '📋 העתק קוד'}
+        </button>
+      </div>
+      <pre className="bg-black/40 text-indigo-100 text-xs rounded-xl p-4 overflow-x-auto whitespace-pre-wrap" dir="ltr">
+        {code}
+      </pre>
+    </div>
+  );
+}

--- a/gamesformykids/app/games/dot-to-dot/editor/components/MetadataForm.tsx
+++ b/gamesformykids/app/games/dot-to-dot/editor/components/MetadataForm.tsx
@@ -1,0 +1,49 @@
+'use client';
+import type { ChangeEvent } from 'react';
+import { DOT_TO_DOT_THEMES } from '../../data/pictures';
+import type { DotToDotTheme } from '../../types';
+
+interface Props {
+  id: string;
+  title: string;
+  emoji: string;
+  theme: DotToDotTheme;
+  onIdChange: (value: string) => void;
+  onTitleChange: (value: string) => void;
+  onEmojiChange: (value: string) => void;
+  onThemeChange: (value: DotToDotTheme) => void;
+}
+
+export default function MetadataForm({ id, title, emoji, theme, onIdChange, onTitleChange, onEmojiChange, onThemeChange }: Props) {
+  return (
+    <div className="grid grid-cols-2 sm:grid-cols-4 gap-3 w-full max-w-2xl">
+      <input
+        value={id}
+        onChange={(e: ChangeEvent<HTMLInputElement>) => onIdChange(e.target.value)}
+        placeholder="id (kebab-case)"
+        className="rounded-xl px-3 py-2 text-sm bg-white/90"
+      />
+      <input
+        value={title}
+        onChange={(e: ChangeEvent<HTMLInputElement>) => onTitleChange(e.target.value)}
+        placeholder="כותרת בעברית"
+        className="rounded-xl px-3 py-2 text-sm bg-white/90"
+      />
+      <input
+        value={emoji}
+        onChange={(e: ChangeEvent<HTMLInputElement>) => onEmojiChange(e.target.value)}
+        placeholder="אימוג'י"
+        className="rounded-xl px-3 py-2 text-sm bg-white/90"
+      />
+      <select
+        value={theme}
+        onChange={(e) => onThemeChange(e.target.value as DotToDotTheme)}
+        className="rounded-xl px-3 py-2 text-sm bg-white/90"
+      >
+        {DOT_TO_DOT_THEMES.map((t) => (
+          <option key={t.id} value={t.id}>{t.emoji} {t.title}</option>
+        ))}
+      </select>
+    </div>
+  );
+}

--- a/gamesformykids/app/games/dot-to-dot/editor/components/PointCanvas.tsx
+++ b/gamesformykids/app/games/dot-to-dot/editor/components/PointCanvas.tsx
@@ -1,0 +1,52 @@
+'use client';
+import Image from 'next/image';
+import type { MouseEvent } from 'react';
+import type { DotPoint } from '../../types';
+import { DISPLAY_WIDTH, VIEW_SIZE } from '../editorConstants';
+
+interface Props {
+  imageDataUrl: string;
+  points: DotPoint[];
+  closed: boolean;
+  onImageClick: (e: MouseEvent<HTMLDivElement>) => void;
+}
+
+export default function PointCanvas({ imageDataUrl, points, closed, onImageClick }: Props) {
+  return (
+    <div
+      onClick={onImageClick}
+      className="relative bg-white rounded-2xl shadow-xl overflow-hidden cursor-crosshair"
+      style={{ width: DISPLAY_WIDTH, height: DISPLAY_WIDTH }}
+    >
+      {/* Square, matching the real game board's aspect-square — object-contain
+          letterboxes non-square source images exactly as they'll appear in-game,
+          so the SVG overlay's 0-300 square viewBox lines up pixel-for-pixel. */}
+      <Image src={imageDataUrl} alt="תמונת מקור" fill unoptimized className="object-contain pointer-events-none" />
+      <svg viewBox={`0 0 ${VIEW_SIZE} ${VIEW_SIZE}`} className="absolute inset-0 w-full h-full pointer-events-none">
+        {points.slice(1).map((p, i) => (
+          <line
+            key={i}
+            x1={points[i]!.x} y1={points[i]!.y}
+            x2={p.x} y2={p.y}
+            stroke="#7c3aed" strokeWidth={3} strokeLinecap="round"
+          />
+        ))}
+        {closed && points.length > 2 && (
+          <line
+            x1={points[points.length - 1]!.x} y1={points[points.length - 1]!.y}
+            x2={points[0]!.x} y2={points[0]!.y}
+            stroke="#7c3aed" strokeWidth={2} strokeDasharray="6 4"
+          />
+        )}
+        {points.map((p, i) => (
+          <g key={i}>
+            <circle cx={p.x} cy={p.y} r={8} fill="#fff" stroke="#7c3aed" strokeWidth={2} />
+            <text x={p.x} y={p.y} textAnchor="middle" dominantBaseline="central" fontSize={10} fontWeight="bold" fill="#4c1d95">
+              {i + 1}
+            </text>
+          </g>
+        ))}
+      </svg>
+    </div>
+  );
+}

--- a/gamesformykids/app/games/dot-to-dot/editor/editorConstants.ts
+++ b/gamesformykids/app/games/dot-to-dot/editor/editorConstants.ts
@@ -1,0 +1,7 @@
+export const VIEW_SIZE = 300;
+export const DISPLAY_WIDTH = 500;
+export const MAX_WORKING_DIMENSION = 500;
+export const MIN_DOTS = 8;
+export const MAX_DOTS = 60;
+export const DEFAULT_DOTS = 20;
+export const SIMPLIFY_EPSILON_RATIO = 0.03;

--- a/gamesformykids/app/games/dot-to-dot/editor/useDotToDotEditor.ts
+++ b/gamesformykids/app/games/dot-to-dot/editor/useDotToDotEditor.ts
@@ -1,0 +1,126 @@
+'use client';
+import { useRef, useState, type ChangeEvent, type MouseEvent } from 'react';
+import type { DotPoint, DotToDotTheme } from '../types';
+import { buildPictureCode } from './buildPictureCode';
+import { buildSilhouetteMask, resampleClosedPolygon, scaleToViewBox, simplifyPolygon, traceOuterContour } from './contourTrace';
+import { DEFAULT_DOTS, MAX_WORKING_DIMENSION, SIMPLIFY_EPSILON_RATIO, VIEW_SIZE } from './editorConstants';
+
+export function useDotToDotEditor() {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const imgElRef = useRef<HTMLImageElement | null>(null);
+  const [imageDataUrl, setImageDataUrl] = useState<string | null>(null);
+  const [points, setPoints] = useState<DotPoint[]>([]);
+  const [closed, setClosed] = useState(true);
+  const [id, setId] = useState('');
+  const [title, setTitle] = useState('');
+  const [emoji, setEmoji] = useState('');
+  const [theme, setTheme] = useState<DotToDotTheme>('animals');
+  const [copied, setCopied] = useState(false);
+
+  const [rawContour, setRawContour] = useState<DotPoint[] | null>(null);
+  const [rawSize, setRawSize] = useState<{ width: number; height: number } | null>(null);
+  const [dotCount, setDotCount] = useState(DEFAULT_DOTS);
+  const [isDetecting, setIsDetecting] = useState(false);
+
+  const handleFileChange = (e: ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onload = (ev) => {
+      const dataUrl = ev.target?.result as string;
+      const img = new window.Image();
+      img.onload = () => {
+        imgElRef.current = img;
+        setImageDataUrl(dataUrl);
+        setPoints([]);
+        setRawContour(null);
+        setRawSize(null);
+      };
+      img.src = dataUrl;
+    };
+    reader.readAsDataURL(file);
+  };
+
+  const handleImageClick = (e: MouseEvent<HTMLDivElement>) => {
+    const rect = e.currentTarget.getBoundingClientRect();
+    const relX = (e.clientX - rect.left) / rect.width;
+    const relY = (e.clientY - rect.top) / rect.height;
+    const x = Math.round(relX * VIEW_SIZE);
+    const y = Math.round(relY * VIEW_SIZE);
+    setPoints((prev) => [...prev, { x, y }]);
+  };
+
+  const applyDotCount = (contour: DotPoint[], size: { width: number; height: number }, count: number) => {
+    const resampled = resampleClosedPolygon(contour, count);
+    setPoints(scaleToViewBox(resampled, size.width, size.height));
+  };
+
+  const handleAutoDetect = () => {
+    const img = imgElRef.current;
+    if (!img) return;
+    setIsDetecting(true);
+    try {
+      const scale = Math.min(1, MAX_WORKING_DIMENSION / Math.max(img.naturalWidth, img.naturalHeight));
+      const workW = Math.max(1, Math.round(img.naturalWidth * scale));
+      const workH = Math.max(1, Math.round(img.naturalHeight * scale));
+      const canvas = document.createElement('canvas');
+      canvas.width = workW;
+      canvas.height = workH;
+      const ctx = canvas.getContext('2d');
+      if (!ctx) return;
+      ctx.drawImage(img, 0, 0, workW, workH);
+      const imageData = ctx.getImageData(0, 0, workW, workH);
+      const mask = buildSilhouetteMask(imageData);
+      const rawTrace = traceOuterContour(mask, workW, workH);
+      // Smooth away fine wiggly detail (e.g. a spiral antenna curl) whose
+      // perimeter is disproportionately large for its size — otherwise even
+      // arc-length resampling "spends" most of the dot budget there instead
+      // of the main silhouette.
+      const epsilon = Math.max(1, Math.hypot(workW, workH) * SIMPLIFY_EPSILON_RATIO);
+      const contour = simplifyPolygon(rawTrace, epsilon);
+      const size = { width: workW, height: workH };
+      setRawContour(contour);
+      setRawSize(size);
+      setClosed(true);
+      applyDotCount(contour, size, dotCount);
+    } finally {
+      setIsDetecting(false);
+    }
+  };
+
+  const handleDotCountChange = (count: number) => {
+    setDotCount(count);
+    if (rawContour && rawSize) applyDotCount(rawContour, rawSize, count);
+  };
+
+  const handleCopy = () => {
+    navigator.clipboard.writeText(buildPictureCode({ id, title, emoji, theme, closed, points }));
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
+
+  return {
+    inputRef,
+    imageDataUrl,
+    points,
+    setPoints,
+    closed,
+    setClosed,
+    id,
+    setId,
+    title,
+    setTitle,
+    emoji,
+    setEmoji,
+    theme,
+    setTheme,
+    copied,
+    dotCount,
+    isDetecting,
+    handleFileChange,
+    handleImageClick,
+    handleAutoDetect,
+    handleDotCountChange,
+    handleCopy,
+  };
+}


### PR DESCRIPTION
## Summary
- Added a `component-splitter` subagent (`.claude/agents/component-splitter.md`) that codifies this repo's file-decomposition conventions (concern boundaries, Style D/C folder shapes, tsc verification).
- Used it to split `app/games/dot-to-dot/editor/DotToDotEditorClient.tsx` (287 lines, mixing state/handlers/JSX/a pure helper) into:
  - `useDotToDotEditor.ts` — state + handlers hook
  - `buildPictureCode.ts` — pure export-code generator
  - `editorConstants.ts` — shared constants
  - `components/PointCanvas.tsx`, `EditorControls.tsx`, `MetadataForm.tsx`, `ExportPanel.tsx` — one file per JSX section
- `DotToDotEditorClient.tsx` is now 91 lines of composition only. No behavior change — pure structural move.

Closes #1536

## Test plan
- [x] `npx tsc --noEmit` passes with zero errors
- [x] Confirmed no other file imports the moved internal symbols (only `page.tsx` imports `DotToDotEditorClient`, unchanged)
- [ ] Manually verify at `/games/dot-to-dot/editor`: image upload, click-to-add-point, auto-detect, dot-count slider, undo/clear, and copy-to-clipboard all still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)