### PR TITLE
feat(multiplication): missed-fact review, mastery stars, mixed practice

### DIFF
--- a/gamesformykids/app/games/multiplication/MultiplicationGame.tsx
+++ b/gamesformykids/app/games/multiplication/MultiplicationGame.tsx
@@ -1,7 +1,31 @@
 'use client';
+import { useEffect, useRef } from 'react';
 import TimedMathGame from '@/components/game/shared/TimedMathGame';
 import { MULTIPLICATION_CONFIG } from './multiplicationConfig';
+import { useMultiplicationGameStore } from './multiplicationGameStore';
+import { QUESTIONS_PER_LEVEL } from './data/tables';
+import { recordLevelResult } from './masteryStorage';
+import { speakHebrew } from '@/lib/utils/speech/speaker';
 
 export default function MultiplicationGame() {
+  const { phase, level, correct, question } = useMultiplicationGameStore();
+  const prevPhase = useRef(phase);
+  const spokenFor = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (prevPhase.current !== 'result' && phase === 'result') {
+      recordLevelResult(level, correct, QUESTIONS_PER_LEVEL);
+    }
+    prevPhase.current = phase;
+  }, [phase, level, correct]);
+
+  useEffect(() => {
+    if (phase !== 'playing' || !question) return;
+    const key = `${question.a}x${question.b}`;
+    if (spokenFor.current === key) return;
+    spokenFor.current = key;
+    speakHebrew(`${question.a} כפול ${question.b}`);
+  }, [phase, question]);
+
   return <TimedMathGame config={MULTIPLICATION_CONFIG} />;
 }

--- a/gamesformykids/app/games/multiplication/data/tables.ts
+++ b/gamesformykids/app/games/multiplication/data/tables.ts
@@ -7,8 +7,10 @@ export interface MultiplicationQuestion {
   choices: number[];
 }
 
+export const MIXED_LEVEL = 0;
+
 export function generateQuestion(level: number): MultiplicationQuestion {
-  const a = level;
+  const a = level === MIXED_LEVEL ? Math.floor(Math.random() * 10) + 1 : level;
   const b = Math.floor(Math.random() * 10) + 1;
   const answer = a * b;
 
@@ -24,6 +26,12 @@ export function generateQuestion(level: number): MultiplicationQuestion {
   return { a, b, answer, choices };
 }
 
-export const LEVELS = Array.from({ length: 10 }, (_, i) => i + 1);
+export const LEVELS = [MIXED_LEVEL, ...Array.from({ length: 10 }, (_, i) => i + 1)];
 export const TIME_PER_QUESTION = 10; // seconds
 export const QUESTIONS_PER_LEVEL = 8;
+
+// Harder tables (and the mixed mode, which draws from all of them) get a few extra seconds.
+const HARD_LEVELS = new Set([6, 7, 8, 9, MIXED_LEVEL]);
+export function getTimeForLevel(level: number): number {
+  return HARD_LEVELS.has(level) ? TIME_PER_QUESTION + 4 : TIME_PER_QUESTION;
+}

--- a/gamesformykids/app/games/multiplication/masteryStorage.ts
+++ b/gamesformykids/app/games/multiplication/masteryStorage.ts
@@ -1,0 +1,24 @@
+const STORAGE_KEY = 'multiplication-mastery-v1';
+const MASTERY_RATIO = 0.75;
+
+function readMastered(): Set<number> {
+  if (typeof window === 'undefined') return new Set();
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    return raw ? new Set(JSON.parse(raw)) : new Set();
+  } catch {
+    return new Set();
+  }
+}
+
+export function isLevelMastered(level: number): boolean {
+  return readMastered().has(level);
+}
+
+export function recordLevelResult(level: number, correct: number, total: number): void {
+  if (typeof window === 'undefined' || total <= 0) return;
+  if (correct / total < MASTERY_RATIO) return;
+  const mastered = readMastered();
+  mastered.add(level);
+  window.localStorage.setItem(STORAGE_KEY, JSON.stringify(Array.from(mastered)));
+}

--- a/gamesformykids/app/games/multiplication/multiplicationConfig.tsx
+++ b/gamesformykids/app/games/multiplication/multiplicationConfig.tsx
@@ -1,12 +1,15 @@
 import type { TimedMathConfig } from '@/components/game/shared/TimedMathGame';
 import { useMultiplicationGameStore, stopMultiplicationTimer } from './multiplicationGameStore';
