### PR TITLE
fix(tetris): fix RTL arrow swap, add hard drop, pause, and wall-kick

### DIFF
--- a/gamesformykids/__tests__/stores/tetrisStore.test.ts
+++ b/gamesformykids/__tests__/stores/tetrisStore.test.ts
@@ -1,6 +1,6 @@
-import { beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { useTetrisStore } from '@/app/games/tetris/store/tetrisStore';
-import { BOARD_HEIGHT, BOARD_WIDTH, EMPTY_BOARD } from '@/app/games/tetris/constants';
+import { BOARD_HEIGHT, BOARD_WIDTH, EMPTY_BOARD, TETROMINOES } from '@/app/games/tetris/constants';
 
 const store = useTetrisStore;
 
@@ -89,6 +89,119 @@ describe('tetrisStore', () => {
       store.getState().startNewGame();
       store.getState().goToStartScreen();
       expect(store.getState().phase).toBe('menu');
+    });
+  });
+
+  describe('togglePause', () => {
+    it('pauses a playing game', () => {
+      store.getState().startNewGame();
+      store.getState().togglePause();
+      expect(store.getState().phase).toBe('paused');
+    });
+
+    it('resumes a paused game', () => {
+      store.getState().startNewGame();
+      store.getState().togglePause();
+      store.getState().togglePause();
+      expect(store.getState().phase).toBe('playing');
+    });
+
+    it('does nothing from menu or gameover', () => {
+      store.setState({ phase: 'gameover' } as unknown as Parameters<typeof store.setState>[0]);
+      store.getState().togglePause();
+      expect(store.getState().phase).toBe('gameover');
+    });
+  });
+
+  describe('handleRotate wall-kick', () => {
+    it('shifts the piece away from the wall when a plain rotation would go out of bounds', () => {
+      // T-piece already rotated once (3 rows x 2 cols), sitting flush against the right wall.
+      store.setState({
+        board: EMPTY_BOARD,
+        currentPiece: { type: 'T', blocks: [[1, 0], [1, 1], [1, 0]], color: TETROMINOES.T!.color },
+        position: { x: 8, y: 5 },
+        phase: 'playing',
+      } as unknown as Parameters<typeof store.setState>[0]);
+
+      store.getState().handleRotate();
+
+      const { currentPiece, position } = store.getState();
+      // Next rotation is 2 rows x 3 cols — doesn't fit at x=8, needs to kick left to x=7.
+      expect(currentPiece?.blocks).toEqual([[1, 1, 1], [0, 1, 0]]);
+      expect(position).toEqual({ x: 7, y: 5 });
+    });
+  });
+
+  describe('hardDrop', () => {
+    it('drops the piece straight to the floor and awards a distance bonus', () => {
+      const nextPiece = { type: 'O', blocks: TETROMINOES.O!.blocks, color: TETROMINOES.O!.color };
+      store.setState({
+        board: EMPTY_BOARD,
+        currentPiece: { type: 'O', blocks: TETROMINOES.O!.blocks, color: TETROMINOES.O!.color },
+        position: { x: 4, y: 0 },
+        score: 0,
+        level: 1,
+        phase: 'playing',
+        nextPiece,
+        linesCleared: 0,
+        clearingRows: [],
+      } as unknown as Parameters<typeof store.setState>[0]);
+
+      store.getState().hardDrop();
+
+      const state = store.getState();
+      // O-piece is 2 rows tall, board is 20 rows — falls 18 rows, 2 points each.
+      expect(state.score).toBe(36);
+      expect(state.currentPiece).toEqual(nextPiece);
+      expect(state.position).toEqual({ x: 4, y: 0 });
+      expect(state.board[BOARD_HEIGHT - 1]!.slice(4, 6)).toEqual([TETROMINOES.O!.color, TETROMINOES.O!.color]);
+    });
+  });
+
+  describe('line clear animation', () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it('flashes the completed row before removing it and advancing', () => {
+      const filledRow = new Array(BOARD_WIDTH).fill('gray').map((cell, x) => (x === 4 || x === 5 ? 0 : cell));
+      const board = EMPTY_BOARD.map((row, y) => (y === BOARD_HEIGHT - 1 ? filledRow : [...row]));
+      const nextPiece = { type: 'O', blocks: TETROMINOES.O!.blocks, color: 'yellow' };
+
+      store.setState({
+        board,
+        currentPiece: { type: 'O', blocks: TETROMINOES.O!.blocks, color: 'cyan' },
+        position: { x: 4, y: BOARD_HEIGHT - 2 },
+        score: 0,
+        level: 1,
+        phase: 'playing',
+        nextPiece,
+        linesCleared: 0,
+        clearingRows: [],
+      } as unknown as Parameters<typeof store.setState>[0]);
+
+      // The O-piece is already resting on the floor — one more down-move locks it in place.
+      store.getState().movePiece(0, 1);
+
+      let state = store.getState();
+      expect(state.clearingRows).toEqual([BOARD_HEIGHT - 1]);
+      expect(state.currentPiece).toBeNull();
+      expect(state.board[BOARD_HEIGHT - 1]!.every(cell => cell !== 0)).toBe(true);
+
+      vi.advanceTimersByTime(500);
+
+      state = store.getState();
+      expect(state.clearingRows).toEqual([]);
+      expect(state.linesCleared).toBe(1);
+      expect(state.score).toBe(100);
+      expect(state.currentPiece).toEqual(nextPiece);
+      expect(state.position).toEqual({ x: 4, y: 0 });
+      // Row above (only the piece's top half) shifts down into the cleared row's place.
+      expect(state.board[BOARD_HEIGHT - 1]).toEqual([0, 0, 0, 0, 'cyan', 'cyan', 0, 0, 0, 0]);
     });
   });
 });

