### PR TITLE
Consolidate duplicated particle/arrow-key/random/modal patterns

### DIFF
--- a/gamesformykids/app/games/arithmetic/data/questions.ts
+++ b/gamesformykids/app/games/arithmetic/data/questions.ts
@@ -1,5 +1,5 @@
 import type { ArithOp as Operation } from '@/lib/types';
-import { randInt as rand } from '@/lib/utils';
+import { randInt as rand, getRandomItem, shuffle } from '@/lib/utils';
 export type { Operation };
 
 export interface ArithmeticLevel {
@@ -43,11 +43,11 @@ function unique(correct: number, count: number, near: number): number[] {
     const candidate = correct + delta;
     if (candidate !== correct && candidate >= 0) set.add(candidate);
   }
-  return Array.from(set).sort(() => Math.random() - 0.5);
+  return shuffle(Array.from(set));
 }
 
 export function generateQuestion(level: ArithmeticLevel): ArithmeticQuestion {
-  const op = level.operations[Math.floor(Math.random() * level.operations.length)]!;
+  const op = getRandomItem(level.operations)!;
   let a: number, b: number, answer: number;
   if (op === '×') {
     a = rand(1, level.maxNum); b = rand(1, level.maxNum); answer = a * b;

--- a/gamesformykids/app/games/balloon-pop/useBalloonPopLoop.ts
+++ b/gamesformykids/app/games/balloon-pop/useBalloonPopLoop.ts
@@ -22,6 +22,7 @@ import {
   BOMB_CHANCE,
   type Balloon,
 } from './balloonPopStore';
+import { getRandomItem } from '@/lib/utils';
 
 export function useBalloonPopLoop() {
   const timerRef = useRef<ReturnType<typeof setInterval> | null>(null);
@@ -50,7 +51,7 @@ export function useBalloonPopLoop() {
         y:  H + 40,
         r:  22 + Math.random() * 18,
         vy: -(0.8 + Math.random() * 1.2),
-        color: BALLOON_COLORS[Math.floor(Math.random() * BALLOON_COLORS.length)]!,
+        color: getRandomItem(BALLOON_COLORS)!,
         isBomb,
         popped:   false,
         popAnim:  0,

--- a/gamesformykids/app/games/brick-breaker/useBrickBreakerGame.ts
+++ b/gamesformykids/app/games/brick-breaker/useBrickBreakerGame.ts
@@ -1,9 +1,11 @@
 'use client';
 
-import { useCallback, useEffect } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 import { useShallow } from 'zustand/react/shallow';
 import { useBrickBreakerStore } from './brickBreakerStore';
 import { createCanvasArcadeHook } from '@/hooks/canvas';
+import { useHeldKeyControls, useKeyboardControls } from '@/hooks/shared/game-controls';
+import { spawnParticles, updateParticles, getRandomItem } from '@/lib/utils';
 import {
   W, H, PAD_W, PAD_H, PAD_Y, BALL_R, ROW_COLORS,
   type Phase, type BrickParticle,
@@ -65,7 +67,10 @@ const _useBrickBreaker = createCanvasArcadeHook({
             const overlapTop = s.ballY + BALL_R - y, overlapBottom = y + h - (s.ballY - BALL_R);
             if (Math.min(overlapLeft, overlapRight) < Math.min(overlapTop, overlapBottom)) s.ballVX *= -1; else s.ballVY *= -1;
             const colors = ROW_COLORS[s.bricks[i]!.row]!;
-            for (let p = 0; p < 6; p++) s.particles.push({ x: x + w / 2, y: y + h / 2, vx: (Math.random() - 0.5) * 5, vy: (Math.random() - 0.5) * 5, life: 1, color: colors[Math.floor(Math.random() * colors.length)]! });
+            s.particles.push(...spawnParticles<BrickParticle>({
+              count: 6, x: x + w / 2, y: y + h / 2, speed: 5,
+              extra: () => ({ color: getRandomItem(colors) }),
+            }));
             useBrickBreakerStore.getState().setScore(s.score);
           }
         }
@@ -80,7 +85,7 @@ const _useBrickBreaker = createCanvasArcadeHook({
           else { _nextLevelRef.current?.(nextLevel); }
         }
       }
-      s.particles = s.particles.filter(p => { p.x += p.vx; p.y += p.vy; p.vy += 0.15; p.life -= 0.04; return p.life > 0; });
+      s.particles = updateParticles(s.particles, { gravity: 0.15, decay: 0.04 });
     }
 
     drawBrickBreakerScene(ctx, {
@@ -136,27 +141,22 @@ export function useBrickBreakerGame() {
   const nudgeRight = () => { st.current.padX = Math.min(W - PAD_W, st.current.padX + 40); };
 
 
+  const heldRef = useRef({ left: false, right: false });
+  useHeldKeyControls({
+    ArrowLeft: { onDown: () => { heldRef.current.left = true; }, onUp: () => { heldRef.current.left = false; } },
+    ArrowRight: { onDown: () => { heldRef.current.right = true; }, onUp: () => { heldRef.current.right = false; } },
+  });
+  useKeyboardControls({ ' ': handleClick });
+
   useEffect(() => {
-    let left = false, right = false;
     const interval = setInterval(() => {
       const s = st.current;
       if (s.phase !== 'playing') return;
-      if (left) s.padX = Math.max(0, s.padX - 8);
-      if (right) s.padX = Math.min(W - PAD_W, s.padX + 8);
+      if (heldRef.current.left) s.padX = Math.max(0, s.padX - 8);
+      if (heldRef.current.right) s.padX = Math.min(W - PAD_W, s.padX + 8);
     }, 16);
-    const kd = (e: KeyboardEvent) => {
-      if (e.key === 'ArrowLeft') left = true;
-      if (e.key === 'ArrowRight') right = true;
-      if (e.code === 'Space') { e.preventDefault(); handleClick(); }
-    };
-    const ku = (e: KeyboardEvent) => {
-      if (e.key === 'ArrowLeft') left = false;
-      if (e.key === 'ArrowRight') right = false;
-    };
-    window.addEventListener('keydown', kd);
-    window.addEventListener('keyup', ku);
-    return () => { clearInterval(interval); window.removeEventListener('keydown', kd); window.removeEventListener('keyup', ku); };
-  }, [handleClick, st]);
+    return () => clearInterval(interval);
+  }, [st]);
 
   const { phase, score, best, lives, level } = useBrickBreakerStore(useShallow(s => ({ phase: s.phase, score: s.score, best: s.best, lives: s.lives, level: s.level })));
 

--- a/gamesformykids/app/games/bubbles/hooks/useBubbleGame.ts
+++ b/gamesformykids/app/games/bubbles/hooks/useBubbleGame.ts
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useRef } from 'react';
 import { useShallow } from 'zustand/react/shallow';
 import { useGameAudio } from '@/hooks/shared/audio/useGameAudio';
 import { useBubblesStore, type BubbleData } from '../bubblesStore';
+import { getRandomItem } from '@/lib/utils';
 
 const BUBBLE_TYPES = [
   { color: '#FF6B6B', frequency: 261.63 },
@@ -28,7 +29,7 @@ export function useBubbleGame() {
     if (!gameContainerRef.current) return;
     const currentLevel = Math.floor(useBubblesStore.getState().poppedCount / 15) + 1;
     const containerWidth = gameContainerRef.current.offsetWidth;
-    const bubbleType = BUBBLE_TYPES[Math.floor(Math.random() * BUBBLE_TYPES.length)]!;
+    const bubbleType = getRandomItem(BUBBLE_TYPES)!;
     const size = 40 + Math.random() * 60;
 
     const newBubble: BubbleData = {

--- a/gamesformykids/app/games/building/store/particleSlice.ts
+++ b/gamesformykids/app/games/building/store/particleSlice.ts
@@ -1,4 +1,5 @@
 import type { StateCreator } from 'zustand';
+import { spawnParticles, updateParticles } from '@/lib/utils';
 import type { BuildingStore } from './buildingStore';
 import type { Particle } from '../types';
 
@@ -13,31 +14,24 @@ export const createParticleSlice: StateCreator<BuildingStore, [], [], ParticleSl
   particles: [],
 
   createParticles: (x, y, color) => {
-    const newParticles: Particle[] = Array.from({ length: 10 }, (_, i) => ({
-      id: `particle-${Date.now()}-${i}`,
+    const newParticles = spawnParticles<Particle>({
+      count: 10,
       x: x + 30,
       y: y + 30,
-      vx: (Math.random() - 0.5) * 8,
-      vy: Math.random() * -8 - 2,
+      velocity: () => ({ vx: (Math.random() - 0.5) * 8, vy: Math.random() * -8 - 2 }),
       life: 30,
-      color,
-      size: Math.random() * 4 + 2,
-    }));
+      extra: (i) => ({ id: `particle-${Date.now()}-${i}`, color, size: Math.random() * 4 + 2 }),
+    });
     set((s) => ({ particles: [...s.particles, ...newParticles] }));
   },
 
   tickParticles: () => {
     set((s) => ({
-      particles: s.particles
-        .map((p) => ({
-          ...p,
-          x: p.x + p.vx,
-          y: p.y + p.vy,
-          vy: p.vy + 0.5,
-          life: p.life - 1,
-          size: Math.max(0, (p.size ?? 6) - 0.2),
-        }))
-        .filter((p) => p.life > 0),
+      particles: updateParticles(s.particles, {
+        gravity: 0.5,
+        decay: 1,
+        extra: (p) => ({ size: Math.max(0, (p.size ?? 6) - 0.2) }),
+      }),
     }));
   },
 

--- a/gamesformykids/app/games/catch-fruit/useCatchFruitGame.ts
+++ b/gamesformykids/app/games/catch-fruit/useCatchFruitGame.ts
@@ -4,6 +4,7 @@ import { useRef } from 'react';
 import { useShallow } from 'zustand/react/shallow';
 import { useCatchFruitStore, GAME_DURATION } from './catchFruitStore';
 import { createCanvasArcadeHook } from '@/hooks/canvas';
+import { getRandomItem } from '@/lib/utils';
 
 export const W = 360;
 export const H = 520;
@@ -43,7 +44,7 @@ const _useCatchFruit = createCanvasArcadeHook({
       if (s.nextItem <= 0) {
         const isBad = Math.random() < 0.18;
         const emojis = isBad ? BAD_ITEMS : GOOD_FRUITS;
-        s.items.push({ id: idCounter++, x: FRUIT_R + Math.random() * (W - FRUIT_R * 2), y: -FRUIT_R, speed: 2.5 + Math.random() * 2 + s.frame / 600, emoji: emojis[Math.floor(Math.random() * emojis.length)]!, isBad });
+        s.items.push({ id: idCounter++, x: FRUIT_R + Math.random() * (W - FRUIT_R * 2), y: -FRUIT_R, speed: 2.5 + Math.random() * 2 + s.frame / 600, emoji: getRandomItem(emojis)!, isBad });
         s.nextItem = 35 + Math.random() * 30;
       }
       for (const item of s.items) item.y += item.speed;

--- a/gamesformykids/app/games/color-tap/colorTapStore.ts
+++ b/gamesformykids/app/games/color-tap/colorTapStore.ts
@@ -3,6 +3,7 @@ import { useGameDifficulty } from '@/lib/stores/gameDifficultyStore';
 import { setupLivesTimer } from '@/lib/stores/livesTimerHelpers';
 import { makeLivesInitial, DEFAULT_DIFFICULTY_LIVES } from '@/lib/stores/utils/sliceUtils';
 import type { LivesGameState } from '@/lib/types';
+import { shuffle } from '@/lib/utils';
 
 // ── Color data ──────────────────────────────────────────────────────────────
 
@@ -25,8 +26,8 @@ export interface Question {
 }
 
 function makeQuestion(): Question {
-  const shuffled = [...COLORS].sort(() => Math.random() - 0.5) as ColorItem[];
-  return { target: shuffled[0]!, options: shuffled.slice(0, 4).sort(() => Math.random() - 0.5) };
+  const shuffled = shuffle(COLORS) as ColorItem[];
+  return { target: shuffled[0]!, options: shuffle(shuffled.slice(0, 4)) };
 }
 
 // ── Store ───────────────────────────────────────────────────────────────────

--- a/gamesformykids/app/games/cooking-game/useCookingGame.ts
+++ b/gamesformykids/app/games/cooking-game/useCookingGame.ts
@@ -2,6 +2,7 @@
 import { useState, useRef, useCallback, useEffect } from 'react';
 import { speakHebrew } from '@/lib/utils/speech/speaker';
 import { shuffle } from '@/lib/utils/game/cardUtils';
+import { getRandomItem } from '@/lib/utils';
 
 interface Ingredient { name: string; emoji: string; label: string; plural: string; }
 
@@ -98,7 +99,7 @@ export function useCookingGame() {
 
   const startGame = useCallback(() => {
     const order = Array.from({ length: RECIPES.length }, (_, i) => i);
-    const idx = order[Math.floor(Math.random() * order.length)]!;
+    const idx = getRandomItem(order)!;
     setRecipeIdx(idx);
     setStepIdx(0);
     setTapped(0);

--- a/gamesformykids/app/games/counting/useCountingGame.ts
+++ b/gamesformykids/app/games/counting/useCountingGame.ts
@@ -5,6 +5,7 @@ import { BaseGameItem } from "@/lib/types/core/base";
 import { speakHebrew } from "@/lib/utils/speech/enhancedSpeechUtils";
 import { useGameAudio } from "@/hooks/shared/audio/useGameAudio";
 import { getRandomItem } from "@/lib/utils/game/gameUtils";
+import { shuffle } from "@/lib/utils";
 import { COUNTING_GAME_CONSTANTS } from "@/lib/constants";
 import { useCountingChallengeStore } from "@/lib/stores/countingChallengeStore";
 import { useNumericQuizRuntime } from "@/hooks/games/useNumericQuizRuntime";
@@ -40,11 +41,8 @@ function generateCountingChallenge(level: number, items: BaseGameItem[]): Counti
 function generateCountingOptions(correctAnswer: number, level: number): number[] {
   const maxCount = getMaxCount(level);
   const allNumbers = Array.from({ length: maxCount }, (_, i) => i + 1);
-  const incorrect = allNumbers
-    .filter(n => n !== correctAnswer)
-    .sort(() => Math.random() - 0.5)
-    .slice(0, 3);
-  return [...incorrect, correctAnswer].sort(() => Math.random() - 0.5);
+  const incorrect = shuffle(allNumbers.filter(n => n !== correctAnswer)).slice(0, 3);
+  return shuffle([...incorrect, correctAnswer]);
 }
 
 function toChallengeItem(challenge: CountingChallenge): BaseGameItem {

--- a/gamesformykids/app/games/dino-runner/useDinoRunnerGame.ts
+++ b/gamesformykids/app/games/dino-runner/useDinoRunnerGame.ts
@@ -1,9 +1,11 @@
 'use client';
 
-import { useCallback, useEffect } from 'react';
+import { useCallback } from 'react';
 import { useShallow } from 'zustand/react/shallow';
 import { useDinoRunnerStore } from './dinoRunnerStore';
 import { createCanvasArcadeHook } from '@/hooks/canvas';
+import { useKeyboardControls } from '@/hooks/shared/game-controls';
+import { getRandomItem } from '@/lib/utils';
 
 export const W = 400;
 export const H = 220;
@@ -59,7 +61,7 @@ const _useDinoRunner = createCanvasArcadeHook({
           x: W + 20,
           w,
           h,
-          emoji: OBSTACLE_EMOJIS[Math.floor(Math.random() * OBSTACLE_EMOJIS.length)]!,
+          emoji: getRandomItem(OBSTACLE_EMOJIS)!,
         });
         s.nextObstacle = 60 + Math.random() * 80;
       }
@@ -159,13 +161,7 @@ export function useDinoRunnerGame() {
   }, [st]);
 
 
-  useEffect(() => {
-    const handler = (e: KeyboardEvent) => {
-      if (e.code === 'Space' || e.code === 'ArrowUp') { e.preventDefault(); jump(); }
-    };
-    window.addEventListener('keydown', handler);
-    return () => window.removeEventListener('keydown', handler);
-  }, [jump]);
+  useKeyboardControls({ ' ': jump, ArrowUp: jump });
 
   const handleTap = (e?: React.MouseEvent | React.TouchEvent) => {
     e?.preventDefault();

--- a/gamesformykids/app/games/emoji-math/emojiMathStore.ts
+++ b/gamesformykids/app/games/emoji-math/emojiMathStore.ts
@@ -3,7 +3,7 @@ import { useGameDifficulty } from '@/lib/stores/gameDifficultyStore';
 import { setupLivesTimer } from '@/lib/stores/livesTimerHelpers';
 import { makeLivesInitial, DEFAULT_DIFFICULTY_LIVES } from '@/lib/stores/utils/sliceUtils';
 import type { LivesGameState } from '@/lib/types';
-import { randInt as rnd } from '@/lib/utils';
+import { randInt as rnd, shuffle, getRandomItem } from '@/lib/utils';
 
 // ── Question helpers ────────────────────────────────────────────────────────
 
@@ -16,7 +16,7 @@ export interface Question {
   choices: number[]; emojiA: string; emojiB: string;
 }
 
-function pickEmoji() { return EMOJIS[Math.floor(Math.random() * EMOJIS.length)]; }
+function pickEmoji() { return getRandomItem(EMOJIS); }
 
 export function makeQuestion(level: number): Question {
   const maxNum = Math.min(5 + level * 2, 15);
@@ -33,7 +33,7 @@ export function makeQuestion(level: number): Question {
     const w = answer + rnd(-3, 3);
     if (w !== answer && w >= 0 && w <= 20) wrong.add(w);
   }
-  const choices = [...wrong, answer].sort(() => Math.random() - 0.5);
+  const choices = shuffle([...wrong, answer]);
   const e1 = pickEmoji()!, e2 = op === '+' ? pickEmoji()! : e1;
   return { a, b, op, answer, choices, emojiA: e1, emojiB: e2 };
 }

--- a/gamesformykids/app/games/escape-room/components/PuzzleOverlay.tsx
+++ b/gamesformykids/app/games/escape-room/components/PuzzleOverlay.tsx
@@ -1,6 +1,7 @@
 'use client';
 import { useState, useMemo, useRef, useEffect } from 'react';
 import type { Hotspot, Puzzle } from './puzzleData';
+import { shuffle } from '@/lib/utils';
 
 type Props = {
   hotspot: Hotspot;
@@ -20,7 +21,7 @@ export default function PuzzleOverlay({ hotspot, puzzle, hintsUsed, onAnswer, on
   useEffect(() => () => clearTimeout(dismissTimerRef.current), []);
 
   const choices = useMemo(
-    () => [puzzle.answer, ...puzzle.wrongOptions].sort(() => Math.random() - 0.5),
+    () => shuffle([puzzle.answer, ...puzzle.wrongOptions]),
     [puzzle],
   );
 

--- a/gamesformykids/app/games/escape-room/escapeRoomStore.ts
+++ b/gamesformykids/app/games/escape-room/escapeRoomStore.ts
@@ -1,6 +1,7 @@
 'use client';
 import { create } from 'zustand';
 import { ROOMS, type Room, type Hotspot, type Puzzle } from './components/puzzleData';
+import { getRandomItem } from '@/lib/utils';
 
 type Phase = 'menu' | 'playing' | 'result';
 
@@ -88,7 +89,7 @@ export const useEscapeRoomStore = create<State & Actions>((set, get) => ({
     if (!activePuzzle || hintsUsed >= 3) return null;
     set({ hintsUsed: hintsUsed + 1 });
     const wrong = activePuzzle.puzzle.wrongOptions;
-    const eliminated = wrong[Math.floor(Math.random() * wrong.length)]!;
+    const eliminated = getRandomItem(wrong)!;
     return `הרמז: "${eliminated}" היא תשובה שגויה.`;
   },
 

--- a/gamesformykids/app/games/frogger/useFroggerGame.ts
+++ b/gamesformykids/app/games/frogger/useFroggerGame.ts
@@ -1,9 +1,10 @@
 'use client';
 
-import { useCallback, useEffect, useRef } from 'react';
+import { useCallback, useRef } from 'react';
 import { useShallow } from 'zustand/react/shallow';
 import { useFroggerStore } from './froggerStore';
 import { createCanvasArcadeHook } from '@/hooks/canvas';
+import { useKeyboardControls } from '@/hooks/shared/game-controls';
 
 const CELL = 40;
 const COLS = 9;
@@ -148,18 +149,12 @@ export function useFroggerGame() {
   };
 
 
-  useEffect(() => {
-    const kd = (e: KeyboardEvent) => {
-      if (!['ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight', 'w', 'a', 's', 'd'].includes(e.key)) return;
-      e.preventDefault();
-      if (e.key === 'ArrowUp'    || e.key === 'w') moveFrog(0, -1);
-      if (e.key === 'ArrowDown'  || e.key === 's') moveFrog(0,  1);
-      if (e.key === 'ArrowLeft'  || e.key === 'a') moveFrog(-1, 0);
-      if (e.key === 'ArrowRight' || e.key === 'd') moveFrog(1, 0);
-    };
-    window.addEventListener('keydown', kd);
-    return () => window.removeEventListener('keydown', kd);
-  }, [moveFrog]);
+  useKeyboardControls({
+    ArrowUp: () => moveFrog(0, -1), w: () => moveFrog(0, -1),
+    ArrowDown: () => moveFrog(0, 1), s: () => moveFrog(0, 1),
+    ArrowLeft: () => moveFrog(-1, 0), a: () => moveFrog(-1, 0),
+    ArrowRight: () => moveFrog(1, 0), d: () => moveFrog(1, 0),
+  });
 
   const { phase, score, lives, best } = useFroggerStore(useShallow(s => ({ phase: s.phase, score: s.score, lives: s.lives, best: s.best })));
 

--- a/gamesformykids/app/games/hangman/hangmanStore.ts
+++ b/gamesformykids/app/games/hangman/hangmanStore.ts
@@ -1,6 +1,7 @@
 'use client';
 import { create } from 'zustand';
 import { WORD_CATEGORIES, CATEGORY_NAMES, type WordEntry } from './data/wordCategories';
+import { getRandomItem } from '@/lib/utils';
 
 const MAX_WRONG = 6;
 
@@ -27,7 +28,7 @@ interface Actions {
 }
 
 function pickRandom<T>(arr: T[]): T {
-  return arr[Math.floor(Math.random() * arr.length)]!;
+  return getRandomItem(arr);
 }
 
 export const useHangmanStore = create<State & Actions>((set, get) => ({

--- a/gamesformykids/app/games/hebrew-letters/store/slices/audioSlice.ts
+++ b/gamesformykids/app/games/hebrew-letters/store/slices/audioSlice.ts
@@ -6,6 +6,7 @@ import {
   ENCOURAGEMENT_MESSAGES,
   STEP_MESSAGES,
 } from '../../constants/hebrewLettersConstants';
+import { getRandomItem } from '@/lib/utils';
 
 export type AudioSlice = {
   isAudioEnabled: boolean;
@@ -41,7 +42,7 @@ export const createAudioSlice: StateCreator<HebrewLettersStore, [['zustand/devto
   playEncouragementSound: () => {
     const { isAudioEnabled, speakText } = get();
     if (!isAudioEnabled) return;
-    const msg = ENCOURAGEMENT_MESSAGES[Math.floor(Math.random() * ENCOURAGEMENT_MESSAGES.length)]!;
+    const msg = getRandomItem([...ENCOURAGEMENT_MESSAGES]);
     speakText(msg);
   },
 

--- a/gamesformykids/app/games/hebrew-letters/store/slices/statsSlice.ts
+++ b/gamesformykids/app/games/hebrew-letters/store/slices/statsSlice.ts
@@ -6,6 +6,7 @@ import {
   DEFAULT_LEARNING_STATS,
   ENCOURAGEMENT_MESSAGES,
 } from '../../constants/hebrewLettersConstants';
+import { getRandomItem } from '@/lib/utils';
 
 // Module-level ref lives here since showEncouragement/hideEncouragement manage it
 let encouragementTimerRef: ReturnType<typeof setTimeout> | null = null;
@@ -28,7 +29,7 @@ export const createStatsSlice: StateCreator<HebrewLettersStore, [['zustand/devto
     if (encouragementTimerRef) clearTimeout(encouragementTimerRef);
     const msg =
       message ??
-      ENCOURAGEMENT_MESSAGES[Math.floor(Math.random() * ENCOURAGEMENT_MESSAGES.length)]!;
+      getRandomItem([...ENCOURAGEMENT_MESSAGES]);
     set(
       { encouragementState: { showEncouragement: true, currentMessage: msg, isStepCompleted: false } },
       false,

--- a/gamesformykids/app/games/hebrew-racer/components/HebrewRacerScreen.tsx
+++ b/gamesformykids/app/games/hebrew-racer/components/HebrewRacerScreen.tsx
@@ -3,12 +3,9 @@ import { useEffect, useState, useCallback } from 'react';
 import { useHebrewRacerStore } from '../hebrewRacerStore';
 import { speakHebrew } from '@/lib/utils/speech/speaker';
 import { TOTAL_CHECKPOINTS } from '../hebrewRacerData';
+import { shuffle, getRandomItem } from '@/lib/utils';
 
 const OBSTACLES = ['🪨', '🌵', '🏔️', '🚧', '🌊'];
-
-function shuffle<T>(arr: T[]): T[] {
-  return [...arr].sort(() => Math.random() - 0.5);
-}
 
 export default function HebrewRacerScreen() {
   const {
@@ -18,7 +15,7 @@ export default function HebrewRacerScreen() {
   } = useHebrewRacerStore();
 
   const [choices, setChoices] = useState<string[]>([]);
-  const [obstacleEmoji] = useState(() => OBSTACLES[Math.floor(Math.random() * OBSTACLES.length)] ?? '🪨');
+  const [obstacleEmoji] = useState(() => getRandomItem(OBSTACLES));
 
   // Shuffle choices when a new question appears
   useEffect(() => {

--- a/gamesformykids/app/games/jumper/useJumperGame.ts
+++ b/gamesformykids/app/games/jumper/useJumperGame.ts
@@ -1,9 +1,9 @@
 'use client';
 
-import { useEffect } from 'react';
 import { useShallow } from 'zustand/react/shallow';
 import { useJumperStore } from './jumperStore';
 import { createCanvasArcadeHook } from '@/hooks/canvas';
+import { useHeldKeyControls } from '@/hooks/shared/game-controls';
 import {
   W, H, GRAVITY, JUMP_VY, PLAT_H, PLAYER_R, PLAT_GAP, INIT_PLATS,
   type JumperState,
@@ -117,19 +117,12 @@ export function useJumperGame() {
   const releaseRight = () => { st.current.rightDown = false; };
 
 
-  useEffect(() => {
-    const kd = (e: KeyboardEvent) => {
-      if (e.key === 'ArrowLeft'  || e.key === 'a') st.current.leftDown  = true;
-      if (e.key === 'ArrowRight' || e.key === 'd') st.current.rightDown = true;
-    };
-    const ku = (e: KeyboardEvent) => {
-      if (e.key === 'ArrowLeft'  || e.key === 'a') st.current.leftDown  = false;
-      if (e.key === 'ArrowRight' || e.key === 'd') st.current.rightDown = false;
-    };
-    window.addEventListener('keydown', kd);
-    window.addEventListener('keyup', ku);
-    return () => { window.removeEventListener('keydown', kd); window.removeEventListener('keyup', ku); };
-  }, [st]);
+  useHeldKeyControls({
+    ArrowLeft: { onDown: pressLeft, onUp: releaseLeft },
+    a: { onDown: pressLeft, onUp: releaseLeft },
+    ArrowRight: { onDown: pressRight, onUp: releaseRight },
+    d: { onDown: pressRight, onUp: releaseRight },
+  });
 
   const handleTouchMove = (e: React.TouchEvent<HTMLCanvasElement>) => {
     e.preventDefault();

--- a/gamesformykids/app/games/letter-bubble-shooter/bubbleShooterGrid.ts
+++ b/gamesformykids/app/games/letter-bubble-shooter/bubbleShooterGrid.ts
@@ -1,4 +1,5 @@
 import { COLS, GRID_ROWS, R, DIA, LETTERS } from './bubbleShooterConstants';
+import { getRandomItem } from '@/lib/utils';
 
 export function bx(col: number, row: number, W: number): number {
   const offset = row % 2 === 1 ? R + 1 : 0;
@@ -10,7 +11,7 @@ export function colsInRow(row: number): number { return row % 2 === 0 ? COLS : C
 export function mkGrid(): (string | null)[][] {
   return Array.from({ length: GRID_ROWS }, (_, row) =>
     Array.from({ length: COLS }, (_, col) =>
-      col < colsInRow(row) && row < 5 ? LETTERS[Math.floor(Math.random() * LETTERS.length)]! : null
+      col < colsInRow(row) && row < 5 ? getRandomItem(LETTERS)! : null
     )
   );
 }

--- a/gamesformykids/app/games/letter-bubble-shooter/useBubbleShooterGame.ts
+++ b/gamesformykids/app/games/letter-bubble-shooter/useBubbleShooterGame.ts
@@ -6,6 +6,7 @@ import { COLS, GRID_ROWS, R, DIA, SPEED, MIN_MATCH, LETTERS, COLORS } from './bu
 import type { Phase, FlyBubble, PopAnim } from './bubbleShooterConstants';
 import { bx, by, mkGrid, flood, snapToGrid, isGridClear, gridTooLow } from './bubbleShooterGrid';
 import { drawBubble } from './bubbleShooterRenderer';
+import { getRandomItem } from '@/lib/utils';
 
 export function useBubbleShooterGame() {
   const [phase, setPhase] = useState<Phase>('menu');
@@ -14,8 +15,8 @@ export function useBubbleShooterGame() {
 
   const gridRef = useRef<(string|null)[][]>(mkGrid());
   const flyRef = useRef<FlyBubble | null>(null);
-  const currentRef = useRef<string>(LETTERS[Math.floor(Math.random() * LETTERS.length)]!);
-  const nextRef = useRef<string>(LETTERS[Math.floor(Math.random() * LETTERS.length)]!);
+  const currentRef = useRef<string>(getRandomItem(LETTERS)!);
+  const nextRef = useRef<string>(getRandomItem(LETTERS)!);
   const aimRef = useRef<number>(-Math.PI / 2);
   const popsRef = useRef<PopAnim[]>([]);
   const scoreRef = useRef(0);
@@ -29,8 +30,8 @@ export function useBubbleShooterGame() {
   const startGame = useCallback(() => {
     gridRef.current = mkGrid();
     flyRef.current = null;
-    currentRef.current = LETTERS[Math.floor(Math.random() * LETTERS.length)]!;
-    nextRef.current = LETTERS[Math.floor(Math.random() * LETTERS.length)]!;
+    currentRef.current = getRandomItem(LETTERS)!;
+    nextRef.current = getRandomItem(LETTERS)!;
     aimRef.current = -Math.PI / 2;
     popsRef.current = [];
     scoreRef.current = 0;
@@ -71,7 +72,7 @@ export function useBubbleShooterGame() {
       vx: Math.cos(angle) * SPEED, vy: Math.sin(angle) * SPEED,
     };
     currentRef.current = nextRef.current;
-    nextRef.current = LETTERS[Math.floor(Math.random() * LETTERS.length)]!;
+    nextRef.current = getRandomItem(LETTERS)!;
   }, []);
 
   const handlePointer = useCallback((e: React.PointerEvent<HTMLElement>) => {

--- a/gamesformykids/app/games/letter-race/letterRaceStore.ts
+++ b/gamesformykids/app/games/letter-race/letterRaceStore.ts
@@ -2,6 +2,7 @@ import { makePersistStore } from '@/lib/stores/createStore';
 import { setupGameTimer } from '@/lib/stores/gameTimerHelpers';
 import { useGameDifficulty } from '@/lib/stores/gameDifficultyStore';
 import type { PhaseDead as Phase } from '@/lib/types';
+import { shuffle, getRandomItem } from '@/lib/utils';
 
 export const GAME_TIME = 30;
 
@@ -64,17 +65,17 @@ export interface LetterQuestion {
 }
 
 export function makeLetterQ(): LetterQuestion {
-  const item = WORDS[Math.floor(Math.random() * WORDS.length)]!;
+  const item = getRandomItem(WORDS)!;
   const wrong = new Set<string>();
   while (wrong.size < 3) {
-    const l = HEBREW_LETTERS[Math.floor(Math.random() * HEBREW_LETTERS.length)]!;
+    const l = getRandomItem(HEBREW_LETTERS)!;
     if (l !== item.letter) wrong.add(l);
   }
   return {
     emoji: item.emoji,
     word: item.word,
     answer: item.letter,
-    choices: [...wrong, item.letter].sort(() => Math.random() - 0.5),
+    choices: shuffle([...wrong, item.letter]),
   };
 }
 

--- a/gamesformykids/app/games/letter-slicer/useLetterSlicerGame.ts
+++ b/gamesformykids/app/games/letter-slicer/useLetterSlicerGame.ts
@@ -2,6 +2,7 @@
 import { useState, useRef, useCallback, useEffect } from 'react';
 import { useCanvasLoop } from '@/hooks/canvas/useCanvasLoop';
 import { speakHebrew } from '@/lib/utils/speech/speaker';
+import { getRandomItem } from '@/lib/utils';
 
 const WORDS = [
   { word: 'כלב',    color: '#3b82f6' }, { word: 'חתול',   color: '#ef4444' },
@@ -49,7 +50,7 @@ export function useLetterSlicerGame() {
   const pickTarget = useCallback(() => {
     const pool = bubblesRef.current;
     if (!pool.length) return;
-    const t = pool[Math.floor(Math.random() * pool.length)]!.word;
+    const t = getRandomItem(pool)!.word;
     targetRef.current = t;
     setTarget(t);
     speakHebrew(`חֲתוֹךְ אֶת: ${t}`);
@@ -99,7 +100,7 @@ export function useLetterSlicerGame() {
 
     spawnTimer.current -= dt;
     if (spawnTimer.current <= 0 && bubblesRef.current.length < MAX_BUBBLES) {
-      const item = WORDS[Math.floor(Math.random() * WORDS.length)]!;
+      const item = getRandomItem(WORDS)!;
       const fromLeft = Math.random() < 0.5;
       const x = fromLeft ? -R : W + R;
       const y = H * (0.45 + Math.random() * 0.35);

--- a/gamesformykids/app/games/letter-trace/letterTraceStore.ts
+++ b/gamesformykids/app/games/letter-trace/letterTraceStore.ts
@@ -1,6 +1,7 @@
 'use client';
 import { create } from 'zustand';
 import { HEBREW_LETTER_PATHS, type HebrewLetterPath } from '@/lib/constants/gameData/hebrewLetterPaths';
+import { shuffle } from '@/lib/utils';
 
 export type TraceDifficulty = 'guided' | 'free';
 export type TracePhase = 'menu' | 'tracing' | 'result';
@@ -32,7 +33,7 @@ export const useLetterTraceStore = create<LetterTraceState & LetterTraceActions>
     set({
       phase: 'tracing',
       difficulty,
-      letters: [...HEBREW_LETTER_PATHS].sort(() => Math.random() - 0.5),
+      letters: shuffle(HEBREW_LETTER_PATHS),
       currentIndex: 0,
       score: 0,
       total: 0,

--- a/gamesformykids/app/games/market-game/marketStore.ts
+++ b/gamesformykids/app/games/market-game/marketStore.ts
@@ -1,6 +1,7 @@
 'use client';
 
 import { create } from 'zustand';
+import { getRandomItem } from '@/lib/utils';
 
 export type Difficulty = 'easy' | 'medium' | 'hard';
 
@@ -41,7 +42,7 @@ const CUSTOMER_EMOJIS = ['👦', '👧', '👴', '👵', '🧒', '🧑', '👱',
 const CUSTOMER_NAMES = ['יעל', 'נועם', 'תום', 'מיה', 'ארי', 'לי', 'עדן', 'איתי'];
 
 function randomItem() {
-  return ITEMS[Math.floor(Math.random() * ITEMS.length)]!;
+  return getRandomItem(ITEMS)!;
 }
 
 function getMaxCount(difficulty: Difficulty) {

--- a/gamesformykids/app/games/math-race/mathRaceStore.ts
+++ b/gamesformykids/app/games/math-race/mathRaceStore.ts
@@ -2,7 +2,7 @@ import { makePersistStore } from '@/lib/stores/createStore';
 import { setupGameTimer } from '@/lib/stores/gameTimerHelpers';
 import { useGameDifficulty } from '@/lib/stores/gameDifficultyStore';
 import type { ArithOp as Op, PhaseDead as Phase } from '@/lib/types';
-import { randInt as rnd } from '@/lib/utils';
+import { randInt as rnd, shuffle } from '@/lib/utils';
 
 const DIFFICULTY_TIME = { easy: 45, medium: 30, hard: 20 } as const;
 
@@ -32,7 +32,7 @@ export function makeQ(score: number): Question {
     const w = answer + rnd(-5, 5) * (level < 3 ? 1 : 2);
     if (w !== answer && w >= 0) wrong.add(w);
   }
-  return { text, answer, choices: [...wrong, answer].sort(() => Math.random() - 0.5) };
+  return { text, answer, choices: shuffle([...wrong, answer]) };
 }
 
 // ── Store ───────────────────────────────────────────────────────────────────

--- a/gamesformykids/app/games/math/hooks/useMathGame.ts
+++ b/gamesformykids/app/games/math/hooks/useMathGame.ts
@@ -5,6 +5,7 @@ import { BaseGameItem } from "@/lib/types/core/base";
 import { speakHebrew } from "@/lib/utils/speech/enhancedSpeechUtils";
 import { useGameAudio } from "@/hooks/shared/audio/useGameAudio";
 import { delay, getRandomItem } from "@/lib/utils/game/gameUtils";
+import { shuffle } from "@/lib/utils";
 import { MATH_GAME_CONSTANTS } from "@/lib/constants";
 import { useMathChallengeStore } from "@/lib/stores/mathChallengeStore";
 import { useNumericQuizRuntime } from "@/hooks/games/useNumericQuizRuntime";
@@ -58,10 +59,10 @@ function generateMathOptions(correctAnswer: number, level: number): number[] {
 
   const close = incorrectNumbers.filter(n => Math.abs(n - correctAnswer) <= 3 && n >= 0);
   const pool = close.length >= 3
-    ? close.sort(() => Math.random() - 0.5)
-    : [...close, ...incorrectNumbers.filter(n => n >= 0)].sort(() => Math.random() - 0.5);
+    ? shuffle(close)
+    : shuffle([...close, ...incorrectNumbers.filter(n => n >= 0)]);
 
-  return [...pool.slice(0, 3), correctAnswer].sort(() => Math.random() - 0.5);
+  return shuffle([...pool.slice(0, 3), correctAnswer]);
 }
 
 function toChallengeItem(challenge: MathChallenge): BaseGameItem {

--- a/gamesformykids/app/games/maze/useMazeGame.ts
+++ b/gamesformykids/app/games/maze/useMazeGame.ts
@@ -1,6 +1,6 @@
 'use client';
-import { useEffect } from 'react';
 import { useMazeStore } from './mazeStore';
+import { useKeyboardControls } from '@/hooks/shared/game-controls';
 
 export function useMazeGame() {
   const phase = useMazeStore(s => s.phase);
@@ -12,19 +12,12 @@ export function useMazeGame() {
   const nextLevel = useMazeStore(s => s.nextLevel);
   const reset = useMazeStore(s => s.reset);
 
-  useEffect(() => {
-    if (phase !== 'playing') return;
-    function handleKey(e: KeyboardEvent) {
-      switch (e.key) {
-        case 'ArrowUp':    e.preventDefault(); move('N'); break;
-        case 'ArrowDown':  e.preventDefault(); move('S'); break;
-        case 'ArrowLeft':  e.preventDefault(); move('W'); break;
-        case 'ArrowRight': e.preventDefault(); move('E'); break;
-      }
-    }
-    window.addEventListener('keydown', handleKey);
-    return () => window.removeEventListener('keydown', handleKey);
-  }, [phase, move]);
+  useKeyboardControls({
+    ArrowUp: () => move('N'),
+    ArrowDown: () => move('S'),
+    ArrowLeft: () => move('W'),
+    ArrowRight: () => move('E'),
+  }, phase === 'playing');
 
   return { phase, level, starsCollectedThisLevel, totalStarsCollected, startGame, move, nextLevel, reset };
 }

--- a/gamesformykids/app/games/memory/stores/useMemoryStore.ts
+++ b/gamesformykids/app/games/memory/stores/useMemoryStore.ts
@@ -1,6 +1,7 @@
 'use client';
 
 import { makeStore } from '@/lib/stores/createStore';
+import { shuffle } from '@/lib/utils';
 import {
   createShuffledMemoryCards,
 } from '@/lib/utils/game/gameUtils';
@@ -119,7 +120,7 @@ export const useMemoryStore = makeStore<MemoryStoreState & MemoryStoreActions>(
       const currentDifficulty = targetDifficulty ?? state.difficulty;
       const config = MEMORY_GAME_CONSTANTS.DIFFICULTY_LEVELS[currentDifficulty];
 
-      const shuffled = [...MEMORY_GAME_ANIMALS].sort(() => Math.random() - 0.5);
+      const shuffled = shuffle(MEMORY_GAME_ANIMALS);
       const animals = shuffled.slice(0, config.pairs);
       const genericCards = createShuffledMemoryCards(animals);
       const cards: MemoryCard[] = genericCards.map((card) => ({

--- a/gamesformykids/app/games/meteor-dodge/useMeteorDodgeGame.ts
+++ b/gamesformykids/app/games/meteor-dodge/useMeteorDodgeGame.ts
@@ -1,9 +1,11 @@
 'use client';
 
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import { useShallow } from 'zustand/react/shallow';
 import { useMeteorDodgeStore } from './meteorDodgeStore';
 import { createCanvasArcadeHook } from '@/hooks/canvas';
+import { useHeldKeyControls } from '@/hooks/shared/game-controls';
+import { getRandomItem } from '@/lib/utils';
 
 export const W = 360;
 export const H = 560;
@@ -41,12 +43,12 @@ const _useMeteorDodge = createCanvasArcadeHook({
       s.nextMeteor--;
       if (s.nextMeteor <= 0) {
         const r = 14 + Math.random() * 20;
-        s.meteors.push({ id: uid++, x: r + Math.random() * (W - r * 2), y: -r, r, speed: (1.8 + Math.random() * 2) * difficulty, emoji: METEOR_EMOJIS[Math.floor(Math.random() * METEOR_EMOJIS.length)]!, spin: (Math.random() - 0.5) * 0.1, angle: 0 });
+        s.meteors.push({ id: uid++, x: r + Math.random() * (W - r * 2), y: -r, r, speed: (1.8 + Math.random() * 2) * difficulty, emoji: getRandomItem(METEOR_EMOJIS)!, spin: (Math.random() - 0.5) * 0.1, angle: 0 });
         s.nextMeteor = Math.max(15, Math.floor((50 - s.score / 20)));
       }
       s.nextStar--;
       if (s.nextStar <= 0) {
-        s.stars.push({ id: uid++, x: 20 + Math.random() * (W - 40), y: -20, vy: 1.5 + Math.random(), emoji: STAR_EMOJIS[Math.floor(Math.random() * STAR_EMOJIS.length)]! });
+        s.stars.push({ id: uid++, x: 20 + Math.random() * (W - 40), y: -20, vy: 1.5 + Math.random(), emoji: getRandomItem(STAR_EMOJIS)! });
         s.nextStar = 100 + Math.random() * 100;
       }
 
@@ -139,19 +141,20 @@ export function useMeteorDodgeGame() {
   };
 
 
+  const heldRef = useRef({ left: false, right: false });
+  useHeldKeyControls({
+    ArrowLeft: { onDown: () => { heldRef.current.left = true; }, onUp: () => { heldRef.current.left = false; } },
+    ArrowRight: { onDown: () => { heldRef.current.right = true; }, onUp: () => { heldRef.current.right = false; } },
+  });
+
   useEffect(() => {
-    let left = false, right = false;
     const interval = setInterval(() => {
       const s = st.current;
       if (s.phase !== 'playing') return;
-      if (left) s.playerX = Math.max(PLAYER_R, s.playerX - 7);
-      if (right) s.playerX = Math.min(W - PLAYER_R, s.playerX + 7);
+      if (heldRef.current.left) s.playerX = Math.max(PLAYER_R, s.playerX - 7);
+      if (heldRef.current.right) s.playerX = Math.min(W - PLAYER_R, s.playerX + 7);
     }, 16);
-    const kd = (e: KeyboardEvent) => { if (e.key === 'ArrowLeft') left = true; if (e.key === 'ArrowRight') right = true; };
-    const ku = (e: KeyboardEvent) => { if (e.key === 'ArrowLeft') left = false; if (e.key === 'ArrowRight') right = false; };
-    window.addEventListener('keydown', kd);
-    window.addEventListener('keyup', ku);
-    return () => { clearInterval(interval); window.removeEventListener('keydown', kd); window.removeEventListener('keyup', ku); };
+    return () => clearInterval(interval);
   }, [st]);
 
   const nudgeLeft = () => {

--- a/gamesformykids/app/games/multiplication/data/tables.ts
+++ b/gamesformykids/app/games/multiplication/data/tables.ts
@@ -1,3 +1,5 @@
+import { shuffle } from '@/lib/utils';
+
 export interface MultiplicationQuestion {
   a: number;
   b: number;
@@ -18,7 +20,7 @@ export function generateQuestion(level: number): MultiplicationQuestion {
     if (wrong > 0 && wrong !== answer) wrongs.add(wrong);
   }
 
-  const choices = [answer, ...Array.from(wrongs)].sort(() => Math.random() - 0.5);
+  const choices = shuffle([answer, ...Array.from(wrongs)]);
   return { a, b, answer, choices };
 }
 

--- a/gamesformykids/app/games/number-slide/numberSlideStore.ts
+++ b/gamesformykids/app/games/number-slide/numberSlideStore.ts
@@ -1,5 +1,6 @@
 'use client';
 import { create } from 'zustand';
+import { getRandomItem } from '@/lib/utils';
 
 export type Grid = number[][];
 export type Direction = 'left' | 'right' | 'up' | 'down';
@@ -21,7 +22,7 @@ function getEmpties(grid: Grid): [number, number][] {
 function spawnTile(grid: Grid): Grid {
   const empties = getEmpties(grid);
   if (empties.length === 0) return grid;
-  const pick = empties[Math.floor(Math.random() * empties.length)]!;
+  const pick = getRandomItem(empties)!;
   const value = Math.random() < 0.8 ? 1 : 2;
   const newGrid = grid.map(r => [...r]);
   newGrid[pick[0]]![pick[1]] = value;

--- a/gamesformykids/app/games/number-slide/useNumberSlide.ts
+++ b/gamesformykids/app/games/number-slide/useNumberSlide.ts
@@ -1,7 +1,8 @@
 'use client';
 import { useEffect, useRef } from 'react';
-import { useNumberSlideStore, type Direction } from './numberSlideStore';
+import { useNumberSlideStore } from './numberSlideStore';
 import { speak } from '@/lib/utils/speech/enhancedSpeechUtils';
+import { useKeyboardControls } from '@/hooks/shared/game-controls';
 
 export function useNumberSlide() {
   const store = useNumberSlideStore();
@@ -18,18 +19,10 @@ export function useNumberSlide() {
   }, [lastMerges]);
 
   // Keyboard input
-  useEffect(() => {
-    const KEY_DIR: Record<string, Direction> = {
-      ArrowLeft: 'left', ArrowRight: 'right',
-      ArrowUp: 'up', ArrowDown: 'down',
-    };
-    const onKey = (e: KeyboardEvent) => {
-      const dir = KEY_DIR[e.key];
-      if (dir) { e.preventDefault(); slide(dir); }
-    };
-    window.addEventListener('keydown', onKey);
-    return () => window.removeEventListener('keydown', onKey);
-  }, [slide]);
+  useKeyboardControls({
+    ArrowLeft: () => slide('left'), ArrowRight: () => slide('right'),
+    ArrowUp: () => slide('up'), ArrowDown: () => slide('down'),
+  });
 
   const onTouchStart = (e: React.TouchEvent) => {
     const t = e.touches[0];

--- a/gamesformykids/app/games/pong/usePongGame.ts
+++ b/gamesformykids/app/games/pong/usePongGame.ts
@@ -1,9 +1,11 @@
 'use client';
 
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import { useShallow } from 'zustand/react/shallow';
 import { usePongStore } from './pongStore';
 import { createCanvasArcadeHook } from '@/hooks/canvas';
+import { useHeldKeyControls } from '@/hooks/shared/game-controls';
+import { spawnParticles, updateParticles, type BaseParticle } from '@/lib/utils';
 import type { PhaseResult as Phase } from '@/lib/types';
 
 export const W = 360;
@@ -22,13 +24,13 @@ const _usePong = createCanvasArcadeHook({
     playerX: W / 2 - PAD_W / 2, aiX: W / 2 - PAD_W / 2,
     ballX: W / 2, ballY: H / 2, ballVX: 3, ballVY: 4,
     playerScore: 0, aiScore: 0, frame: 0, startTime: 0,
-    particles: [] as { x: number; y: number; vx: number; vy: number; life: number }[],
+    particles: [] as BaseParticle[],
   }),
   onPointerX: (s, x) => { s.playerX = Math.max(0, Math.min(W - PAD_W, x - PAD_W / 2)); },
   draw: (ctx, s, _dt, saveRef) => {    s.frame++;
 
     function addParticles(x: number, y: number) {
-      for (let i = 0; i < 8; i++) s.particles.push({ x, y, vx: (Math.random() - 0.5) * 6, vy: (Math.random() - 0.5) * 6, life: 1 });
+      s.particles.push(...spawnParticles({ count: 8, x, y }));
     }
 
     function serveBall(direction: 1 | -1) {
@@ -65,7 +67,7 @@ const _usePong = createCanvasArcadeHook({
       if (s.ballY + BALL_R > H) { s.aiScore++; const aiWon = usePongStore.getState().aiScores(s.aiScore); if (aiWon) { s.phase = 'result'; saveRef.current({ score: s.playerScore, level: 1, durationSeconds: Math.round((Date.now() - s.startTime) / 1000) }); } else serveBall(-1); }
       if (s.ballY - BALL_R < 0) { s.playerScore++; const playerWon = usePongStore.getState().playerScores(s.playerScore); if (playerWon) { s.phase = 'result'; saveRef.current({ score: s.playerScore, level: 1, durationSeconds: Math.round((Date.now() - s.startTime) / 1000) }); } else serveBall(1); }
 
-      s.particles = s.particles.filter(p => { p.x += p.vx; p.y += p.vy; p.vy += 0.08; p.life -= 0.05; return p.life > 0; });
+      s.particles = updateParticles(s.particles, { gravity: 0.08, decay: 0.05 });
     }
 
     ctx.fillStyle = '#0F172A'; ctx.fillRect(0, 0, W, H);
@@ -118,25 +120,20 @@ export function usePongGame() {
   };
 
 
+  const heldRef = useRef({ left: false, right: false });
+  useHeldKeyControls({
+    ArrowLeft: { onDown: () => { heldRef.current.left = true; }, onUp: () => { heldRef.current.left = false; } },
+    ArrowRight: { onDown: () => { heldRef.current.right = true; }, onUp: () => { heldRef.current.right = false; } },
+  });
+
   useEffect(() => {
-    let left = false, right = false;
     const interval = setInterval(() => {
       const s = st.current;
       if (s.phase !== 'playing') return;
-      if (left) s.playerX = Math.max(0, s.playerX - 8);
-      if (right) s.playerX = Math.min(W - PAD_W, s.playerX + 8);
+      if (heldRef.current.left) s.playerX = Math.max(0, s.playerX - 8);
+      if (heldRef.current.right) s.playerX = Math.min(W - PAD_W, s.playerX + 8);
     }, 16);
-    const kd = (e: KeyboardEvent) => {
-      if (e.key === 'ArrowLeft') left = true;
-      if (e.key === 'ArrowRight') right = true;
-    };
-    const ku = (e: KeyboardEvent) => {
-      if (e.key === 'ArrowLeft') left = false;
-      if (e.key === 'ArrowRight') right = false;
-    };
-    window.addEventListener('keydown', kd);
-    window.addEventListener('keyup', ku);
-    return () => { clearInterval(interval); window.removeEventListener('keydown', kd); window.removeEventListener('keyup', ku); };
+    return () => clearInterval(interval);
   }, [st]);
 
   const { phase, playerScore, aiScore } = usePongStore(useShallow(s => ({ phase: s.phase, playerScore: s.playerScore, aiScore: s.aiScore })));

--- a/gamesformykids/app/games/puzzles/custom/CustomHelpModal.tsx
+++ b/gamesformykids/app/games/puzzles/custom/CustomHelpModal.tsx
@@ -2,78 +2,67 @@
 
 import { RotateCcw, Eye, Settings, Upload, Shuffle } from 'lucide-react';
 import { usePuzzleGame } from '../usePuzzleGame';
-import { useEscapeKey } from '@/hooks/shared/useEscapeKey';
+import HelpModalShell from '@/components/shared/overlays/HelpModalShell';
 
 export default function CustomHelpModal() {
   const { showHelp, toggleHelp } = usePuzzleGame();
-  useEscapeKey(toggleHelp, showHelp);
-  if (!showHelp) return null;
+
   return (
-    <div
-      className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50"
-      onClick={toggleHelp}
+    <HelpModalShell
+      isOpen={showHelp}
+      onClose={toggleHelp}
+      title="🧩 איך לשחק?"
+      cardClassName="rounded-2xl p-8 max-w-2xl mx-4 max-h-[80vh] overflow-y-auto"
     >
-      <div
-        className="bg-white rounded-2xl p-8 max-w-2xl mx-4 max-h-[80vh] overflow-y-auto"
-        role="dialog"
-        aria-modal="true"
-        aria-label="איך לשחק?"
-        onClick={(e) => e.stopPropagation()}
-      >
-        <div className="flex justify-between items-center mb-6">
-          <h2 className="text-2xl font-bold text-gray-800">🧩 איך לשחק?</h2>
-          <button onClick={toggleHelp} className="text-gray-500 hover:text-gray-700 text-2xl">×</button>
+      <div className="space-y-4 text-right">
+        <div className="bg-blue-50 p-4 rounded-lg">
+          <h3 className="font-bold text-blue-800 mb-2">📋 שלבי המשחק:</h3>
+          <ol className="list-decimal list-inside space-y-2 text-blue-700">
+            <li>העלה תמונה מהמחשב שלך</li>
+            <li>בחר רמת קושי (2x2 עד 5x5)</li>
+            <li>גרור את החלקים למקום הנכון בלוח</li>
+            <li>השלם את הפאזל במהירות הגבוהה ביותר!</li>
+          </ol>
         </div>
-        <div className="space-y-4 text-right">
-          <div className="bg-blue-50 p-4 rounded-lg">
-            <h3 className="font-bold text-blue-800 mb-2">📋 שלבי המשחק:</h3>
-            <ol className="list-decimal list-inside space-y-2 text-blue-700">
-              <li>העלה תמונה מהמחשב שלך</li>
-              <li>בחר רמת קושי (2x2 עד 5x5)</li>
-              <li>גרור את החלקים למקום הנכון בלוח</li>
-              <li>השלם את הפאזל במהירות הגבוהה ביותר!</li>
-            </ol>
-          </div>
-          <div className="bg-green-50 p-4 rounded-lg">
-            <h3 className="font-bold text-green-800 mb-2">💡 טיפים:</h3>
-            <ul className="list-disc list-inside space-y-2 text-green-700">
-              <li>חלקים נכונים יוצגו עם מסגרת ירוקה וכוכב</li>
-              <li>חלקים שגויים יוצגו עם מסגרת אדומה וX</li>
-              <li>ניתן לגרור חלקים מהלוח אם הם לא במקום הנכון</li>
-              <li>השתמש בכפתור &ldquo;רמזים&rdquo; לעזרה נוספת</li>
-            </ul>
-          </div>
-          <div className="bg-purple-50 p-4 rounded-lg">
-            <h3 className="font-bold text-purple-800 mb-2">🎮 פקדים:</h3>
-            <div className="grid grid-cols-1 sm:grid-cols-2 gap-2 text-purple-700">
-              <div className="flex items-center gap-2"><Upload className="w-4 h-4" /><span><strong>תמונה חדשה:</strong> החלף תמונה</span></div>
-              <div className="flex items-center gap-2"><Shuffle className="w-4 h-4" /><span><strong>ערבב חלקים:</strong> מערבב סדר</span></div>
-              <div className="flex items-center gap-2"><RotateCcw className="w-4 h-4" /><span><strong>התחל מחדש:</strong> מאפס משחק</span></div>
-              <div className="flex items-center gap-2"><Eye className="w-4 h-4" /><span><strong>רמזים:</strong> עזרות ויזואליות</span></div>
-              <div className="flex items-center gap-2"><Settings className="w-4 h-4" /><span><strong>ניפוי באגים:</strong> מידע טכני</span></div>
-            </div>
-          </div>
-          <div className="bg-orange-50 p-4 rounded-lg">
-            <h3 className="font-bold text-orange-800 mb-2">⌨️ קיצורי מקלדת:</h3>
-            <div className="grid grid-cols-1 sm:grid-cols-2 gap-2 text-orange-700">
-              <div><strong>H:</strong> הפעל/כבה רמזים</div>
-              <div><strong>D:</strong> הפעל/כבה מצב ניפוי באגים</div>
-              <div><strong>S:</strong> ערבב חלקים</div>
-              <div><strong>R:</strong> התחל מחדש</div>
-              <div><strong>?:</strong> פתח/סגור עזרה</div>
-              <div><strong>Escape:</strong> סגור עזרה</div>
-            </div>
+        <div className="bg-green-50 p-4 rounded-lg">
+          <h3 className="font-bold text-green-800 mb-2">💡 טיפים:</h3>
+          <ul className="list-disc list-inside space-y-2 text-green-700">
+            <li>חלקים נכונים יוצגו עם מסגרת ירוקה וכוכב</li>
+            <li>חלקים שגויים יוצגו עם מסגרת אדומה וX</li>
+            <li>ניתן לגרור חלקים מהלוח אם הם לא במקום הנכון</li>
+            <li>השתמש בכפתור &ldquo;רמזים&rdquo; לעזרה נוספת</li>
+          </ul>
+        </div>
+        <div className="bg-purple-50 p-4 rounded-lg">
+          <h3 className="font-bold text-purple-800 mb-2">🎮 פקדים:</h3>
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-2 text-purple-700">
+            <div className="flex items-center gap-2"><Upload className="w-4 h-4" /><span><strong>תמונה חדשה:</strong> החלף תמונה</span></div>
+            <div className="flex items-center gap-2"><Shuffle className="w-4 h-4" /><span><strong>ערבב חלקים:</strong> מערבב סדר</span></div>
+            <div className="flex items-center gap-2"><RotateCcw className="w-4 h-4" /><span><strong>התחל מחדש:</strong> מאפס משחק</span></div>
+            <div className="flex items-center gap-2"><Eye className="w-4 h-4" /><span><strong>רמזים:</strong> עזרות ויזואליות</span></div>
+            <div className="flex items-center gap-2"><Settings className="w-4 h-4" /><span><strong>ניפוי באגים:</strong> מידע טכני</span></div>
           </div>
         </div>
-        <div className="mt-6 text-center">
-          <button
-            onClick={toggleHelp}
-            className="bg-blue-500 hover:bg-blue-600 text-white px-6 py-2 rounded-lg transition-colors"
-          >
-            סגירה
-          </button>
+        <div className="bg-orange-50 p-4 rounded-lg">
+          <h3 className="font-bold text-orange-800 mb-2">⌨️ קיצורי מקלדת:</h3>
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-2 text-orange-700">
+            <div><strong>H:</strong> הפעל/כבה רמזים</div>
+            <div><strong>D:</strong> הפעל/כבה מצב ניפוי באגים</div>
+            <div><strong>S:</strong> ערבב חלקים</div>
+            <div><strong>R:</strong> התחל מחדש</div>
+            <div><strong>?:</strong> פתח/סגור עזרה</div>
+            <div><strong>Escape:</strong> סגור עזרה</div>
+          </div>
         </div>
       </div>
-    </div>
+      <div className="mt-6 text-center">
+        <button
+          onClick={toggleHelp}
+          className="bg-blue-500 hover:bg-blue-600 text-white px-6 py-2 rounded-lg transition-colors"
+        >
+          סגירה
+        </button>
+      </div>
+    </HelpModalShell>
   );
 }

--- a/gamesformykids/app/games/puzzles/simple/SimpleHelpModal.tsx
+++ b/gamesformykids/app/games/puzzles/simple/SimpleHelpModal.tsx
@@ -1,61 +1,43 @@
 'use client';
 
-import { X, Mouse, RotateCcw, HelpCircle, Eye, Settings } from 'lucide-react';
+import { Mouse, RotateCcw, HelpCircle, Eye, Settings } from 'lucide-react';
 import { usePuzzleGame } from '../usePuzzleGame';
-import { useEscapeKey } from '@/hooks/shared/useEscapeKey';
+import HelpModalShell from '@/components/shared/overlays/HelpModalShell';
 
 export default function SimpleHelpModal() {
   const { showHelp, toggleHelp } = usePuzzleGame();
-  useEscapeKey(toggleHelp, showHelp);
-  if (!showHelp) return null;
+
   return (
-    <div
-      className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50"
-      onClick={toggleHelp}
-    >
-      <div
-        className="bg-white rounded-lg p-6 max-w-md w-full mx-4"
-        role="dialog"
-        aria-modal="true"
-        aria-label="איך לשחק?"
-        onClick={(e) => e.stopPropagation()}
-      >
-        <div className="flex justify-between items-center mb-4">
-          <h3 className="text-xl font-bold">איך לשחק?</h3>
-          <button onClick={toggleHelp} className="text-gray-500 hover:text-gray-700 transition-colors">
-            <X className="w-6 h-6" />
-          </button>
+    <HelpModalShell isOpen={showHelp} onClose={toggleHelp} title="איך לשחק?">
+      <div className="space-y-3 text-right">
+        <div className="flex items-center gap-2">
+          <Mouse className="w-5 h-5 text-blue-500" />
+          <span>גרור חלקים לכיוונים הנכונים</span>
         </div>
-        <div className="space-y-3 text-right">
-          <div className="flex items-center gap-2">
-            <Mouse className="w-5 h-5 text-blue-500" />
-            <span>גרור חלקים לכיוונים הנכונים</span>
-          </div>
-          <div className="flex items-center gap-2">
-            <RotateCcw className="w-5 h-5 text-green-500" />
-            <span>לחץ על R להתחלה מחדש</span>
-          </div>
-          <div className="flex items-center gap-2">
-            <HelpCircle className="w-5 h-5 text-purple-500" />
-            <span>לחץ על H לעזרה</span>
-          </div>
-          <div className="flex items-center gap-2">
-            <Eye className="w-5 h-5 text-orange-500" />
-            <span>לחץ על Shift+H לרמזים</span>
-          </div>
-          <div className="flex items-center gap-2">
-            <Settings className="w-5 h-5 text-gray-500" />
-            <span>לחץ על D למצב ניפוי באגים</span>
-          </div>
+        <div className="flex items-center gap-2">
+          <RotateCcw className="w-5 h-5 text-green-500" />
+          <span>לחץ על R להתחלה מחדש</span>
         </div>
-        <div className="mt-6 p-4 bg-blue-50 rounded-lg">
-          <h4 className="font-bold text-blue-800 mb-2">🎯 המטרה:</h4>
-          <p className="text-blue-700 text-sm">
-            גרור את כל חלקי הפאזל למקומם הנכון כדי להשלים את התמונה.
-            חלקים נכונים יהיו ירוקים וחלקים שגויים יהיו אדומים.
-          </p>
+        <div className="flex items-center gap-2">
+          <HelpCircle className="w-5 h-5 text-purple-500" />
+          <span>לחץ על H לעזרה</span>
+        </div>
+        <div className="flex items-center gap-2">
+          <Eye className="w-5 h-5 text-orange-500" />
+          <span>לחץ על Shift+H לרמזים</span>
+        </div>
+        <div className="flex items-center gap-2">
+          <Settings className="w-5 h-5 text-gray-500" />
+          <span>לחץ על D למצב ניפוי באגים</span>
         </div>
       </div>
-    </div>
+      <div className="mt-6 p-4 bg-blue-50 rounded-lg">
+        <h4 className="font-bold text-blue-800 mb-2">🎯 המטרה:</h4>
+        <p className="text-blue-700 text-sm">
+          גרור את כל חלקי הפאזל למקומם הנכון כדי להשלים את התמונה.
+          חלקים נכונים יהיו ירוקים וחלקים שגויים יהיו אדומים.
+        </p>
+      </div>
+    </HelpModalShell>
   );
 }

--- a/gamesformykids/app/games/puzzles/store/slices/gameSlice.ts
+++ b/gamesformykids/app/games/puzzles/store/slices/gameSlice.ts
@@ -4,6 +4,7 @@ import { createPuzzlePieces } from '../../utils/puzzleUtils';
 import type { SimplePuzzle } from '../../constants/simplePuzzlesData';
 import { MENU_RESET } from '../puzzleStoreConstants';
 import type { PuzzleStore } from '../puzzleStore';
+import { shuffle } from '@/lib/utils';
 export interface GameSlice {
   initializeGame: (img: HTMLImageElement, difficulty?: number) => void;
   initializeSimpleGame: (puzzle: SimplePuzzle) => void;
@@ -66,7 +67,7 @@ export const createGameSlice: StateCreator<PuzzleStore, [], [], GameSlice> = (se
 
   shufflePieces: () => {
     const { pieces, speak } = get();
-    set({ pieces: [...pieces].sort(() => Math.random() - 0.5) });
+    set({ pieces: shuffle(pieces) });
     speak('הַחֲלָקִים עֻרְבְּבוּ');
   },
 

--- a/gamesformykids/app/games/puzzles/utils/puzzlePieceFactory.ts
+++ b/gamesformykids/app/games/puzzles/utils/puzzlePieceFactory.ts
@@ -1,4 +1,5 @@
 import { type PuzzlePiece, type SimplePuzzlePiece } from './puzzleTypes';
+import { shuffle } from '@/lib/utils';
 
 /**
  * Creates puzzle pieces from an image
@@ -54,7 +55,7 @@ export const createPuzzlePieces = (
       }
     }
 
-    return type === 'simple' ? pieces.sort(() => Math.random() - 0.5) : pieces;
+    return type === 'simple' ? shuffle(pieces) : pieces;
   } catch (error) {
     console.error('Error in createPuzzlePieces:', error);
     return [];

--- a/gamesformykids/app/games/reflex/useReflexGame.ts
+++ b/gamesformykids/app/games/reflex/useReflexGame.ts
@@ -5,6 +5,7 @@ import { useReflexStore } from './reflexStore';
 import { useGameCompletion } from '@/hooks/shared/progress/useGameCompletion';
 import { usePhaseGameCompletion } from '@/hooks/shared/progress/usePhaseGameCompletion';
 import { TARGET_EMOJIS, getLifetime, getSpawnInterval } from './data/targets';
+import { getRandomItem } from '@/lib/utils';
 
 export type { Target } from './reflexStore';
 
@@ -37,7 +38,7 @@ export function useReflexGame() {
         id,
         x:        5 + Math.random() * 80,
         y:        10 + Math.random() * 70,
-        emoji:    TARGET_EMOJIS[Math.floor(Math.random() * TARGET_EMOJIS.length)]!,
+        emoji:    getRandomItem(TARGET_EMOJIS)!,
         lifetime: getLifetime(score),
         born:     Date.now(),
       };

--- a/gamesformykids/app/games/shesh-besh/SheshBeshGame.tsx
+++ b/gamesformykids/app/games/shesh-besh/SheshBeshGame.tsx
@@ -9,23 +9,19 @@ import { ActionButtons }  from './components/ActionButtons';
 
 export default function SheshBeshGame() {
   const { phase } = useGameStatus();
-  const isPlaying = phase === 'rolling' || phase === 'moving' || phase === 'computer';
+
+  if (phase === 'menu') return <MenuScreen />;
+  if (phase === 'won' || phase === 'lost') return <GameOverScreen />;
 
   return (
     <div
       className="min-h-screen bg-gradient-to-br from-stone-950 via-amber-950 to-stone-950 flex flex-col items-center justify-start pt-4 pb-6 px-2 select-none"
     >
-      {phase === 'menu' && <MenuScreen />}
-
-      {(phase === 'won' || phase === 'lost') && <GameOverScreen />}
-
-      {isPlaying && (
-        <div className="flex flex-col items-center gap-2 w-full" style={{ maxWidth: 720 }}>
-          <Scoreboard />
-          <GameBoard />
-          <ActionButtons />
-        </div>
-      )}
+      <div className="flex flex-col items-center gap-2 w-full" style={{ maxWidth: 720 }}>
+        <Scoreboard />
+        <GameBoard />
+        <ActionButtons />
+      </div>
     </div>
   );
 }

--- a/gamesformykids/app/games/shesh-besh/components/GameOverScreen.tsx
+++ b/gamesformykids/app/games/shesh-besh/components/GameOverScreen.tsx
@@ -1,3 +1,6 @@
+'use client';
+
+import GameResultCard from '@/components/game/shared/GameResultCard';
 import { useGameStatus }  from '../hooks';
 import { useGameScores }  from '../hooks';
 import { useGameActions } from '../hooks';
@@ -9,46 +12,33 @@ export function GameOverScreen() {
   const { startGame }                  = useGameActions();
 
   return (
-    <div className="flex flex-col items-center gap-6 text-center mt-12">
-      <div className="text-8xl drop-shadow-2xl">{won ? '🎉' : '😢'}</div>
-      <div className={[
-        'text-5xl font-extrabold bg-clip-text text-transparent',
-        won
-          ? 'bg-gradient-to-b from-yellow-200 to-amber-400'
-          : 'bg-gradient-to-b from-slate-300 to-slate-500',
-      ].join(' ')}>
-        {won ? 'ניצחת!' : 'הפסדת'}
-      </div>
-      <p className="text-white/70 text-sm">{message}</p>
-
-      {/* Score summary */}
-      <div className="flex gap-4 text-sm font-bold">
+    <GameResultCard
+      emoji={won ? '🎉' : '😢'}
+      title={won ? 'ניצחת!' : 'הפסדת'}
+      gradientClass={won ? 'from-stone-950 via-amber-950 to-stone-950' : 'from-stone-950 via-slate-900 to-stone-950'}
+      buttonClass="from-amber-300 to-amber-500"
+      onRestart={startGame}
+      restartLabel="🔄 שחק שוב"
+    >
+      <p className="text-gray-500 dark:text-white/70 text-sm mb-4">{message}</p>
+      <div className="flex justify-center gap-4 text-sm font-bold">
         <div className={`flex items-center gap-2 rounded-xl px-5 py-2.5 border ${
-          won ? 'bg-rose-900/80 border-rose-600 ring-2 ring-rose-400' : 'bg-rose-950/50 border-rose-900'
+          won
+            ? 'bg-rose-100 border-rose-400 ring-2 ring-rose-400 dark:bg-rose-900/80 dark:border-rose-600'
+            : 'bg-rose-50 border-rose-200 dark:bg-rose-950/50 dark:border-rose-900'
         }`}>
           <div className="w-3 h-3 rounded-full bg-gradient-to-br from-rose-400 to-rose-600" />
-          <span className="text-rose-200">{playerScore}</span>
+          <span className="text-rose-700 dark:text-rose-200">{playerScore}</span>
         </div>
         <div className={`flex items-center gap-2 rounded-xl px-5 py-2.5 border ${
-          !won ? 'bg-slate-700/80 border-slate-500 ring-2 ring-slate-300' : 'bg-slate-800/50 border-slate-800'
+          !won
+            ? 'bg-slate-200 border-slate-400 ring-2 ring-slate-300 dark:bg-slate-700/80 dark:border-slate-500'
+            : 'bg-slate-100 border-slate-200 dark:bg-slate-800/50 dark:border-slate-800'
         }`}>
-          <div className="w-3 h-3 rounded-full bg-gradient-to-br from-gray-100 to-gray-300" />
-          <span className="text-slate-200">{computerScore}</span>
+          <div className="w-3 h-3 rounded-full bg-gradient-to-br from-gray-400 to-gray-600 dark:from-gray-100 dark:to-gray-300" />
+          <span className="text-slate-700 dark:text-slate-200">{computerScore}</span>
         </div>
       </div>
-
-      <button
-        onClick={startGame}
-        className={[
-          'bg-gradient-to-b from-amber-300 to-amber-500 hover:from-amber-200 hover:to-amber-400',
-          'active:scale-95 text-gray-900 font-extrabold text-xl px-12 py-4 rounded-2xl',
-          'shadow-[0_5px_0_#92400e,0_6px_24px_rgba(251,191,36,0.3)]',
-          'active:shadow-[0_2px_0_#92400e] active:translate-y-[3px]',
-          'transition duration-150 mt-2',
-        ].join(' ')}
-      >
-        🔄 שחק שוב
-      </button>
-    </div>
+    </GameResultCard>
   );
 }

--- a/gamesformykids/app/games/shesh-besh/components/MenuScreen.tsx
+++ b/gamesformykids/app/games/shesh-besh/components/MenuScreen.tsx
@@ -1,54 +1,37 @@
+'use client';
+
+import GameMenuCard from '@/components/game/shared/GameMenuCard';
 import { useGameScores }  from '../hooks';
 import { useGameActions } from '../hooks';
 
 export function MenuScreen() {
   const { playerScore, computerScore } = useGameScores();
   const { startGame }                  = useGameActions();
-  return (
-    <div className="flex flex-col items-center gap-6 text-center max-w-sm w-full mt-6">
-      {/* Title */}
-      <div className="flex flex-col items-center gap-2">
-        <div className="text-6xl drop-shadow-2xl">🎲</div>
-        <h1 className="text-3xl font-extrabold text-amber-300 bg-gradient-to-b from-yellow-200 via-amber-300 to-amber-500 bg-clip-text text-transparent drop-shadow-lg">
-          שש-בש
-        </h1>
-        <p className="text-amber-200/70 text-sm">
-          משחק הקלאסי נגד המחשב
-        </p>
-      </div>
 
-      {/* Previous scores */}
+  return (
+    <GameMenuCard
+      emoji="🎲"
+      title="שש-בש"
+      description="המשחק הקלאסי נגד המחשב"
+      gradientClass="from-stone-950 via-amber-950 to-stone-950"
+      buttonClass="from-amber-300 to-amber-500"
+      onStart={startGame}
+      startLabel="🎮 התחל משחק"
+    >
       {(playerScore > 0 || computerScore > 0) && (
-        <div className="flex gap-3 text-sm font-bold">
-          <div className="flex items-center gap-2 bg-rose-950/70 border border-rose-800/60 rounded-xl px-4 py-2">
+        <div className="flex justify-center gap-3 text-sm font-bold mb-2">
+          <div className="flex items-center gap-2 bg-rose-100 dark:bg-rose-950/70 border border-rose-300 dark:border-rose-800/60 rounded-xl px-4 py-2">
             <div className="w-3 h-3 rounded-full bg-gradient-to-br from-rose-400 to-rose-600" />
-            <span className="text-rose-200">{playerScore} ניצחונות</span>
+            <span className="text-rose-700 dark:text-rose-200">{playerScore} ניצחונות</span>
           </div>
-          <div className="flex items-center gap-2 bg-slate-800/70 border border-slate-700/60 rounded-xl px-4 py-2">
-            <div className="w-3 h-3 rounded-full bg-gradient-to-br from-gray-100 to-gray-300" />
-            <span className="text-slate-200">{computerScore} ניצחונות</span>
+          <div className="flex items-center gap-2 bg-slate-100 dark:bg-slate-800/70 border border-slate-300 dark:border-slate-700/60 rounded-xl px-4 py-2">
+            <div className="w-3 h-3 rounded-full bg-gradient-to-br from-gray-400 to-gray-600 dark:from-gray-100 dark:to-gray-300" />
+            <span className="text-slate-700 dark:text-slate-200">{computerScore} ניצחונות</span>
           </div>
         </div>
       )}
-
-      {/* Start button */}
-      <button
-        onClick={startGame}
-        className={[
-          'bg-gradient-to-b from-amber-300 to-amber-500 hover:from-amber-200 hover:to-amber-400',
-          'active:scale-95 text-gray-900 font-extrabold text-xl px-14 py-4 rounded-2xl',
-          'shadow-[0_6px_0_#92400e,0_8px_30px_rgba(251,191,36,0.35)]',
-          'hover:shadow-[0_6px_0_#92400e,0_8px_36px_rgba(251,191,36,0.45)]',
-          'active:shadow-[0_2px_0_#92400e] active:translate-y-[4px]',
-          'transition duration-150',
-        ].join(' ')}
-      >
-        🎮 התחל משחק
-      </button>
-
-      {/* Rules */}
-      <div className="bg-black/30 border border-amber-800/30 rounded-2xl p-4 text-sm w-full space-y-1.5">
-        <p className="font-bold text-amber-300 mb-2.5 text-center text-base">כיצד לשחק</p>
+      <div className="bg-amber-50 dark:bg-black/30 border border-amber-200 dark:border-amber-800/30 rounded-2xl p-4 text-sm w-full space-y-1.5">
+        <p className="font-bold text-amber-700 dark:text-amber-300 mb-2.5 text-center text-base">כיצד לשחק</p>
         {([
           ['🔴', 'אתה = אדום · זזים מ-24 ל-1'],
           ['⚪', 'מחשב = לבן · זזים מ-1 ל-24'],
@@ -57,12 +40,12 @@ export function MenuScreen() {
           ['🏠', 'מגרש הבית שלך: נקודות 1–6'],
           ['✅', 'כשכולם בבית — ניתן לצאת'],
         ] as [string, string][]).map(([icon, text]) => (
-          <div key={text} className="flex items-center gap-2 text-amber-200/75">
+          <div key={text} className="flex items-center gap-2 text-gray-600 dark:text-amber-200/75">
             <span className="text-base w-6 text-center">{icon}</span>
             <span>{text}</span>
           </div>
         ))}
       </div>
-    </div>
+    </GameMenuCard>
   );
 }

--- a/gamesformykids/app/games/simon/simonStore.ts
+++ b/gamesformykids/app/games/simon/simonStore.ts
@@ -1,5 +1,6 @@
 import { makePersistStore } from '@/lib/stores/createStore';
 import type { PhaseSimon as Phase } from '@/lib/types';
+import { getRandomItem } from '@/lib/utils';
 
 export const BUTTONS = [
   { id: 'red',    bg: 'bg-red-500',    active: 'bg-red-200',    label: '▲' },
@@ -48,7 +49,7 @@ export const useSimonStore = makePersistStore<SimonState & SimonActions>('SimonS
   setSequence:    (seq)   => set({ sequence: seq }, false, 'simon/setSequence'),
 
   initGame: () => {
-    const first = BUTTONS[Math.floor(Math.random() * BUTTONS.length)]!.id;
+    const first = getRandomItem([...BUTTONS]).id;
     const seq: ButtonId[] = [first];
     set({ ...INITIAL, sequence: seq, roundScore: 0 }, false, 'simon/initGame');
   },

--- a/gamesformykids/app/games/simon/useSimonGame.ts
+++ b/gamesformykids/app/games/simon/useSimonGame.ts
@@ -4,6 +4,7 @@ import { useEffect, useRef } from 'react';
 import { useShallow } from 'zustand/react/shallow';
 import { useSimonStore, BUTTONS } from './simonStore';
 import { useGameCompletion } from '@/hooks/shared/progress/useGameCompletion';
+import { getRandomItem } from '@/lib/utils';
 export type { ButtonId } from './simonStore';
 export { BUTTONS };
 
@@ -83,7 +84,7 @@ export function useSimonGame() {
 
     if (next >= seq.length) {
       setRoundScore(seq.length);
-      const nextBtn = BUTTONS[Math.floor(Math.random() * BUTTONS.length)]!.id;
+      const nextBtn = getRandomItem([...BUTTONS]).id;
       const newSeq = [...seq, nextBtn];
       setSequence(newSeq);
       setTimeout(() => runSequence(newSeq), 900);

--- a/gamesformykids/app/games/snake/useSnakeInput.ts
+++ b/gamesformykids/app/games/snake/useSnakeInput.ts
@@ -1,31 +1,27 @@
 'use client';
 
-import { useEffect, useRef, MutableRefObject } from 'react';
+import { useRef, MutableRefObject } from 'react';
 import { type Dir, type SnakeRefs, OPPOSITE_DIR } from './snakeConstants';
+import { useKeyboardControls } from '@/hooks/shared/game-controls';
 
 /**
  * Registers keyboard and touch input handlers for the snake game.
  * Returns `{ handleTouchStart, handleTouchEnd, controlDir }`.
  */
 export function useSnakeInput(st: MutableRefObject<SnakeRefs>) {
-  // Keyboard
-  useEffect(() => {
-    const handle = (e: KeyboardEvent) => {
-      const s = st.current;
-      if (s.phase !== 'playing') return;
-      const map: Record<string, Dir> = {
-        ArrowUp: 'U', ArrowDown: 'D', ArrowLeft: 'L', ArrowRight: 'R',
-        w: 'U', s: 'D', a: 'L', d: 'R',
-      };
-      const newDir = map[e.key];
-      if (!newDir) return;
-      if (newDir !== OPPOSITE_DIR[s.dir]) s.nextDir = newDir;
-      e.preventDefault();
-    };
-    window.addEventListener('keydown', handle);
-    return () => window.removeEventListener('keydown', handle);
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  // On-screen D-pad (also used for keyboard input below)
+  const controlDir = (dir: Dir) => {
+    const s = st.current;
+    if (s.phase !== 'playing') return;
+    if (dir !== OPPOSITE_DIR[s.dir]) s.nextDir = dir;
+  };
+
+  useKeyboardControls({
+    ArrowUp: () => controlDir('U'), w: () => controlDir('U'),
+    ArrowDown: () => controlDir('D'), s: () => controlDir('D'),
+    ArrowLeft: () => controlDir('L'), a: () => controlDir('L'),
+    ArrowRight: () => controlDir('R'), d: () => controlDir('R'),
+  });
 
   // Touch
   const touchStart = useRef<{ x: number; y: number } | null>(null);
@@ -47,13 +43,6 @@ export function useSnakeInput(st: MutableRefObject<SnakeRefs>) {
     if (adx > ady) newDir = dx > 0 ? 'R' : 'L';
     else newDir = dy > 0 ? 'D' : 'U';
     if (newDir !== OPPOSITE_DIR[s.dir]) s.nextDir = newDir;
-  };
-
-  // On-screen D-pad
-  const controlDir = (dir: Dir) => {
-    const s = st.current;
-    if (s.phase !== 'playing') return;
-    if (dir !== OPPOSITE_DIR[s.dir]) s.nextDir = dir;
   };
 
   return { handleTouchStart, handleTouchEnd, controlDir };

--- a/gamesformykids/app/games/snakes-ladders/components/QuizPopup.tsx
+++ b/gamesformykids/app/games/snakes-ladders/components/QuizPopup.tsx
@@ -2,6 +2,7 @@
 import { useMemo } from 'react';
 import type { SNLQuestion } from '../data/questions';
 import { LADDERS, SNAKES } from '../snakesLaddersStore';
+import { shuffle } from '@/lib/utils';
 
 interface Props {
   question: SNLQuestion;
@@ -16,7 +17,7 @@ interface Props {
 export default function QuizPopup({ question, square, specialType, playerName, playerEmoji, isAI, onAnswer }: Props) {
   const choices = useMemo(() => {
     const all = [question.answer, ...question.wrongOptions];
-    return all.sort(() => Math.random() - 0.5);
+    return shuffle(all);
   }, [question]);
 
   const destination = specialType === 'ladder' ? LADDERS[square] : SNAKES[square];

--- a/gamesformykids/app/games/space-defender/useSpaceDefenderGame.ts
+++ b/gamesformykids/app/games/space-defender/useSpaceDefenderGame.ts
@@ -1,9 +1,11 @@
 'use client';
 
-import { useCallback, useEffect } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 import { useShallow } from 'zustand/react/shallow';
 import { useSpaceDefenderStore, GAME_DURATION } from './spaceDefenderStore';
 import { createCanvasArcadeHook } from '@/hooks/canvas';
+import { getRandomItem } from '@/lib/utils';
+import { useHeldKeyControls, useKeyboardControls } from '@/hooks/shared/game-controls';
 import {
   W, H, SHIP_W, SHIP_H, BULLET_SPEED, BULLET_R, ASTEROID_EMOJIS,
   type Bullet, type Asteroid,
@@ -41,7 +43,7 @@ const _useSpaceDefender = createCanvasArcadeHook({
       s.nextAsteroid--;
       if (s.nextAsteroid <= 0) {
         const r = 16 + Math.random() * 20;
-        s.asteroids.push({ id: uid++, x: r + Math.random() * (W - r * 2), y: -r, speed: 1.5 + Math.random() * 2 + s.score / 500, r, emoji: ASTEROID_EMOJIS[Math.floor(Math.random() * ASTEROID_EMOJIS.length)]!, angle: 0, spin: (Math.random() - 0.5) * 0.06 });
+        s.asteroids.push({ id: uid++, x: r + Math.random() * (W - r * 2), y: -r, speed: 1.5 + Math.random() * 2 + s.score / 500, r, emoji: getRandomItem(ASTEROID_EMOJIS)!, angle: 0, spin: (Math.random() - 0.5) * 0.06 });
         s.nextAsteroid = Math.max(20, 55 - Math.floor(s.score / 100) * 3);
       }
       s.bullets = s.bullets.filter(b => { b.y -= BULLET_SPEED; return b.y > -10; });
@@ -129,27 +131,22 @@ export function useSpaceDefenderGame() {
     if (st.current.phase !== 'playing') startGame();
   };
 
+  const heldRef = useRef({ left: false, right: false });
+  useHeldKeyControls({
+    ArrowLeft: { onDown: () => { heldRef.current.left = true; }, onUp: () => { heldRef.current.left = false; } },
+    ArrowRight: { onDown: () => { heldRef.current.right = true; }, onUp: () => { heldRef.current.right = false; } },
+  });
+  useKeyboardControls({ ' ': shoot });
+
   useEffect(() => {
-    let leftDown = false, rightDown = false;
-    const kd = (e: KeyboardEvent) => {
-      if (e.key === 'ArrowLeft') leftDown = true;
-      if (e.key === 'ArrowRight') rightDown = true;
-      if (e.code === 'Space') { e.preventDefault(); shoot(); }
-    };
-    const ku = (e: KeyboardEvent) => {
-      if (e.key === 'ArrowLeft') leftDown = false;
-      if (e.key === 'ArrowRight') rightDown = false;
-    };
     const moveInterval = setInterval(() => {
       const s = st.current;
       if (s.phase !== 'playing') return;
-      if (leftDown) s.shipX = Math.max(SHIP_W / 2, s.shipX - 5);
-      if (rightDown) s.shipX = Math.min(W - SHIP_W / 2, s.shipX + 5);
+      if (heldRef.current.left) s.shipX = Math.max(SHIP_W / 2, s.shipX - 5);
+      if (heldRef.current.right) s.shipX = Math.min(W - SHIP_W / 2, s.shipX + 5);
     }, 16);
-    window.addEventListener('keydown', kd);
-    window.addEventListener('keyup', ku);
-    return () => { window.removeEventListener('keydown', kd); window.removeEventListener('keyup', ku); clearInterval(moveInterval); };
-  }, [st, shoot]);
+    return () => clearInterval(moveInterval);
+  }, [st]);
 
   const { phase, best, score, lives, timeLeft } = useSpaceDefenderStore(useShallow(s => ({ phase: s.phase, best: s.best, score: s.score, lives: s.lives, timeLeft: s.timeLeft })));
 

--- a/gamesformykids/app/games/stack/useStackGame.ts
+++ b/gamesformykids/app/games/stack/useStackGame.ts
@@ -1,9 +1,10 @@
 'use client';
 
-import { useCallback, useEffect } from 'react';
+import { useCallback } from 'react';
 import { useShallow } from 'zustand/react/shallow';
 import { useStackStore } from './stackStore';
 import { createCanvasArcadeHook } from '@/hooks/canvas';
+import { useKeyboardControls } from '@/hooks/shared/game-controls';
 
 export const W = 300;
 export const H = 480;
@@ -135,13 +136,7 @@ export function useStackGame() {
   };
 
 
-  useEffect(() => {
-    const kd = (e: KeyboardEvent) => {
-      if (e.code === 'Space' || e.key === 'Enter') { e.preventDefault(); drop(); }
-    };
-    window.addEventListener('keydown', kd);
-    return () => window.removeEventListener('keydown', kd);
-  }, [drop]);
+  useKeyboardControls({ ' ': drop, Enter: drop });
 
   const { phase, best, score } = useStackStore(useShallow(s => ({ phase: s.phase, best: s.best, score: s.score })));
 

--- a/gamesformykids/app/games/sudoku/sudokuLogic.ts
+++ b/gamesformykids/app/games/sudoku/sudokuLogic.ts
@@ -1,3 +1,5 @@
+import { shuffle } from '@/lib/utils';
+
 export type Size = 6 | 9;
 export type Difficulty = 'easy' | 'medium' | 'hard';
 export type SudokuGrid = number[][];
@@ -12,15 +14,6 @@ export const SIZE_CONFIGS: Record<Size, SizeConfig> = {
   6: { boxRows: 2, boxCols: 3, clues: { easy: 22, medium: 17, hard: 13 } },
   9: { boxRows: 3, boxCols: 3, clues: { easy: 40, medium: 32, hard: 26 } },
 };
-
-function shuffle<T>(items: T[]): T[] {
-  const arr = [...items];
-  for (let i = arr.length - 1; i > 0; i--) {
-    const j = Math.floor(Math.random() * (i + 1));
-    [arr[i], arr[j]] = [arr[j]!, arr[i]!];
-  }
-  return arr;
-}
 
 function emptyGrid(size: Size): SudokuGrid {
   return Array.from({ length: size }, () => Array(size).fill(0));

--- a/gamesformykids/app/games/sudoku/useSudoku.ts
+++ b/gamesformykids/app/games/sudoku/useSudoku.ts
@@ -3,6 +3,7 @@ import { useEffect } from 'react';
 import { useSudokuStore } from './sudokuStore';
 import { generatePuzzle } from './sudokuLogic';
 import { speak } from '@/lib/utils/speech/enhancedSpeechUtils';
+import { useKeyboardControls } from '@/hooks/shared/game-controls';
 
 export function useSudoku() {
   const store = useSudokuStore();
@@ -32,31 +33,21 @@ export function useSudoku() {
   }, [phase]);
 
   // Keyboard: digits fill the selected cell, arrows move selection.
-  useEffect(() => {
-    if (phase !== 'playing') return;
-    const onKey = (e: KeyboardEvent) => {
-      const digit = Number(e.key);
-      if (digit >= 1 && digit <= size) {
-        e.preventDefault();
-        inputNumber(digit);
-        return;
-      }
-      if (!selected) return;
-      const { row, col } = selected;
-      const moves: Record<string, [number, number]> = {
-        ArrowUp: [-1, 0], ArrowDown: [1, 0], ArrowLeft: [0, -1], ArrowRight: [0, 1],
-      };
-      const move = moves[e.key];
-      if (move) {
-        e.preventDefault();
-        const nextRow = Math.min(size - 1, Math.max(0, row + move[0]));
-        const nextCol = Math.min(size - 1, Math.max(0, col + move[1]));
-        selectCell(nextRow, nextCol);
-      }
-    };
-    window.addEventListener('keydown', onKey);
-    return () => window.removeEventListener('keydown', onKey);
-  }, [phase, size, selected, selectCell, inputNumber]);
+  const moveSelection = (dr: number, dc: number) => {
+    if (!selected) return;
+    const nextRow = Math.min(size - 1, Math.max(0, selected.row + dr));
+    const nextCol = Math.min(size - 1, Math.max(0, selected.col + dc));
+    selectCell(nextRow, nextCol);
+  };
+  useKeyboardControls({
+    ...Object.fromEntries(
+      Array.from({ length: size }, (_, i) => [String(i + 1), () => inputNumber(i + 1)]),
+    ),
+    ArrowUp: () => moveSelection(-1, 0),
+    ArrowDown: () => moveSelection(1, 0),
+    ArrowLeft: () => moveSelection(0, -1),
+    ArrowRight: () => moveSelection(0, 1),
+  }, phase === 'playing');
 
   return store;
 }

--- a/gamesformykids/app/games/tetris/constants.ts
+++ b/gamesformykids/app/games/tetris/constants.ts
@@ -1,4 +1,5 @@
 import { Piece } from './types';
+import { getRandomItem } from '@/lib/utils';
 
 // Game Constants
 export const BOARD_WIDTH = 10;
@@ -45,7 +46,7 @@ export const getRandomPiece = (): Piece => {
     throw new Error('No tetrominoes defined');
   }
   
-  const randomPiece = pieces[Math.floor(Math.random() * pieces.length)]!;
+  const randomPiece = getRandomItem(pieces)!;
   const pieceData = TETROMINOES[randomPiece];
   
   if (!pieceData || !pieceData.blocks || !pieceData.color) {

--- a/gamesformykids/app/games/tetris/hooks/useTetrisGame.ts
+++ b/gamesformykids/app/games/tetris/hooks/useTetrisGame.ts
@@ -3,6 +3,7 @@
 import { useEffect, useRef } from 'react';
 import { useTetrisStore } from '../store/tetrisStore';
 import { useGameCompletion } from '@/hooks/shared/progress/useGameCompletion';
+import { useKeyboardControls } from '@/hooks/shared/game-controls';
 
 /**
  * הוק דק שמנהל רק את ה-side-effects של המשחק:
@@ -14,6 +15,7 @@ export const useTetrisGame = () => {
   const phase = useTetrisStore(s => s.phase);
   const level = useTetrisStore(s => s.level);
   const movePiece = useTetrisStore(s => s.movePiece);
+  const handleRotate = useTetrisStore(s => s.handleRotate);
 
   const { saveGameResultRef } = useGameCompletion('tetris');
   const startTimeRef = useRef(0);
@@ -57,29 +59,12 @@ export const useTetrisGame = () => {
     return () => clearInterval(gameLoop);
   }, [isPlaying, level, movePiece]);
 
-  // פקדי מקלדת — משתמש ב-getState() כדי להמנע מ-stale closures
-  useEffect(() => {
-    const handleKeyPress = (e: KeyboardEvent) => {
-      if (useTetrisStore.getState().phase !== 'playing') return;
-
-      // מנע גלילת מסך במהלך המשחק
-      if (['ArrowLeft', 'ArrowRight', 'ArrowDown', 'ArrowUp', ' '].includes(e.key)) {
-        e.preventDefault();
-        e.stopPropagation();
-      }
-
-      const { movePiece: move, handleRotate } = useTetrisStore.getState();
-      switch (e.key) {
-        case 'ArrowLeft':  move(-1, 0); break;
-        case 'ArrowRight': move(1, 0);  break;
-        case 'ArrowDown':  move(0, 1);  break;
-        case 'ArrowUp':
-        case ' ':          handleRotate(); break;
-      }
-    };
-
-    window.addEventListener('keydown', handleKeyPress);
-    return () => window.removeEventListener('keydown', handleKeyPress);
-    // [] intentional — handler uses getState() to avoid stale closures
-  }, []);
+  // פקדי מקלדת
+  useKeyboardControls({
+    ArrowLeft: () => movePiece(-1, 0),
+    ArrowRight: () => movePiece(1, 0),
+    ArrowDown: () => movePiece(0, 1),
+    ArrowUp: handleRotate,
+    ' ': handleRotate,
+  }, isPlaying);
 };

--- a/gamesformykids/app/games/tzedakah/useCharityCoinGame.ts
+++ b/gamesformykids/app/games/tzedakah/useCharityCoinGame.ts
@@ -4,6 +4,7 @@ import { useShallow } from 'zustand/react/shallow';
 import { useTzedakahStore } from './tzedakahStore';
 import { GamesRegistry } from '@/lib/registry/gamesRegistry';
 import { useRouter } from 'next/navigation';
+import { useKeyboardControls } from '@/hooks/shared/game-controls';
 
 export type { Coin } from './tzedakahStore';
 
@@ -51,15 +52,10 @@ export function useCharityCoinGame() {
     return () => clearInterval(id);
   }, [gameStarted, timerTick]);
 
-  useEffect(() => {
-    if (!gameStarted || isMobile) return;
-    const onKey = (e: KeyboardEvent) => {
-      if (e.key === 'ArrowLeft')  { e.preventDefault(); stepBasket(-1); }
-      if (e.key === 'ArrowRight') { e.preventDefault(); stepBasket(1); }
-    };
-    window.addEventListener('keydown', onKey);
-    return () => window.removeEventListener('keydown', onKey);
-  }, [gameStarted, isMobile, stepBasket]);
+  useKeyboardControls({
+    ArrowLeft: () => stepBasket(-1),
+    ArrowRight: () => stepBasket(1),
+  }, gameStarted && !isMobile);
 
   const nextGame = useMemo(() => {
     const all = GamesRegistry.getAllGameRegistrations()

--- a/gamesformykids/app/games/whack-a-mole/useWhackAMoleGame.ts
+++ b/gamesformykids/app/games/whack-a-mole/useWhackAMoleGame.ts
@@ -3,6 +3,7 @@ import { useEffect, useRef } from 'react';
 import { createShallowHook } from '@/lib/stores/utils/sliceUtils';
 import { useWhackAMoleStore, GAME_DURATION, MOLES, BAD } from './whackAMoleStore';
 import { useGameCompletion } from '@/hooks/shared/progress/useGameCompletion';
+import { getRandomItem } from '@/lib/utils';
 
 export type { HoleState } from './whackAMoleStore';
 export { GAME_DURATION } from './whackAMoleStore';
@@ -50,9 +51,9 @@ export function useWhackAMoleGame() {
         .map(({ i }) => i);
 
       if (emptyIdxs.length > 0) {
-        const idx   = emptyIdxs[Math.floor(Math.random() * emptyIdxs.length)]!;
+        const idx   = getRandomItem(emptyIdxs)!;
         const isBad = Math.random() < 0.15;
-        const val   = isBad ? BAD : MOLES[Math.floor(Math.random() * MOLES.length)]!;
+        const val   = isBad ? BAD : getRandomItem(MOLES)!;
         store.getState().showMole(idx, val, isBad);
 
         moleTimersRef.current[idx] = setTimeout(() => {

--- a/gamesformykids/app/games/word-builder/data/words.ts
+++ b/gamesformykids/app/games/word-builder/data/words.ts
@@ -1,3 +1,5 @@
+import { shuffleArray } from '@/lib/utils';
+
 export interface WordPuzzle {
   id: string;
   word: string;       // Hebrew word
@@ -39,12 +41,9 @@ export const WORD_PUZZLES: WordPuzzle[] = [
 export function shuffleLetters(word: string): string[] {
   const letters = word.split('');
   // ensure shuffled order differs from original
-  const shuffled = [...letters];
+  let shuffled = letters;
   do {
-    for (let i = shuffled.length - 1; i > 0; i--) {
-      const j = Math.floor(Math.random() * (i + 1));
-      [shuffled[i], shuffled[j]] = [shuffled[j]!, shuffled[i]!];
-    }
+    shuffled = shuffleArray(letters);
   } while (shuffled.join('') === word && word.length > 1);
   return shuffled;
 }

--- a/gamesformykids/app/games/word-builder/wordBuilderStore.ts
+++ b/gamesformykids/app/games/word-builder/wordBuilderStore.ts
@@ -1,6 +1,7 @@
 import { makeStore } from '@/lib/stores/createStore';
 import type { PhaseResult as Phase } from '@/lib/types';
 import { WORD_PUZZLES, type WordPuzzle, shuffleLetters } from './data/words';
+import { shuffle } from '@/lib/utils';
 
 // ── Types ──────────────────────────────────────────────────────────────────
 
@@ -32,7 +33,7 @@ const INITIAL: WordBuilderState = {
 };
 
 function makePuzzles(): WordPuzzle[] {
-  return [...WORD_PUZZLES].sort(() => Math.random() - 0.5).slice(0, 10);
+  return shuffle(WORD_PUZZLES).slice(0, 10);
 }
 
 function loadLetters(word: string): AvailableLetter[] {

--- a/gamesformykids/app/games/word-clicker/wordClickerStore.ts
+++ b/gamesformykids/app/games/word-clicker/wordClickerStore.ts
@@ -1,5 +1,6 @@
 'use client';
 import { create } from 'zustand';
+import { shuffle } from '@/lib/utils';
 
 export interface FloatingLetter {
   id: string;
@@ -60,7 +61,7 @@ function buildFloatingLetters(word: string): FloatingLetter[] {
 
   const distractors: FloatingLetter[] = [];
   const pool = EXTRA_LETTERS.split('').filter(l => !word.includes(l));
-  const shuffledPool = pool.sort(() => Math.random() - 0.5).slice(0, 3);
+  const shuffledPool = shuffle(pool).slice(0, 3);
   shuffledPool.forEach((letter, i) => {
     distractors.push({
       id: `d-${i}-${letter}`,
@@ -72,7 +73,7 @@ function buildFloatingLetters(word: string): FloatingLetter[] {
     });
   });
 
-  return [...wordLetters, ...distractors].sort(() => Math.random() - 0.5);
+  return shuffle([...wordLetters, ...distractors]);
 }
 
 export const useWordClickerStore = create<WordClickerState & WordClickerActions>((set, get) => ({
@@ -86,7 +87,7 @@ export const useWordClickerStore = create<WordClickerState & WordClickerActions>
   wordComplete: false,
 
   startGame: () => {
-    const words = [...WORD_LIST].sort(() => Math.random() - 0.5).slice(0, 8);
+    const words = shuffle(WORD_LIST).slice(0, 8);
     const firstWord = words[0] ?? WORD_LIST[0] ?? 'שמש';
     set({
       phase: 'playing',

--- a/gamesformykids/app/games/word-maze/useWordMaze.ts
+++ b/gamesformykids/app/games/word-maze/useWordMaze.ts
@@ -1,8 +1,9 @@
 'use client';
-import { useState, useCallback, useRef, useEffect } from 'react';
+import { useState, useCallback, useRef } from 'react';
 import { MAZE_WORDS, type MazeDifficulty } from '@/lib/constants/wordMazeWords';
 import { speakHebrew } from '@/lib/utils/speech/enhancedSpeechUtils';
 import { shuffle } from '@/lib/utils/game/cardUtils';
+import { useKeyboardControls } from '@/hooks/shared/game-controls';
 
 export const GRID_SIZE = 13;
 export const CELL_SIZE = 34;
@@ -143,18 +144,12 @@ export function useWordMaze() {
   }, []);
 
   // Keyboard input
-  useEffect(() => {
-    const handler = (e: KeyboardEvent) => {
-      if (!['ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight'].includes(e.key)) return;
-      e.preventDefault();
-      if (e.key === 'ArrowUp')    movePlayer(-1, 0);
-      if (e.key === 'ArrowDown')  movePlayer(1, 0);
-      if (e.key === 'ArrowLeft')  movePlayer(0, -1);
-      if (e.key === 'ArrowRight') movePlayer(0, 1);
-    };
-    window.addEventListener('keydown', handler);
-    return () => window.removeEventListener('keydown', handler);
-  }, [movePlayer]);
+  useKeyboardControls({
+    ArrowUp: () => movePlayer(-1, 0),
+    ArrowDown: () => movePlayer(1, 0),
+    ArrowLeft: () => movePlayer(0, -1),
+    ArrowRight: () => movePlayer(0, 1),
+  });
 
   const nextLevel = useCallback(() => {
     const nextLvl: MazeDifficulty = level === 'easy' ? 'medium' : level === 'medium' ? 'hard' : 'easy';

--- a/gamesformykids/app/games/word-search/wordSearchStore.ts
+++ b/gamesformykids/app/games/word-search/wordSearchStore.ts
@@ -1,6 +1,7 @@
 'use client';
 import { create } from 'zustand';
 import { WORD_SETS, type WordSet } from './data/wordSets';
+import { getRandomItem } from '@/lib/utils';
 
 export const GRID_SIZE = 9;
 const HEBREW_FILL = 'אבגדהוזחטיכלמנסעפצקרשת';
@@ -53,7 +54,7 @@ function buildGrid(words: string[]): { grid: string[][]; placed: PlacedWord[] } 
     const letters = word.split('');
     let success = false;
     for (let attempt = 0; attempt < 100; attempt++) {
-      const dir = DIRECTIONS[Math.floor(Math.random() * DIRECTIONS.length)]!;
+      const dir = getRandomItem(DIRECTIONS)!;
       const row = Math.floor(Math.random() * GRID_SIZE);
       const col = Math.floor(Math.random() * GRID_SIZE);
       if (canPlace(grid, letters, row, col, dir)) {

--- a/gamesformykids/components/game/quiz/screens/useLifeCyclesInteraction.ts
+++ b/gamesformykids/components/game/quiz/screens/useLifeCyclesInteraction.ts
@@ -2,6 +2,7 @@
 import { useState, useEffect } from 'react';
 import { useQuizGameStore } from '@/lib/stores';
 import type { LifeCycleQuestion } from '@/lib/quiz/data/life-cycles';
+import { shuffle } from '@/lib/utils';
 
 export function useLifeCyclesInteraction(current: LifeCycleQuestion, onComplete: () => void) {
   const [placed, setPlaced] = useState<number[]>([]);
@@ -13,7 +14,7 @@ export function useLifeCyclesInteraction(current: LifeCycleQuestion, onComplete:
 
   useEffect(() => {
     const indices: number[] = [0, 1, 2, 3];
-    setShuffled(indices.sort(() => Math.random() - 0.5));
+    setShuffled(shuffle(indices));
     setPlaced([]);
     setWrongIdx(null);
   }, [current.id]);

--- a/gamesformykids/components/game/shared/GameCompletionCelebration.tsx
+++ b/gamesformykids/components/game/shared/GameCompletionCelebration.tsx
@@ -8,6 +8,7 @@ import { getGameConfettiEmojis } from '@/lib/utils/game/getGameConfettiEmojis';
 import { useAvatarEmoji } from '@/hooks/shared/user/useAvatarEmoji';
 import { getActiveHoliday } from '@/lib/constants/holidayLanes';
 import { useAudioSettingsStore } from '@/lib/stores/audioSettingsStore';
+import { getRandomItem } from '@/lib/utils';
 
 const CELEBRATION_PHRASES = [
   'כָּל הַכָּבוֹד! עָשִׂיתָ עֲבוֹדָה מַדְהִימָה!',
@@ -58,7 +59,7 @@ export function GameCompletionCelebration({ isPerfect = false }: Props) {
 
   useEffect(() => {
     playSuccessSound();
-    const phrase = CELEBRATION_PHRASES[Math.floor(Math.random() * CELEBRATION_PHRASES.length)]!;
+    const phrase = getRandomItem([...CELEBRATION_PHRASES]);
     speakHebrew(phrase);
     if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
       setVisible(false);

--- a/gamesformykids/components/marketing/NotFoundSuggestions.tsx
+++ b/gamesformykids/components/marketing/NotFoundSuggestions.tsx
@@ -3,10 +3,11 @@
 import { useState } from 'react';
 import Link from 'next/link';
 import { GamesRegistry } from '@/lib/registry/gamesRegistry';
+import { shuffle } from '@/lib/utils';
 
 function pickThree() {
   const all = GamesRegistry.getAllGameRegistrations().filter(g => g.available);
-  const shuffled = [...all].sort(() => Math.random() - 0.5);
+  const shuffled = shuffle(all);
   return shuffled.slice(0, 3);
 }
 

--- a/gamesformykids/components/marketing/SurpriseMeButton.tsx
+++ b/gamesformykids/components/marketing/SurpriseMeButton.tsx
@@ -3,6 +3,7 @@
 import { useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { GamesRegistry } from '@/lib/registry/gamesRegistry';
+import { getRandomItem } from '@/lib/utils';
 
 export default function SurpriseMeButton() {
   const router = useRouter();
@@ -15,7 +16,7 @@ export default function SurpriseMeButton() {
     const available = GamesRegistry.getAllGameRegistrations().filter(g => g.available);
     if (available.length === 0) return;
 
-    const pick = available[Math.floor(Math.random() * available.length)]!;
+    const pick = getRandomItem(available)!;
 
     setTimeout(() => {
       setSpinning(false);

--- a/gamesformykids/components/shared/overlays/HelpModalShell.tsx
+++ b/gamesformykids/components/shared/overlays/HelpModalShell.tsx
@@ -1,0 +1,46 @@
+'use client';
+
+import { ReactNode } from 'react';
+import { X } from 'lucide-react';
+import { useEscapeKey } from '@/hooks/shared/useEscapeKey';
+
+interface Props {
+  isOpen: boolean;
+  onClose: () => void;
+  title: string;
+  /** Card sizing/scroll classes, e.g. "max-w-2xl max-h-[80vh] overflow-y-auto". Default fits a small modal. */
+  cardClassName?: string;
+  children: ReactNode;
+}
+
+/**
+ * Shared "how to play" modal shell — backdrop-click-to-close, Escape-to-close,
+ * and the dialog card with a title + close button. Pass the body as children.
+ */
+export default function HelpModalShell({ isOpen, onClose, title, cardClassName = 'rounded-lg p-6 max-w-md w-full', children }: Props) {
+  useEscapeKey(onClose, isOpen);
+  if (!isOpen) return null;
+
+  return (
+    <div
+      className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50"
+      onClick={onClose}
+    >
+      <div
+        className={`bg-white mx-4 ${cardClassName}`}
+        role="dialog"
+        aria-modal="true"
+        aria-label={title}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex justify-between items-center mb-4">
+          <h3 className="text-xl font-bold text-gray-800">{title}</h3>
+          <button onClick={onClose} className="text-gray-500 hover:text-gray-700 transition-colors">
+            <X className="w-6 h-6" />
+          </button>
+        </div>
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/gamesformykids/hooks/shared/audio/useWrongAnswerFeedback.ts
+++ b/gamesformykids/hooks/shared/audio/useWrongAnswerFeedback.ts
@@ -3,6 +3,7 @@
 import { useState, useEffect } from 'react';
 import { useHaptic } from '@/hooks/shared/haptic/useHaptic';
 import { speakHebrew } from '@/lib/utils/speech/speaker';
+import { getRandomItem } from '@/lib/utils';
 
 const WRONG_PHRASES = ['כמעט!', 'נסה שוב!', 'לא נורא, תנסה שוב!'] as const;
 
@@ -16,7 +17,7 @@ export function useWrongAnswerFeedback(
   useEffect(() => {
     if (selected !== null && selected !== correctValue) {
       hapticWrong();
-      const phrase = WRONG_PHRASES[Math.floor(Math.random() * WRONG_PHRASES.length)]!;
+      const phrase = getRandomItem([...WRONG_PHRASES]);
       void speakHebrew(phrase);
       setShakingChoice(selected);
       const id = setTimeout(() => setShakingChoice(null), 600);

--- a/gamesformykids/hooks/shared/game-controls/index.ts
+++ b/gamesformykids/hooks/shared/game-controls/index.ts
@@ -1,1 +1,2 @@
 export { useKeyboardControls } from './useKeyboardControls';
+export { useHeldKeyControls } from './useHeldKeyControls';

--- a/gamesformykids/hooks/shared/game-controls/useHeldKeyControls.ts
+++ b/gamesformykids/hooks/shared/game-controls/useHeldKeyControls.ts
@@ -1,0 +1,31 @@
+'use client';
+import { useEffect, useRef } from 'react';
+
+interface HeldKeyBinding {
+  onDown: () => void;
+  onUp: () => void;
+}
+
+/**
+ * For continuous "held" movement (e.g. an arcade paddle or platformer)
+ * rather than one-shot key presses — see useKeyboardControls for that case.
+ */
+export function useHeldKeyControls(
+  bindings: Record<string, HeldKeyBinding>,
+  enabled = true,
+) {
+  const ref = useRef(bindings);
+  ref.current = bindings;
+
+  useEffect(() => {
+    if (!enabled) return;
+    const onKeyDown = (e: KeyboardEvent) => ref.current[e.key]?.onDown();
+    const onKeyUp = (e: KeyboardEvent) => ref.current[e.key]?.onUp();
+    window.addEventListener('keydown', onKeyDown);
+    window.addEventListener('keyup', onKeyUp);
+    return () => {
+      window.removeEventListener('keydown', onKeyDown);
+      window.removeEventListener('keyup', onKeyUp);
+    };
+  }, [enabled]);
+}

--- a/gamesformykids/lib/quiz/data/sorting.ts
+++ b/gamesformykids/lib/quiz/data/sorting.ts
@@ -1,3 +1,5 @@
+import { shuffle, getRandomItem } from '@/lib/utils';
+
 export interface SortingItem {
   name: string;
   emoji: string;
@@ -161,10 +163,10 @@ export interface SortingQuestion {
 }
 
 export function buildSortingQuestions(count: number): SortingQuestion[] {
-  const set = SORTING_SETS[Math.floor(Math.random() * SORTING_SETS.length)]!;
+  const set = getRandomItem(SORTING_SETS)!;
   const allItems: SortingQuestion[] = [
     ...set.categoryA.items.map(item => ({ item, itemCategory: 'A' as const, categoryA: set.categoryA, categoryB: set.categoryB })),
     ...set.categoryB.items.map(item => ({ item, itemCategory: 'B' as const, categoryA: set.categoryA, categoryB: set.categoryB })),
   ];
-  return allItems.sort(() => Math.random() - 0.5).slice(0, count);
+  return shuffle(allItems).slice(0, count);
 }

--- a/gamesformykids/lib/quiz/useColorMixGame.ts
+++ b/gamesformykids/lib/quiz/useColorMixGame.ts
@@ -3,6 +3,7 @@ import { useCallback } from 'react';
 import { COLOR_MIXES, type ColorMix } from '@/lib/quiz/data/color-mix';
 import { QUESTIONS_PER_GAME } from '@/lib/quiz/constants';
 import { useQuizSession } from '@/lib/quiz/useQuizSession';
+import { shuffle } from '@/lib/utils';
 
 interface ColorMixQuestion {
   mix: ColorMix;
@@ -11,12 +12,11 @@ interface ColorMixQuestion {
 
 function buildQuestion(mix: ColorMix): ColorMixQuestion {
   const pool = [mix.resultLabel, ...mix.wrongOptions.slice(0, 3)];
-  return { mix, choices: pool.sort(() => Math.random() - 0.5) };
+  return { mix, choices: shuffle(pool) };
 }
 
 function buildQuestions(): ColorMixQuestion[] {
-  return [...COLOR_MIXES]
-    .sort(() => Math.random() - 0.5)
+  return shuffle(COLOR_MIXES)
     .slice(0, QUESTIONS_PER_GAME)
     .map(buildQuestion);
 }

--- a/gamesformykids/lib/quiz/usePatternsGame.ts
+++ b/gamesformykids/lib/quiz/usePatternsGame.ts
@@ -11,8 +11,7 @@ export interface PatternQuestionWithChoices {
 }
 
 function buildQuestions(): PatternQuestionWithChoices[] {
-  return [...PATTERN_QUESTIONS]
-    .sort(() => Math.random() - 0.5)
+  return shuffle(PATTERN_QUESTIONS)
     .slice(0, QUESTIONS_PER_GAME)
     .map(q => ({ question: q, choices: shuffle([q.answer, ...q.wrongOptions]) }));
 }

--- a/gamesformykids/lib/quiz/useRiddlesProGame.ts
+++ b/gamesformykids/lib/quiz/useRiddlesProGame.ts
@@ -2,6 +2,7 @@
 import { useState, useCallback, useRef } from 'react';
 import { RIDDLES_PRO, type RiddlePro } from './data/riddles-pro';
 import { speakHebrew } from '@/lib/utils/speech/enhancedSpeechUtils';
+import { shuffle } from '@/lib/utils';
 
 const SESSION_SIZE = 10;
 
@@ -26,12 +27,12 @@ export interface RiddlesProState {
 }
 
 function pickSession(): RiddlePro[] {
-  const shuffled = [...RIDDLES_PRO].sort(() => Math.random() - 0.5);
+  const shuffled = shuffle(RIDDLES_PRO);
   return shuffled.slice(0, SESSION_SIZE);
 }
 
 function makeChoices(riddle: RiddlePro): string[] {
-  return [riddle.answer, ...riddle.wrongOptions].sort(() => Math.random() - 0.5);
+  return shuffle([riddle.answer, ...riddle.wrongOptions]);
 }
 
 export function useRiddlesProGame(): RiddlesProState {

--- a/gamesformykids/lib/utils/game/index.ts
+++ b/gamesformykids/lib/utils/game/index.ts
@@ -6,3 +6,4 @@ export * from './feedbackUtils';
 export * from './gameMetadata';
 export * from './gameNavigation';
 export * from './getGameConfettiEmojis';
+export * from './particles';

--- a/gamesformykids/lib/utils/game/particles.ts
+++ b/gamesformykids/lib/utils/game/particles.ts
@@ -1,0 +1,65 @@
+/**
+ * Shared particle-burst physics for canvas games and Zustand-driven effects.
+ * Covers the common "spawn N particles → apply gravity → decay life → drop dead ones" loop.
+ */
+
+export interface BaseParticle {
+  x: number;
+  y: number;
+  vx: number;
+  vy: number;
+  life: number;
+}
+
+export interface SpawnParticlesOptions<T extends BaseParticle> {
+  count: number;
+  x: number;
+  y: number;
+  /** Random velocity spread per axis when `velocity` isn't given: vx/vy = (Math.random() - 0.5) * speed. Default 6. */
+  speed?: number;
+  /** Override to fully control per-particle velocity (e.g. an upward-biased burst). */
+  velocity?: (index: number) => { vx: number; vy: number };
+  /** Initial life value. Default 1. */
+  life?: number;
+  /** Extra per-particle fields beyond x/y/vx/vy/life (e.g. color, size, id). */
+  extra?: (index: number) => Omit<T, keyof BaseParticle>;
+}
+
+export function spawnParticles<T extends BaseParticle = BaseParticle>(
+  opts: SpawnParticlesOptions<T>,
+): T[] {
+  const { count, x, y, speed = 6, velocity, life = 1, extra } = opts;
+  return Array.from({ length: count }, (_, i) => {
+    const { vx, vy } = velocity
+      ? velocity(i)
+      : { vx: (Math.random() - 0.5) * speed, vy: (Math.random() - 0.5) * speed };
+    return { x, y, vx, vy, life, ...(extra ? extra(i) : {}) } as T;
+  });
+}
+
+export interface UpdateParticlesOptions<T extends BaseParticle> {
+  /** Added to vy every tick. Default 0 (no gravity). */
+  gravity?: number;
+  /** Subtracted from life every tick. Default 0.05. */
+  decay?: number;
+  /** Per-tick transform for extra fields beyond the base kinematics (e.g. shrinking size). */
+  extra?: (p: T) => Partial<T>;
+}
+
+/** Advances position/velocity/life for one frame and drops particles whose life has run out. */
+export function updateParticles<T extends BaseParticle>(
+  particles: T[],
+  opts: UpdateParticlesOptions<T> = {},
+): T[] {
+  const { gravity = 0, decay = 0.05, extra } = opts;
+  return particles
+    .map((p) => ({
+      ...p,
+      x: p.x + p.vx,
+      y: p.y + p.vy,
+      vy: p.vy + gravity,
+      life: p.life - decay,
+      ...(extra ? extra(p) : null),
+    }))
+    .filter((p) => p.life > 0);
+}


### PR DESCRIPTION
## Summary
- Add `lib/utils/game/particles.ts` (spawnParticles/updateParticles) and adopt it in pong, brick-breaker, and building instead of three separate hand-rolled gravity/decay particle loops.
- Adopt the existing (but previously unused) `useKeyboardControls` hook across ~13 game hooks, and add a new `useHeldKeyControls` for the ~5 games needing continuous held-key movement — replacing duplicated manual keydown/keyup wiring in ~16 files.
- Replace ~50 inline random-pick/shuffle call sites with the shared `getRandomItem`/`shuffle` utilities, and remove 3 local Fisher-Yates reimplementations a prior cleanup pass missed.
- Migrate shesh-besh's Menu/GameOver screens onto `GameMenuCard`/`GameResultCard` (same shared components taki/checkers use), restructuring `SheshBeshGame.tsx` so the persistent board wrapper only renders during play.
- Add `components/shared/overlays/HelpModalShell.tsx` and migrate both puzzle variants' "how to play" modals onto it.

No behavior change intended.

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run` — 362 tests passing
- [x] `npm run build` — all 503 pages generate successfully
- [x] Manual browser smoke test (headless) on shesh-besh, pong, brick-breaker, frogger, and the puzzle help modal — no console errors, visuals confirmed via screenshot

Closes #1546

🤖 Generated with [Claude Code](https://claude.com/claude-code)