-import { LEVELS, QUESTIONS_PER_LEVEL, TIME_PER_QUESTION, MultiplicationQuestion } from './data/tables';
+import {
+  LEVELS, QUESTIONS_PER_LEVEL, MIXED_LEVEL, MultiplicationQuestion, getTimeForLevel,
+} from './data/tables';
+import { isLevelMastered } from './masteryStorage';
 
 export const MULTIPLICATION_CONFIG: TimedMathConfig<number, MultiplicationQuestion> = {
   useStore: useMultiplicationGameStore,
   stopTimer: stopMultiplicationTimer,
   totalQuestions: QUESTIONS_PER_LEVEL,
-  timePerQuestion: TIME_PER_QUESTION,
+  timePerQuestion: getTimeForLevel,
 
   emoji: '✖️',
   title: 'לוח הכפל',
@@ -14,23 +17,33 @@ export const MULTIPLICATION_CONFIG: TimedMathConfig<number, MultiplicationQuesti
   gradient: 'from-violet-50 to-purple-100',
   levels: LEVELS,
   getKey: (lv) => lv,
-  renderLevelItem: (lv) => lv,
+  renderLevelItem: (lv) => (
+    <span className="flex flex-col items-center leading-none">
+      <span>{lv === MIXED_LEVEL ? '🎲' : lv}</span>
+      {isLevelMastered(lv) && <span className="text-sm mt-0.5">⭐</span>}
+    </span>
+  ),
   levelColumns: 5,
   levelGap: 3,
   levelButtonClass: 'aspect-square rounded-2xl text-2xl font-black text-white shadow-lg hover:scale-105 active:scale-95 transition bg-gradient-to-br from-purple-500 to-violet-600 hover:from-purple-400 hover:to-violet-500',
   menuFooter: (
     <p className="text-center text-purple-500 text-sm mt-4">
-      {QUESTIONS_PER_LEVEL} שאלות ל-{TIME_PER_QUESTION} שניות כל אחת
+      {QUESTIONS_PER_LEVEL} שאלות כל סבב • 🎲 = תרגול מעורב • ⭐ = לוח שנשלט
     </p>
   ),
 
-  renderLevelLabel: (lv) => `לוח ${lv}`,
-  renderEquation: (q) => `${q.a} × ${q.b} = ?`,
+  renderLevelLabel: (lv) => (lv === MIXED_LEVEL ? 'תרגול מעורב' : `לוח ${lv}`),
+  renderEquation: (q) => (
+    <span dir="ltr" className="inline-flex items-center gap-3">
+      <span>{q.a} × {q.b}</span>
+      <span>= ?</span>
+    </span>
+  ),
   renderFeedbackText: (q, ok) =>
     ok ? `✅ נכון! ${q.a} × ${q.b} = ${q.answer}` : `❌ ${q.a} × ${q.b} = ${q.answer}`,
   answerHoverClass: 'hover:border-purple-400 hover:bg-purple-50',
 
-  renderResultTitle: (lv) => `לוח ${lv} — סיום!`,
+  renderResultTitle: (lv) => (lv === MIXED_LEVEL ? 'תרגול מעורב — סיום!' : `לוח ${lv} — סיום!`),
   accentText700: 'text-purple-700',
   accentText500: 'text-purple-500',
   accentBg100: 'bg-purple-100',
@@ -38,4 +51,19 @@ export const MULTIPLICATION_CONFIG: TimedMathConfig<number, MultiplicationQuesti
   gradientBtn: 'from-purple-500 to-violet-600',
   resultBg: 'bg-purple-50',
   resultBar: 'bg-purple-400',
+  renderWrongList: (wrong) => {
+    const unique = Array.from(new Map(wrong.map((q) => [`${q.a}x${q.b}`, q])).values());
+    return (
+      <div className="mt-4 rounded-2xl bg-purple-50 p-4 text-right">
+        <p className="font-bold text-purple-700 mb-2">כדאי לתרגל עוד:</p>
+        <div className="flex flex-wrap gap-2 justify-center" dir="ltr">
+          {unique.map((q) => (
+            <span key={`${q.a}x${q.b}`} className="bg-white rounded-xl px-3 py-1 text-purple-700 font-bold shadow-sm">
+              {q.a} × {q.b} = {q.answer}
+            </span>
+          ))}
+        </div>
+      </div>
+    );
+  },
 };