--- a/gamesformykids/app/games/tetris/components/GameBoard.tsx
+++ b/gamesformykids/app/games/tetris/components/GameBoard.tsx
@@ -1,30 +1,89 @@
+import { useRef } from 'react';
 import { GameBoardProps } from '../types';
+import { useTetrisStore } from '../store/tetrisStore';
 
-const GameBoard = ({ displayBoard }: GameBoardProps) => (
-  <div className="bg-gradient-to-br from-gray-900/50 to-black/50 backdrop-blur-lg rounded-3xl p-3 lg:p-4 shadow-2xl border border-white/20">
-    <div dir="ltr" style={{ direction: 'ltr' }} className="grid grid-cols-10 gap-0.5 lg:gap-1 bg-gradient-to-br from-gray-800/80 to-gray-900/80 p-2 lg:p-3 rounded-2xl border border-gray-600/50">
-      {displayBoard.map((row, y) =>
-        row.map((cell, x) => {
-          const isEmpty = !cell || cell === 0;
-          return (
-            <div
-              key={`${y}-${x}`}
-              className={`w-4 h-4 lg:w-6 lg:h-6 rounded-md border border-gray-600/50 ${isEmpty ? '' : 'transform transition duration-150'}`}
-              style={{
-                background: isEmpty 
-                  ? 'linear-gradient(135deg, #1f2937 0%, #111827 100%)' 
-                  : cell,
-                boxShadow: isEmpty
-                  ? 'inset 0 1px 2px rgba(0,0,0,0.3)'
-                  : '0 1px 4px rgba(0,0,0,0.4), inset 0 1px 0 rgba(255,255,255,0.3)',
-                willChange: isEmpty ? 'auto' : 'transform'
-              }}
-            />
-          );
-        })
+// Below this many pixels a touch gesture counts as a tap (rotate) rather than a swipe.
+const SWIPE_THRESHOLD = 25;
+
+const GameBoard = ({ displayBoard }: GameBoardProps) => {
+  const phase = useTetrisStore(s => s.phase);
+  const clearingRows = useTetrisStore(s => s.clearingRows);
+  const movePiece = useTetrisStore(s => s.movePiece);
+  const handleRotate = useTetrisStore(s => s.handleRotate);
+  const hardDrop = useTetrisStore(s => s.hardDrop);
+  const touchStart = useRef<{ x: number; y: number } | null>(null);
+
+  const onTouchStart = (e: React.TouchEvent) => {
+    const touch = e.touches[0];
+    touchStart.current = touch ? { x: touch.clientX, y: touch.clientY } : null;
+  };
+
+  const onTouchEnd = (e: React.TouchEvent) => {
+    const start = touchStart.current;
+    touchStart.current = null;
+    if (phase !== 'playing' || !start) return;
+
+    const touch = e.changedTouches[0];
+    if (!touch) return;
+
+    const dx = touch.clientX - start.x;
+    const dy = touch.clientY - start.y;
+
+    if (Math.abs(dx) < SWIPE_THRESHOLD && Math.abs(dy) < SWIPE_THRESHOLD) {
+      handleRotate();
+      return;
+    }
+
+    if (Math.abs(dx) > Math.abs(dy)) {
+      movePiece(dx > 0 ? 1 : -1, 0);
+    } else if (dy > 0) {
+      hardDrop();
+    }
+  };
+
+  return (
+    <div
+      onTouchStart={onTouchStart}
+      onTouchEnd={onTouchEnd}
+      className="relative bg-gradient-to-br from-gray-900/50 to-black/50 backdrop-blur-lg rounded-3xl p-3 lg:p-4 shadow-2xl border border-white/20 touch-none"
+    >
+      {phase === 'paused' && (
+        <div className="absolute inset-3 lg:inset-4 flex items-center justify-center bg-black/70 backdrop-blur-sm rounded-2xl z-10">
+          <div className="text-center">
+            <p className="text-6xl mb-2">⏸️</p>
+            <p className="text-white font-black text-xl drop-shadow-lg">מושהה</p>
+          </div>
+        </div>
       )}
+      <div dir="ltr" style={{ direction: 'ltr' }} className="grid grid-cols-10 gap-0.5 lg:gap-1 bg-gradient-to-br from-gray-800/80 to-gray-900/80 p-2 lg:p-3 rounded-2xl border border-gray-600/50">
+        {displayBoard.map((row, y) =>
+          row.map((cell, x) => {
+            const isEmpty = !cell || cell === 0;
+            const isClearing = clearingRows.includes(y);
+            return (
+              <div
+                key={`${y}-${x}`}
+                className={`w-6 h-6 lg:w-7 lg:h-7 rounded-md border border-gray-600/50 ${isEmpty ? '' : 'transform transition duration-150'} ${isClearing ? 'animate-pulse' : ''}`}
+                style={{
+                  background: isClearing
+                    ? '#ffffff'
+                    : isEmpty
+                    ? 'linear-gradient(135deg, #1f2937 0%, #111827 100%)'
+                    : cell,
+                  boxShadow: isClearing
+                    ? '0 0 16px 4px rgba(255,255,255,0.9)'
+                    : isEmpty
+                    ? 'inset 0 1px 2px rgba(0,0,0,0.3)'
+                    : '0 1px 4px rgba(0,0,0,0.4), inset 0 1px 0 rgba(255,255,255,0.3)',
+                  willChange: isEmpty ? 'auto' : 'transform'
+                }}
+              />
+            );
+          })
+        )}
+      </div>
     </div>
-  </div>
-);
+  );
+};
 
 export default GameBoard;

--- a/gamesformykids/app/games/tetris/components/InfoPanels.tsx
+++ b/gamesformykids/app/games/tetris/components/InfoPanels.tsx
@@ -36,27 +36,27 @@ export const DesktopInfoPanel = () => {
     <div className="space-y-6">
       {/* Score Card */}
       <div className="bg-gradient-to-br from-purple-600/80 to-purple-800/80 backdrop-blur-lg p-6 rounded-2xl border border-purple-300/30 shadow-2xl">
-        <h3 className="text-white font-bold text-2xl mb-4 text-center">Score</h3>
+        <h3 className="text-white font-bold text-2xl mb-4 text-center">ניקוד</h3>
         <p className="text-yellow-300 text-3xl font-black text-center">{score.toLocaleString()}</p>
       </div>
-      
+
       {/* Level & Lines */}
       <div className="bg-gradient-to-br from-blue-600/80 to-blue-800/80 backdrop-blur-lg p-6 rounded-2xl border border-blue-300/30 shadow-2xl">
         <div className="space-y-4">
           <div className="text-center">
-            <h4 className="text-white font-bold text-lg">Level</h4>
+            <h4 className="text-white font-bold text-lg">רמה</h4>
             <p className="text-cyan-300 text-2xl font-black">{level}</p>
           </div>
           <div className="border-t border-blue-400/30 pt-4 text-center">
-            <h4 className="text-white font-bold text-lg">Lines</h4>
+            <h4 className="text-white font-bold text-lg">שורות</h4>
             <p className="text-cyan-300 text-2xl font-black">{linesCleared}</p>
           </div>
         </div>
       </div>
-      
+
       {/* Next Piece */}
       <div className="bg-gradient-to-br from-green-600/80 to-green-800/80 backdrop-blur-lg p-6 rounded-2xl border border-green-300/30 shadow-2xl">
-        <h3 className="text-white font-bold text-xl mb-4 text-center">Next Piece</h3>
+        <h3 className="text-white font-bold text-xl mb-4 text-center">החלק הבא</h3>
         <div className="flex justify-center">
           <NextPieceDisplay nextPiece={nextPiece} />
         </div>

--- a/gamesformykids/app/games/tetris/components/TouchControls.tsx
+++ b/gamesformykids/app/games/tetris/components/TouchControls.tsx
@@ -8,8 +8,9 @@ interface TouchControlsProps {
 const TouchControls = ({ isDesktop = false }: TouchControlsProps) => {
   const { phase, score, startNewGame: onStartGame } = useTetrisState();
   const isGameRunning = phase === 'playing';
+  const isPaused = phase === 'paused';
   const gameOver = phase === 'gameover';
-  const { handleMove, handleRotate } = useTouchControls();
+  const { handleMove, handleRotate, handleHardDrop, handleTogglePause } = useTouchControls();
 
   // פריסה למחשב
   if (isDesktop) {
@@ -29,7 +30,7 @@ const TouchControls = ({ isDesktop = false }: TouchControlsProps) => {
           </div>
         )}
 
-        {!isGameRunning && !gameOver && (
+        {!isGameRunning && !gameOver && !isPaused && (
           <div className="text-center">
             <button
               onClick={onStartGame}
@@ -40,10 +41,32 @@ const TouchControls = ({ isDesktop = false }: TouchControlsProps) => {
           </div>
         )}
 
+        {/* Paused */}
+        {isPaused && (
+          <div className="text-center bg-indigo-900/80 text-white p-4 rounded-xl backdrop-blur-sm border border-indigo-300/30">
+            <h2 className="text-2xl font-bold mb-2">⏸️ המשחק מושהה</h2>
+            <button
+              onClick={handleTogglePause}
+              className="bg-gradient-to-br from-green-400 to-emerald-500 text-white px-6 py-3 rounded-xl font-bold text-lg shadow-lg hover:scale-105 transition-transform duration-200"
+            >
+              ▶️ המשך משחק
+            </button>
+          </div>
+        )}
+
         {/* Desktop Controls - Keyboard Instructions */}
-        {isGameRunning && (
+        {(isGameRunning || isPaused) && (
           <div className="bg-black/60 p-4 rounded-xl backdrop-blur-sm border border-blue-300/30">
-            <h3 className="text-white font-bold text-lg mb-3 text-center">פקדי מקלדת</h3>
+            <div className="flex justify-between items-center mb-3">
+              <h3 className="text-white font-bold text-lg text-center flex-1">פקדי מקלדת</h3>
+              <button
+                onClick={handleTogglePause}
+                aria-label={isPaused ? 'המשך משחק' : 'השהה משחק'}
+                className="bg-white/10 hover:bg-white/20 text-white p-2 rounded-lg border border-white/20 transition-colors"
+              >
+                {isPaused ? '▶️' : '⏸️'}
+              </button>
+            </div>
             <div className="space-y-2 text-white text-sm">
               <div className="flex justify-between">
                 <span>הזזה שמאלה:</span>
@@ -61,6 +84,14 @@ const TouchControls = ({ isDesktop = false }: TouchControlsProps) => {
                 <span>סיבוב:</span>
                 <span className="bg-gray-700 px-2 py-1 rounded">↑</span>
               </div>
+              <div className="flex justify-between">
+                <span>נפילה מהירה:</span>
+                <span className="bg-gray-700 px-2 py-1 rounded">Space</span>
+              </div>
+              <div className="flex justify-between">
+                <span>השהיה:</span>
+                <span className="bg-gray-700 px-2 py-1 rounded">Esc / P</span>
+              </div>
             </div>
           </div>
         )}
@@ -71,50 +102,70 @@ const TouchControls = ({ isDesktop = false }: TouchControlsProps) => {
   // פריסה למובייל
   return (
     <div className="mt-6 w-full max-w-xs">
-      {/* Rotate Button */}
-      <div className="flex justify-center mb-4">
+      {/* Rotate + Pause */}
+      <div className="flex justify-center items-center gap-3 mb-4">
         <button
           onClick={handleRotate}
+          aria-label="סובב חלק"
           className="bg-gradient-to-br from-green-400 to-emerald-500 text-white px-6 py-3 rounded-xl font-black text-lg shadow-2xl active:scale-95 transition-transform duration-150 border-2 border-green-300/30 touch-manipulation"
           disabled={!isGameRunning}
         >
           🔄 סיבוב
         </button>
+        <button
+          onClick={handleTogglePause}
+          aria-label={isPaused ? 'המשך משחק' : 'השהה משחק'}
+          className="bg-gradient-to-br from-slate-500 to-slate-700 text-white px-4 py-3 rounded-xl font-black text-lg shadow-2xl active:scale-95 transition-transform duration-150 border-2 border-slate-300/30 touch-manipulation"
+          disabled={!isGameRunning && !isPaused}
+        >
+          {isPaused ? '▶️' : '⏸️'}
+        </button>
       </div>
-      
-      {/* Movement Controls */}
-      <div className="grid grid-cols-3 gap-3 mb-4">
+
+      {/* Movement Controls — forced LTR so left/right visually match the move direction regardless of page RTL */}
+      <div dir="ltr" style={{ direction: 'ltr' }} className="grid grid-cols-3 gap-3 mb-4">
         <button
           onClick={() => handleMove(-1, 0)}
+          aria-label="הזז שמאלה"
           className="bg-gradient-to-br from-blue-400 to-blue-600 text-white p-3 rounded-xl font-black text-lg shadow-2xl active:scale-95 transition-transform duration-150 border-2 border-blue-300/30 touch-manipulation"
           disabled={!isGameRunning}
         >
           ⬅️
         </button>
         <button
-          onClick={() => handleMove(0, 1)}
+          onClick={handleHardDrop}
+          aria-label="הפל מיד"
           className="bg-gradient-to-br from-red-400 to-red-600 text-white p-3 rounded-xl font-black text-sm shadow-2xl active:scale-95 transition-transform duration-150 border-2 border-red-300/30 touch-manipulation"
           disabled={!isGameRunning}
         >
-          ⬇️ מהר
+          ⏬ צנח
         </button>
         <button
           onClick={() => handleMove(1, 0)}
+          aria-label="הזז ימינה"
           className="bg-gradient-to-br from-blue-400 to-blue-600 text-white p-3 rounded-xl font-black text-lg shadow-2xl active:scale-95 transition-transform duration-150 border-2 border-blue-300/30 touch-manipulation"
           disabled={!isGameRunning}
         >
           ➡️
         </button>
       </div>
-      
+
       {/* Start Button */}
       <button
         onClick={onStartGame}
         className="w-full bg-gradient-to-r from-purple-500 via-pink-500 to-yellow-500 text-white px-6 py-4 rounded-xl font-black text-lg shadow-2xl active:scale-95 transition-transform duration-150 border-2 border-white/30 touch-manipulation"
       >
-        {gameOver ? '🔄 משחק חדש' : isGameRunning ? '🔄 התחל מחדש' : '▶️ התחל לשחק'}
+        {gameOver ? '🔄 משחק חדש' : isGameRunning || isPaused ? '🔄 התחל מחדש' : '▶️ התחל לשחק'}
       </button>
-      
+
+      {/* Paused Message */}
+      {isPaused && (
+        <div className="bg-gradient-to-br from-indigo-400/20 to-slate-500/20 backdrop-blur-lg border-2 border-indigo-400/50 rounded-xl p-4 text-center mt-4 shadow-2xl">
+          <h3 className="text-xl font-black text-white mb-2 drop-shadow-lg">⏸️ המשחק מושהה</h3>
+          <p className="text-white/80 text-sm">לחץ על ▶️ כדי להמשיך</p>
+        </div>
+      )}
+
       {/* Game Over Message */}
       {gameOver && (
         <div className="bg-gradient-to-br from-red-400/20 to-pink-500/20 backdrop-blur-lg border-2 border-red-400/50 rounded-xl p-4 text-center mt-4 shadow-2xl">
@@ -122,11 +173,11 @@ const TouchControls = ({ isDesktop = false }: TouchControlsProps) => {
           <p className="text-yellow-300 text-lg font-bold drop-shadow-lg">הניקוד שלך: {score.toLocaleString()}</p>
         </div>
       )}
-      
+
       {/* Control Instructions */}
       <div className="bg-gradient-to-br from-white/10 to-white/5 backdrop-blur-lg rounded-xl p-3 mt-4 text-center border border-white/20">
         <p className="text-white/80 font-medium text-sm">
-          השתמש בכפתורים למעלה או בחיצי המקלדת 📱⌨️
+          השתמש בכפתורים למעלה, בחיצי המקלדת או בהחלקת אצבע על הלוח 📱⌨️
         </p>
       </div>
     </div>

--- a/gamesformykids/app/games/tetris/components/useTouchControls.ts
+++ b/gamesformykids/app/games/tetris/components/useTouchControls.ts
@@ -6,6 +6,8 @@ export function useTouchControls() {
   const isGameRunning = useTetrisStore(s => s.phase === 'playing');
   const movePiece = useTetrisStore(s => s.movePiece);
   const handleRotateAction = useTetrisStore(s => s.handleRotate);
+  const hardDropAction = useTetrisStore(s => s.hardDrop);
+  const togglePauseAction = useTetrisStore(s => s.togglePause);
 
   const handleMove = (dx: number, dy: number) => {
     if (!isGameRunning) return;
@@ -17,5 +19,14 @@ export function useTouchControls() {
     handleRotateAction();
   };
 
-  return { handleMove, handleRotate };
+  const handleHardDrop = () => {
+    if (!isGameRunning) return;
+    hardDropAction();
+  };
+
+  const handleTogglePause = () => {
+    togglePauseAction();
+  };
+
+  return { handleMove, handleRotate, handleHardDrop, handleTogglePause };
 }

--- a/gamesformykids/app/games/tetris/hooks/useTetrisGame.ts
+++ b/gamesformykids/app/games/tetris/hooks/useTetrisGame.ts
@@ -15,11 +15,14 @@ export const useTetrisGame = () => {
   const phase = useTetrisStore(s => s.phase);
   const level = useTetrisStore(s => s.level);
   const movePiece = useTetrisStore(s => s.movePiece);
+  const hardDrop = useTetrisStore(s => s.hardDrop);
   const handleRotate = useTetrisStore(s => s.handleRotate);
+  const togglePause = useTetrisStore(s => s.togglePause);
 
   const { saveGameResultRef } = useGameCompletion('tetris');
   const startTimeRef = useRef(0);
   const prevGameOverRef = useRef(false);
+  const prevPhaseRef = useRef(phase);
 
   // אופטימיזציה למובייל — התחלה לאחר טעינה מלאה
   useEffect(() => {
@@ -29,15 +32,17 @@ export const useTetrisGame = () => {
   }, []);
 
   const isPlaying = phase === 'playing';
+  const isPaused = phase === 'paused';
   const isGameOver = phase === 'gameover';
 
-  // מעקב אחר זמן תחילת המשחק
+  // מעקב אחר זמן תחילת המשחק — לא מתאפס בחזרה מהשהיה
   useEffect(() => {
-    if (isPlaying) {
+    if (isPlaying && prevPhaseRef.current !== 'paused') {
       startTimeRef.current = Date.now();
       prevGameOverRef.current = false;
     }
-  }, [isPlaying]);
+    prevPhaseRef.current = phase;
+  }, [phase, isPlaying]);
 
   // שמירת ניקוד בסיום המשחק
   useEffect(() => {
@@ -59,12 +64,19 @@ export const useTetrisGame = () => {
     return () => clearInterval(gameLoop);
   }, [isPlaying, level, movePiece]);
 
-  // פקדי מקלדת
+  // פקדי מקלדת בזמן משחק
   useKeyboardControls({
     ArrowLeft: () => movePiece(-1, 0),
     ArrowRight: () => movePiece(1, 0),
     ArrowDown: () => movePiece(0, 1),
     ArrowUp: handleRotate,
-    ' ': handleRotate,
+    ' ': hardDrop,
   }, isPlaying);
+
+  // השהיה/המשך — פעיל גם במצב מושהה כדי לאפשר לחזור למשחק
+  useKeyboardControls({
+    Escape: togglePause,
+    p: togglePause,
+    P: togglePause,
+  }, isPlaying || isPaused);
 };

--- a/gamesformykids/app/games/tetris/store/tetrisStore.ts
+++ b/gamesformykids/app/games/tetris/store/tetrisStore.ts
@@ -9,6 +9,11 @@ import {
   rotatePiece,
 } from '../constants';
 
+// Rows finish their clear-flash animation before the board actually shifts down.
+const LINE_CLEAR_ANIMATION_MS = 350;
+// Simple wall-kick offsets tried in order when a rotation is blocked near an edge.
+const WALL_KICK_OFFSETS = [0, 1, -1, 2, -2];
+
 // ── Pure game logic helpers (no React state closures) ─────────────────────────
 
 function checkValidPosition(piece: Piece | null, pos: Position, board: Board): boolean {
@@ -44,20 +49,29 @@ function mergePiece(piece: Piece, pos: Position, board: Board): Board {
   return newBoard;
 }
 
-function clearFullLines(board: Board): { board: Board; linesCleared: number } {
-  const newBoard: Board = [];
-  let linesCleared = 0;
-  for (let y = BOARD_HEIGHT - 1; y >= 0; y--) {
-    if (board[y]!.every(cell => cell !== 0)) {
-      linesCleared++;
-    } else {
-      newBoard.unshift(board[y]!);
-    }
+function findFullLines(board: Board): number[] {
+  const lines: number[] = [];
+  for (let y = 0; y < board.length; y++) {
+    if (board[y]!.every(cell => cell !== 0)) lines.push(y);
   }
-  while (newBoard.length < BOARD_HEIGHT) {
-    newBoard.unshift([...EMPTY_ROW]);
+  return lines;
+}
+
+function removeLines(board: Board, lines: number[]): Board {
+  const lineSet = new Set(lines);
+  const remaining = board.filter((_, y) => !lineSet.has(y)).map(row => [...row]);
+  while (remaining.length < BOARD_HEIGHT) {
+    remaining.unshift([...EMPTY_ROW]);
   }
-  return { board: newBoard, linesCleared };
+  return remaining;
+}
+
+function dropDistance(piece: Piece, pos: Position, board: Board): number {
+  let dy = 0;
+  while (checkValidPosition(piece, { x: pos.x, y: pos.y + dy + 1 }, board)) {
+    dy++;
+  }
+  return dy;
 }
 
 // ── State & Actions types ──────────────────────────────────────────────────────
@@ -66,7 +80,9 @@ interface TetrisActions {
   setLoaded: () => void;
   startNewGame: () => void;
   movePiece: (dx: number, dy: number) => void;
+  hardDrop: () => void;
   handleRotate: () => void;
+  togglePause: () => void;
   goToStartScreen: () => void;
   getBoardWithCurrentPiece: () => Board;
 }
@@ -80,85 +96,138 @@ const INITIAL_STATE: TetrisGameState = {
   phase: 'loading',
   nextPiece: null,
   linesCleared: 0,
+  clearingRows: [],
 };
 
 // ── Store ──────────────────────────────────────────────────────────────────────
 
-export const useTetrisStore = makeStore<TetrisGameState & TetrisActions>('TetrisStore', (set, get) => ({
-  ...INITIAL_STATE,
+export const useTetrisStore = makeStore<TetrisGameState & TetrisActions>('TetrisStore', (set, get) => {
+  // Locks `piece` at `pos` into the board, then either advances immediately
+  // (no lines cleared) or plays a brief flash on the full rows before
+  // actually removing them and advancing.
+  function lockPiece(piece: Piece, pos: Position, bonusScore: number) {
+    const { board, score, level, linesCleared } = get();
+    const merged = mergePiece(piece, pos, board);
+    const linesToClear = findFullLines(merged);
 
-  setLoaded: () => set({ phase: 'menu' }),
-
-  startNewGame: () => {
-    set({
-      board: EMPTY_BOARD,
-      currentPiece: getRandomPiece(),
-      position: { x: 4, y: 0 },
-      score: 0,
-      level: 1,
-      phase: 'playing',
-      nextPiece: getRandomPiece(),
-      linesCleared: 0,
-    });
-  },
-
-  movePiece: (dx, dy) => {
-    const { currentPiece, phase, position, board, score, level, nextPiece, linesCleared } = get();
-    if (!currentPiece || phase !== 'playing') return;
-
-    const newPos = { x: position.x + dx, y: position.y + dy };
-
-    if (checkValidPosition(currentPiece, newPos, board)) {
-      set({ position: newPos });
+    if (linesToClear.length === 0) {
+      advanceToNextPiece(merged, score + bonusScore, level, linesCleared);
       return;
     }
 
-    if (dy > 0) {
-      const merged = mergePiece(currentPiece, position, board);
-      const { board: clearedBoard, linesCleared: newLines } = clearFullLines(merged);
-      const newScore = score + newLines * 100 * level;
-      const newLevel = newLines > 0 ? Math.floor(newScore / 1000) + 1 : level;
-      const startPos = { x: 4, y: 0 };
+    set({ board: merged, clearingRows: linesToClear, currentPiece: null });
 
-      if (nextPiece && checkValidPosition(nextPiece, startPos, clearedBoard)) {
-        set({
-          board: clearedBoard,
-          currentPiece: nextPiece,
-          nextPiece: getRandomPiece(),
-          position: startPos,
-          score: newScore,
-          level: newLevel,
-          linesCleared: linesCleared + newLines,
-        });
-      } else {
-        set({
-          board: clearedBoard,
-          phase: 'gameover',
-          score: newScore,
-          level: newLevel,
-          linesCleared: linesCleared + newLines,
-        });
+    setTimeout(() => {
+      // Bail out if the game was reset/left mid-animation.
+      if (get().phase !== 'playing' || get().clearingRows.length === 0) return;
+
+      const clearedBoard = removeLines(merged, linesToClear);
+      const newScore = score + bonusScore + linesToClear.length * 100 * level;
+      const newLevel = Math.floor(newScore / 1000) + 1;
+      advanceToNextPiece(clearedBoard, newScore, newLevel, linesCleared + linesToClear.length);
+    }, LINE_CLEAR_ANIMATION_MS);
+  }
+
+  function advanceToNextPiece(board: Board, score: number, level: number, linesCleared: number) {
+    const { nextPiece } = get();
+    const startPos = { x: 4, y: 0 };
+
+    if (nextPiece && checkValidPosition(nextPiece, startPos, board)) {
+      set({
+        board,
+        currentPiece: nextPiece,
+        nextPiece: getRandomPiece(),
+        position: startPos,
+        score,
+        level,
+        linesCleared,
+        clearingRows: [],
+      });
+    } else {
+      set({
+        board,
+        phase: 'gameover',
+        score,
+        level,
+        linesCleared,
+        clearingRows: [],
+      });
+    }
+  }
+
+  return {
+    ...INITIAL_STATE,
+
+    setLoaded: () => set({ phase: 'menu' }),
+
+    startNewGame: () => {
+      set({
+        board: EMPTY_BOARD,
+        currentPiece: getRandomPiece(),
+        position: { x: 4, y: 0 },
+        score: 0,
+        level: 1,
+        phase: 'playing',
+        nextPiece: getRandomPiece(),
+        linesCleared: 0,
+        clearingRows: [],
+      });
+    },
+
+    movePiece: (dx, dy) => {
+      const { currentPiece, phase, position, board, clearingRows } = get();
+      if (!currentPiece || phase !== 'playing' || clearingRows.length > 0) return;
+
+      const newPos = { x: position.x + dx, y: position.y + dy };
+
+      if (checkValidPosition(currentPiece, newPos, board)) {
+        set({ position: newPos });
+        return;
       }
-    }
-  },
 
-  handleRotate: () => {
-    const { currentPiece, phase, position, board } = get();
-    if (!currentPiece || phase !== 'playing') return;
-    const rotated = rotatePiece(currentPiece);
-    if (checkValidPosition(rotated, position, board)) {
-      set({ currentPiece: rotated });
-    }
-  },
+      if (dy > 0) {
+        lockPiece(currentPiece, position, 0);
+      }
+    },
 
-  goToStartScreen: () => set({ phase: 'menu' }),
+    hardDrop: () => {
+      const { currentPiece, phase, position, board, clearingRows } = get();
+      if (!currentPiece || phase !== 'playing' || clearingRows.length > 0) return;
 
-  getBoardWithCurrentPiece: () => {
-    const { board, currentPiece, position } = get();
-    let displayBoard = board.map(row => [...row]);
-    if (currentPiece && checkValidPosition(currentPiece, position, board)) {
-      displayBoard = mergePiece(currentPiece, position, displayBoard);
-    }
-    return displayBoard;
-  },
-}));
+      const dy = dropDistance(currentPiece, position, board);
+      // Small score bonus per row skipped, rewarding decisive drops.
+      lockPiece(currentPiece, { x: position.x, y: position.y + dy }, dy * 2);
+    },
+
+    handleRotate: () => {
+      const { currentPiece, phase, position, board, clearingRows } = get();
+      if (!currentPiece || phase !== 'playing' || clearingRows.length > 0) return;
+
+      const rotated = rotatePiece(currentPiece);
+      for (const dx of WALL_KICK_OFFSETS) {
+        const kicked = { x: position.x + dx, y: position.y };
+        if (checkValidPosition(rotated, kicked, board)) {
+          set({ currentPiece: rotated, position: kicked });
+          return;
+        }
+      }
+    },
+
+    togglePause: () => {
+      const { phase } = get();
+      if (phase === 'playing') set({ phase: 'paused' });
+      else if (phase === 'paused') set({ phase: 'playing' });
+    },
+
+    goToStartScreen: () => set({ phase: 'menu' }),
+
+    getBoardWithCurrentPiece: () => {
+      const { board, currentPiece, position } = get();
+      let displayBoard = board.map(row => [...row]);
+      if (currentPiece && checkValidPosition(currentPiece, position, board)) {
+        displayBoard = mergePiece(currentPiece, position, displayBoard);
+      }
+      return displayBoard;
+    },
+  };
+});

--- a/gamesformykids/app/games/tetris/types/index.ts
+++ b/gamesformykids/app/games/tetris/types/index.ts
@@ -10,7 +10,7 @@ export interface Piece {
 
 export type Board = (string | number)[][];
 
-export type TetrisPhase = 'loading' | 'menu' | 'playing' | 'gameover';
+export type TetrisPhase = 'loading' | 'menu' | 'playing' | 'paused' | 'gameover';
 
 export interface TetrisGameState {
   board: Board;
@@ -21,6 +21,8 @@ export interface TetrisGameState {
   phase: TetrisPhase;
   nextPiece: Piece | null;
   linesCleared: number;
+  /** Row indices currently flashing before being removed from the board. */
+  clearingRows: number[];
 }
 
 export interface GameBoardProps {


### PR DESCRIPTION
## Summary
- **Fixed the mobile arrow bug**: the movement button row inherited the page's global `dir="rtl"`, which mirrors CSS grid item order — the left-arrow button rendered visually on the right and vice versa. The row now forces `dir="ltr"`, matching the pattern already used by the game board itself.
- Added **hard drop** (⏬ צנח button, Space key, swipe-down on the board) with a small distance score bonus.
- Added **pause/resume** (⏸️ button, Esc/P keys) with an overlay on the board and a panel message; the game-duration tracker no longer resets when resuming from pause.
- Added simple **wall-kick** on rotation so pieces near the edges rotate instead of silently refusing to.
- Added a brief **white flash animation** on completed rows before they're cleared, instead of an instant disappear.
- Enlarged the mobile board cells (16px → 24px) for better visibility.
- Made the desktop info panel consistently Hebrew (was mixed Hebrew/English: "Score", "Level", "Next Piece").
- Added basic **swipe gestures** on the board (swipe left/right to move, swipe down to hard drop, tap to rotate) and `aria-label`s on all touch controls.

## Test plan
- [x] `tsc --noEmit` passes
- [x] `eslint` passes on changed files
- [x] `vitest run __tests__/stores/tetrisStore.test.ts` — 19/19 passing, including new coverage for `togglePause`, wall-kick rotation, `hardDrop`, and the line-clear animation timing (fake timers)
- [x] `next build` succeeds
- [x] Manually verified in a real browser (Playwright) at mobile (390px) and desktop (1440px) viewports: arrow buttons now match visual left/right, hard drop works, pause/resume works, wall-kick rotation works, line-clear flash fires, Hebrew labels render

🤖 Generated with [Claude Code](https://claude.com/claude-code)