### PR TITLE
fix(multiplication): equation/score numbers still render right-to-left

### DIFF
--- a/gamesformykids/app/games/multiplication/multiplicationConfig.tsx
+++ b/gamesformykids/app/games/multiplication/multiplicationConfig.tsx
@@ -1,9 +1,17 @@
+import type { ReactNode } from 'react';
 import type { TimedMathConfig } from '@/components/game/shared/TimedMathGame';
 import { useMultiplicationGameStore, stopMultiplicationTimer } from './multiplicationGameStore';
 import {
   LEVELS, QUESTIONS_PER_LEVEL, MIXED_LEVEL, MultiplicationQuestion, getTimeForLevel,
 } from './data/tables';
 import { isLevelMastered } from './masteryStorage';
+
+// globals.css forces `direction: rtl` on every element (`* { direction: rtl }`), which
+// overrides inherited direction on any child — so equations need this on each element
+// that renders one, not just a shared ancestor.
+function Eq({ children }: { children: ReactNode }) {
+  return <span style={{ direction: 'ltr', unicodeBidi: 'bidi-override' }}>{children}</span>;
+}
 
 export const MULTIPLICATION_CONFIG: TimedMathConfig<number, MultiplicationQuestion> = {
   useStore: useMultiplicationGameStore,
@@ -33,14 +41,13 @@ export const MULTIPLICATION_CONFIG: TimedMathConfig<number, MultiplicationQuesti
   ),
 
   renderLevelLabel: (lv) => (lv === MIXED_LEVEL ? 'תרגול מעורב' : `לוח ${lv}`),
-  renderEquation: (q) => (
-    <span dir="ltr" className="inline-flex items-center gap-3">
-      <span>{q.a} × {q.b}</span>
-      <span>= ?</span>
-    </span>
+  renderEquation: (q) => <Eq>{q.a} × {q.b} = ?</Eq>,
+  renderFeedbackText: (q, ok) => (
+    <>
+      {ok ? '✅ נכון! ' : '❌ '}
+      <Eq>{q.a} × {q.b} = {q.answer}</Eq>
+    </>
   ),
-  renderFeedbackText: (q, ok) =>
-    ok ? `✅ נכון! ${q.a} × ${q.b} = ${q.answer}` : `❌ ${q.a} × ${q.b} = ${q.answer}`,
   answerHoverClass: 'hover:border-purple-400 hover:bg-purple-50',
 
   renderResultTitle: (lv) => (lv === MIXED_LEVEL ? 'תרגול מעורב — סיום!' : `לוח ${lv} — סיום!`),
@@ -56,10 +63,10 @@ export const MULTIPLICATION_CONFIG: TimedMathConfig<number, MultiplicationQuesti
     return (
       <div className="mt-4 rounded-2xl bg-purple-50 p-4 text-right">
         <p className="font-bold text-purple-700 mb-2">כדאי לתרגל עוד:</p>
-        <div className="flex flex-wrap gap-2 justify-center" dir="ltr">
+        <div className="flex flex-wrap gap-2 justify-center">
           {unique.map((q) => (
             <span key={`${q.a}x${q.b}`} className="bg-white rounded-xl px-3 py-1 text-purple-700 font-bold shadow-sm">
-              {q.a} × {q.b} = {q.answer}
+              <Eq>{q.a} × {q.b} = {q.answer}</Eq>
             </span>
           ))}
         </div>

--- a/gamesformykids/components/game/shared/TimedMathGame.tsx
+++ b/gamesformykids/components/game/shared/TimedMathGame.tsx
@@ -42,7 +42,7 @@ export interface TimedMathConfig<Level, Q extends { answer: number; choices: num
 
   renderLevelLabel: (lv: Level) => string;
   renderEquation: (q: Q) => ReactNode;
-  renderFeedbackText: (q: Q, isCorrect: boolean) => string;
+  renderFeedbackText: (q: Q, isCorrect: boolean) => ReactNode;
   answerHoverClass: string;
 
   renderResultTitle: (lv: Level) => string;
@@ -166,7 +166,7 @@ export default function TimedMathGame<Level, Q extends { answer: number; choices
       secondaryAction={{ label: '📋 רמות', onClick: goMenu }}
     >
       <div className={`${config.resultBg} rounded-2xl p-5`}>
-        <p className={`text-4xl font-black ${config.accentText700}`}>{correct} / {config.totalQuestions}</p>
+        <p className={`text-4xl font-black ${config.accentText700}`} style={{ direction: 'ltr', unicodeBidi: 'bidi-override' }}>{correct} / {config.totalQuestions}</p>
         <p className={`${config.accentText500} text-sm mt-1`}>תשובות נכונות</p>
         <p className={`text-xl font-bold ${config.accentText700} mt-2`}>⭐ {score} נקודות</p>
         <div className="mt-2 h-3 bg-white/50 rounded-full">


### PR DESCRIPTION
## Summary
- Follow-up to #1548/#1549: after merging, the equation and score displays were still visually reversed
- Root cause: `globals.css` has `* { direction: rtl; }` — a universal selector that beats the `dir` HTML attribute (a low-priority presentational hint) and re-applies individually to every element, including children of a `dir="ltr"` parent
- Setting `direction` alone also has no effect on inline bidi reordering unless paired with `unicode-bidi` — so the original `dir="ltr"` attempt never actually reordered anything
- Fixed by applying `style={{ direction: 'ltr', unicodeBidi: 'bidi-override' }}` directly to each element that renders a numeric equation/fraction: the multiplication equation, feedback text, wrong-answer list, and the shared result screen's correct/total score fraction (`TimedMathGame.tsx`, also used by arithmetic)
- Verified visually with a local dev server + Playwright screenshots: equation now reads `1 × 1 = ?`, feedback reads `1 × 2 = 2`, result screen reads `1 / 8`, wrong-answer chips read `3 × 7 = 21` etc.

Closes #1551

## Test plan
- [x] `npx tsc --noEmit` clean for both touched files
- [x] `npx eslint` clean for both touched files
- [x] Manually played multiplication rounds via local dev server + screenshots, confirmed correct left-to-right equation/score order
- [ ] Confirm arithmetic game result screen (shares `TimedMathGame`) also displays its score fraction correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)