### PR TITLE
fix(sudoku): improve UI/UX — navigation, onboarding, feedback

### DIFF
--- a/gamesformykids/app/games/sudoku/SudokuClient.tsx
+++ b/gamesformykids/app/games/sudoku/SudokuClient.tsx
@@ -1,9 +1,11 @@
 'use client';
 import { useState } from 'react';
+import Link from 'next/link';
 import { useSudoku } from './useSudoku';
 import SudokuBoard from './components/SudokuBoard';
 import SudokuNumberPad from './components/SudokuNumberPad';
-import type { Size, Difficulty } from './sudokuLogic';
+import { GameTutorial } from '@/components/game/GameTutorial';
+import { SIZE_CONFIGS, type Size, type Difficulty } from './sudokuLogic';
 
 const SIZE_OPTIONS: { value: Size; label: string }[] = [
   { value: 6, label: '6×6 (קליל)' },
@@ -16,20 +18,52 @@ const DIFFICULTY_OPTIONS: { value: Difficulty; label: string }[] = [
   { value: 'hard', label: 'קשה' },
 ];
 
+const SUDOKU_TUTORIAL = [
+  { emoji: '🔢', title: 'משחק הסודוקו', body: 'הלוח מחולק לשורות, עמודות וריבועים. המטרה: למלא כל תא במספר.' },
+  { emoji: '🚫', title: 'בלי חזרות', body: 'בכל שורה, בכל עמודה ובכל ריבוע מודגש - כל מספר יכול להופיע פעם אחת בלבד.' },
+  { emoji: '💡', title: 'תקועים? יש רמזים', body: 'בחרו תא ולחצו על מספר כדי למלא אותו. אם נתקעתם, כפתור הרמז ימלא תא בשבילכם.' },
+];
+
+function MiniBoardPreview({ size }: { size: Size }) {
+  const { boxRows, boxCols } = SIZE_CONFIGS[size];
+  const cells = Array.from({ length: size * size });
+  return (
+    <div
+      className="grid gap-px bg-sky-300 rounded p-0.5 mx-auto mb-1"
+      style={{ gridTemplateColumns: `repeat(${size}, 5px)` }}
+    >
+      {cells.map((_, i) => {
+        const r = Math.floor(i / size);
+        const c = i % size;
+        const shade = (Math.floor(r / boxRows) + Math.floor(c / boxCols)) % 2 === 0
+          ? 'bg-white'
+          : 'bg-sky-100';
+        return <div key={i} className={shade} style={{ width: 5, height: 5 }} />;
+      })}
+    </div>
+  );
+}
+
 export default function SudokuClient() {
   const {
-    puzzle, given, size, boxRows, boxCols, selected, phase, mistakes, hintsLeft, errorCell,
+    puzzle, given, size, difficulty, boxRows, boxCols, selected, phase, mistakes, hintsLeft, errorCell, lockedCell,
     chooseSetup, selectCell, inputNumber, useHint, reset,
   } = useSudoku();
 
   const [pickedSize, setPickedSize] = useState<Size>(9);
   const [pickedDifficulty, setPickedDifficulty] = useState<Difficulty>('easy');
 
+  const totalCells = size * size;
+  const filledCells = puzzle.reduce((sum, row) => sum + row.filter((v) => v !== 0).length, 0);
+  const progressPct = totalCells > 0 ? Math.round((filledCells / totalCells) * 100) : 0;
+
   return (
     <div
       className="min-h-screen flex flex-col items-center justify-center p-4"
       style={{ background: 'linear-gradient(135deg, #e0f2fe 0%, #bae6fd 50%, #7dd3fc 100%)' }}
     >
+      <GameTutorial steps={SUDOKU_TUTORIAL} storageKey="gfk_tutorial_sudoku" />
+
       <h1 className="text-3xl font-bold text-sky-900 mb-1" dir="rtl">🔢 סודוקו</h1>
       <p className="text-sky-700 text-sm mb-4" dir="rtl">מלאו כל שורה, עמודה וריבוע במספרים ללא חזרות!</p>
 
@@ -45,6 +79,7 @@ export default function SudokuClient() {
                   pickedSize === opt.value ? 'bg-sky-600 text-white' : 'bg-sky-100 text-sky-700'
                 }`}
               >
+                <MiniBoardPreview size={opt.value} />
                 {opt.label}
               </button>
             ))}
@@ -71,6 +106,10 @@ export default function SudokuClient() {
           >
             🚀 התחל משחק
           </button>
+
+          <Link href="/" className="mt-4 block text-sm text-sky-400 hover:text-sky-600" dir="rtl">
+            ← חזרה לבית
+          </Link>
         </div>
       )}
 
@@ -83,10 +122,28 @@ export default function SudokuClient() {
 
       {(phase === 'playing' || phase === 'won') && (
         <>
-          <div className="flex gap-4 mb-3">
+          <div className="flex gap-3 mb-3 items-stretch">
+            <Link
+              href="/"
+              className="flex items-center justify-center bg-white bg-opacity-80 rounded-2xl px-4 shadow text-sky-700 font-bold hover:bg-opacity-100 transition-colors"
+              dir="rtl"
+            >
+              🏠 בית
+            </Link>
+            <button
+              onClick={reset}
+              className="flex items-center justify-center bg-white bg-opacity-80 rounded-2xl px-4 shadow text-sky-700 font-bold hover:bg-opacity-100 transition-colors"
+              dir="rtl"
+            >
+              🔁 תפריט
+            </button>
             <div className="bg-white bg-opacity-80 rounded-2xl px-5 py-2 shadow">
               <p className="text-center text-xs text-gray-500 font-medium" dir="rtl">טעויות</p>
               <p className="text-center text-2xl font-bold text-sky-700">{mistakes}</p>
+            </div>
+            <div className="bg-white bg-opacity-80 rounded-2xl px-5 py-2 shadow min-w-[88px]">
+              <p className="text-center text-xs text-gray-500 font-medium" dir="rtl">הושלם</p>
+              <p className="text-center text-2xl font-bold text-sky-700">{progressPct}%</p>
             </div>
           </div>
 
@@ -98,6 +155,7 @@ export default function SudokuClient() {
             boxCols={boxCols}
             selected={selected}
             errorCell={errorCell}
+            lockedCell={lockedCell}
             onSelect={selectCell}
           />
 
@@ -116,12 +174,20 @@ export default function SudokuClient() {
           <div className="text-5xl mb-3">🎉</div>
           <p className="text-2xl font-bold text-green-700 mb-1" dir="rtl">כל הכבוד! פתרת את הסודוקו!</p>
           <p className="text-gray-600 text-sm mb-4" dir="rtl">טעויות: {mistakes}</p>
-          <button
-            onClick={reset}
-            className="bg-green-500 hover:bg-green-600 text-white font-bold px-6 py-2 rounded-xl transition-colors"
-          >
-            משחק חדש
-          </button>
+          <div className="flex gap-2 justify-center">
+            <button
+              onClick={() => chooseSetup(size, difficulty)}
+              className="bg-sky-500 hover:bg-sky-600 text-white font-bold px-5 py-2 rounded-xl transition-colors"
+            >
+              🔁 שוב, אותה רמה
+            </button>
+            <button
+              onClick={reset}
+              className="bg-green-500 hover:bg-green-600 text-white font-bold px-5 py-2 rounded-xl transition-colors"
+            >
+              משחק חדש
+            </button>
+          </div>
         </div>
       )}
     </div>

--- a/gamesformykids/app/games/sudoku/components/SudokuBoard.tsx
+++ b/gamesformykids/app/games/sudoku/components/SudokuBoard.tsx
@@ -10,19 +10,22 @@ interface Props {
   boxCols: number;
   selected: CellPos | null;
   errorCell: CellPos | null;
+  lockedCell: CellPos | null;
   onSelect: (row: number, col: number) => void;
 }
 
 export default function SudokuBoard({
-  puzzle, given, size, boxRows, boxCols, selected, errorCell, onSelect,
+  puzzle, given, size, boxRows, boxCols, selected, errorCell, lockedCell, onSelect,
 }: Props) {
-  const cellPx = size === 9 ? 36 : 48;
+  // clamp() keeps cells at a real touch-target size (44px+) on tablets/desktop
+  // while still fitting a 9-wide board on a narrow phone screen.
+  const cellSize = size === 9 ? 'clamp(38px, 9vw, 50px)' : 'clamp(46px, 13vw, 62px)';
 
   return (
     <div
       dir="ltr"
       className="grid bg-gray-700 rounded-xl p-1 select-none shadow-lg"
-      style={{ gridTemplateColumns: `repeat(${size}, ${cellPx}px)` }}
+      style={{ gridTemplateColumns: `repeat(${size}, ${cellSize})` }}
     >
       {puzzle.map((row, r) =>
         row.map((value, c) => {
@@ -38,6 +41,7 @@ export default function SudokuBoard({
           const isSameValue =
             !!selected && value !== 0 && puzzle[selected.row]?.[selected.col] === value;
           const isError = errorCell?.row === r && errorCell?.col === c;
+          const isLocked = lockedCell?.row === r && lockedCell?.col === c;
 
           const rightBorder = (c + 1) % boxCols === 0 && c !== size - 1;
           const bottomBorder = (r + 1) % boxRows === 0 && r !== size - 1;
@@ -46,18 +50,20 @@ export default function SudokuBoard({
             <button
               key={`${r}-${c}`}
               onClick={() => onSelect(r, c)}
+              aria-label={`שורה ${r + 1}, עמודה ${c + 1}${value !== 0 ? `, ${value}` : ''}`}
               className={[
                 'flex items-center justify-center font-bold transition-colors duration-150 border border-gray-300',
                 isGiven ? 'bg-gray-100 text-gray-900' : 'bg-white text-blue-700',
-                isSelected ? 'bg-blue-300 text-blue-900' : '',
-                !isSelected && isSameValue ? 'bg-blue-100' : '',
+                isSelected ? 'bg-blue-400 text-white ring-2 ring-inset ring-blue-700' : '',
+                !isSelected && isSameValue ? 'bg-blue-200' : '',
                 !isSelected && isPeer && !isSameValue ? 'bg-blue-50' : '',
                 isError ? 'bg-red-300 animate-pulse' : '',
+                isLocked && !isError ? 'bg-amber-200 animate-pulse' : '',
                 rightBorder ? 'border-r-2 border-r-gray-700' : '',
                 bottomBorder ? 'border-b-2 border-b-gray-700' : '',
                 size === 9 ? 'text-lg' : 'text-2xl',
               ].join(' ')}
-              style={{ width: cellPx, height: cellPx }}
+              style={{ width: cellSize, height: cellSize }}
             >
               {value !== 0 ? value : ''}
             </button>

--- a/gamesformykids/app/games/sudoku/components/SudokuNumberPad.tsx
+++ b/gamesformykids/app/games/sudoku/components/SudokuNumberPad.tsx
@@ -10,15 +10,24 @@ interface Props {
 
 export default function SudokuNumberPad({ size, hintsLeft, canPlay, onInput, onHint }: Props) {
   const numbers = Array.from({ length: size }, (_, i) => i + 1);
+  const hintTitle = !canPlay
+    ? undefined
+    : hintsLeft <= 0
+      ? 'נגמרו הרמזים להיום'
+      : 'ממלא את התא הנבחר במספר הנכון';
 
   return (
     <div className="flex flex-col items-center gap-3 mt-4">
-      <div className="flex gap-2 flex-wrap justify-center max-w-xs">
+      <div
+        className="grid gap-2 justify-center"
+        style={{ gridTemplateColumns: `repeat(${Math.min(size, 5)}, minmax(0, 1fr))` }}
+      >
         {numbers.map((n) => (
           <button
             key={n}
             disabled={!canPlay}
             onClick={() => onInput(n)}
+            aria-label={`מספר ${n}`}
             className="w-11 h-11 rounded-xl bg-blue-500 hover:bg-blue-600 disabled:opacity-40 text-white font-bold text-xl shadow transition-colors"
           >
             {n}
@@ -28,6 +37,7 @@ export default function SudokuNumberPad({ size, hintsLeft, canPlay, onInput, onH
       <button
         disabled={!canPlay || hintsLeft <= 0}
         onClick={onHint}
+        title={hintTitle}
         className="bg-amber-400 hover:bg-amber-500 disabled:opacity-40 text-amber-900 font-bold px-4 py-2 rounded-xl shadow transition-colors"
         dir="rtl"
       >

--- a/gamesformykids/app/games/sudoku/sudokuStore.ts
+++ b/gamesformykids/app/games/sudoku/sudokuStore.ts
@@ -24,6 +24,7 @@ interface State {
   mistakes: number;
   hintsLeft: number;
   errorCell: CellPos | null;
+  lockedCell: CellPos | null;
 }
 
 interface Actions {
@@ -33,6 +34,7 @@ interface Actions {
   inputNumber: (n: number) => void;
   useHint: () => void;
   clearError: () => void;
+  clearLocked: () => void;
   reset: () => void;
 }
 
@@ -49,6 +51,7 @@ export const useSudokuStore = create<State & Actions>((set) => ({
   mistakes: 0,
   hintsLeft: MAX_HINTS,
   errorCell: null,
+  lockedCell: null,
 
   chooseSetup: (size, difficulty) => {
     const { boxRows, boxCols } = SIZE_CONFIGS[size];
@@ -62,6 +65,7 @@ export const useSudokuStore = create<State & Actions>((set) => ({
     mistakes: 0,
     hintsLeft: MAX_HINTS,
     errorCell: null,
+    lockedCell: null,
   }),
 
   selectCell: (row, col) => set({ selected: { row, col } }),
@@ -69,8 +73,9 @@ export const useSudokuStore = create<State & Actions>((set) => ({
   inputNumber: (n) => set((state) => {
     if (state.phase !== 'playing' || !state.selected) return state;
     const { row, col } = state.selected;
-    if (state.given[row]?.[col]) return state;
-    if (state.puzzle[row]?.[col] !== 0) return state;
+    if (state.given[row]?.[col] || state.puzzle[row]?.[col] !== 0) {
+      return { ...state, lockedCell: { row, col } };
+    }
 
     if (state.solution[row]?.[col] === n) {
       const puzzle = state.puzzle.map((r) => [...r]);
@@ -79,10 +84,11 @@ export const useSudokuStore = create<State & Actions>((set) => ({
         ...state,
         puzzle,
         errorCell: null,
+        lockedCell: null,
         phase: isComplete(puzzle) ? 'won' : state.phase,
       };
     }
-    return { ...state, mistakes: state.mistakes + 1, errorCell: { row, col } };
+    return { ...state, mistakes: state.mistakes + 1, errorCell: { row, col }, lockedCell: null };
   }),
 
   useHint: () => set((state) => {
@@ -101,6 +107,7 @@ export const useSudokuStore = create<State & Actions>((set) => ({
   }),
 
   clearError: () => set({ errorCell: null }),
+  clearLocked: () => set({ lockedCell: null }),
 
   reset: () => set({
     phase: 'idle',
@@ -111,5 +118,6 @@ export const useSudokuStore = create<State & Actions>((set) => ({
     mistakes: 0,
     hintsLeft: MAX_HINTS,
     errorCell: null,
+    lockedCell: null,
   }),
 }));

--- a/gamesformykids/app/games/sudoku/useSudoku.ts
+++ b/gamesformykids/app/games/sudoku/useSudoku.ts
@@ -7,7 +7,10 @@ import { useKeyboardControls } from '@/hooks/shared/game-controls';
 
 export function useSudoku() {
   const store = useSudokuStore();
-  const { phase, size, difficulty, applyPuzzle, errorCell, clearError, selected, selectCell, inputNumber } = store;
+  const {
+    phase, size, difficulty, applyPuzzle, errorCell, clearError, lockedCell, clearLocked,
+    selected, selectCell, inputNumber,
+  } = store;
 
   // Generate the puzzle off the render that shows the "generating" spinner,
   // so the UI can paint before the (potentially slow) backtracking solver runs.
@@ -20,12 +23,21 @@ export function useSudoku() {
     return () => clearTimeout(timer);
   }, [phase, size, difficulty, applyPuzzle]);
 
-  // Clear the transient wrong-answer flash.
+  // Clear the transient wrong-answer flash. Held a bit longer than the CSS
+  // transition so a child has time to register cause and effect.
   useEffect(() => {
     if (!errorCell) return;
-    const timer = setTimeout(clearError, 500);
+    speak('אופס, נסה שוב');
+    const timer = setTimeout(clearError, 800);
     return () => clearTimeout(timer);
   }, [errorCell, clearError]);
+
+  // Clear the transient "can't overwrite this cell" flash.
+  useEffect(() => {
+    if (!lockedCell) return;
+    const timer = setTimeout(clearLocked, 500);
+    return () => clearTimeout(timer);
+  }, [lockedCell, clearLocked]);
 
   // Speak a congratulation when the puzzle is solved.
   useEffect(() => {


### PR DESCRIPTION
## Summary
- Add a home link + menu button during play, and a home link on setup — previously the game was a navigation dead end.
- Add a first-play tutorial (`GameTutorial`, matches the Memory game's pattern).
- Increase/responsive board touch targets (`clamp()` sizing) instead of a fixed 36px 9×9 cell.
- Distinguish "tapped a given/filled cell" (amber flash) from "wrong answer" (red flash, now 800ms + short speech) — previously overwriting a given cell silently did nothing.
- Stable grid layout for the number pad (was `flex-wrap`, broke unevenly on 9×9).
- Add a live completion-% indicator next to the mistakes counter.
- Add mini board-size previews on the setup screen (6×6 vs 9×9).
- Add a "same level" quick-replay button on the win screen alongside "new game".
- Minor accessibility: `aria-label`s on board cells and number-pad buttons, hint-button tooltip when disabled.

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `eslint app/games/sudoku` — clean
- [x] `npm run build` — clean
- [x] Manual pass via headless browser: tutorial → setup (mini previews) → play (progress %, back-nav) → cell selection → locked-cell flash (tapping a given cell no-ops with feedback) → wrong-answer flash (mistake counter increments) — zero console errors

Closes #1553