--- a/gamesformykids/app/games/multiplication/multiplicationGameStore.ts
+++ b/gamesformykids/app/games/multiplication/multiplicationGameStore.ts
@@ -1,12 +1,12 @@
 import { createTimedQuizStore } from '@/lib/stores/createTimedQuizStore';
 import {
-  generateQuestion, QUESTIONS_PER_LEVEL, TIME_PER_QUESTION,
+  generateQuestion, QUESTIONS_PER_LEVEL, getTimeForLevel,
 } from './data/tables';
 
 const { useStore, stopTimer } = createTimedQuizStore({
   initialLevel: 1,
   questionsPerGame: QUESTIONS_PER_LEVEL,
-  timePerQuestion: TIME_PER_QUESTION,
+  timePerQuestion: getTimeForLevel,
   generateQuestion,
   calcScore: (score, timeLeft) => score + timeLeft,
 });

--- a/gamesformykids/components/game/shared/TimedMathGame.tsx
+++ b/gamesformykids/components/game/shared/TimedMathGame.tsx
@@ -13,6 +13,7 @@ interface TimedMathStore<Level, Q> {
   selected: number | null;
   isCorrect: boolean | null;
   timeLeft: number;
+  wrongQuestions: Q[];
   startGame: (level: Level) => void;
   selectAnswer: (val: number) => void;
   advance: () => void;
@@ -25,7 +26,7 @@ export interface TimedMathConfig<Level, Q extends { answer: number; choices: num
   stopTimer: () => void;
   onMount?: () => void;
   totalQuestions: number;
-  timePerQuestion: number;
+  timePerQuestion: number | ((level: Level) => number);
 
   emoji: string;
   title: string;
@@ -52,6 +53,8 @@ export interface TimedMathConfig<Level, Q extends { answer: number; choices: num
   gradientBtn: string;
   resultBg: string;
   resultBar: string;
+  /** Optional list of missed questions rendered on the result screen. */
+  renderWrongList?: (wrong: Q[]) => ReactNode;
 }
 
 export default function TimedMathGame<Level, Q extends { answer: number; choices: number[] }>({
@@ -61,7 +64,7 @@ export default function TimedMathGame<Level, Q extends { answer: number; choices
 }) {
   const {
     phase, level, question, questionNum, score, correct,
-    selected, isCorrect, timeLeft,
+    selected, isCorrect, timeLeft, wrongQuestions,
     startGame, selectAnswer, advance, tick, goMenu,
   } = config.useStore();
 
@@ -102,14 +105,15 @@ export default function TimedMathGame<Level, Q extends { answer: number; choices
 
   if (phase === 'playing') {
     if (!question) return null;
-    const timePct = (timeLeft / config.timePerQuestion) * 100;
+    const timePerQ = typeof config.timePerQuestion === 'function' ? config.timePerQuestion(level) : config.timePerQuestion;
+    const timePct = (timeLeft / timePerQ) * 100;
     const timerColor = timePct > 60 ? 'bg-green-400' : timePct > 30 ? 'bg-yellow-400' : 'bg-red-400';
 
     return (
       <div className={`min-h-screen bg-gradient-to-br ${config.gradient} p-4`} dir="rtl">
         <div className="max-w-xl mx-auto">
           <div className="flex justify-between items-center mb-3">
-            <button onClick={goMenu} className={`${config.accentText500} text-sm ${config.accentBg100} rounded-full px-3 py-1`}>← חזור</button>
+            <button onClick={goMenu} className={`${config.accentText500} text-base font-bold ${config.accentBg100} rounded-full px-4 py-2 active:scale-95 transition-transform`}>← חזור</button>
             <span className={`font-bold ${config.accentText700}`}>{config.renderLevelLabel(level)} | שאלה {questionNum + 1}/{config.totalQuestions}</span>
             <span className={`font-bold ${config.accentText700}`}>⭐ {score}</span>
           </div>
@@ -169,6 +173,7 @@ export default function TimedMathGame<Level, Q extends { answer: number; choices
           <div className={`h-full ${config.resultBar} rounded-full`} style={{ width: `${pct}%` }} />
         </div>
       </div>
+      {wrongQuestions.length > 0 && config.renderWrongList?.(wrongQuestions)}
     </GameResultCard>
   );
 }

--- a/gamesformykids/lib/stores/createTimedQuizStore.ts
+++ b/gamesformykids/lib/stores/createTimedQuizStore.ts
@@ -4,7 +4,7 @@ import type { PhaseResult as Phase } from '@/lib/types';
 interface TimedQuizConfig<Level, Question extends { answer: number }> {
   initialLevel: Level;
   questionsPerGame: number;
-  timePerQuestion: number;
+  timePerQuestion: number | ((level: Level) => number);
   generateQuestion: (level: Level) => Question;
   calcScore: (currentScore: number, timeLeft: number) => number;
 }
@@ -19,6 +19,7 @@ interface TimedQuizState<Level, Question> {
   selected: number | null;
   isCorrect: boolean | null;
   timeLeft: number;
+  wrongQuestions: Question[];
 }
 
 interface TimedQuizActions<Level> {
@@ -32,6 +33,9 @@ interface TimedQuizActions<Level> {
 export function createTimedQuizStore<Level, Question extends { answer: number }>(
   config: TimedQuizConfig<Level, Question>
 ) {
+  const resolveTime = (lv: Level) =>
+    typeof config.timePerQuestion === 'function' ? config.timePerQuestion(lv) : config.timePerQuestion;
+
   const useStore = makeStore<TimedQuizState<Level, Question> & TimedQuizActions<Level>>('TimedQuizStore', (set, get) => ({
     phase: 'menu',
     level: config.initialLevel,
@@ -41,7 +45,8 @@ export function createTimedQuizStore<Level, Question extends { answer: number }>
     correct: 0,
     selected: null,
     isCorrect: null,
-    timeLeft: config.timePerQuestion,
+    timeLeft: resolveTime(config.initialLevel),
+    wrongQuestions: [],
 
     startGame: (lv: Level) => {
       set({
@@ -53,12 +58,13 @@ export function createTimedQuizStore<Level, Question extends { answer: number }>
         correct: 0,
         selected: null,
         isCorrect: null,
-        timeLeft: config.timePerQuestion,
+        timeLeft: resolveTime(lv),
+        wrongQuestions: [],
       });
     },
 
     selectAnswer: (val: number) => {
-      const { selected, question, timeLeft, score, correct } = get();
+      const { selected, question, timeLeft, score, correct, wrongQuestions } = get();
       if (selected !== null || !question) return;
       const ok = val === question.answer;
       set({
@@ -66,6 +72,7 @@ export function createTimedQuizStore<Level, Question extends { answer: number }>
         isCorrect: ok,
         score: ok ? config.calcScore(score, timeLeft) : score,
         correct: ok ? correct + 1 : correct,
+        wrongQuestions: ok ? wrongQuestions : [...wrongQuestions, question],
       });
     },
 
@@ -80,16 +87,21 @@ export function createTimedQuizStore<Level, Question extends { answer: number }>
           question: config.generateQuestion(level),
           selected: null,
           isCorrect: null,
-          timeLeft: config.timePerQuestion,
+          timeLeft: resolveTime(level),
         });
       }
     },
 
     tick: () => {
-      const { timeLeft, selected, phase } = get();
+      const { timeLeft, selected, phase, question, wrongQuestions } = get();
       if (phase !== 'playing' || selected !== null) return;
       if (timeLeft <= 1) {
-        set({ selected: -1, isCorrect: false, timeLeft: 0 });
+        set({
+          selected: -1,
+          isCorrect: false,
+          timeLeft: 0,
+          wrongQuestions: question ? [...wrongQuestions, question] : wrongQuestions,
+        });
       } else {
         set({ timeLeft: timeLeft - 1 });
       }


### PR DESCRIPTION
## Summary
- Result screen now lists the specific facts the child missed ("כדאי לתרגל עוד"), not just a score
- Level-menu buttons show a ⭐ once a table is mastered (≥75% correct), tracked in localStorage
- Harder tables (6-9) and the new mixed-practice level get 4 extra seconds per question
- New "🎲 תרגול מעורב" level draws questions from all tables
- Each equation is now spoken aloud via the existing `speakHebrew` TTS utility
- Back button during play is larger/more prominent

Changes to the shared `TimedMathGame`/`createTimedQuizStore` are additive (new optional `renderWrongList` config, `timePerQuestion` now also accepts a per-level function) — the arithmetic game, which shares this infra, is unaffected and still typechecks/lints clean.

Closes #1548

## Test plan
- [x] `npx tsc --noEmit` clean for all touched files
- [x] `npx eslint` clean for all touched files
- [ ] Manually play a few multiplication rounds (menu → mixed mode → miss a question → check result screen list and mastery star)
- [ ] Confirm arithmetic game still plays normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)