### PR TITLE
fix(tetris): replace hard drop with hold-to-repeat soft drop

### DIFF
--- a/gamesformykids/__tests__/stores/tetrisStore.test.ts
+++ b/gamesformykids/__tests__/stores/tetrisStore.test.ts
@@ -132,32 +132,6 @@ describe('tetrisStore', () => {
     });
   });
 
-  describe('hardDrop', () => {
-    it('drops the piece straight to the floor and awards a distance bonus', () => {
-      const nextPiece = { type: 'O', blocks: TETROMINOES.O!.blocks, color: TETROMINOES.O!.color };
-      store.setState({
-        board: EMPTY_BOARD,
-        currentPiece: { type: 'O', blocks: TETROMINOES.O!.blocks, color: TETROMINOES.O!.color },
-        position: { x: 4, y: 0 },
-        score: 0,
-        level: 1,
-        phase: 'playing',
-        nextPiece,
-        linesCleared: 0,
-        clearingRows: [],
-      } as unknown as Parameters<typeof store.setState>[0]);
-
-      store.getState().hardDrop();
-
-      const state = store.getState();
-      // O-piece is 2 rows tall, board is 20 rows — falls 18 rows, 2 points each.
-      expect(state.score).toBe(36);
-      expect(state.currentPiece).toEqual(nextPiece);
-      expect(state.position).toEqual({ x: 4, y: 0 });
-      expect(state.board[BOARD_HEIGHT - 1]!.slice(4, 6)).toEqual([TETROMINOES.O!.color, TETROMINOES.O!.color]);
-    });
-  });
-
   describe('line clear animation', () => {
     beforeEach(() => {
       vi.useFakeTimers();

--- a/gamesformykids/app/games/tetris/components/GameBoard.tsx
+++ b/gamesformykids/app/games/tetris/components/GameBoard.tsx
@@ -10,7 +10,6 @@ const GameBoard = ({ displayBoard }: GameBoardProps) => {
   const clearingRows = useTetrisStore(s => s.clearingRows);
   const movePiece = useTetrisStore(s => s.movePiece);
   const handleRotate = useTetrisStore(s => s.handleRotate);
-  const hardDrop = useTetrisStore(s => s.hardDrop);
   const touchStart = useRef<{ x: number; y: number } | null>(null);
 
   const onTouchStart = (e: React.TouchEvent) => {
@@ -37,7 +36,7 @@ const GameBoard = ({ displayBoard }: GameBoardProps) => {
     if (Math.abs(dx) > Math.abs(dy)) {
       movePiece(dx > 0 ? 1 : -1, 0);
     } else if (dy > 0) {
-      hardDrop();
+      movePiece(0, 1);
     }
   };
 

--- a/gamesformykids/app/games/tetris/components/TouchControls.tsx
+++ b/gamesformykids/app/games/tetris/components/TouchControls.tsx
@@ -10,7 +10,7 @@ const TouchControls = ({ isDesktop = false }: TouchControlsProps) => {
   const isGameRunning = phase === 'playing';
   const isPaused = phase === 'paused';
   const gameOver = phase === 'gameover';
-  const { handleMove, handleRotate, handleHardDrop, handleTogglePause } = useTouchControls();
+  const { handleMove, handleRotate, startSoftDropHold, stopSoftDropHold, handleTogglePause } = useTouchControls();
 
   // פריסה למחשב
   if (isDesktop) {
@@ -77,16 +77,12 @@ const TouchControls = ({ isDesktop = false }: TouchControlsProps) => {
                 <span className="bg-gray-700 px-2 py-1 rounded">→</span>
               </div>
               <div className="flex justify-between">
-                <span>הזזה מטה:</span>
+                <span>הזזה מטה (החזק להורדה רציפה):</span>
                 <span className="bg-gray-700 px-2 py-1 rounded">↓</span>
               </div>
               <div className="flex justify-between">
                 <span>סיבוב:</span>
-                <span className="bg-gray-700 px-2 py-1 rounded">↑</span>
-              </div>
-              <div className="flex justify-between">
-                <span>נפילה מהירה:</span>
-                <span className="bg-gray-700 px-2 py-1 rounded">Space</span>
+                <span className="bg-gray-700 px-2 py-1 rounded">↑ / Space</span>
               </div>
               <div className="flex justify-between">
                 <span>השהיה:</span>
@@ -133,12 +129,17 @@ const TouchControls = ({ isDesktop = false }: TouchControlsProps) => {
           ⬅️
         </button>
         <button
-          onClick={handleHardDrop}
-          aria-label="הפל מיד"
-          className="bg-gradient-to-br from-red-400 to-red-600 text-white p-3 rounded-xl font-black text-sm shadow-2xl active:scale-95 transition-transform duration-150 border-2 border-red-300/30 touch-manipulation"
+          onTouchStart={startSoftDropHold}
+          onTouchEnd={stopSoftDropHold}
+          onTouchCancel={stopSoftDropHold}
+          onMouseDown={startSoftDropHold}
+          onMouseUp={stopSoftDropHold}
+          onMouseLeave={stopSoftDropHold}
+          aria-label="הזז מטה, החזק להורדה רציפה"
+          className="bg-gradient-to-br from-red-400 to-red-600 text-white p-3 rounded-xl font-black text-lg shadow-2xl active:scale-95 transition-transform duration-150 border-2 border-red-300/30 touch-manipulation"
           disabled={!isGameRunning}
         >
-          ⏬ צנח
+          ⬇️
         </button>
         <button
           onClick={() => handleMove(1, 0)}
@@ -177,7 +178,7 @@ const TouchControls = ({ isDesktop = false }: TouchControlsProps) => {
       {/* Control Instructions */}
       <div className="bg-gradient-to-br from-white/10 to-white/5 backdrop-blur-lg rounded-xl p-3 mt-4 text-center border border-white/20">
         <p className="text-white/80 font-medium text-sm">
-          השתמש בכפתורים למעלה, בחיצי המקלדת או בהחלקת אצבע על הלוח 📱⌨️
+          לחיצה על ⬇️ מזיזה שורה אחת, החזקה מורידה ברצף 📱⌨️
         </p>
       </div>
     </div>

--- a/gamesformykids/app/games/tetris/components/useTouchControls.ts
+++ b/gamesformykids/app/games/tetris/components/useTouchControls.ts
@@ -1,13 +1,23 @@
 'use client';
 
+import { useEffect, useRef } from 'react';
 import { useTetrisStore } from '../store/tetrisStore';
+
+// How often the piece steps down, in ms, while the down button is held.
+const SOFT_DROP_HOLD_INTERVAL_MS = 80;
 
 export function useTouchControls() {
   const isGameRunning = useTetrisStore(s => s.phase === 'playing');
   const movePiece = useTetrisStore(s => s.movePiece);
   const handleRotateAction = useTetrisStore(s => s.handleRotate);
-  const hardDropAction = useTetrisStore(s => s.hardDrop);
   const togglePauseAction = useTetrisStore(s => s.togglePause);
+  const holdIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (holdIntervalRef.current) clearInterval(holdIntervalRef.current);
+    };
+  }, []);
 
   const handleMove = (dx: number, dy: number) => {
     if (!isGameRunning) return;
@@ -19,14 +29,23 @@ export function useTouchControls() {
     handleRotateAction();
   };
 
-  const handleHardDrop = () => {
-    if (!isGameRunning) return;
-    hardDropAction();
+  // Single press moves one row down; holding keeps stepping down until released.
+  const startSoftDropHold = () => {
+    if (!isGameRunning || holdIntervalRef.current) return;
+    movePiece(0, 1);
+    holdIntervalRef.current = setInterval(() => movePiece(0, 1), SOFT_DROP_HOLD_INTERVAL_MS);
+  };
+
+  const stopSoftDropHold = () => {
+    if (holdIntervalRef.current) {
+      clearInterval(holdIntervalRef.current);
+      holdIntervalRef.current = null;
+    }
   };
 
   const handleTogglePause = () => {
     togglePauseAction();
   };
 
-  return { handleMove, handleRotate, handleHardDrop, handleTogglePause };
+  return { handleMove, handleRotate, startSoftDropHold, stopSoftDropHold, handleTogglePause };
 }

--- a/gamesformykids/app/games/tetris/hooks/useTetrisGame.ts
+++ b/gamesformykids/app/games/tetris/hooks/useTetrisGame.ts
@@ -15,7 +15,6 @@ export const useTetrisGame = () => {
   const phase = useTetrisStore(s => s.phase);
   const level = useTetrisStore(s => s.level);
   const movePiece = useTetrisStore(s => s.movePiece);
-  const hardDrop = useTetrisStore(s => s.hardDrop);
   const handleRotate = useTetrisStore(s => s.handleRotate);
   const togglePause = useTetrisStore(s => s.togglePause);
 
@@ -70,7 +69,7 @@ export const useTetrisGame = () => {
     ArrowRight: () => movePiece(1, 0),
     ArrowDown: () => movePiece(0, 1),
     ArrowUp: handleRotate,
-    ' ': hardDrop,
+    ' ': handleRotate,
   }, isPlaying);
 
   // השהיה/המשך — פעיל גם במצב מושהה כדי לאפשר לחזור למשחק

--- a/gamesformykids/app/games/tetris/store/tetrisStore.ts
+++ b/gamesformykids/app/games/tetris/store/tetrisStore.ts
@@ -66,21 +66,12 @@ function removeLines(board: Board, lines: number[]): Board {
   return remaining;
 }
 
-function dropDistance(piece: Piece, pos: Position, board: Board): number {
-  let dy = 0;
-  while (checkValidPosition(piece, { x: pos.x, y: pos.y + dy + 1 }, board)) {
-    dy++;
-  }
-  return dy;
-}
-
 // ── State & Actions types ──────────────────────────────────────────────────────
 
 interface TetrisActions {
   setLoaded: () => void;
   startNewGame: () => void;
   movePiece: (dx: number, dy: number) => void;
-  hardDrop: () => void;
   handleRotate: () => void;
   togglePause: () => void;
   goToStartScreen: () => void;
@@ -105,13 +96,13 @@ export const useTetrisStore = makeStore<TetrisGameState & TetrisActions>('Tetris
   // Locks `piece` at `pos` into the board, then either advances immediately
   // (no lines cleared) or plays a brief flash on the full rows before
   // actually removing them and advancing.
-  function lockPiece(piece: Piece, pos: Position, bonusScore: number) {
+  function lockPiece(piece: Piece, pos: Position) {
     const { board, score, level, linesCleared } = get();
     const merged = mergePiece(piece, pos, board);
     const linesToClear = findFullLines(merged);
 
     if (linesToClear.length === 0) {
-      advanceToNextPiece(merged, score + bonusScore, level, linesCleared);
+      advanceToNextPiece(merged, score, level, linesCleared);
       return;
     }
 
@@ -122,7 +113,7 @@ export const useTetrisStore = makeStore<TetrisGameState & TetrisActions>('Tetris
       if (get().phase !== 'playing' || get().clearingRows.length === 0) return;
 
       const clearedBoard = removeLines(merged, linesToClear);
-      const newScore = score + bonusScore + linesToClear.length * 100 * level;
+      const newScore = score + linesToClear.length * 100 * level;
       const newLevel = Math.floor(newScore / 1000) + 1;
       advanceToNextPiece(clearedBoard, newScore, newLevel, linesCleared + linesToClear.length);
     }, LINE_CLEAR_ANIMATION_MS);
@@ -186,17 +177,8 @@ export const useTetrisStore = makeStore<TetrisGameState & TetrisActions>('Tetris
       }
 
       if (dy > 0) {
-        lockPiece(currentPiece, position, 0);
+        lockPiece(currentPiece, position);
       }
-    },
-
-    hardDrop: () => {
-      const { currentPiece, phase, position, board, clearingRows } = get();
-      if (!currentPiece || phase !== 'playing' || clearingRows.length > 0) return;
-
-      const dy = dropDistance(currentPiece, position, board);
-      // Small score bonus per row skipped, rewarding decisive drops.
-      lockPiece(currentPiece, { x: position.x, y: position.y + dy }, dy * 2);
     },
 
     handleRotate: () => {


### PR DESCRIPTION
## Summary
Follow-up to #1550. Feedback after that merged: the instant hard-drop-to-floor mechanic wasn't the right fit for this audience — replaced with a simpler down control:
- A single press/tap moves the piece down **one row**, same as before.
- **Holding** the down button (mobile) now keeps stepping the piece down every 80ms until released, instead of jumping straight to the floor.
- Keyboard: holding `↓` already auto-repeats via the browser's native key-repeat, so no change needed there. `Space` goes back to rotating (it had been reassigned to hard drop in #1550).
- Removed the hard-drop button, the swipe-down-to-hard-drop gesture (swipe-down is now a single soft-drop step), and the distance-based score bonus that came with it.

## Test plan
- [x] `tsc --noEmit` and `eslint` passed on this exact diff before committing (verified in the source checkout prior to cherry-picking here)
- [x] `vitest run __tests__/stores/tetrisStore.test.ts` — 18/18 passing (removed the now-obsolete `hardDrop` test, kept pause/wall-kick/line-clear-animation coverage)
- [x] `next build` succeeded on this diff
- [x] `git diff` against the already-verified source branch confirms this cherry-picked commit is byte-identical to what was tested

🤖 Generated with [Claude Code](https://claude.com/claude-code)