### PR TITLE
fix(sudoku): fix invisible entered digits and unstyled size previews

### DIFF
--- a/gamesformykids/app/games/sudoku/SudokuClient.tsx
+++ b/gamesformykids/app/games/sudoku/SudokuClient.tsx
@@ -29,16 +29,16 @@ function MiniBoardPreview({ size }: { size: Size }) {
   const cells = Array.from({ length: size * size });
   return (
     <div
-      className="grid gap-px bg-sky-300 rounded p-0.5 mx-auto mb-1"
-      style={{ gridTemplateColumns: `repeat(${size}, 5px)` }}
+      className="grid gap-px bg-gray-700 rounded p-1 mx-auto mb-1 shadow-sm"
+      style={{ gridTemplateColumns: `repeat(${size}, 6px)` }}
     >
       {cells.map((_, i) => {
         const r = Math.floor(i / size);
         const c = i % size;
         const shade = (Math.floor(r / boxRows) + Math.floor(c / boxCols)) % 2 === 0
           ? 'bg-white'
-          : 'bg-sky-100';
-        return <div key={i} className={shade} style={{ width: 5, height: 5 }} />;
+          : 'bg-gray-300';
+        return <div key={i} className={shade} style={{ width: 6, height: 6 }} />;
       })}
     </div>
   );

--- a/gamesformykids/app/games/sudoku/components/SudokuBoard.tsx
+++ b/gamesformykids/app/games/sudoku/components/SudokuBoard.tsx
@@ -46,6 +46,17 @@ export default function SudokuBoard({
           const rightBorder = (c + 1) % boxCols === 0 && c !== size - 1;
           const bottomBorder = (r + 1) % boxRows === 0 && r !== size - 1;
 
+          // Exactly one bg/text pair wins — never mix them, or Tailwind's
+          // cascade order (not class-list order) picks a winner and can
+          // leave entered digits low-contrast against the selected fill.
+          let bg = isGiven ? 'bg-gray-100' : 'bg-white';
+          let text = isGiven ? 'text-gray-900' : 'text-blue-700';
+          if (!isSelected && isSameValue) bg = 'bg-blue-200';
+          if (!isSelected && isPeer && !isSameValue) bg = 'bg-blue-50';
+          if (isSelected) { bg = 'bg-blue-400'; text = 'text-white'; }
+          if (isLocked && !isError) bg = 'bg-amber-200';
+          if (isError) bg = 'bg-red-300';
+
           return (
             <button
               key={`${r}-${c}`}
@@ -53,12 +64,10 @@ export default function SudokuBoard({
               aria-label={`שורה ${r + 1}, עמודה ${c + 1}${value !== 0 ? `, ${value}` : ''}`}
               className={[
                 'flex items-center justify-center font-bold transition-colors duration-150 border border-gray-300',
-                isGiven ? 'bg-gray-100 text-gray-900' : 'bg-white text-blue-700',
-                isSelected ? 'bg-blue-400 text-white ring-2 ring-inset ring-blue-700' : '',
-                !isSelected && isSameValue ? 'bg-blue-200' : '',
-                !isSelected && isPeer && !isSameValue ? 'bg-blue-50' : '',
-                isError ? 'bg-red-300 animate-pulse' : '',
-                isLocked && !isError ? 'bg-amber-200 animate-pulse' : '',
+                bg,
+                text,
+                isSelected ? 'ring-2 ring-inset ring-blue-700' : '',
+                isError || (isLocked && !isError) ? 'animate-pulse' : '',
                 rightBorder ? 'border-r-2 border-r-gray-700' : '',
                 bottomBorder ? 'border-b-2 border-b-gray-700' : '',
                 size === 9 ? 'text-lg' : 'text-2xl',


### PR DESCRIPTION
## Summary
Two visual regressions from #1554, reported right after merge:

- **Entered digits invisible until you select a different cell**: the selected cell simultaneously carried the base text-color class (`text-blue-700`/`text-gray-900`) and `text-white` (applied on selection). Both target `color`; Tailwind's compiled stylesheet order — not the order classes appear in the class list — decides which one wins, so the just-typed digit could render low-contrast against the blue selected background. Fixed by computing a single, mutually-exclusive `bg`/`text` pair per cell.
- **6×6 / 9×9 size-preview "frames" look unstyled**: the mini board preview used `bg-sky-300`/`bg-sky-100`, nearly identical to the surrounding button's own `bg-sky-100`, so it visually disappeared. Switched to the same dark `gray-700` frame the real board uses, for clear contrast regardless of button state.

## Test plan
- [x] `npx tsc --noEmit` — clean (verified on this exact diff before pushing)
- [x] Manual headless-browser pass: typed a digit into a selected cell — clearly visible in white against the blue fill; same-value cells correctly highlighted; both size-preview buttons now render as distinct dark-framed mini boards — zero console errors

Closes #1558