### PR TITLE
fix(sudoku): fix box divider borders misaligned by RTL direction override

### DIFF
--- a/gamesformykids/app/games/sudoku/components/SudokuBoard.tsx
+++ b/gamesformykids/app/games/sudoku/components/SudokuBoard.tsx
@@ -25,7 +25,11 @@ export default function SudokuBoard({
     <div
       dir="ltr"
       className="grid bg-gray-700 rounded-xl p-1 select-none shadow-lg"
-      style={{ gridTemplateColumns: `repeat(${size}, ${cellSize})` }}
+      // globals.css forces `direction: rtl` on every element (`* { direction: rtl }`),
+      // which overrides the `dir="ltr"` attribute's implicit direction — without this
+      // inline override the grid flows right-to-left and box-boundary borders (computed
+      // for left-to-right column indices) land on the wrong side of each box.
+      style={{ gridTemplateColumns: `repeat(${size}, ${cellSize})`, direction: 'ltr' }}
     >
       {puzzle.map((row, r) =>
         row.map((value, c) => {
@@ -63,13 +67,24 @@ export default function SudokuBoard({
               onClick={() => onSelect(r, c)}
               aria-label={`שורה ${r + 1}, עמודה ${c + 1}${value !== 0 ? `, ${value}` : ''}`}
               className={[
-                'flex items-center justify-center font-bold transition-colors duration-150 border border-gray-300',
+                'flex items-center justify-center font-bold transition-colors duration-150',
                 bg,
                 text,
-                isSelected ? 'ring-2 ring-inset ring-blue-700' : '',
+                isSelected ? 'ring-2 ring-inset ring-blue-700 z-10' : '',
                 isError || (isLocked && !isError) ? 'animate-pulse' : '',
-                rightBorder ? 'border-r-2 border-r-gray-700' : '',
-                bottomBorder ? 'border-b-2 border-b-gray-700' : '',
+                // Each shared edge is drawn by exactly one cell (right/bottom only) so
+                // adjacent 1px borders never stack into an uneven 2px line, and box
+                // separators stay a clean, consistent 2px regardless of neighbors.
+                c !== size - 1
+                  ? rightBorder
+                    ? 'border-r-2 border-r-gray-700'
+                    : 'border-r border-r-gray-300'
+                  : '',
+                r !== size - 1
+                  ? bottomBorder
+                    ? 'border-b-2 border-b-gray-700'
+                    : 'border-b border-b-gray-300'
+                  : '',
                 size === 9 ? 'text-lg' : 'text-2xl',
               ].join(' ')}
               style={{ width: cellSize, height: cellSize }}


### PR DESCRIPTION
## Summary
The Sudoku board's box-divider lines rendered in the wrong place — e.g. the 6x6 board split its columns 4/2 instead of the correct 3/3.

**Root cause**: `globals.css` forces `direction: rtl` on every element (`* { direction: rtl }`), which overrides the `dir="ltr"` attribute on the board container — the attribute's implicit direction loses to any author CSS rule regardless of specificity (same gotcha already documented in `multiplicationConfig.tsx`). The grid actually rendered right-to-left despite `dir="ltr"`, so box-boundary border classes (computed for left-to-right column indices) landed on the physically wrong side of each column. Confirmed via `getComputedStyle(board).direction` → `"rtl"` before the fix.

**Fix**: add `direction: 'ltr'` via inline `style` (not just the `dir` attribute) on the board container.

Also cleaned up a secondary issue while in here: every cell drew a full 4-side border, so shared edges between adjacent cells doubled up (1px+1px), making thin/thick lines look uneven. Each shared edge is now drawn by exactly one cell (right/bottom only).

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npm run build` — clean
- [x] Manual Playwright pass against the local dev server: measured `getBoundingClientRect`/computed border widths per cell — confirmed the divider now lands exactly on the 3/3 boundary for the 6x6 board (was 4/2) and 9x9 remains correct 3/3/3
- [x] Manually verified in-browser by the requester — confirmed fixed

Closes #1562